### PR TITLE
Short circuiting invalid context file in context.go

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -153,7 +153,7 @@ func TestSetLocalConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("", false)
+			cfg, err := NewLocalConfigInfo("")
 			if err != nil {
 				t.Error(err)
 			}
@@ -247,7 +247,7 @@ func TestLocalUnsetConfiguration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("", false)
+			cfg, err := NewLocalConfigInfo("")
 			if err != nil {
 				t.Error(err)
 			}
@@ -294,7 +294,7 @@ func TestLocalConfigInitDoesntCreateLocalOdoFolder(t *testing.T) {
 	}
 	os.RemoveAll(filename)
 
-	conf, err := NewLocalConfigInfo("", false)
+	conf, err := NewLocalConfigInfo("")
 	if err != nil {
 		t.Errorf("error while creating local config %v", err)
 	}
@@ -304,7 +304,7 @@ func TestLocalConfigInitDoesntCreateLocalOdoFolder(t *testing.T) {
 }
 
 func TestMetaTypePopulatedInLocalConfig(t *testing.T) {
-	ci, err := NewLocalConfigInfo("", false)
+	ci, err := NewLocalConfigInfo("")
 
 	if err != nil {
 		t.Error(err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -414,7 +414,7 @@ func TestGetOSSourcePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("", false)
+			cfg, err := NewLocalConfigInfo("")
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -4143,7 +4143,7 @@ func TestDeleteEnvVars(t *testing.T) {
 }
 
 func fakeComponentSettings(cmpName string, appName string, projectName string, srcType config.SrcType, cmpType string, t *testing.T) config.LocalConfigInfo {
-	lci, err := config.NewLocalConfigInfo("", false)
+	lci, err := config.NewLocalConfigInfo("")
 	if err != nil {
 		t.Errorf("failed to init fake component configuration")
 		return *lci

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -231,7 +231,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.interactive = true
 	}
 
-	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext, false)
+	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/odo/pkg/component"
-	odoconfig "github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -47,10 +46,6 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	_, err = odoconfig.NewLocalConfigInfo("", true)
-	if err != nil {
-		return err
-	}
 	return odoutil.CheckOutputFlag(lo.outputFlag)
 }
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -64,8 +64,7 @@ func NewPushOptions() *PushOptions {
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.client = genericclioptions.Client(cmd)
 
-	// Retrieve configuration
-	conf, err := config.NewLocalConfigInfo(po.componentContext, false)
+	conf, err := config.NewLocalConfigInfo(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve configuration information")
 	}

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -63,7 +63,7 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 		return errors.Wrapf(err, "failed to update component")
 	}
 
-	uo.cmpConfig, err = config.NewLocalConfigInfo(uo.cmpCfgContext, false)
+	uo.cmpConfig, err = config.NewLocalConfigInfo(uo.cmpCfgContext)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update component")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -56,7 +56,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.client = genericclioptions.Client(cmd)
 
 	// Retrieve configuration
-	conf, err := config.NewLocalConfigInfo(wo.componentContext, false)
+	conf, err := config.NewLocalConfigInfo(wo.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve configuration information")
 	}

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -43,6 +43,8 @@ type SetOptions struct {
 	paramName       string
 	paramValue      string
 	configForceFlag bool
+	contextDir      string
+	context         *genericclioptions.Context
 	envArray        []string
 }
 
@@ -57,7 +59,7 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 		o.paramName = args[0]
 		o.paramValue = args[1]
 	}
-
+	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 
@@ -69,7 +71,7 @@ func (o *SetOptions) Validate() (err error) {
 // Run contains the logic for the command
 func (o *SetOptions) Run() (err error) {
 
-	cfg, err := config.New()
+	cfg, err := config.NewLocalConfigInfo(o.contextDir)
 
 	if err != nil {
 		return errors.Wrapf(err, "unable to set configuration")

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
+
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 
@@ -43,6 +45,8 @@ var (
 type UnsetOptions struct {
 	paramName       string
 	configForceFlag bool
+	contextDir      string
+	context         *genericclioptions.Context
 	envArray        []string
 }
 
@@ -56,6 +60,7 @@ func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	if o.envArray == nil {
 		o.paramName = args[0]
 	}
+	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 
@@ -67,7 +72,7 @@ func (o *UnsetOptions) Validate() (err error) {
 // Run contains the logic for the command
 func (o *UnsetOptions) Run() (err error) {
 
-	cfg, err := config.New()
+	cfg, err := config.NewLocalConfigInfo(o.contextDir)
 
 	if err != nil {
 		return errors.Wrapf(err, "")

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -23,6 +23,8 @@ var viewExample = ktemplates.Examples(`# For viewing the current local configura
 
 // ViewOptions encapsulates the options for the command
 type ViewOptions struct {
+	contextDir string
+	context    *genericclioptions.Context
 }
 
 // NewViewOptions creates a new ViewOptions instance
@@ -32,6 +34,7 @@ func NewViewOptions() *ViewOptions {
 
 // Complete completes ViewOptions after they've been created
 func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 
@@ -42,8 +45,7 @@ func (o *ViewOptions) Validate() (err error) {
 
 // Run contains the logic for the command
 func (o *ViewOptions) Run() (err error) {
-
-	cfg, err := config.New()
+	cfg, err := config.NewLocalConfigInfo(o.contextDir)
 	if err != nil {
 		util.LogErrorAndExit(err, "")
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -341,3 +341,16 @@ func ignoreButLog(err error) {
 		glog.V(4).Infof("Ignoring error as it usually means flag wasn't set: %v", err)
 	}
 }
+
+// ApplyIgnore will take the current ignores []string and either ignore it (if .odoignore is used)
+// or find the .gitignore file in the directory and use that instead.
+func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
+	if len(*ignores) == 0 {
+		rules, err := pkgUtil.GetIgnoreRulesFromDirectory(sourcePath)
+		if err != nil {
+			util.LogErrorAndExit(err, "")
+		}
+		*ignores = append(*ignores, rules...)
+	}
+	return nil
+}

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -71,6 +71,8 @@ func componentTests(componentCmdPrefix string) {
 			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
 			session = runCmdShouldFail("odo app list")
 			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
+			session = runCmdShouldFail("odo config view")
+			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
 			// clean up
 			runCmdShouldPass("mv .odo_tmp .odo")
 			os.RemoveAll(dirName)

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -69,6 +69,8 @@ func componentTests(componentCmdPrefix string) {
 			runCmdShouldPass("mv .odo .odo_tmp")
 			session := runCmdShouldFail("odo component list")
 			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
+			session = runCmdShouldFail("odo app list")
+			Expect(session).To(ContainSubstring("the current directory does not represent an odo component"))
 			// clean up
 			runCmdShouldPass("mv .odo_tmp .odo")
 			os.RemoveAll(dirName)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -264,6 +264,7 @@ var _ = Describe("odoe2e", func() {
 				},
 			}
 			for _, testCase := range cases {
+				runCmdShouldPass("odo create nodejs")
 				runCmdShouldPass(fmt.Sprintf("odo config set %s %s -f", testCase.paramName, testCase.paramValue))
 				Value := getConfigValue(testCase.paramName)
 				Expect(Value).To(ContainSubstring(testCase.paramValue))


### PR DESCRIPTION
 - Does above
 - Removes old fix for component list as this covers that
   more easily
 - Does some breakup of functions of context.go along the way.

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
#1486 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Go into a directory where there is no .odo file and try `odo app list` or `odo component list`