### PR TITLE
Implement new odo workflow for: odo watch

### DIFF
--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -1,8 +1,6 @@
 package component
 
 import (
-	"github.com/openshift/odo/pkg/config"
-	"github.com/openshift/odo/pkg/occlient"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,13 +34,4 @@ type ComponentStatus struct {
 	Active           bool                `json:"active"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
-}
-
-// ComponentOptions are generic options that are used between commands such as watch and push
-type ComponentOptions struct {
-	SourceType       config.SrcType
-	SourcePath       string
-	LocalConfig      *config.LocalConfigInfo
-	ComponentContext string
-	Client           *occlient.Client
 }

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/occlient"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,4 +36,13 @@ type ComponentStatus struct {
 	Active           bool                `json:"active"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
+}
+
+// ComponentOptions are generic options that are used between commands such as watch and push
+type ComponentOptions struct {
+	SourceType       config.SrcType
+	SourcePath       string
+	LocalConfig      *config.LocalConfigInfo
+	ComponentContext string
+	Client           *occlient.Client
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -526,10 +526,10 @@ func GetSrcType(ctStr string) (SrcType, error) {
 	}
 }
 
-// CorrectSourcePath corrects the current sourcePath depending on local or binary configuration,
+// GetOSSourcePath corrects the current sourcePath depending on local or binary configuration,
 // if Git has been passed, we simply return the source location from LocalConfig
 // this will get the correct source path whether on Windows, macOS or Linux.
-func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
+func GetOSSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 
 	cmpName := localConfig.GetName()
 	sourceType := localConfig.GetSourceType()
@@ -564,7 +564,7 @@ func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
 		}
 
-		return util.ReadFilePath(u, runtime.GOOS), nil
+		return sourcePath, nil
 
 	}
 	return "", fmt.Errorf("SourceType for correcting a SourcePath must be binary or local")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -526,7 +526,8 @@ func GetSrcType(ctStr string) (SrcType, error) {
 	}
 }
 
-// correctSourcePath corrects the current sourcePath depending on local or binary configuration
+// CorrectSourcePath corrects the current sourcePath depending on local or binary configuration
+// this will get the correct source path whether on Windows, macOS or Linux.
 func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 
 	cmpName := localConfig.GetName()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -531,6 +531,10 @@ func GetSrcType(ctStr string) (SrcType, error) {
 // this will get the correct source path whether on Windows, macOS or Linux.
 func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 
+	// TODO:
+	// Always piped to "fromslash" so it's correct for the OS..
+	//
+
 	cmpName := lci.GetName()
 	sourceType := lci.GetSourceType()
 	sourceLocation := lci.GetSourceLocation()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -526,7 +526,8 @@ func GetSrcType(ctStr string) (SrcType, error) {
 	}
 }
 
-// CorrectSourcePath corrects the current sourcePath depending on local or binary configuration
+// CorrectSourcePath corrects the current sourcePath depending on local or binary configuration,
+// if Git has been passed, we simply return the source location from LocalConfig
 // this will get the correct source path whether on Windows, macOS or Linux.
 func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 
@@ -534,31 +535,37 @@ func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 	sourceType := localConfig.GetSourceType()
 	sourceLocation := localConfig.GetSourceLocation()
 
-	// We use "ToSlash" here to make sure that deliminators are in a slash format
 	if sourceLocation == "" {
 		return "", fmt.Errorf("Blank source location provided")
 	}
 
-	sourcePath := filepath.ToSlash(localConfig.GetSourceLocation())
+	// If we are passing in a GIT source type, we make no changes.
+	// if it's binary or local, we will correct the source path.
+	if sourceType == GIT {
+		glog.V(4).Info("Git source type detected, not correcting SourcePath location")
+		return sourceLocation, nil
+	} else if sourceType == BINARY || sourceType == LOCAL {
 
-	if sourceType == BINARY || sourceType == LOCAL {
+		// We use "ToSlash" here to make sure that deliminators are in a slash format
+		sourcePath := filepath.ToSlash(localConfig.GetSourceLocation())
 		u, err := url.Parse(sourcePath)
 		if err != nil {
 			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)
 		}
 
-		// See https://github.com/golang/go/issues/13276
-		// url/parse is unable to parse Windows file paths.. so here we detect if there is one character in the Scheme
-		// Ex. C or Z drive, etc.. as well as check to see if we're on Windows.
-		// else
-		// we check the schema normally (on Linux / macOS)
 		if len(u.Scheme) == 1 && runtime.GOOS == "windows" {
+			// See https://github.com/golang/go/issues/13276
+			// url/parse is unable to parse Windows file paths.. so here we detect if there is one character in the Scheme
+			// Ex. C or Z drive, etc.. as well as check to see if we're on Windows.
+			// else
+			// we check the schema normally (on Linux / macOS)
 			glog.V(4).Info("We're using Windows here and unfortunately net/url doesn't support parsing.. we're going to skip this")
 		} else if u.Scheme != "" && u.Scheme != "file" {
 			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
 		}
 
 		return util.ReadFilePath(u, runtime.GOOS), nil
+
 	}
 	return "", fmt.Errorf("SourceType for correcting a SourcePath must be binary or local")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,11 +2,14 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/odo/pkg/util"
