### PR TITLE
added context in config

### DIFF
--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -55,7 +55,8 @@ func NewSetOptions() *SetOptions {
 
 // Complete completes SetOptions after they've been created
 func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if o.envArray == nil {
+
+	if o.envArray != nil {
 		o.paramName = args[0]
 		o.paramValue = args[1]
 	}
@@ -143,6 +144,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		},
 	}
 	configurationSetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, set the config directly")
-	configurationSetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Set the environment variables in config")
+	configurationSetCmd.Flags().StringVar(&o.componentContext, "context", "", "Use given context directory as a source for component settings")
+
 	return configurationSetCmd
 }

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -144,6 +144,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		},
 	}
 	configurationSetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, set the config directly")
+	configurationSetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Set the environment variables in config")
 	genericclioptions.AddContextFlag(configurationSetCmd, &o.contextDir)
 
 	return configurationSetCmd

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -56,7 +56,7 @@ func NewSetOptions() *SetOptions {
 // Complete completes SetOptions after they've been created
 func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 
-	if o.envArray != nil {
+	if o.envArray == nil {
 		o.paramName = args[0]
 		o.paramValue = args[1]
 	}
@@ -144,7 +144,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		},
 	}
 	configurationSetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, set the config directly")
-	configurationSetCmd.Flags().StringVar(&o.componentContext, "context", "", "Use given context directory as a source for component settings")
+	genericclioptions.AddContextFlag(configurationSetCmd, &o.contextDir)
 
 	return configurationSetCmd
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 
 	"github.com/openshift/odo/pkg/config"
-	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -135,13 +134,12 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 			}
 
 		}, Run: func(cmd *cobra.Command, args []string) {
-			util.LogErrorAndExit(o.Complete(name, cmd, args), "")
-			util.LogErrorAndExit(o.Validate(), "")
-			util.LogErrorAndExit(o.Run(), "")
+			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
 	configurationUnsetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, unsetting the config directly")
 	configurationUnsetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Unset the environment variables in config")
+	configurationUnsetCmd.Flags().StringVar(&o.componentContext, "context", "", "Use given context directory as a source for component settings")
 
 	return configurationUnsetCmd
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -139,7 +139,7 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 	}
 	configurationUnsetCmd.Flags().BoolVarP(&o.configForceFlag, "force", "f", false, "Don't ask for confirmation, unsetting the config directly")
 	configurationUnsetCmd.Flags().StringSliceVarP(&o.envArray, "env", "e", nil, "Unset the environment variables in config")
-	configurationUnsetCmd.Flags().StringVar(&o.componentContext, "context", "", "Use given context directory as a source for component settings")
+	genericclioptions.AddContextFlag(configurationUnsetCmd, &o.contextDir)
 
 	return configurationUnsetCmd
 }

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -41,12 +39,6 @@ func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (
 
 // Validate validates the ViewOptions based on completed values
 func (o *ViewOptions) Validate() (err error) {
-	if len(o.componentContext) > 0 {
-		o.componentContext, err = util.GetAbsPath(o.componentContext)
-		if err != nil {
-			return errors.Wrapf(err, "please provide the context relative to your current directory")
-		}
-	}
 	return
 }
 
@@ -130,7 +122,7 @@ func NewCmdView(name, fullName string) *cobra.Command {
 		},
 	}
 
