### PR TITLE
Add `--config` and `--source` flags to push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-cmp-e2e:
 ifdef TIMEOUT
 	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.succinct -timeout $(TIMEOUT)
 else
-	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.succinct -timeout 15m
+	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpE2e" -ginkgo.succinct
 endif
 
 # Run component subcommands e2e tests
@@ -122,7 +122,7 @@ test-cmp-sub-e2e:
 ifdef TIMEOUT
 	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpSubE2e" -ginkgo.succinct -timeout $(TIMEOUT)
 else
-	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpSubE2e" -ginkgo.succinct -timeout 15m
+	go test -v github.com/openshift/odo/tests/e2e --ginkgo.focus="odoCmpSubE2e" -ginkgo.succinct
 endif
 
 # Run java e2e tests

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -167,7 +167,7 @@ func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) e
 			log.Errorf("Failed to update config to component deployed. Error %+v", err)
 			os.Exit(1)
 		}
-		log.Successf("Successfully created component with name: %v", cmpName)
+		log.Successf("Successfully updated component with name: %v", cmpName)
 	}
 	return nil
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -65,7 +65,6 @@ func NewPushOptions() *PushOptions {
 
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	po.Context.Client = genericclioptions.Client(cmd)
 	po.resolveSrcAndConfigFlags()
 
 	conf, err := config.NewLocalConfigInfo(po.componentContext)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -279,6 +279,7 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Annotations = map[string]string{"command": "component"}
 	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)
+	completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)
 
 	return pushCmd
 }

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -531,8 +531,7 @@ func componentTests(componentCmdPrefix string) {
 					cmpName := "nodejs"
 					helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName)
-					//TODO: verify that config was properly created
+					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName + " --project " + project)
 
 					// component doesn't exist yet so attempt to only push source should fail
 					helper.CmdShouldFail("odo push --source")
@@ -563,7 +562,7 @@ func componentTests(componentCmdPrefix string) {
 					cmpName := "nodejs-push-atonce"
 					helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName)
+					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName + " --project " + project)
 
 					// Push only config and see that the component is created but wothout any source copied
 					helper.CmdShouldPass("odo push")
