### PR TITLE
added env variables in component config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,13 +140,6 @@ func getFromFile(lc *LocalConfig, filename string) error {
 	return nil
 }
 
-func writeToFile(lc *LocalConfig, filename string) error {
-	plc := newProxyLocalConfig()
-	plc.TypeMeta = lc.typeMeta
-	plc.ComponentSettings = lc.componentSettings
-	return util.WriteToFile(&plc, filename)
-}
-
 // NewLocalConfig creates an empty LocalConfig struct with typeMeta populated
 func NewLocalConfig() LocalConfig {
 	return LocalConfig{
@@ -288,7 +281,10 @@ func (lci *LocalConfigInfo) GetEnvVars() EnvVarList {
 }
 
 func (lci *LocalConfigInfo) writeToFile() error {
-	return util.WriteToFile(&lci.LocalConfig, lci.Filename)
+	plc := newProxyLocalConfig()
+	plc.TypeMeta = lci.typeMeta
+	plc.ComponentSettings = lci.componentSettings
+	return util.WriteToFile(&plc, lci.Filename)
 }
 
 // GetType returns type of component (builder image name) in the config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,8 @@ type ComponentSettings struct {
 	MinCPU *string `yaml:"MinCPU,omitempty"`
 
 	MaxCPU *string `yaml:"MaxCPU,omitempty"`
+
+	Envs EnvVarList `yaml:"Envs,omitempty"`
 }
 
 // LocalConfig holds all the config relavent to a specific Component.
@@ -216,7 +218,7 @@ func (lci *LocalConfigInfo) SetConfiguration(parameter string, value interface{}
 
 		}
 
-		return writeToFile(&lci.LocalConfig, lci.Filename)
+		return lci.writeToFile()
 	}
 	return errors.Errorf("unknown parameter :'%s' is not a parameter in local odo config", parameter)
 
@@ -254,7 +256,7 @@ func (lci *LocalConfigInfo) DeleteConfiguration(parameter string) error {
 				return err
 			}
 		}
-		return writeToFile(&lci.LocalConfig, lci.Filename)
+		return lci.writeToFile()
 	}
 	return errors.Errorf("unknown parameter :'%s' is not a parameter in local odo config", parameter)
 
