### PR TITLE
add machine readable output flag to odo project delete

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -2,10 +2,8 @@ package project
 
 import (
 	"github.com/openshift/odo/pkg/application"
-	"github.com/pkg/errors"
-
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
+	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,9 +33,6 @@ func Create(client *occlient.Client, projectName string, wait bool) error {
 
 // Delete deletes the project with name projectName and returns errors if any
 func Delete(client *occlient.Client, projectName string) error {
-	// Loading spinner
-	s := log.Spinnerf("Deleting project %s", projectName)
-	defer s.End(false)
 
 	// Delete the requested project
 	err := client.DeleteProject(projectName)
@@ -45,7 +40,6 @@ func Delete(client *occlient.Client, projectName string) error {
 		return errors.Wrap(err, "unable to delete project")
 	}
 
-	s.End(true)
 	return nil
 }
 

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -115,6 +115,14 @@ var _ = Describe("odojsonoutput", func() {
 			Expect(areEqual).To(BeTrue())
 
 		})
+
+		// odo project delete -o json
+		It("should be able to delete project", func() {
+			runCmdShouldPass("odo project create project-deletion-test")
+			// validating that it ran with exit status 0
+			runCmdShouldPass("odo project delete project-deletion-test -o json")
+		})
+
 		// cleanup
 		It("Cleanup", func() {
 			ocDeleteProject("json-test")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
add machine readable output flag to odo project delete

## Was the change discussed in an issue?
fixes #???
#1383
## How to test changes?
<!-- Please describe the steps to test the PR -->
Try odo project delete command with -o json flag and validate exit code is 0 and not asking for user inputs