### PR TITLE
Adding context flag function and updating all components to use it

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -412,7 +412,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	componentCreateCmd.Flags().StringVarP(&co.componentBinary, "binary", "b", "", "Use a binary as the source file for the component")
 	componentCreateCmd.Flags().StringVarP(&co.componentGit, "git", "g", "", "Use a git repository as the source file for the component")
 	componentCreateCmd.Flags().StringVarP(&co.componentGitRef, "ref", "r", "", "Use a specific ref e.g. commit, branch or tag of the git repository")
-	componentCreateCmd.Flags().StringVar(&co.componentContext, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+	genericclioptions.AddContextFlag(componentCreateCmd, &co.componentContext)
 	componentCreateCmd.Flags().StringVar(&co.memory, "memory", "", "Amount of memory to be allocated to the component. ex. 100Mi")
 	componentCreateCmd.Flags().StringVar(&co.memoryMin, "min-memory", "", "Limit minimum amount of memory to be allocated to the component. ex. 100Mi")
 	componentCreateCmd.Flags().StringVar(&co.memoryMax, "max-memory", "", "Limit maximum amount of memory to be allocated to the component. ex. 100Mi")

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -28,12 +28,13 @@ var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'.
 // DeleteOptions is a container to attach complete, validate and run pattern
 type DeleteOptions struct {
 	componentForceDeleteFlag bool
+	componentContext         string
 	*ComponentOptions
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, &ComponentOptions{}}
+	return &DeleteOptions{false, "", &ComponentOptions{}}
 }
 
 // Complete completes log args
@@ -100,6 +101,8 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Annotations = map[string]string{"command": "component"}
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)
+	//Adding `--context` flag
+	genericclioptions.AddContextFlag(componentDeleteCmd, &do.componentContext)
 
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentDeleteCmd)

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -26,13 +26,14 @@ var describeExample = ktemplates.Examples(`  # Describe nodejs component,
 
 // DescribeOptions is a dummy container to attach complete, validate and run pattern
 type DescribeOptions struct {
-	outputFlag string
+	outputFlag       string
+	componentContext string
 	*ComponentOptions
 }
 
 // NewDescribeOptions returns new instance of ListOptions
 func NewDescribeOptions() *DescribeOptions {
-	return &DescribeOptions{"", &ComponentOptions{}}
+	return &DescribeOptions{"", "", &ComponentOptions{}}
 }
 
 // Complete completes describe args
@@ -94,6 +95,8 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 	describeCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(describeCmd, completion.ComponentNameCompletionHandler)
 	describeCmd.Flags().StringVarP(&do.outputFlag, "output", "o", "", "output in json format")
+	// Adding --context flag
+	genericclioptions.AddContextFlag(describeCmd, &do.componentContext)
 
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(describeCmd)

--- a/pkg/odo/cli/component/get.go
+++ b/pkg/odo/cli/component/get.go
@@ -23,6 +23,7 @@ var getExample = ktemplates.Examples(`  # Get the currently active component
 type GetOptions struct {
 	componentShortFlag bool
 	componentName      string
+	componentContext   string
 	*genericclioptions.Context
 }
 
@@ -75,6 +76,8 @@ func NewCmdGet(name, fullName string) *cobra.Command {
 	}
 
 	componentGetCmd.Flags().BoolVarP(&o.componentShortFlag, "short", "q", false, "If true, display only the component name")
+	// add --context flag
+	genericclioptions.AddContextFlag(componentGetCmd, &o.componentContext)
 
 	//Adding `--project` flag
 	project.AddProjectFlag(componentGetCmd)

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 
@@ -66,7 +67,8 @@ DB_PASSWORD=secret`
 
 // LinkOptions encapsulates the options for the odo link command
 type LinkOptions struct {
-	waitForTarget bool
+	waitForTarget    bool
+	componentContext string
 	*commonLinkOptions
 }
 
@@ -140,6 +142,8 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	appCmd.AddApplicationFlag(linkCmd)
 	//Adding `--component` flag
 	AddComponentFlag(linkCmd)
+	//Adding context flag
+	genericclioptions.AddContextFlag(linkCmd, &o.componentContext)
 
 	completion.RegisterCommandHandler(linkCmd, completion.LinkCompletionHandler)
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -29,7 +29,8 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
-	outputFlag string
+	outputFlag       string
+	componentContext string
 	*genericclioptions.Context
 }
 
@@ -103,7 +104,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	}
 	// Add a defined annotation in order to appear in the help menu
 	componentListCmd.Annotations = map[string]string{"command": "component"}
-
+	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
 
 	//Adding `--project` flag

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -2,8 +2,9 @@ package component
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"os"
+
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
 
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -25,13 +26,14 @@ var logExample = ktemplates.Examples(`  # Get the logs for the nodejs component
 
 // LogOptions contains log options
 type LogOptions struct {
-	logFollow bool
+	logFollow        bool
+	componentContext string
 	*ComponentOptions
 }
 
 // NewLogOptions returns new instance of LogOptions
 func NewLogOptions() *LogOptions {
-	return &LogOptions{false, &ComponentOptions{}}
+	return &LogOptions{false, "", &ComponentOptions{}}
 }
 
 // Complete completes log args
@@ -75,6 +77,8 @@ func NewCmdLog(name, fullName string) *cobra.Command {
 	logCmd.Annotations = map[string]string{"command": "component"}
 	logCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(logCmd, completion.ComponentNameCompletionHandler)
+	// Adding `--context` flag
+	genericclioptions.AddContextFlag(logCmd, &o.componentContext)
 
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(logCmd)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -232,8 +232,7 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(po, cmd, args)
 		},
 	}