@@ -268,11 +270,28 @@ func (lci *LocalConfigInfo) GetComponentSettings() ComponentSettings {
 // SetComponentSettings sets the componentSettings from to the local config and writes to the file
 func (lci *LocalConfigInfo) SetComponentSettings(cs ComponentSettings) error {
 	lci.componentSettings = cs
-	return writeToFile(&lci.LocalConfig, lci.Filename)
+	return lci.writeToFile()
+}
+
+// SetEnvVars sets the env variables on the component settings
+func (lci *LocalConfigInfo) SetEnvVars(envVars EnvVarList) error {
+	lci.ComponentSettings.Envs = envVars
+	return lci.writeToFile()
+}
+
+// GetEnvVars gets the env variables from the component settings
+func (lci *LocalConfigInfo) GetEnvVars() EnvVarList {
+	if lci.ComponentSettings.Envs == nil {
+		return EnvVarList{}
+	}
+	return lci.ComponentSettings.Envs
+}
+
+func (lci *LocalConfigInfo) writeToFile() error {
+	return util.WriteToFile(&lci.LocalConfig, lci.Filename)
 }
 
 // GetType returns type of component (builder image name) in the config
-// and if absent then returns default
 func (lc *LocalConfig) GetType() string {
 	if lc.componentSettings.Type == nil {
 		return ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -275,16 +275,16 @@ func (lci *LocalConfigInfo) SetComponentSettings(cs ComponentSettings) error {
 
 // SetEnvVars sets the env variables on the component settings
 func (lci *LocalConfigInfo) SetEnvVars(envVars EnvVarList) error {
-	lci.ComponentSettings.Envs = envVars
+	lci.componentSettings.Envs = envVars
 	return lci.writeToFile()
 }
 
 // GetEnvVars gets the env variables from the component settings
 func (lci *LocalConfigInfo) GetEnvVars() EnvVarList {
-	if lci.ComponentSettings.Envs == nil {
+	if lci.componentSettings.Envs == nil {
 		return EnvVarList{}
 	}
-	return lci.ComponentSettings.Envs
+	return lci.componentSettings.Envs
 }
 
 func (lci *LocalConfigInfo) writeToFile() error {

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -47,14 +47,6 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 
 }
 
-// MergeEnvVarList merges the two provided envVarList
-func MergeEnvVarList(evl EnvVarList, otherEvl EnvVarList) EnvVarList {
-	for _, envVar := range otherEvl {
-		evl = append(evl, envVar)
-	}
-	return evl
-}
-
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
 func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/redhat-developer/odo/pkg/util"
+)
+
+// EnvVar represents an enviroment variable
+type EnvVar struct {
+	Name  string `yaml:"Name"`
+	Value string `yaml:"Value"`
+}
+
+// EnvVarList represents a list of environment variables
+type EnvVarList []*EnvVar
+
+// NewEnvVarFromString takes a string of format "name=value" and returns an Env
+// variable struct
+func NewEnvVarFromString(envStr string) (*EnvVar, error) {
+	envList := strings.Split(envStr, "=")
+	// if there is not = in the string
+	if len(envList) < 2 {
+		return nil, errors.New("invalid environment variable format")
+	}
+
+	return &EnvVar{
+		Name:  strings.TrimSpace(envList[0]),
+		Value: strings.TrimSpace(envList[1]),
+	}, nil
+}
+
+// NewEnvVarListFromSlice takes multiple env variables with format
+// "name=value" and returns an EnvVarList
+func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
+	var envVarList EnvVarList
+	for _, envStr := range envList {
+		envVar, err := NewEnvVarFromString(envStr)
+		if err != nil {
+			return nil, err
+		}
+		envVarList = append(envVarList, envVar)
+	}
+
+	return envVarList, nil
+
+}
+
+// MergeEnvVarList merges the two provided envVarList
+func MergeEnvVarList(evl EnvVarList, otherEvl EnvVarList) EnvVarList {
+	for _, envVar := range otherEvl {
+		evl = append(evl, envVar)
+	}
+	return evl
+}
+
+// RemoveEnvVarsFromList removes the env variables based on the keys provided
+// and returns a new EnvVarList
+func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {
+	newEnvVarList := EnvVarList{}
+	for _, envVar := range envVarList {
+		// if the env is in the keys we skip it
+		if util.In(keys, envVar.Name) {
+			continue
+		}
+
+		newEnvVarList = append(newEnvVarList, envVar)
+	}
+	return newEnvVarList
+}

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -23,7 +23,7 @@ func (evl EnvVarList) Merge(other EnvVarList) EnvVarList {
 	var dedupNewEvl EnvVarList
 	newEvl := append(evl, other...)
 	uniqueMap := make(map[string]string)
-	// last value will be kept in case o
+	// last value will be kept in case of duplicate env vars
 	for _, envVar := range newEvl {
 		uniqueMap[envVar.Name] = envVar.Value
 	}

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -16,6 +16,29 @@ type EnvVar struct {
 // EnvVarList represents a list of environment variables
 type EnvVarList []EnvVar
 
+// Merge merges the other EnvVarlist with keeping last value for duplicate EnvVars
+// and returns a new EnvVarList
+func (evl EnvVarList) Merge(other EnvVarList) EnvVarList {
+
+	var dedupNewEvl EnvVarList
+	newEvl := append(evl, other...)
+	uniqueMap := make(map[string]string)
+	// last value will be kept in case o
+	for _, envVar := range newEvl {
+		uniqueMap[envVar.Name] = envVar.Value
+	}
+
+	for key, value := range uniqueMap {
+		dedupNewEvl = append(dedupNewEvl, EnvVar{
+			Name:  key,
+			Value: value,
+		})
+	}
+
+	return dedupNewEvl
+
+}
+
 // NewEnvVarFromString takes a string of format "name=value" and returns an Env
 // variable struct
 func NewEnvVarFromString(envStr string) (EnvVar, error) {

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/redhat-developer/odo/pkg/util"
+	"github.com/openshift/odo/pkg/util"
 )
 
 // EnvVar represents an enviroment variable

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -14,18 +14,18 @@ type EnvVar struct {
 }
 
 // EnvVarList represents a list of environment variables
-type EnvVarList []*EnvVar
+type EnvVarList []EnvVar
 
 // NewEnvVarFromString takes a string of format "name=value" and returns an Env
 // variable struct
-func NewEnvVarFromString(envStr string) (*EnvVar, error) {
-	envList := strings.Split(envStr, "=")
+func NewEnvVarFromString(envStr string) (EnvVar, error) {
+	envList := strings.SplitN(envStr, "=", 2)
 	// if there is not = in the string
 	if len(envList) < 2 {
-		return nil, errors.New("invalid environment variable format")
+		return EnvVar{}, errors.New("invalid environment variable format")
 	}
 
-	return &EnvVar{
+	return EnvVar{
 		Name:  strings.TrimSpace(envList[0]),
 		Value: strings.TrimSpace(envList[1]),
 	}, nil

--- a/pkg/config/env_var_test.go
+++ b/pkg/config/env_var_test.go
@@ -8,24 +8,24 @@ import (
 func TestNewEnvVarFromString(t *testing.T) {
 	cases := []struct {
 		envStr   string
-		expected *EnvVar
+		expected EnvVar
 		wantErr  bool
 	}{
 		{
 			envStr: "foo=bar",
-			expected: &EnvVar{
+			expected: EnvVar{
 				Name:  "foo",
 				Value: "bar",
 			},
 		},
 		{
 			envStr:   "foo",
-			expected: nil,
+			expected: EnvVar{},
 			wantErr:  true,
 		},
 		{
 			envStr: " foo=bar ",
-			expected: &EnvVar{
+			expected: EnvVar{
 				Name:  "foo",
 				Value: "bar",
 			},
@@ -36,7 +36,8 @@ func TestNewEnvVarFromString(t *testing.T) {
 		envVar, err := NewEnvVarFromString(testCase.envStr)
 		// expected an error
 		if testCase.wantErr {
-			if envVar != nil || err == nil {
+			emptyEnvVar := EnvVar{}
+			if envVar != emptyEnvVar || err == nil {
 				t.Errorf("expected error for %s", testCase.envStr)
 			}
 		} else {
@@ -59,7 +60,7 @@ func TestNewEnvVarListFromSlice(t *testing.T) {
 		{
 			envList: []string{"foo=bar"},
 			expected: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
@@ -73,7 +74,7 @@ func TestNewEnvVarListFromSlice(t *testing.T) {
 		{
 			envList: []string{" foo=bar "},
 			expected: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
@@ -83,11 +84,11 @@ func TestNewEnvVarListFromSlice(t *testing.T) {
 			envList: []string{"foo=bar", "fizz=buzz"},
 
 			expected: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "fizz",
 					Value: "buzz",
 				},
@@ -98,6 +99,15 @@ func TestNewEnvVarListFromSlice(t *testing.T) {
 
 			expected: nil,
 			wantErr:  true,
+		},
+		{
+			envList: []string{"foo=bar="},
+			expected: EnvVarList{
+				EnvVar{
+					Name:  "foo",
+					Value: "bar=",
+				},
+			},
 		},
 	}
 
@@ -128,17 +138,17 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 	}{
 		{
 			envVarList: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "fizz",
 					Value: "buzz",
 				},
 			},
 			expected: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
@@ -147,11 +157,11 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 		},
 		{
 			envVarList: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "fizz",
 					Value: "buzz",
 				},
@@ -161,21 +171,21 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 		},
 		{
 			envVarList: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "fizz",
 					Value: "buzz",
 				},
 			},
 			expected: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "fizz",
 					Value: "buzz",
 				},
@@ -183,11 +193,11 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 		},
 		{
 			envVarList: EnvVarList{
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},
-				&EnvVar{
+				EnvVar{
 					Name:  "foo",
 					Value: "bar",
 				},

--- a/pkg/config/env_var_test.go
+++ b/pkg/config/env_var_test.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewEnvVarFromString(t *testing.T) {
+	cases := []struct {
+		envStr   string
+		expected *EnvVar
+		wantErr  bool
+	}{
+		{
+			envStr: "foo=bar",
+			expected: &EnvVar{
+				Name:  "foo",
+				Value: "bar",
+			},
+		},
+		{
+			envStr:   "foo",
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			envStr: " foo=bar ",
+			expected: &EnvVar{
+				Name:  "foo",
+				Value: "bar",
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		envVar, err := NewEnvVarFromString(testCase.envStr)
+		// expected an error
+		if testCase.wantErr {
+			if envVar != nil || err == nil {
+				t.Errorf("expected error for %s", testCase.envStr)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(envVar, testCase.expected) {
+				t.Errorf("the %+v and %+v are not equal", envVar, testCase.expected)
+			}
+		}
+	}
+}
+
+func TestNewEnvVarListFromSlice(t *testing.T) {
+	cases := []struct {
+		envList  []string
+		expected EnvVarList
+		wantErr  bool
+	}{
+		{
+			envList: []string{"foo=bar"},
+			expected: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+		},
+		{
+			envList:  []string{"foo"},
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			envList: []string{" foo=bar "},
+			expected: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+		},
+		{
+			envList: []string{"foo=bar", "fizz=buzz"},
+
+			expected: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "fizz",
+					Value: "buzz",
+				},
+			},
+		},
+		{
+			envList: []string{"foo=bar", "fizz=buzz", "test"},
+
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, testCase := range cases {
+
+		envVarList, err := NewEnvVarListFromSlice(testCase.envList)
+		// expected an error
+		if testCase.wantErr {
+			if envVarList != nil || err == nil {
+				t.Errorf("expected error for %s", testCase.envList)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(envVarList, testCase.expected) {
+				t.Errorf("the %+v and %+v are not equal", envVarList, testCase.expected)
+			}
+		}
+	}
+}
+
+func TestRemoveEnvVarsFromList(t *testing.T) {
+	cases := []struct {
+		envVarList EnvVarList
+		expected   EnvVarList
+		keys       []string
+	}{
+		{
+			envVarList: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "fizz",
+					Value: "buzz",
+				},
+			},
+			expected: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+			keys: []string{"fizz"},
+		},
+		{
+			envVarList: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "fizz",
+					Value: "buzz",
+				},
+			},
+			expected: EnvVarList{},
+			keys:     []string{"fizz", "foo"},
+		},
+		{
+			envVarList: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "fizz",
+					Value: "buzz",
+				},
+			},
+			expected: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "fizz",
+					Value: "buzz",
+				},
+			},
+		},
+		{
+			envVarList: EnvVarList{
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				&EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+			expected: EnvVarList{},
+			keys:     []string{"foo"},
+		},
+	}
+
+	for _, testCase := range cases {
+
+		envVarList := RemoveEnvVarsFromList(testCase.envVarList, testCase.keys)
+		// expected an error
+
+		if !reflect.DeepEqual(envVarList, testCase.expected) {
+			t.Errorf("the %+v and %+v are not equal", envVarList, testCase.expected)
+		}
+	}
+
+}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -61,6 +61,7 @@ func (lo *ListOptions) Run() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch components list")
 	}
+	fmt.Println("asdfsdfsa")
 	glog.V(4).Infof("the components are %+v", components)
 
 	if lo.outputFlag == "json" {

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -61,7 +61,6 @@ func (lo *ListOptions) Run() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch components list")
 	}
-	fmt.Println("asdfsdfsa")
 	glog.V(4).Infof("the components are %+v", components)
 
 	if lo.outputFlag == "json" {

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -84,8 +84,8 @@ func (o *SetOptions) Run() (err error) {
 			return err
 		}
 		// keeping the old env vars as well
-		envVarList := cfg.GetEnvVars()
-		newEnvVarList = append(newEnvVarList, envVarList...)
+		presentEnvVarList := cfg.GetEnvVars()
+		newEnvVarList = presentEnvVarList.Merge(newEnvVarList)
 		if err := cfg.SetEnvVars(newEnvVarList); err != nil {
 			return err
 		}

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -39,12 +39,6 @@ var (
    %[1]s %[2]s --env PORT=4000
    %[1]s %[3]s --env DB_USERNAME=postgres,DB_HOSTNAME=postgres
    %[1]s %[4]s --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
-   %[1]s %[5]s 500M
-   %[1]s %[6]s 250M
-   %[1]s %[7]s false 
-   %[1]s %[8]s 0.5 
-   %[1]s %[9]s 2 
-   %[1]s %[10]s 1 
 	`)
 )
 

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -34,9 +34,7 @@ var (
    %[1]s %[10]s 1 
 
    # Set a env variable in the local config
-   %[1]s %[2]s --env PORT=4000
-   %[1]s %[3]s --env DB_USERNAME=postgres,DB_HOSTNAME=postgres
-   %[1]s %[4]s --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
+   %[1]s --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
 	`)
 )
 

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -7,11 +7,9 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/pkg/errors"
-	"github.com/redhat-developer/odo/pkg/config"
-	"github.com/redhat-developer/odo/pkg/log"
-	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
 
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -9,6 +9,10 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo/pkg/config"
+	"github.com/redhat-developer/odo/pkg/log"
+	"github.com/redhat-developer/odo/pkg/odo/genericclioptions"
+
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -30,6 +34,17 @@ var (
    %[1]s %[8]s 0.5 
    %[1]s %[9]s 2 
    %[1]s %[10]s 1 
+
+   # Set a env variable in the local config
+   %[1]s %[2]s --env PORT=4000
+   %[1]s %[3]s --env DB_USERNAME=postgres,DB_HOSTNAME=postgres
+   %[1]s %[4]s --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
+   %[1]s %[5]s 500M
+   %[1]s %[6]s 250M
+   %[1]s %[7]s false 
+   %[1]s %[8]s 0.5 
+   %[1]s %[9]s 2 
+   %[1]s %[10]s 1 
 	`)
 )
 
@@ -38,6 +53,7 @@ type SetOptions struct {
 	paramName       string
 	paramValue      string
 	configForceFlag bool
+	envArray        []string
 }
 
 // NewSetOptions creates a new SetOptions instance
@@ -47,8 +63,11 @@ func NewSetOptions() *SetOptions {
 
 // Complete completes SetOptions after they've been created
 func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.paramName = args[0]
-	o.paramValue = args[1]
+	if o.envArray == nil {
+		o.paramName = args[0]
+		o.paramValue = args[1]
+	}
+
 	return
 }
 
@@ -64,6 +83,23 @@ func (o *SetOptions) Run() (err error) {
 
 	if err != nil {
 		return errors.Wrapf(err, "unable to set configuration")
+	}
+
+	// env variables have been provided
+	if o.envArray != nil {
+		newEnvVarList, err := config.NewEnvVarListFromSlice(o.envArray)
+		if err != nil {
+			return err
+		}
+		// keeping the old env vars as well
+		envVarList := cfg.GetEnvVars()
+		finalEvl := config.MergeEnvVarList(newEnvVarList, envVarList)
+		if err := cfg.SetEnvVars(finalEvl); err != nil {
+			return err
+		}
+
+		log.Info("Environment variables were successfully updated.")
+		return nil
 	}
 
 	if !o.configForceFlag {
@@ -94,6 +130,14 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName, config.Type,
 			config.Name, config.MinMemory, config.MaxMemory, config.Memory, config.Ignore, config.MinCPU, config.MaxCPU, config.CPU),
 		Args: func(cmd *cobra.Command, args []string) error {
+			if o.envArray != nil {
+				// no args are needed
+				if len(args) > 0 {
+					return fmt.Errorf("expected 0 args")
+				}
+				return nil
+			}
+
 			if len(args) < 2 {
 				return fmt.Errorf("please provide a parameter name and value")
 			} else if len(args) > 2 {
@@ -107,5 +151,6 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		},
 	}
 	configurationSetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, set the config directly")
+	configurationSetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Set the environment variables in config")
 	return configurationSetCmd
 }

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -87,8 +87,8 @@ func (o *SetOptions) Run() (err error) {
 		}
 		// keeping the old env vars as well
 		envVarList := cfg.GetEnvVars()
-		finalEvl := config.MergeEnvVarList(newEnvVarList, envVarList)
-		if err := cfg.SetEnvVars(finalEvl); err != nil {
+		newEnvVarList = append(newEnvVarList, envVarList...)
+		if err := cfg.SetEnvVars(newEnvVarList); err != nil {
 			return err
 		}
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -35,9 +35,7 @@ var (
    %[1]s %[10]s
 
    # Unset a env variable in the local config
-   %[1]s %[2]s --env PORT
-   %[1]s %[3]s --env DB_USERNAME,DB_HOSTNAME
-   %[1]s %[4]s --env KAFKA_HOST --env KAFKA_PORT
+    %[1]s --env KAFKA_HOST --env KAFKA_PORT
 	`)
 )
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
-	"github.com/redhat-developer/odo/pkg/log"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/odo/util"

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/odo/cli/ui"
+	"github.com/redhat-developer/odo/pkg/log"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/odo/util"
@@ -32,6 +33,11 @@ var (
    %[1]s %[8]s 
    %[1]s %[9]s 
    %[1]s %[10]s
+
+   # Set a env variable in the local config
+   %[1]s %[2]s --env PORT
+   %[1]s %[3]s --env DB_USERNAME,DB_HOSTNAME
+   %[1]s %[4]s --env KAFKA_HOST --env KAFKA_PORT
 	`)
 )
 
@@ -39,6 +45,7 @@ var (
 type UnsetOptions struct {
 	paramName       string
 	configForceFlag bool
+	envArray        []string
 }
 
 // NewUnsetOptions creates a new UnsetOptions instance
@@ -48,7 +55,9 @@ func NewUnsetOptions() *UnsetOptions {
 
 // Complete completes UnsetOptions after they've been created
 func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.paramName = args[0]
+	if o.envArray == nil {
+		o.paramName = args[0]
+	}
 	return
 }
 
@@ -64,6 +73,18 @@ func (o *UnsetOptions) Run() (err error) {
 
 	if err != nil {
 		return errors.Wrapf(err, "")
+	}
+	// env variables have been provided
+	if o.envArray != nil {
+
+		envList := cfg.GetEnvVars()
+		newEnvList := config.RemoveEnvVarsFromList(envList, o.envArray)
+		if err := cfg.SetEnvVars(newEnvList); err != nil {
+			return err
+		}
+
+		log.Info("Environment variables were successfully updated.")
+		return nil
 	}
 
 	if isSet := cfg.IsSet(o.paramName); isSet {
@@ -94,6 +115,14 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName,
 			config.Type, config.Name, config.MinMemory, config.MaxMemory, config.Memory, config.Ignore, config.MinCPU, config.MaxCPU, config.CPU),
 		Args: func(cmd *cobra.Command, args []string) error {
+			if o.envArray != nil {
+				// no args are needed
+				if len(args) > 0 {
+					return fmt.Errorf("expected 0 args")
+				}
+				return nil
+			}
+
 			if len(args) < 1 {
 				return fmt.Errorf("please provide a parameter name")
 			} else if len(args) > 1 {
@@ -109,6 +138,7 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		},
 	}
 	configurationUnsetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, unsetting the config directly")
+	configurationUnsetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Unset the environment variables in config")
 
 	return configurationUnsetCmd
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -34,7 +34,7 @@ var (
    %[1]s %[9]s 
    %[1]s %[10]s
 
-   # Set a env variable in the local config
+   # Unset a env variable in the local config
    %[1]s %[2]s --env PORT
    %[1]s %[3]s --env DB_USERNAME,DB_HOSTNAME
    %[1]s %[4]s --env KAFKA_HOST --env KAFKA_PORT

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -18,6 +18,7 @@ const viewCommandName = "view"
 
 var viewExample = ktemplates.Examples(`# For viewing the current local configuration
    %[1]s
+   
   `)
 
 // ViewOptions encapsulates the options for the command
@@ -48,6 +49,21 @@ func (o *ViewOptions) Run() (err error) {
 	}
 	cs := cfg.GetComponentSettings()
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 2, ' ', tabwriter.TabIndent)
+	envVarList := cfg.GetEnvVars()
+	if len(envVarList) != 0 {
+		fmt.Fprintln(w, "ENVIRONMENT VARIABLES")
+		fmt.Fprintln(w, "------------------------------------------------")
+		fmt.Fprintln(w, "NAME", "\t", "VALUE")
+		for _, envVar := range envVarList {
+			fmt.Fprintln(w, envVar.Name, "\t", envVar.Value)
+		}
+
+		fmt.Fprintln(w)
+
+	}
+	fmt.Fprintln(w, "COMPONENT SETTINGS")
+	fmt.Fprintln(w, "------------------------------------------------")
+
 	fmt.Fprintln(w, "PARAMETER", "\t", "CURRENT_VALUE")
 	fmt.Fprintln(w, "Type", "\t", showBlankIfNil(cs.Type))
 	fmt.Fprintln(w, "Application", "\t", showBlankIfNil(cs.Application))

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -78,6 +78,16 @@ func GenerateRandomString(n int) string {
 	return string(b)
 }
 
+// In checks if the value is in the array
+func In(arr []string, value string) bool {
+	for _, item := range arr {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
 // Hyphenate applicationName and componentName
 func NamespaceOpenShiftObject(componentName string, applicationName string) (string, error) {
 

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -169,7 +169,7 @@ func componentTests(componentCmdPrefix string) {
 					"https://gist.github.com/mik-dass/f95bd818ddba508ff76a386f8d984909/raw/e5bc575ac8b14ba2b23d66b5cb4873657e1a1489/sample.war")
 				runCmdShouldPass(componentCmdPrefix + " create wildfly wildfly --binary " + tmpDir + "/sample-binary-testing-1.war --memory 500Mi")
 
-				// TODO: remove this once https://github.com/redhat-developer/odo/issues/943 is implemented
+				// TODO: remove this once https://github.com/openshift/odo/issues/943 is implemented
 				time.Sleep(90 * time.Second)
 
 				// Run push
@@ -345,7 +345,7 @@ func componentTests(componentCmdPrefix string) {
 				SourceTest(appTestName, "git", wildflyURI2)
 			})
 
-			// This is expected to be removed at the time of fixing https://github.com/redhat-developer/odo/issues/1008
+			// This is expected to be removed at the time of fixing https://github.com/openshift/odo/issues/1008
 			It("should create a wildfly git component", func() {
 				runCmdShouldPass(componentCmdPrefix + " delete wildfly -f")
 				runCmdShouldPass(componentCmdPrefix + " create wildfly wildfly --git " + wildflyURI1)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -342,6 +342,32 @@ var _ = Describe("odoe2e", func() {
 			timeoutValue := getPreferenceValue("Timeout")
 			Expect(timeoutValue).To(BeEmpty())
 		})
+
+		It("should set env variables", func() {
+			runCmdShouldPass("odo config set --env PORT=4000")
+			configValue := runCmdShouldPass("odo config view")
+			Expect(configValue).To(ContainSubstring("PORT"))
+			runCmdShouldPass("odo config set --env SECRET_KEY=R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q=")
+			configValue = runCmdShouldPass("odo config view")
+			Expect(configValue).To(ContainSubstring("SECRET_KEY"))
+			Expect(configValue).To(ContainSubstring("R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q="))
+			Expect(configValue).To(ContainSubstring("PORT"))
+			Expect(configValue).To(ContainSubstring("4000"))
+
+		})
+
+		It("should unset env variables", func() {
+			runCmdShouldPass("odo config set --env PORT=4000")
+			runCmdShouldPass("odo config set --env SECRET_KEY=R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q=")
+			configValue := runCmdShouldPass("odo config view")
+			Expect(configValue).To(ContainSubstring("PORT"))
+			Expect(configValue).To(ContainSubstring("SECRET_KEY"))
+			runCmdShouldPass("odo config unset --env PORT")
+			runCmdShouldPass("odo config unset --env SECRET_KEY")
+			configValue = runCmdShouldPass("odo config view")
+			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
+			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
+		})
 	})
 
 	Context("creating component without an application and url", func() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -345,13 +345,12 @@ var _ = Describe("odoe2e", func() {
 
 		It("should set env variables", func() {
 			runCmdShouldPass("odo config set --env PORT=4000 --env PORT=1234")
-			configValue := runCmdShouldPass("odo config view")
-			Expect(configValue).To(ContainSubstring("PORT"))
+			configValue := getConfigValue("PORT")
+			Expect(configValue).To(ContainSubstring("1234"))
 			runCmdShouldPass("odo config set --env SECRET_KEY=R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q=")
-			configValue = runCmdShouldPass("odo config view")
-			Expect(configValue).To(ContainSubstring("SECRET_KEY"))
-			Expect(configValue).To(ContainSubstring("R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q="))
-			Expect(configValue).To(ContainSubstring("PORT"))
+			configValue = getConfigValue("SECRET_KEY")
+			Expect(configValue).To(ContainSubstring("R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q"))
+			configValue = getConfigValue("PORT")
 			Expect(configValue).To(ContainSubstring("1234"))
 
 		})
@@ -359,9 +358,10 @@ var _ = Describe("odoe2e", func() {
 		It("should unset env variables", func() {
 			runCmdShouldPass("odo config set --env PORT=4000")
 			runCmdShouldPass("odo config set --env SECRET_KEY=R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q=")
-			configValue := runCmdShouldPass("odo config view")
-			Expect(configValue).To(ContainSubstring("PORT"))
-			Expect(configValue).To(ContainSubstring("SECRET_KEY"))
+			configValue := getConfigValue("SECRET_KEY")
+			Expect(configValue).To(ContainSubstring("R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q"))
+			configValue = getConfigValue("PORT")
+			Expect(configValue).To(ContainSubstring("4000"))
 			runCmdShouldPass("odo config unset --env PORT")
 			runCmdShouldPass("odo config unset --env SECRET_KEY")
 			configValue = runCmdShouldPass("odo config view")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -344,7 +344,7 @@ var _ = Describe("odoe2e", func() {
 		})
 
 		It("should set env variables", func() {
-			runCmdShouldPass("odo config set --env PORT=4000")
+			runCmdShouldPass("odo config set --env PORT=4000 --env PORT=1234")
 			configValue := runCmdShouldPass("odo config view")
 			Expect(configValue).To(ContainSubstring("PORT"))
 			runCmdShouldPass("odo config set --env SECRET_KEY=R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q=")
@@ -352,7 +352,7 @@ var _ = Describe("odoe2e", func() {
 			Expect(configValue).To(ContainSubstring("SECRET_KEY"))
 			Expect(configValue).To(ContainSubstring("R2lyaXNoIFJhbW5hbmkgaXMgdGhlIGJlc3Q="))
 			Expect(configValue).To(ContainSubstring("PORT"))
-			Expect(configValue).To(ContainSubstring("4000"))
+			Expect(configValue).To(ContainSubstring("1234"))
 
 		})
 

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -32,7 +32,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("git clone " + nodejsURI + " " + tmpDir + "/nodejs-ex")
 				runCmdShouldPass("odo create nodejs nodejs-watch --local " + tmpDir + "/nodejs-ex --min-memory 400Mi --max-memory 700Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create --port 8080")
 
@@ -106,7 +106,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("git clone " + pythonURI + " " + tmpDir + "/os-sample-python")
 				runCmdShouldPass("odo create python python-watch --local " + tmpDir + "/os-sample-python --memory 400Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create")
 
@@ -171,7 +171,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("git clone " + wildflyURI + " " + tmpDir + "/katacoda-odo-backend")
 				runCmdShouldPass("odo create wildfly wildfly-watch --local " + tmpDir + "/katacoda-odo-backend --min-memory 400Mi --max-memory 700Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create --port 8080")
 
@@ -252,7 +252,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("git clone " + openjdkURI + " " + tmpDir + "/javalin-helloworld")
 				runCmdShouldPass("odo create openjdk18 openjdk-watch --local " + tmpDir + "/javalin-helloworld --min-memory 400Mi --max-memory 700Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create --port 8080")
 
@@ -328,7 +328,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("mvn package -f " + tmpDir + "/binary/javalin-helloworld")
 				runCmdShouldPass("odo create openjdk18 openjdk-watch-binary --binary " + tmpDir + "/binary/javalin-helloworld/target/javalin-hello-world-0.1-SNAPSHOT.jar --min-memory 400Mi --max-memory 700Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create --port 8080")
 
@@ -390,7 +390,7 @@ var _ = Describe("odoWatchE2e", func() {
 				runCmdShouldPass("mvn package -f " + tmpDir + "/binary/katacoda-odo-backend")
 				runCmdShouldPass("odo create wildfly wildfly-watch-binary --binary " + tmpDir + "/binary/katacoda-odo-backend/target/ROOT.war --min-memory 400Mi --max-memory 700Mi")
 				runCmdShouldPass("odo push -v 4")
-				// Test multiple push so as to avoid regressions like: https://github.com/redhat-developer/odo/issues/1054
+				// Test multiple push so as to avoid regressions like: https://github.com/openshift/odo/issues/1054
 				runCmdShouldPass("odo push -v 4")
 				runCmdShouldPass("odo url create --port 8080")
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Added env variables in the component settings of local odo config.

Note - using the env variables in workflow is not in the scope of this PR, its in the next one once this gets merged

## Was the change discussed in an issue?
partly  https://github.com/redhat-developer/odo/issues/1390
<!-- Please do Link issues here. -->

## How to test changes?

```
odo config set --env PORT=4000
odo config set  --env DB_USERNAME=postgres,DB_HOSTNAME=postgres
odo config set  --env KAFKA_HOST=kafka --env KAFKA_PORT=6639

# Unset a env variable in the local config
odo config unset --env PORT
odo config unset --env DB_USERNAME,DB_HOSTNAME
odo config unset --env KAFKA_HOST --env KAFKA_PORT

# should show the env variables
odo config view 

```