### PR TITLE
Removing extra backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ $ minishift start
 
 2. Log into the OpenShift cluster.
 ```sh
-$ odo login -u developer -p developer`
+$ odo login -u developer -p developer
 ```
 
 3. Create an application. An application in OpenShift Do is an umbrella under which you add other components.
 ```sh
-$ odo app create node-example-app`
+$ odo app create node-example-app
 ```
 
 4. Download the Node.js sample code and change directory to the location of the sample code.


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
To remove a couple of extra backticks that could interfere with users who copy/paste the commands

## Was the change discussed in an issue?
fixes #???
No

## How to test changes?
Look at the rendered markdown
