### PR TITLE
Fix the problem of attempts to build component w/o source

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -167,6 +167,12 @@ func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) e
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
 	}
+
+	// Setup component source paths
+	err = component.SetupS2ISrcPaths(po.Context.Client, po.localConfig.GetApplication(), po.localConfig.GetName(), os.Stdout)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup source paths on the component")
+	}
 	log.Successf("Successfully updated component with name: %v", cmpName)
 
 	return nil

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -538,6 +538,16 @@ func componentTests(componentCmdPrefix string) {
 						// Push only config and see that the component is created but wothout any source copied
 						helper.CmdShouldPass("odo push --config")
 						helper.VerifyCmpExists(cmpName, appName, project)
+						// Verify that the autostart=false
+						helper.CheckCmdOpInRemoteCmpPod(
+							cmpName,
+							appName,
+							project,
+							"cat /var/lib/supervisord/conf/supervisor.conf",
+							func(cmdOp string, err error) bool {
+								return strings.Contains(cmdOp, "autostart=false")
+							},
+						)
 
 						// Push only source and see that the component is updated with source code
 						helper.CmdShouldPass("odo push --source")
@@ -555,6 +565,16 @@ func componentTests(componentCmdPrefix string) {
 							},
 						)
 						Expect(remoteCmdExecPass).To(Equal(true))
+						// Verify that the autostart=true
+						helper.CheckCmdOpInRemoteCmpPod(
+							cmpName,
+							appName,
+							project,
+							"cat /var/lib/supervisord/conf/supervisor.conf",
+							func(cmdOp string, err error) bool {
+								return strings.Contains(cmdOp, "autostart=true")
+							},
+						)
 					})
 
 					It("create local nodejs component and push source and code at once", func() {


### PR DESCRIPTION
This PR starts supervisord as part of push which sets the stage
for push for example at the moment by creating the source dir
structure as configured also by the `command` config in
`supervisor.conf`

fixes #1066 
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>
