### PR TITLE
Forbid the creation of a link that would link a component to itself

### DIFF
--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -122,6 +122,11 @@ You may have to wait a few seconds until OpenShift fully provisions it.`, servic
 			fmt.Printf("Service %s has been successfully linked to the component %s.\n", serviceName, sourceComponentName)
 		} else if cmpExists {
 			targetComponent := args[0]
+			// forbid linking the component to itself
+			if targetComponent == sourceComponentName {
+				fmt.Println("Source and target component must not be the same component.")
+				os.Exit(1)
+			}
 
 			secretName, err := secret.DetermineSecretName(client, targetComponent, applicationName, port)
 			util.CheckError(err, "")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Forbid the creation of a link that would link a component to itself.
Although this wouldn't affect the operation of the pod, it however makes no sense to link from a component to itself

## Was the change discussed in an issue?
Fixes: #1052

## How to test changes?

Path this PR prevents: 
```
odo create nodejs frontend
odo link frontend
```

The other link scenarios should work as previously
