### PR TITLE
Scripts to run on OpenShift CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,5 +206,9 @@ vendor-update:
 	glide update --strip-vendor
 
 .PHONY: openshiftci-presubmit-e2e
-openshiftci-presubmit:
+openshiftci-presubmit-e2e:
 	./scripts/openshiftci-presubmit-e2e.sh
+
+.PHONY: openshiftci-presubmit-unittests
+openshiftci-presubmit-unittests:
+	./scripts/openshiftci-presubmit-unittests.sh

--- a/Makefile
+++ b/Makefile
@@ -204,3 +204,7 @@ upload-packages:
 .PHONY: vendor-update
 vendor-update:
 	glide update --strip-vendor
+
+.PHONY: openshiftci-presubmit-e2e
+openshiftci-presubmit:
+	./scripts/openshiftci-presubmit-e2e.sh

--- a/scripts/openshiftci-presubmit-e2e.sh
+++ b/scripts/openshiftci-presubmit-e2e.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+export CI="openshift"
+export TIMEOUT="30m"
+make configure-installer-tests-cluster
+make bin
+export PATH="$PATH:$(pwd)"
+export CUSTOM_HOMEDIR="/tmp/artifacts"
+make test-main-e2e
+make test-odo-login-e2e
+make test-json-format-output
+make test-java-e2e
+make test-source-e2e
+make test-cmp-e2e
+make test-cmp-sub-e2e
+

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+export CUSTOM_HOMEDIR="/tmp/artifacts"
+make test

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -5,5 +5,10 @@ set -e
 # show commands
 set -x
 
-export CUSTOM_HOMEDIR="/tmp/artifacts"
+export ARTIFACTS_DIR=/tmp/artifacts
+export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
+
 make test
+
+make cross
+cp -r dist $ARTIFACTS_DIR


### PR DESCRIPTION
This abstracts all commands that are run on OpenShift CI into separate scripts in this repository. 
This will allow us to modify those scripts without touching openshift/release repo.

Idea is that jobs will just run `make openshiftci-presubmit` and `make openshiftci-master`.

https://github.com/openshift/release/blob/0f4bf0f581103c14f54dd6eee548c63c3455ab36/ci-operator/config/openshift/odo/openshift-odo-master.yaml

https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/odo/openshift-odo-master-presubmits.yaml