### PR TITLE
Fixing error when user lists component in directory without one

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,28 +95,14 @@ func getLocalConfigFile(cfgDir string) (string, error) {
 	return filepath.Join(cfgDir, ".odo", configFileName), nil
 }
 
-// LocalConfigExists checks if a config file exists.
-// If not it returns false
-func LocalConfigExists(cfgDir string) (bool, error) {
-	localConfig, err := getLocalConfigFile(cfgDir)
-	if err != nil {
-		return false, err
-	}
-	_, err = os.Stat(localConfig)
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, nil
-}
-
 // New returns the localConfigInfo
 func New() (*LocalConfigInfo, error) {
-	return NewLocalConfigInfo("")
+	return NewLocalConfigInfo("", false)
 }
 
 // NewLocalConfigInfo gets the LocalConfigInfo from local config file and creates the local config file in case it's
 // not present then it
-func NewLocalConfigInfo(cfgDir string) (*LocalConfigInfo, error) {
+func NewLocalConfigInfo(cfgDir string, errorNoLocalConfig bool) (*LocalConfigInfo, error) {
 	configFile, err := getLocalConfigFile(cfgDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get odo config file")
@@ -128,6 +114,9 @@ func NewLocalConfigInfo(cfgDir string) (*LocalConfigInfo, error) {
 
 	// if the config file doesn't exist then we dont worry about it and return
 	if _, err = os.Stat(configFile); os.IsNotExist(err) {
+		if errorNoLocalConfig {
+			return nil, fmt.Errorf("the current directory does not represent an odo component.\nMaybe use 'odo create' to create component here or switch to directory with a component")
+		}
 		return &c, nil
 	}
 	err = getFromFile(&c.LocalConfig, c.Filename)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,6 +95,20 @@ func getLocalConfigFile(cfgDir string) (string, error) {
 	return filepath.Join(cfgDir, ".odo", configFileName), nil
 }
 
+// LocalConfigExists checks if a config file exists.
+// If not it returns false
+func LocalConfigExists(cfgDir string) (bool, error) {
+	localConfig, err := getLocalConfigFile(cfgDir)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(localConfig)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, nil
+}
+
 // New returns the localConfigInfo
 func New() (*LocalConfigInfo, error) {
 	return NewLocalConfigInfo("")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,7 +81,7 @@ func TestSetLocalConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("")
+			cfg, err := NewLocalConfigInfo("", false)
 			if err != nil {
 				t.Error(err)
 			}
@@ -175,7 +175,7 @@ func TestLocalUnsetConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("")
+			cfg, err := NewLocalConfigInfo("", false)
 			if err != nil {
 				t.Error(err)
 			}
@@ -222,7 +222,7 @@ func TestLocalConfigInitDoesntCreateLocalOdoFolder(t *testing.T) {
 	}
 	os.RemoveAll(filename)
 
-	conf, err := NewLocalConfigInfo("")
+	conf, err := NewLocalConfigInfo("", false)
 	if err != nil {
 		t.Errorf("error while creating local config %v", err)
 	}
@@ -232,7 +232,7 @@ func TestLocalConfigInitDoesntCreateLocalOdoFolder(t *testing.T) {
 }
 
 func TestMetaTypePopulatedInLocalConfig(t *testing.T) {
-	ci, err := NewLocalConfigInfo("")
+	ci, err := NewLocalConfigInfo("", false)
 
 	if err != nil {
 		t.Error(err)

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -4143,7 +4143,7 @@ func TestDeleteEnvVars(t *testing.T) {
 }
 
 func fakeComponentSettings(cmpName string, appName string, projectName string, srcType config.SrcType, cmpType string, t *testing.T) config.LocalConfigInfo {
-	lci, err := config.NewLocalConfigInfo("")
+	lci, err := config.NewLocalConfigInfo("", false)
 	if err != nil {
 		t.Errorf("failed to init fake component configuration")
 		return *lci

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -231,7 +231,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.interactive = true
 	}
 
-	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
+	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext, false)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/odo/pkg/component"
+	odoconfig "github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -46,11 +47,19 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
+	configExists, err := odoconfig.LocalConfigExists("")
+	if err != nil {
+		return err
+	}
+	if !configExists {
+		return fmt.Errorf("the current directory does not represent an odo component")
+	}
 	return odoutil.CheckOutputFlag(lo.outputFlag)
 }
 
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
+
 	components, err := component.List(lo.Client, lo.Application)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch components list")

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -47,7 +47,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	_, err := odoconfig.NewLocalConfigInfo("", true)
+	_, err = odoconfig.NewLocalConfigInfo("", true)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -52,7 +52,8 @@ func (lo *ListOptions) Validate() (err error) {
 		return err
 	}
 	if !configExists {
-		return fmt.Errorf("the current directory does not represent an odo component")
+
+		return fmt.Errorf("the current directory does not represent an odo component.\nMaybe use 'odo create' to create component here or switch to directory with a component")
 	}
 	return odoutil.CheckOutputFlag(lo.outputFlag)
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -47,13 +47,9 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	configExists, err := odoconfig.LocalConfigExists("")
+	_, err := odoconfig.NewLocalConfigInfo("", true)
 	if err != nil {
 		return err
-	}
-	if !configExists {
-
-		return fmt.Errorf("the current directory does not represent an odo component.\nMaybe use 'odo create' to create component here or switch to directory with a component")
 	}
 	return odoutil.CheckOutputFlag(lo.outputFlag)
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -63,7 +63,7 @@ func NewPushOptions() *PushOptions {
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.client = genericclioptions.Client(cmd)
 
-	conf, err := config.NewLocalConfigInfo(po.componentContext)
+	conf, err := config.NewLocalConfigInfo(po.componentContext, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch component config")
 	}

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -63,7 +63,7 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 		return errors.Wrapf(err, "failed to update component")
 	}
 
-	uo.cmpConfig, err = config.NewLocalConfigInfo(uo.cmpCfgContext)
+	uo.cmpConfig, err = config.NewLocalConfigInfo(uo.cmpCfgContext, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update component")
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -89,7 +89,7 @@ func resolveProject(command *cobra.Command, client *occlient.Client) string {
 			util.LogErrorAndExit(err, "")
 			fileName = fileAbs
 		}
-		lci, err := config.NewLocalConfigInfo(fileName)
+		lci, err := config.NewLocalConfigInfo(fileName, false)
 		util.LogErrorAndExit(err, "could not get component settings from config file")
 
 		ns = lci.GetProject()
@@ -127,7 +127,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 		util.LogErrorAndExit(err, "")
 		fileName = fAbs
 	}
-	lci, err := config.NewLocalConfigInfo(fileName)
+	lci, err := config.NewLocalConfigInfo(fileName, false)
 	util.LogErrorAndExit(err, "could not get component settings from config file")
 
 	// resolve application

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -71,7 +71,7 @@ func componentTests(componentCmdPrefix string) {
 			// simulate .odo not being present
 			runCmdShouldPass("mv .odo .odo_tmp")
 			session := runCmdShouldFail("odo component list")
-			Expect(session).To(ContainSubstring("doesn't represent"))
+			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
 			// clean up
 			runCmdShouldPass("mv .odo_tmp .odo")
 			runCmdShouldPass("odo component delete " + componentName + " -f")

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -68,9 +68,12 @@ func componentTests(componentCmdPrefix string) {
 			dirName := generateTimeBasedName("context_dir")
 			runCmdShouldPass(fmt.Sprint("mkdir ", dirName))
 			runCmdShouldPass(componentCmdPrefix + " create nodejs " + componentName + " --git https://github.com/openshift/nodejs-ex --context " + dirName)
+			// simulate .odo not being present
+			runCmdShouldPass("mv .odo .odo_tmp")
 			session := runCmdShouldFail("odo component list")
 			Expect(session).To(ContainSubstring("doesn't represent"))
 			// clean up
+			runCmdShouldPass("mv .odo_tmp .odo")
 			runCmdShouldPass("odo component delete " + componentName + " -f")
 			os.RemoveAll(dirName)
 		})

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,20 @@ func componentTests(componentCmdPrefix string) {
 			runCmdShouldPass("odo component delete " + componentName + " -f")
 			runCmdShouldPass("odo app delete -f")
 
+		})
+	})
+
+	Context("Regression : listing component outside of component directory should fail", func() {
+		It("creates a component from local context, tries to list components from outside and fails", func() {
+			componentName := generateTimeBasedName("nodejs-ex")
+			dirName := generateTimeBasedName("context_dir")
+			runCmdShouldPass(fmt.Sprint("mkdir ", dirName))
+			runCmdShouldPass(componentCmdPrefix + " create nodejs " + componentName + " --git https://github.com/openshift/nodejs-ex --context " + dirName)
+			session := runCmdShouldFail("odo component list")
+			Expect(session).To(ContainSubstring("doesn't represent"))
+			// clean up
+			runCmdShouldPass("odo component delete " + componentName + " -f")
+			os.RemoveAll(dirName)
 		})
 	})
 

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -64,17 +64,13 @@ func componentTests(componentCmdPrefix string) {
 
 	Context("Regression : listing component outside of component directory should fail", func() {
 		It("creates a component from local context, tries to list components from outside and fails", func() {
-			componentName := generateTimeBasedName("nodejs-ex")
 			dirName := generateTimeBasedName("context_dir")
-			runCmdShouldPass(fmt.Sprint("mkdir ", dirName))
-			runCmdShouldPass(componentCmdPrefix + " create nodejs " + componentName + " --git https://github.com/openshift/nodejs-ex --context " + dirName)
 			// simulate .odo not being present
 			runCmdShouldPass("mv .odo .odo_tmp")
 			session := runCmdShouldFail("odo component list")
 			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
 			// clean up
 			runCmdShouldPass("mv .odo_tmp .odo")
-			runCmdShouldPass("odo component delete " + componentName + " -f")
 			os.RemoveAll(dirName)
 		})
 	})


### PR DESCRIPTION

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
See title
 - Adding fuction that allows to check if a config file exists
 - Updating component list to check existence of odo config and fail
   if it does not exist
 - Adding regression tests

## Was the change discussed in an issue?
fixes #1485 
<!-- Please do Link issues here. -->

## How to test changes?
```
$ cd nodejs-ex
$ pwd
/redacted//nodejs-ex
$ odo component list
ACTIVE     NAME            TYPE
*          nodejs-vypi     nodejs
$ cd someotherdir
$ odo component list
 ✗  the current directory does not represent an odo component

```
