### PR TITLE
fix: prevent panic when no classes are available

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -88,6 +88,11 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		if err != nil {
 			return fmt.Errorf("unable to retrieve service classes: %v", err)
 		}
+
+		if len(classesByCategory) == 0 {
+			return fmt.Errorf("no available service classes")
+		}
+
 		class, o.ServiceType = ui.SelectClassInteractively(classesByCategory)
 
 		plans, err := client.GetMatchingPlans(class)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Fixes a panic when no service class is available on the cluster in interactive mode (will happen for example if service catalog is deployed on minishift but not brokers).

## Was the change discussed in an issue?
No.

## How to test changes?