-	configurationViewCmd.Flags().StringVar(&o.componentContext, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+	genericclioptions.AddContextFlag(configurationViewCmd, &o.contextDir)
 
 	return configurationViewCmd
 }

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -10,8 +10,8 @@ func AddOutputFlag(cmd *cobra.Command) {
 // AddContextFlag adds `context` flag to given cobra command
 func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
 	if setValueTo != nil {
-		cmd.Flags().StringVar(setValueTo, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+		cmd.Flags().StringVar(setValueTo, "context", "", "Use given context directory as a source for component settings")
 	} else {
-		cmd.Flags().String("context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+		cmd.Flags().String("context", "", "Use given context directory as a source for component settings")
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -329,12 +329,82 @@ var _ = Describe("odoe2e", func() {
 			}
 
 			for _, testCase := range cases {
-				runCmdShouldPass(fmt.Sprintf("odo config set %s %s", testCase.paramName, testCase.paramValue))
+				runCmdShouldPass(fmt.Sprintf("odo config set -f %s %s", testCase.paramName, testCase.paramValue))
 				configOutput := runCmdShouldPass(fmt.Sprintf("odo config unset -f %s", testCase.paramName))
 				Expect(configOutput).To(ContainSubstring("Local config was successfully updated."))
 				Value := getConfigValue(testCase.paramName)
 				Expect(Value).To(BeEmpty())
 			}
+		})
+
+		It("should allow setting and unsetting a config locally with context", func() {
+			cases := []struct {
+				paramName  string
+				paramValue string
+			}{
+				{
+					paramName:  "Type",
+					paramValue: "java",
+				},
+				{
+					paramName:  "Name",
+					paramValue: "odo-java",
+				},
+				{
+					paramName:  "MinCPU",
+					paramValue: "0.2",
+				},
+				{
+					paramName:  "MaxCPU",
+					paramValue: "2",
+				},
+				{
+					paramName:  "MinMemory",
+					paramValue: "100M",
+				},
+				{
+					paramName:  "MaxMemory",
+					paramValue: "500M",
+				},
+				{
+					paramName:  "Ports",
+					paramValue: "8080/TCP,45/UDP",
+				},
+				{
+					paramName:  "Application",
+					paramValue: "odotestapp",
+				},
+				{
+					paramName:  "Project",
+					paramValue: "odotestproject",
+				},
+				{
+					paramName:  "SourceType",
+					paramValue: "git",
+				},
+				{
+					paramName:  "Ref",
+					paramValue: "develop",
+				},
+				{
+					paramName:  "SourceLocation",
+					paramValue: "https://github.com/sclorg/nodejs-ex",
+				},
+			}
+			folderName := "odoconfigtest"
+			runCmdShouldPass("mkdir -p " + folderName)
+			runCmdShouldPass("odo create nodejs --context " + folderName)
+
+			for _, testCase := range cases {
+
+				runCmdShouldPass(fmt.Sprintf("odo config set -f --context %s %s %s", folderName, testCase.paramName, testCase.paramValue))
+				configOutput := runCmdShouldPass(fmt.Sprintf("odo config unset -f --context %s %s", folderName, testCase.paramName))
+				Expect(configOutput).To(ContainSubstring("Local config was successfully updated."))
+				Value := getConfigValueWithContext(testCase.paramName, folderName)
+				Expect(Value).To(BeEmpty())
+			}
+			runCmdShouldPass("rm -rf " + folderName)
+
 		})
 
 		It("should allow unsetting a config globally", func() {

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -97,7 +97,17 @@ func getActiveApplication() string {
 // returns a local config value of given key or
 // returns an empty string if value is not set
 func getConfigValue(key string) string {
-	stdOut, _, _ := cmdRunner("odo config view")
+	return getConfigValueWithContext(key, "")
+}
+
+// returns a local config value of given key and contextdir or
+// returns an empty string if value is not set
+func getConfigValueWithContext(key string, context string) string {
+	command := "odo config view"
+	if context != "" {
+		command = fmt.Sprintf("%s --context %s", command, context)
+	}
+	stdOut, _, _ := cmdRunner(command)
 	re := regexp.MustCompile(key + `.+`)
 	odoConfigKeyValue := re.FindString(stdOut)
 	if odoConfigKeyValue == "" {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Added `--context` flag to `odo config`

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1371
<!-- Please do Link issues here. -->

## How to test changes?

```
odo config view --context <dir>
odo config set --context <dir> Ports 8080/TCP
odo config set --context <dir> Name Test
odo config unset --context <dir> Name 
```
should work