@@ -521,4 +524,40 @@ func GetSrcType(ctStr string) (SrcType, error) {
 	default:
 		return NONE, fmt.Errorf("Unsupported component source type: %s", ctStr)
 	}
+}
+
+// correctSourcePath corrects the current sourcePath depending on local or binary configuration
+func CorrectSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
+
+	cmpName := localConfig.GetName()
+	sourceType := localConfig.GetSourceType()
+	sourceLocation := localConfig.GetSourceLocation()
+
+	// We use "ToSlash" here to make sure that deliminators are in a slash format
+	if sourceLocation == "" {
+		return "", fmt.Errorf("Blank source location provided")
+	}
+
+	sourcePath := filepath.ToSlash(localConfig.GetSourceLocation())
+
+	if sourceType == BINARY || sourceType == LOCAL {
+		u, err := url.Parse(sourcePath)
+		if err != nil {
+			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)
+		}
+
+		// See https://github.com/golang/go/issues/13276
+		// url/parse is unable to parse Windows file paths.. so here we detect if there is one character in the Scheme
+		// Ex. C or Z drive, etc.. as well as check to see if we're on Windows.
+		// else
+		// we check the schema normally (on Linux / macOS)
+		if len(u.Scheme) == 1 && runtime.GOOS == "windows" {
+			glog.V(4).Info("We're using Windows here and unfortunately net/url doesn't support parsing.. we're going to skip this")
+		} else if u.Scheme != "" && u.Scheme != "file" {
+			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
+		}
+
+		return util.ReadFilePath(u, runtime.GOOS), nil
+	}
+	return "", fmt.Errorf("SourceType for correcting a SourcePath must be binary or local")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -529,11 +529,11 @@ func GetSrcType(ctStr string) (SrcType, error) {
 // GetOSSourcePath corrects the current sourcePath depending on local or binary configuration,
 // if Git has been passed, we simply return the source location from LocalConfig
 // this will get the correct source path whether on Windows, macOS or Linux.
-func GetOSSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
+func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 
-	cmpName := localConfig.GetName()
-	sourceType := localConfig.GetSourceType()
-	sourceLocation := localConfig.GetSourceLocation()
+	cmpName := lci.GetName()
+	sourceType := lci.GetSourceType()
+	sourceLocation := lci.GetSourceLocation()
 
 	if sourceLocation == "" {
 		return "", fmt.Errorf("Blank source location provided")
@@ -547,7 +547,7 @@ func GetOSSourcePath(localConfig *LocalConfigInfo) (path string, err error) {
 	} else if sourceType == BINARY || sourceType == LOCAL {
 
 		// We use "ToSlash" here to make sure that deliminators are in a slash format
-		sourcePath := filepath.ToSlash(localConfig.GetSourceLocation())
+		sourcePath := filepath.ToSlash(lci.GetSourceLocation())
 		u, err := url.Parse(sourcePath)
 		if err != nil {
 			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -315,7 +315,7 @@ func TestMetaTypePopulatedInLocalConfig(t *testing.T) {
 }
 
 // TODO: Write Windows tests for below
-func TestCorrectSourcePath(t *testing.T) {
+func TestGetOSSourcePath(t *testing.T) {
 	tempConfigFile, err := ioutil.TempFile("", "odoconfig")
 	if err != nil {
 		t.Fatal(err)
@@ -429,7 +429,7 @@ func TestCorrectSourcePath(t *testing.T) {
 				t.Errorf("the '%v' was not set", tt.parameter)
 			}
 
-			_, err = CorrectSourcePath(cfg)
+			_, err = GetOSSourcePath(cfg)
 			if tt.wantErr && err == nil {
 				t.Errorf("expected error for %s source path", tt.value)
 			} else if !tt.wantErr && err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -314,6 +314,7 @@ func TestMetaTypePopulatedInLocalConfig(t *testing.T) {
 	}
 }
 
+// TODO: Write Windows tests for below
 func TestCorrectSourcePath(t *testing.T) {
 	tempConfigFile, err := ioutil.TempFile("", "odoconfig")
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -429,7 +429,7 @@ func TestGetOSSourcePath(t *testing.T) {
 				t.Errorf("the '%v' was not set", tt.parameter)
 			}
 
-			_, err = GetOSSourcePath(cfg)
+			_, err = cfg.GetOSSourcePath()
 			if tt.wantErr && err == nil {
 				t.Errorf("expected error for %s source path", tt.value)
 			} else if !tt.wantErr && err != nil {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -75,7 +75,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.sourceType = conf.LocalConfig.GetSourceType()
 
 	// Get SourceLocation here...
-	po.sourcePath, err = config.CorrectSourcePath(po.localConfig)
+	po.sourcePath, err = config.GetOSSourcePath(po.localConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve absolute path to source location")
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/odo/cli/utils"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/project"
@@ -61,7 +60,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.options.Client = genericclioptions.Client(cmd)
 
 	// Retrieve configuration configuration as well as SourcePath
-	conf, err := utils.RetrieveLocalConfigInfo(po.options.ComponentContext)
+	conf, err := genericclioptions.RetrieveLocalConfigInfo(po.options.ComponentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve config information")
 	}
@@ -72,7 +71,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.options.SourceType = conf.LocalConfig.GetSourceType()
 
 	// Apply ignore information
-	err = utils.ApplyIgnore(&po.ignores, po.options.SourcePath)
+	err = genericclioptions.ApplyIgnore(&po.ignores, po.options.SourcePath)
 	if err != nil {
 		return errors.Wrap(err, "unable to apply ignore information")
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -42,7 +42,7 @@ type PushOptions struct {
 	ignores []string
 	show    bool
 
-	options component.ComponentOptions
+	options genericclioptions.ComponentOptions
 
 	*genericclioptions.Context
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -75,7 +75,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.sourceType = conf.LocalConfig.GetSourceType()
 
 	// Get SourceLocation here...
-	po.sourcePath, err = config.GetOSSourcePath(po.localConfig)
+	po.sourcePath, err = conf.GetOSSourcePath()
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve absolute path to source location")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -66,7 +66,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.sourceType = conf.LocalConfig.GetSourceType()
 
 	// Get SourceLocation here...
-	wo.sourcePath, err = config.CorrectSourcePath(wo.localConfig)
+	wo.sourcePath, err = config.GetOSSourcePath(wo.localConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve absolute path to source location")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -35,7 +35,7 @@ type WatchOptions struct {
 	ignores []string
 	delay   int
 
-	options component.ComponentOptions
+	options genericclioptions.ComponentOptions
 
 	*genericclioptions.Context
 }

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -66,7 +66,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.sourceType = conf.LocalConfig.GetSourceType()
 
 	// Get SourceLocation here...
-	wo.sourcePath, err = config.GetOSSourcePath(wo.localConfig)
+	wo.sourcePath, err = conf.GetOSSourcePath()
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve absolute path to source location")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -6,7 +6,6 @@ import (
 
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
-	"github.com/openshift/odo/pkg/odo/cli/utils"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/pkg/errors"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -51,7 +50,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.options.Client = genericclioptions.Client(cmd)
 
 	// Retrieve configuration configuration as well as SourcePath
-	conf, err := utils.RetrieveLocalConfigInfo(wo.options.ComponentContext)
+	conf, err := genericclioptions.RetrieveLocalConfigInfo(wo.options.ComponentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve config information")
 	}
@@ -62,7 +61,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.options.SourceType = conf.LocalConfig.GetSourceType()
 
 	// Apply ignore information
-	err = utils.ApplyIgnore(&wo.ignores, wo.options.SourcePath)
+	err = genericclioptions.ApplyIgnore(&wo.ignores, wo.options.SourcePath)
 	if err != nil {
 		return errors.Wrap(err, "unable to apply ignore information")
 	}

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -2,14 +2,8 @@ package utils
 
 import (
 	"fmt"
-	"net/url"
-	"runtime"
 
-	"github.com/openshift/odo/pkg/config"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/util"
-
-	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 )
@@ -41,64 +35,4 @@ func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
 	for _, child := range cmd.Commands() {
 		VisitCommands(child, f)
 	}
-}
-
-// LocalConfigInfo is a struct that will contain the LocalConfig as well as SourcePath
-// the reasoning behind SourcePath is due to the fact that we must correct what the path is
-// on different platforms (Linux, Windows, etc.) as well as get the absolute path of the component.
-type LocalConfigInfo struct {
-	LocalConfig *config.LocalConfigInfo
-	SourcePath  string
-}
-
-// RetrieveLocalConfigInfo retrieves the local configuration
-func RetrieveLocalConfigInfo(componentContext string) (configInfo LocalConfigInfo, err error) {
-
-	conf, err := config.NewLocalConfigInfo(componentContext, false)
-	if err != nil {
-		return LocalConfigInfo{}, errors.Wrap(err, "failed to fetch component config")
-	}
-
-	sourcePath, err := correctSourcePath(conf)
-	if err != nil {
-		return LocalConfigInfo{}, errors.Wrap(err, "unable to validate source path")
-	}
-
-	return LocalConfigInfo{
-		LocalConfig: conf,
-		SourcePath:  sourcePath}, nil
-}
-
-// correctSourcePath corrects the current sourcePath depending on local or binary configuration
-func correctSourcePath(localConfig *config.LocalConfigInfo) (path string, err error) {
-
-	cmpName := localConfig.GetName()
-	sourceType := localConfig.GetSourceType()
-	sourcePath := localConfig.GetSourceLocation()
-
-	if sourceType == config.BINARY || sourceType == config.LOCAL {
-		u, err := url.Parse(sourcePath)
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)
-		}
-
-		if u.Scheme != "" && u.Scheme != "file" {
-			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
-		}
-		return util.ReadFilePath(u, runtime.GOOS), nil
-	}
-	return sourcePath, nil
-}
-
-// ApplyIgnore will take the current ignores []string and either ignore it (if .odoignore is used)
-// or find the .gitignore file in the directory and use that instead.
-func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
-	if len(*ignores) == 0 {
-		rules, err := util.GetIgnoreRulesFromDirectory(sourcePath)
-		if err != nil {
-			odoutil.LogErrorAndExit(err, "")
-		}
-		*ignores = append(*ignores, rules...)
-	}
-	return nil
 }

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -2,8 +2,14 @@ package utils
 
 import (
 	"fmt"
+	"net/url"
+	"runtime"
 
-	"github.com/openshift/odo/pkg/odo/util"
+	"github.com/openshift/odo/pkg/config"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
+	"github.com/openshift/odo/pkg/util"
+
+	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 )
@@ -12,7 +18,7 @@ const RecommendedCommandName = "utils"
 
 // NewCmdUtils implements the utils odo command
 func NewCmdUtils(name, fullName string) *cobra.Command {
-	terminalCmd := NewCmdTerminal(terminalCommandName, util.GetFullName(fullName, terminalCommandName))
+	terminalCmd := NewCmdTerminal(terminalCommandName, odoutil.GetFullName(fullName, terminalCommandName))
 	utilsCmd := &cobra.Command{
 		Use:   name,
 		Short: "Utilities for terminal commands and modifying Odo configurations",
@@ -22,7 +28,7 @@ func NewCmdUtils(name, fullName string) *cobra.Command {
 	}
 
 	utilsCmd.Annotations = map[string]string{"command": "utility"}
-	utilsCmd.SetUsageTemplate(util.CmdUsageTemplate)
+	utilsCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	utilsCmd.AddCommand(terminalCmd)
 	return utilsCmd
@@ -35,4 +41,64 @@ func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
 	for _, child := range cmd.Commands() {
 		VisitCommands(child, f)
 	}
+}
+
+// LocalConfigInfo is a struct that will contain the LocalConfig as well as SourcePath
+// the reasoning behind SourcePath is due to the fact that we must correct what the path is
+// on different platforms (Linux, Windows, etc.) as well as get the absolute path of the component.
+type LocalConfigInfo struct {
+	LocalConfig *config.LocalConfigInfo
+	SourcePath  string
+}
+
+// RetrieveLocalConfigInfo retrieves the local configuration
+func RetrieveLocalConfigInfo(componentContext string) (configInfo LocalConfigInfo, err error) {
+
+	conf, err := config.NewLocalConfigInfo(componentContext, false)
+	if err != nil {
+		return LocalConfigInfo{}, errors.Wrap(err, "failed to fetch component config")
+	}
+
+	sourcePath, err := correctSourcePath(conf)
+	if err != nil {
+		return LocalConfigInfo{}, errors.Wrap(err, "unable to validate source path")
+	}
+
+	return LocalConfigInfo{
+		LocalConfig: conf,
+		SourcePath:  sourcePath}, nil
+}
+
+// correctSourcePath corrects the current sourcePath depending on local or binary configuration
+func correctSourcePath(localConfig *config.LocalConfigInfo) (path string, err error) {
+
+	cmpName := localConfig.GetName()
+	sourceType := localConfig.GetSourceType()
+	sourcePath := localConfig.GetSourceLocation()
+
+	if sourceType == config.BINARY || sourceType == config.LOCAL {
+		u, err := url.Parse(sourcePath)
+		if err != nil {
+			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)
+		}
+
+		if u.Scheme != "" && u.Scheme != "file" {
+			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
+		}
+		return util.ReadFilePath(u, runtime.GOOS), nil
+	}
+	return sourcePath, nil
+}
+
+// ApplyIgnore will take the current ignores []string and either ignore it (if .odoignore is used)
+// or find the .gitignore file in the directory and use that instead.
+func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
+	if len(*ignores) == 0 {
+		rules, err := util.GetIgnoreRulesFromDirectory(sourcePath)
+		if err != nil {
+			odoutil.LogErrorAndExit(err, "")
+		}
+		*ignores = append(*ignores, rules...)
+	}
+	return nil
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -17,15 +17,6 @@ import (
 	"github.com/openshift/odo/pkg/util"
 )
 
-// ComponentOptions are generic options that are used between commands such as watch and push
-type ComponentOptions struct {
-	SourceType       config.SrcType
-	SourcePath       string
-	LocalConfig      *config.LocalConfigInfo
-	ComponentContext string
-	Client           *occlient.Client
-}
-
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
 func NewContext(command *cobra.Command) *Context {
 	return newContext(command, false)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -20,6 +20,15 @@ import (
 	"github.com/openshift/odo/pkg/util"
 )
 
+// ComponentOptions are generic options that are used between commands such as watch and push
+type ComponentOptions struct {
+	SourceType       config.SrcType
+	SourcePath       string
+	LocalConfig      *config.LocalConfigInfo
+	ComponentContext string
+	Client           *occlient.Client
+}
+
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
 func NewContext(command *cobra.Command) *Context {
 	return newContext(command, false)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -2,9 +2,12 @@ package genericclioptions
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"runtime"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/odo/pkg/application"
@@ -12,9 +15,9 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/project"
-	pkgUtil "github.com/openshift/odo/pkg/util"
+	"github.com/openshift/odo/pkg/util"
 )
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
@@ -48,7 +51,7 @@ func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient
 	case 0:
 		var err error
 		skipConnectionCheck, err = command.Flags().GetBool(SkipConnectionCheckFlagName)
-		util.LogErrorAndExit(err, "")
+		odoutil.LogErrorAndExit(err, "")
 	case 1:
 		skipConnectionCheck = shouldSkipConnectionCheck[0]
 	default:
@@ -58,7 +61,7 @@ func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient
 	}
 
 	client, err := occlient.New(skipConnectionCheck)
-	util.LogErrorAndExit(err, "")
+	odoutil.LogErrorAndExit(err, "")
 
 	return client
 }
@@ -68,7 +71,7 @@ func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient
 func checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command *cobra.Command, errFormatForCommand string) {
 	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || command.Name() == "delete") {
 		err := fmt.Errorf(errFormatForCommand, command.Root().Name())
-		util.LogErrorAndExit(err, "")
+		odoutil.LogErrorAndExit(err, "")
 	}
 }
 
@@ -79,18 +82,18 @@ func resolveProject(command *cobra.Command, client *occlient.Client) string {
 	if len(projectFlag) > 0 {
 		// if project flag was set, check that the specified project exists and use it
 		_, err := project.Exists(client, projectFlag)
-		util.LogErrorAndExit(err, "")
+		odoutil.LogErrorAndExit(err, "")
 		ns = projectFlag
 	} else {
 		// Get details from config file
 		fileName := FlagValueIfSet(command, ContextFlagName)
 		if fileName != "" {
-			fileAbs, err := pkgUtil.GetAbsPath(fileName)
-			util.LogErrorAndExit(err, "")
+			fileAbs, err := util.GetAbsPath(fileName)
+			odoutil.LogErrorAndExit(err, "")
 			fileName = fileAbs
 		}
 		lci, err := config.NewLocalConfigInfo(fileName, false)
-		util.LogErrorAndExit(err, "could not get component settings from config file")
+		odoutil.LogErrorAndExit(err, "could not get component settings from config file")
 
 		ns = lci.GetProject()
 		if ns == "" {
@@ -123,12 +126,12 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 	// Get details from config file
 	fileName := FlagValueIfSet(command, ContextFlagName)
 	if fileName != "" {
-		fAbs, err := pkgUtil.GetAbsPath(fileName)
-		util.LogErrorAndExit(err, "")
+		fAbs, err := util.GetAbsPath(fileName)
+		odoutil.LogErrorAndExit(err, "")
 		fileName = fAbs
 	}
 	lci, err := config.NewLocalConfigInfo(fileName, false)
-	util.LogErrorAndExit(err, "could not get component settings from config file")
+	odoutil.LogErrorAndExit(err, "could not get component settings from config file")
 
 	// resolve application
 	var app string
@@ -142,7 +145,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 				var err error
 				app, err = application.GetDefaultAppName()
 				if err != nil {
-					util.LogErrorAndExit(err, "failed to generate a random app name")
+					odoutil.LogErrorAndExit(err, "failed to generate a random app name")
 				}
 			}
 		}
@@ -244,7 +247,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 // existsOrExit checks if the specified component exists with the given context and exits the app if not.
 func (o *Context) checkComponentExistsOrFail(cmp string) {
 	exists, err := component.Exists(o.Client, cmp, o.Application)
-	util.LogErrorAndExit(err, "")
+	odoutil.LogErrorAndExit(err, "")
 	if !exists {
 		log.Errorf("Component %v does not exist in application %s", cmp, o.Application)
 		os.Exit(1)
@@ -256,4 +259,64 @@ func ignoreButLog(err error) {
 	if err != nil {
 		glog.V(4).Infof("Ignoring error as it usually means flag wasn't set: %v", err)
 	}
+}
+
+// LocalConfigInfo is a struct that will contain the LocalConfig as well as SourcePath
+// the reasoning behind SourcePath is due to the fact that we must correct what the path is
+// on different platforms (Linux, Windows, etc.) as well as get the absolute path of the component.
+type LocalConfigInfo struct {
+	LocalConfig *config.LocalConfigInfo
+	SourcePath  string
+}
+
+// RetrieveLocalConfigInfo retrieves the local configuration
+func RetrieveLocalConfigInfo(componentContext string) (configInfo LocalConfigInfo, err error) {
+
+	conf, err := config.NewLocalConfigInfo(componentContext, false)
+	if err != nil {
+		return LocalConfigInfo{}, errors.Wrap(err, "failed to fetch component config")
+	}
+
+	sourcePath, err := correctSourcePath(conf)
+	if err != nil {
+		return LocalConfigInfo{}, errors.Wrap(err, "unable to validate source path")
+	}
+
+	return LocalConfigInfo{
+		LocalConfig: conf,
+		SourcePath:  sourcePath}, nil
+}
+
+// correctSourcePath corrects the current sourcePath depending on local or binary configuration
+func correctSourcePath(localConfig *config.LocalConfigInfo) (path string, err error) {
+
+	cmpName := localConfig.GetName()
+	sourceType := localConfig.GetSourceType()
+	sourcePath := localConfig.GetSourceLocation()
+
+	if sourceType == config.BINARY || sourceType == config.LOCAL {
+		u, err := url.Parse(sourcePath)
+		if err != nil {
+			return "", errors.Wrapf(err, "unable to parse source %s from component %s", sourcePath, cmpName)
+		}
+
+		if u.Scheme != "" && u.Scheme != "file" {
+			return "", fmt.Errorf("Component %s has invalid source path %s", cmpName, u.Scheme)
+		}
+		return util.ReadFilePath(u, runtime.GOOS), nil
+	}
+	return sourcePath, nil
+}
+
+// ApplyIgnore will take the current ignores []string and either ignore it (if .odoignore is used)
+// or find the .gitignore file in the directory and use that instead.
+func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
+	if len(*ignores) == 0 {
+		rules, err := util.GetIgnoreRulesFromDirectory(sourcePath)
+		if err != nil {
+			odoutil.LogErrorAndExit(err, "")
+		}
+		*ignores = append(*ignores, rules...)
+	}
+	return nil
 }


### PR DESCRIPTION
Implements `odo watch` by using the local configuration file.

To use these changes, simply use: `odo watch` in the same directory that
you've deployed, or `odo watch --context ~/nodejs-ex`.

This builds upon: https://github.com/redhat-developer/odo/pull/1360

Closes https://github.com/redhat-developer/odo/issues/1419