### PR TITLE
PoC: Initial implementation of a very basic kubectl-style plugin system.

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -13,10 +13,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 const pluginSuffix = ".odo.plugin"
@@ -32,13 +32,7 @@ type pluginImpl struct {
 }
 
 func (p pluginImpl) execute(args []string) error {
-	cmd := exec.Command(p.path, args...)
-	out, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(out))
-	return nil
+	return syscall.Exec(p.path, append([]string{p.path}, args...), os.Environ())
 }
 
 func main() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,10 @@ type LocalConfigInfo struct {
 }
 
 func getGlobalConfigFile() (string, error) {
+	if env, ok := os.LookupEnv(globalConfigEnvName); ok {
+		return env, nil
+	}
+
 	configDir, err := GetGlobalConfigDir()
 	if err != nil {
 		return "", err
@@ -127,10 +131,6 @@ func GetPluginsDir() (string, error) {
 
 // GetGlobalConfigDir retrieves the odo configuration directory path
 func GetGlobalConfigDir() (string, error) {
-	if env, ok := os.LookupEnv(globalConfigEnvName); ok {
-		return env, nil
-	}
-
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,6 +115,7 @@ func getGlobalConfigFile() (string, error) {
 	return filepath.Join(configDir, configFileName), nil
 }
 
+// GetPluginsDir returns the global plugins directory
 func GetPluginsDir() (string, error) {
 	configDir, err := GetGlobalConfigDir()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,24 @@ type LocalConfigInfo struct {
 }
 
 func getGlobalConfigFile() (string, error) {
+	configDir, err := GetGlobalConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, configFileName), nil
+}
+
+func GetPluginsDir() (string, error) {
+	configDir, err := GetGlobalConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(configDir, "plugins"), nil
+}
+
+// GetGlobalConfigDir retrieves the odo configuration directory path
+func GetGlobalConfigDir() (string, error) {
 	if env, ok := os.LookupEnv(globalConfigEnvName); ok {
 		return env, nil
 	}
@@ -116,7 +134,19 @@ func getGlobalConfigFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(currentUser.HomeDir, ".odo", configFileName), nil
+
+	configDir := filepath.Join(currentUser.HomeDir, ".odo")
+
+	// Check whether directory present or not
+	_, err = os.Stat(filepath.Dir(configDir))
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(filepath.Dir(configDir), 0755)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return configDir, nil
 }
 
 func getLocalConfigFile() (string, error) {

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -53,6 +53,9 @@ Component Commands:{{range .Commands}}{{if eq .Annotations.command "component"}}
 Other Commands:{{range .Commands}}{{if eq .Annotations.command "other"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
+Plugin Commands:{{range .Commands}}{{if eq .Annotations.command "plugin"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
 Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") (eq .Name "help") }}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
See what's involved in supporting a `kubectl`-style of plugins. Note that this currently doesn't attempt to do sub-commands as `kubectl` does. Currently, `odo` will only load plugins defined as binaries located in `~/.odo/plugins` directory and named `<name>.odo.plugin` where name is the name of the command `odo` will use for the plugin. So, to implement a `scaffold` command in `odo`, you could write a binary that does this, put it in `~/.odo/plugins` and name it `scaffold.odo.plugin`. Since `odo` doesn't know any such command, it will attempt to see if it knows a plugin by that name when you run `odo scaffold`. All arguments are passed. Any standard output from the called binary is output directly. Any output to `stderr` is interpreted as an error.

## Was the change discussed in an issue?
Not exactly, but see #1173 

## How to test changes?
Put any binary in `~/.odo/plugins` with the appropriate name format and go crazy! Hint: it's possible to have `odo` call itself as a plugin.
