### PR TITLE
add test to validate the second push

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -519,6 +519,7 @@ var _ = Describe("odoe2e", func() {
 				runCmdShouldPass("odo create nodejs:8 nodejs-doublepush --local " + tmpDir + "/nodejs-ex")
 				runCmdShouldPass("odo push")
 				runCmdShouldPass("odo push")
+				runCmdShouldPass("odo component delete nodejs-doublepush -f")
 			})
 
 			It("should be able to push changes while showing logging", func() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -514,6 +514,12 @@ var _ = Describe("odoe2e", func() {
 				// remove the .odoignore file
 				Expect(os.Remove(ignoreFilePath)).To(BeNil())
 			})
+			// should be tested after the perviour It
+			It("should be able to push the local files on second iteration successfully", func() {
+				runCmdShouldPass("odo create nodejs:8 nodejs-doublepush --local " + tmpDir + "/nodejs-ex")
+				runCmdShouldPass("odo push")
+				runCmdShouldPass("odo push")
+			})
 
 			It("should be able to push changes while showing logging", func() {
 				// Push the changes with --show-log

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -516,10 +516,10 @@ var _ = Describe("odoe2e", func() {
 			})
 			// should be tested after the perviour It
 			It("should be able to push the local files on second iteration successfully", func() {
-				runCmdShouldPass("odo create nodejs:8 nodejs-doublepush --local " + tmpDir + "/nodejs-ex")
-				runCmdShouldPass("odo push")
-				runCmdShouldPass("odo push")
-				runCmdShouldPass("odo component delete nodejs-doublepush -f")
+				runCmdShouldPass("odo create nodejs:8 nodejs-doublepush --app testapp --context " + tmpDir + "/nodejs-ex")
+				runCmdShouldPass("odo push --context " + tmpDir + "/nodejs-ex")
+				runCmdShouldPass("odo push --context " + tmpDir + "/nodejs-ex")
+				runCmdShouldPass("odo component delete --app testapp nodejs-doublepush -f")
 			})
 
 			It("should be able to push changes while showing logging", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
add test to cover the second iteration of `odo push`

## Was the change discussed in an issue?
https://github.com/redhat-developer/odo/issues/1231
https://github.com/redhat-developer/odo-supervisord-image/pull/17#issuecomment-471906401

## How to test changes?
run `make test-e2e` and validate the tests are succeeding 

#### Merge only after merging https://github.com/redhat-developer/odo-supervisord-image/pull/17