### PR TITLE
Adding .exe extension for make bin on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ default: bin
 
 .PHONY: debug
 debug:
-	go build ${DEBUG_BUILD_FLAGS} -o odo cmd/odo/odo.go
+	go build ${DEBUG_BUILD_FLAGS} cmd/odo/odo.go
 
 .PHONY: bin
 bin:
-	go build ${BUILD_FLAGS} -o odo cmd/odo/odo.go
+	go build ${BUILD_FLAGS} cmd/odo/odo.go
 
 .PHONY: install
 install:


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Running test suite on master from windows platform. Added windows executable extension for odo file.

## Was the change discussed in an issue?
Part of #1131
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Run ```make bin``` on Windows platform and run  ```.\odo.exe -h``` to verify it