@@ -591,7 +590,7 @@ func componentTests(componentCmdPrefix string) {
 					cmpName := "nodejs"
 					helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --context " + context + " --app " + appName)
+					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --context " + context + " --app " + appName + " --project " + project)
 					//TODO: verify that config was properly created
 
 					// component doesn't exist yet so attempt to only push source should fail
@@ -623,7 +622,7 @@ func componentTests(componentCmdPrefix string) {
 					cmpName := "nodejs-push-atonce"
 					helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName + " --context " + context)
+					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName + " --context " + context + " --project " + project)
 
 					// Push both config and source
 					helper.CmdShouldPass("odo push --context " + context)

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -568,23 +568,6 @@ func componentTests(componentCmdPrefix string) {
 					// Push only config and see that the component is created but wothout any source copied
 					helper.CmdShouldPass("odo push")
 					helper.VerifyCmpExists(cmpName, appName)
-					// No source code yet
-					remoteCmdExecFail := helper.CheckCmdOpInRemoteCmpPod(
-						cmpName,
-						appName,
-						"ls -lai /tmp/src/package.json",
-						func(cmdOp string, err error) bool {
-							if err != nil {
-								return false
-							}
-							return true
-						},
-					)
-					Expect(remoteCmdExecFail).To(Equal(false))
-
-					// Push only source and see that the component is updated with source code
-					helper.CmdShouldPass("odo push --source")
-					helper.VerifyCmpExists(cmpName, appName)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,
 						appName,
@@ -642,12 +625,8 @@ func componentTests(componentCmdPrefix string) {
 
 					helper.CmdShouldPass("odo component create nodejs " + cmpName + " --app " + appName + " --context " + context)
 
-					// Push only config and see that the component is created but wothout any source copied
+					// Push both config and source
 					helper.CmdShouldPass("odo push --context " + context)
-					helper.VerifyCmpExists(cmpName, appName)
-
-					// Push only source and see that the component is updated with source code
-					helper.CmdShouldPass("odo push --source")
 					helper.VerifyCmpExists(cmpName, appName)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -492,6 +492,7 @@ func componentTests(componentCmdPrefix string) {
 		// This is before every spec (It)
 		var _ = BeforeEach(func() {
 			project = helper.OcCreateRandProject()
+			helper.OcSwitchProject(project)
 			context = helper.CreateNewContext()
 		})
 
@@ -505,6 +506,7 @@ func componentTests(componentCmdPrefix string) {
 		// we will be testing components that are created from the current directory
 		// switch to the clean context dir before each test
 		var _ = JustBeforeEach(func() {
+			originalProject = helper.OcGetCurrentProject()
 			originalDir = helper.Getwd()
 			helper.Chdir(context)
 		})
@@ -512,19 +514,12 @@ func componentTests(componentCmdPrefix string) {
 		// go back to original directory after each test
 		var _ = JustAfterEach(func() {
 			helper.Chdir(originalDir)
+			helper.OcSwitchProject(originalProject)
 		})
 
 		var _ = Context("when --context is not used", func() {
 			var _ = Context("when project from KUBECONFIG is used", func() {
-				// Set active project for each test spec
-				var _ = JustBeforeEach(func() {
-					helper.OcSwitchProject(project)
-				})
 				// go back to original project after each test
-				var _ = JustAfterEach(func() {
-					helper.OcSwitchProject(originalProject)
-				})
-
 				It("create local nodejs component and push source and code separately", func() {
 					appName := "nodejs-push-test"
 					cmpName := "nodejs"
@@ -604,39 +599,10 @@ func componentTests(componentCmdPrefix string) {
 
 	var _ = Context("when component is not in the current directory", func() {
 
-		//new clean project and context for each test
-		var project string
 		var context string
-
-		//  current directory and project (before eny test is run) so it can restored  after all testing is done
-		var originalProject string
-
-		// Setup up state for each test spec
-		// create new project (not set as active) and new context directory for each test spec
-		// This is before every spec (It)
-		var _ = BeforeEach(func() {
-			project = helper.OcCreateRandProject()
-			context = helper.CreateNewContext()
-		})
-
-		// Clean up after the test
-		// This is run after every Spec (It)
-		var _ = AfterEach(func() {
-			helper.OcDeleteProject(project)
-			helper.DeleteDir(context)
-		})
 
 		var _ = Context("when --context is used", func() {
 			var _ = Context("when project from KUBECONFIG is used", func() {
-				// Set active project for each test spec
-				var _ = JustBeforeEach(func() {
-					helper.OcSwitchProject(project)
-				})
-				// go back to original project after each test
-				var _ = JustAfterEach(func() {
-					helper.OcSwitchProject(originalProject)
-				})
-
 				It("create local nodejs component and push source and code separately", func() {
 					appName := "nodejs-push-context-test"
 					cmpName := "nodejs"

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -484,7 +484,6 @@ func componentTests(componentCmdPrefix string) {
 
 		//  current directory and project (before eny test is run) so it can restored  after all testing is done
 		var originalDir string
-		var originalProject string
 
 		// Setup up state for each test spec
 		// create new project (not set as active) and new context directory for each test spec
@@ -501,17 +500,7 @@ func componentTests(componentCmdPrefix string) {
 			helper.DeleteDir(context)
 		})
 
-		Context("when project from KUBECONFIG is used", func() {
-			// we will switching project to new one for each test
-			JustBeforeEach(func() {
-				originalProject = helper.OcGetCurrentProject()
-				helper.OcSwitchProject(project)
-			})
-
-			// go back to original project after each test
-			JustAfterEach(func() {
-				helper.OcSwitchProject(originalProject)
-			})
+		Context("when project flag(--project) is used", func() {
 
 			Context("when using current directory", func() {
 				// we will be testing components that are created from the current directory
@@ -538,14 +527,15 @@ func componentTests(componentCmdPrefix string) {
 
 					// Push only config and see that the component is created but wothout any source copied
 					helper.CmdShouldPass("odo push --config")
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 
 					// Push only source and see that the component is updated with source code
 					helper.CmdShouldPass("odo push --source")
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,
 						appName,
+						project,
 						"ls -lai /tmp/src/package.json",
 						func(cmdOp string, err error) bool {
 							if err != nil {
@@ -566,10 +556,11 @@ func componentTests(componentCmdPrefix string) {
 
 					// Push only config and see that the component is created but wothout any source copied
 					helper.CmdShouldPass("odo push")
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,
 						appName,
+						project,
 						"ls -lai /tmp/src/package.json",
 						func(cmdOp string, err error) bool {
 							if err != nil {
@@ -598,14 +589,15 @@ func componentTests(componentCmdPrefix string) {
 
 					// Push only config and see that the component is created but wothout any source copied
 					helper.CmdShouldPass("odo push --config --context " + context)
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 
 					// Push only source and see that the component is updated with source code
 					helper.CmdShouldPass("odo push --source --context " + context)
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,
 						appName,
+						project,
 						"ls -lai /tmp/src/package.json",
 						func(cmdOp string, err error) bool {
 							if err != nil {
@@ -626,10 +618,11 @@ func componentTests(componentCmdPrefix string) {
 
 					// Push both config and source
 					helper.CmdShouldPass("odo push --context " + context)
-					helper.VerifyCmpExists(cmpName, appName)
+					helper.VerifyCmpExists(cmpName, appName, project)
 					remoteCmdExecPass := helper.CheckCmdOpInRemoteCmpPod(
 						cmpName,
 						appName,
+						project,
 						"ls -lai /tmp/src/package.json",
 						func(cmdOp string, err error) bool {
 							if err != nil {

--- a/tests/e2e/helper/helper_oc.go
+++ b/tests/e2e/helper/helper_oc.go
@@ -36,9 +36,6 @@ func OcSwitchProject(project string) {
 func OcDeleteProject(project string) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", project)
 	CmdShouldPass(fmt.Sprintf("oc delete project %s --now", project))
-	waitForCmdOut("oc get projects", CmdWaitTimeOut, true, func(output string) bool {
-		return !strings.Contains(output, project)
-	})
 }
 
 // OcCurrentProject get currently active project in oc

--- a/tests/e2e/helper/helper_oc.go
+++ b/tests/e2e/helper/helper_oc.go
@@ -46,10 +46,10 @@ func OcGetCurrentProject() string {
 }
 
 // CheckCmdOpInRemoteCmpPod runs the provided command on remote component pod and returns the return value of command output handler function passed to it
-func CheckCmdOpInRemoteCmpPod(cmpName string, appName string, cmd string, checkOp func(cmdOp string, err error) bool) bool {
+func CheckCmdOpInRemoteCmpPod(cmpName string, appName string, prjName string, cmd string, checkOp func(cmdOp string, err error) bool) bool {
 	cmpDCName := fmt.Sprintf("%s-%s", cmpName, appName)
-	podName := CmdShouldPass(fmt.Sprintf("oc get pods --selector=\"deploymentconfig=%s\" -o jsonpath='{.items[0].metadata.name}'", cmpDCName))
-	remoteCmpPodExecCmdStr := fmt.Sprintf("oc exec %s -c %s -- %s;exit", podName, cmpDCName, cmd)
+	podName := CmdShouldPass(fmt.Sprintf("oc get pods --namespace %s --selector=\"deploymentconfig=%s\" -o jsonpath='{.items[0].metadata.name}'", prjName, cmpDCName))
+	remoteCmpPodExecCmdStr := fmt.Sprintf("oc exec %s --namespace %s -c %s -- %s;exit", podName, prjName, cmpDCName, cmd)
 	stdout, stderr, exitcode := cmdRunner(remoteCmpPodExecCmdStr)
 	if exitcode != 0 || stderr != "" {
 		return checkOp(stdout, fmt.Errorf("cmd %s failed with error %s on pod %s", cmd, stderr, podName))
@@ -58,9 +58,9 @@ func CheckCmdOpInRemoteCmpPod(cmpName string, appName string, cmd string, checkO
 }
 
 // VerifyCmpExists verifies if component was created successfully
-func VerifyCmpExists(cmpName string, appName string) {
+func VerifyCmpExists(cmpName string, appName string, prjName string) {
 	cmpDCName := fmt.Sprintf("%s-%s", cmpName, appName)
-	CmdShouldPass(fmt.Sprintf("oc get dc %s", cmpDCName))
+	CmdShouldPass(fmt.Sprintf("oc get dc %s --namespace %s", cmpDCName, prjName))
 }
 
 // waitForCmdOut runs a command until it gets

--- a/tests/e2e/helper/helper_oc.go
+++ b/tests/e2e/helper/helper_oc.go
@@ -2,10 +2,15 @@ package helper
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	//. "github.com/onsi/gomega"
 )
+
+const CmdWaitTimeOut time.Duration = 5 * time.Minute
 
 // CreateRandProject create new project with random name (10 letters)
 // without writing to the config file (without switching project)
@@ -13,18 +18,27 @@ func OcCreateRandProject() string {
 	projectName := randString(10)
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	CmdShouldPass(fmt.Sprintf("oc new-project %s --skip-config-write", projectName))
+	waitForCmdOut("oc get projects", CmdWaitTimeOut, true, func(output string) bool {
+		return strings.Contains(output, projectName)
+	})
 	return projectName
 }
 
 // OcSwitchProject switch to the project
 func OcSwitchProject(project string) {
 	CmdShouldPass(fmt.Sprintf("oc project %s ", project))
+	waitForCmdOut("oc project -q", CmdWaitTimeOut, true, func(output string) bool {
+		return (strings.Compare(strings.TrimSpace(output), project) == 0)
+	})
 }
 
 // DeleteProject deletes a specified project
 func OcDeleteProject(project string) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", project)
 	CmdShouldPass(fmt.Sprintf("oc delete project %s --now", project))
+	waitForCmdOut("oc get projects", CmdWaitTimeOut, true, func(output string) bool {
+		return !strings.Contains(output, project)
+	})
 }
 
 // OcCurrentProject get currently active project in oc
@@ -35,4 +49,55 @@ func OcGetCurrentProject() string {
 		return stdout
 	}
 	return ""
+}
+
+// CheckCmdOpInRemoteCmpPod runs the provided command on remote component pod and returns the return value of command output handler function passed to it
+func CheckCmdOpInRemoteCmpPod(cmpName string, appName string, cmd string, checkOp func(cmdOp string, err error) bool) bool {
+	cmpDCName := fmt.Sprintf("%s-%s", cmpName, appName)
+	podName := CmdShouldPass(fmt.Sprintf("oc get pods --selector=\"deploymentconfig=%s\" -o jsonpath='{.items[0].metadata.name}'", cmpDCName))
+	remoteCmpPodExecCmdStr := fmt.Sprintf("oc exec %s -c %s -- %s;exit", podName, cmpDCName, cmd)
+	stdout, stderr, exitcode := cmdRunner(remoteCmpPodExecCmdStr)
+	if exitcode != 0 || stderr != "" {
+		return checkOp(stdout, fmt.Errorf("cmd %s failed with error %s on pod %s", cmd, stderr, podName))
+	}
+	return checkOp(stdout, nil)
+}
+
+// VerifyCmpExists verifies if component was created successfully
+func VerifyCmpExists(cmpName string, appName string) {
+	cmpDCName := fmt.Sprintf("%s-%s", cmpName, appName)
+	CmdShouldPass(fmt.Sprintf("oc get dc %s", cmpDCName))
+}
+
+// waitForCmdOut runs a command until it gets
+// the expected output.
+// It accepts 4 arguments, cmd (command to be run)
+// timeout (the time to wait for the output)
+// errOnFail (flag to set if test should fail if command fails)
+// check (function with output check logic)
+// It times out if the command doesn't fetch the
+// expected output  within the timeout period.
+func waitForCmdOut(cmd string, timeout time.Duration, errOnFail bool, check func(output string) bool) bool {
+
+	pingTimeout := time.After(timeout)
+	tick := time.Tick(time.Second)
+
+	for {
+		select {
+		case <-pingTimeout:
+			Fail(fmt.Sprintf("Timeout out after %v minutes", timeout))
+
+		case <-tick:
+			out, err := exec.Command("/bin/sh", "-c", cmd).Output()
+			if err != nil && errOnFail {
+				fmt.Fprintf(GinkgoWriter, "Command (%s) output: %s\n", cmd, out)
+				Fail(err.Error())
+			}
+
+			if check(strings.TrimSpace(string(out))) {
+				return true
+			}
+		}
+	}
+
 }

--- a/tests/e2e/helper/helper_oc.go
+++ b/tests/e2e/helper/helper_oc.go
@@ -27,9 +27,6 @@ func OcCreateRandProject() string {
 // OcSwitchProject switch to the project
 func OcSwitchProject(project string) {
 	CmdShouldPass(fmt.Sprintf("oc project %s ", project))
-	waitForCmdOut("oc project -q", CmdWaitTimeOut, true, func(output string) bool {
-		return (strings.Compare(strings.TrimSpace(output), project) == 0)
-	})
 }
 
 // DeleteProject deletes a specified project

--- a/tests/e2e/helper/helper_run.go
+++ b/tests/e2e/helper/helper_run.go
@@ -26,7 +26,7 @@ func cmdRunner(cmdS string) (string, string, int) {
 	stderr := string(session.Err.Contents())
 	exitCode := session.ExitCode()
 
-	fmt.Fprintf(GinkgoWriter, "Result: \n stdout: %s\n stderr:%s \n exitcode: %d \n", stdout, stderr, exitCode)
+	//fmt.Fprintf(GinkgoWriter, "Result: \n stdout: %s\n stderr:%s \n exitcode: %d \n", stdout, stderr, exitCode)
 
 	return stdout, stderr, exitCode
 }

--- a/tests/e2e/helper/helper_run.go
+++ b/tests/e2e/helper/helper_run.go
@@ -26,7 +26,7 @@ func cmdRunner(cmdS string) (string, string, int) {
 	stderr := string(session.Err.Contents())
 	exitCode := session.ExitCode()
 
-	//fmt.Fprintf(GinkgoWriter, "Result: \n stdout: %s\n stderr:%s \n exitcode: %d \n", stdout, stderr, exitCode)
+	fmt.Fprintf(GinkgoWriter, "Result: \n stdout: %s\n stderr:%s \n exitcode: %d \n", stdout, stderr, exitCode)
 
 	return stdout, stderr, exitCode
 }
@@ -39,7 +39,7 @@ func CmdShouldPass(cmd string) string {
 	return strings.TrimSpace(stdout)
 }
 
-// CmdShouldFail command needs to retrun non 0 as en exit code
+// CmdShouldFail command needs to return non 0 as en exit code
 // returns just stderr
 func CmdShouldFail(cmd string) string {
 	_, stderr, exitcode := cmdRunner(cmd)

--- a/tests/e2e/helper/helper_run.go
+++ b/tests/e2e/helper/helper_run.go
@@ -38,3 +38,11 @@ func CmdShouldPass(cmd string) string {
 	Expect(exitcode).To(Equal(0))
 	return strings.TrimSpace(stdout)
 }
+
+// CmdShouldFail command needs to retrun non 0 as en exit code
+// returns just stderr
+func CmdShouldFail(cmd string) string {
+	_, stderr, exitcode := cmdRunner(cmd)
+	Expect(exitcode).NotTo(Equal(0))
+	return strings.TrimSpace(stderr)
+}

--- a/tests/e2e/source_test.go
+++ b/tests/e2e/source_test.go
@@ -17,7 +17,7 @@ var _ = Describe("odoSourceE2e", func() {
 	// Create a separate project for source
 	Context("create source project", func() {
 		It("should create a new source project", func() {
-			session := runCmdShouldPass("odo project create odo-source")
+			session := runCmdShouldPass("odo project create odo-source -w")
 			Expect(session).To(ContainSubstring("odo-source"))
 		})
 	})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

This commit adds:
1. `--config` flag to update the component with component settings
2. `--source` flag to push only the source to an already existing
   component.
3. If neither `--config` nor `--source` flags are passed, update
   both source and configuration onto the component

fixes #1489
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>

## How to test changes?
<!-- Please describe the steps to test the PR -->
* `odo push`
* `odo push --source`
* `odo push --config`

The above 3 with `--context` also should behave with changes above
