### PR TITLE
Fix issue of 2 deployments on one odo push

### DIFF
--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -105,7 +105,7 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, com
 					// The application container
 					Containers: []corev1.Container{
 						{
-							Image: fmt.Sprintf("%s/%s:%s", commonImageMeta.Namespace, commonImageMeta.Name, commonImageMeta.Tag),
+							Image: " ",
 							Name:  commonObjectMeta.Name,
 							Ports: commonImageMeta.Ports,
 							// Run the actual supervisord binary that has been mounted into the container


### PR DESCRIPTION
Fixes the issues of two DeploymentConfig revisions happening on one `odo
push`.

OpenShift will automatically propagate the actual image using the
TriggerChange and thus having it blank is viable / okay.

Closes https://github.com/openshift/odo/issues/1493


note from @kadel:
This is why it works: https://github.com/openshift/origin/blob/f5f540d6503b3978a242117fb94b229135201df3/pkg/apps/controller/deploymentconfig/deploymentconfig_controller.go#L146