### PR TITLE
Update OpenShift version based on what minishift supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenShift Do is designed to be simple and concise with the following key feature
 ## Installation
 
 **Prerequisites:**
-* OpenShift 3.9.0 and above is required.
+* OpenShift 3.10.0 and above is required.
 * We recommend using [Minishift](https://github.com/minishift/minishift).
 
 <details>


### PR DESCRIPTION
minishift supports OpenShift version 3.10 and above.

## What is the purpose of this change? What does it change?

It modifies the OpenShift version based on what minishift supports.

## Was the change discussed in an issue?

<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