-
-	pushCmd.Flags().StringVarP(&po.componentContext, "context", "c", "", "Use given context directory as a source for component settings")
+	genericclioptions.AddContextFlag(pushCmd, &po.componentContext)
 	pushCmd.Flags().BoolVar(&po.show, "show-log", false, "If enabled, logs will be shown when built")
 	pushCmd.Flags().StringSliceVar(&po.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
@@ -39,6 +40,7 @@ For this command to be successful, the service or component needs to have been l
 
 // UnlinkOptions encapsulates the options for the odo link command
 type UnlinkOptions struct {
+	componentContext string
 	*commonLinkOptions
 }
 
@@ -93,6 +95,8 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	appCmd.AddApplicationFlag(unlinkCmd)
 	//Adding `--component` flag
 	AddComponentFlag(unlinkCmd)
+	// Adding context flag
+	genericclioptions.AddContextFlag(unlinkCmd, &o.componentContext)
 
 	completion.RegisterCommandHandler(unlinkCmd, completion.UnlinkCompletionHandler)
 

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -162,8 +162,7 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(uo, cmd, args)
 		},
 	}
-
-	updateCmd.Flags().StringVarP(&uo.cmpCfgContext, "context", "c", ".", "Use context to specify the location of a component config file if not already in the component source directory")
+	genericclioptions.AddContextFlag(updateCmd, &uo.cmpCfgContext)
 	updateCmd.Flags().StringVarP(&uo.git, "git", "g", "", "git source")
 	updateCmd.Flags().StringVarP(&uo.local, "local", "l", "", "Use local directory as a source for component.")
 	updateCmd.Flags().StringVarP(&uo.ref, "ref", "r", "", "Use a specific ref e.g. commit, branch or tag of the git repository")

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -153,6 +153,8 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
+	// Adding context flag
+	genericclioptions.AddContextFlag(watchCmd, &wo.componentContext)
 
 	//Adding `--application` flag
 	appCmd.AddApplicationFlag(watchCmd)

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -148,7 +148,6 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 
 	watchCmd.Flags().StringSliceVar(&wo.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 	watchCmd.Flags().IntVar(&wo.delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
-	watchCmd.Flags().StringVarP(&wo.componentContext, "context", "c", "", "Use given context directory as a source for component settings")
 
 	// Add a defined annotation in order to appear in the help menu
 	watchCmd.Annotations = map[string]string{"command": "component"}

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -6,3 +6,8 @@ import "github.com/spf13/cobra"
 func AddOutputFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(OutputFlagName, "o", "", "Specify output format, supported format: json")
 }
+
+// AddContextFlag adds `context` flag to given cobra command
+func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
+	cmd.Flags().StringVar(setValueTo, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+}

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -9,5 +9,9 @@ func AddOutputFlag(cmd *cobra.Command) {
 
 // AddContextFlag adds `context` flag to given cobra command
 func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
-	cmd.Flags().StringVar(setValueTo, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+	if setValueTo != nil {
+		cmd.Flags().StringVar(setValueTo, "context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+	} else {
+		cmd.Flags().String("context", "", "Use context to indicate the path where the component settings need to be saved and this directory should contain component source for local and binary components")
+	}
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR aims to add context flag to all commands that should have them

<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
$ odo create nodejs --context ~/nodejs-ex/helm
 ✓  Checking component
 ✓  Checking component version
Please use `odo push` command to create the component with source deployed
```
This should work for most commands with exceptions as listed
