### PR TITLE
Increases checks when deploying DeploymentConfig

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -3674,7 +3674,7 @@ func TestPatchCurrentDC(t *testing.T) {
 			if err != nil {
 				t.Errorf("client.PatchCurrentDC() unexpected error attempting to fetch component container. error %v", err)
 			}
-			err = fakeClient.PatchCurrentDC(tt.args.name, tt.args.dcPatch, tt.args.prePatchDCHandler, func(*appsv1.DeploymentConfig) bool {
+			err = fakeClient.PatchCurrentDC(tt.args.name, tt.args.dcPatch, tt.args.prePatchDCHandler, func(*appsv1.DeploymentConfig, int64) bool {
 				return true
 			}, &(tt.args.dcBefore), existingContainer)
 
@@ -3730,7 +3730,7 @@ func TestUpdateDCToGit(t *testing.T) {
 				resourceLimits:             corev1.ResourceRequirements{},
 				envVars:                    []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 				isDeleteSupervisordVolumes: false,
-				dcRollOutWaitCond: func(*appsv1.DeploymentConfig) bool {
+				dcRollOutWaitCond: func(*appsv1.DeploymentConfig, int64) bool {
 					return true
 				},
 			},
@@ -3750,7 +3750,7 @@ func TestUpdateDCToGit(t *testing.T) {
 				resourceLimits:             corev1.ResourceRequirements{},
 				envVars:                    []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 				isDeleteSupervisordVolumes: false,
-				dcRollOutWaitCond: func(*appsv1.DeploymentConfig) bool {
+				dcRollOutWaitCond: func(*appsv1.DeploymentConfig, int64) bool {
 					return true
 				},
 			},
@@ -3770,7 +3770,7 @@ func TestUpdateDCToGit(t *testing.T) {
 				resourceLimits:             corev1.ResourceRequirements{},
 				envVars:                    []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 				isDeleteSupervisordVolumes: false,
-				dcRollOutWaitCond: func(*appsv1.DeploymentConfig) bool {
+				dcRollOutWaitCond: func(*appsv1.DeploymentConfig, int64) bool {
 					return true
 				},
 			},
@@ -3790,7 +3790,7 @@ func TestUpdateDCToGit(t *testing.T) {
 				resourceLimits:             corev1.ResourceRequirements{},
 				envVars:                    []corev1.EnvVar{{Name: "key1", Value: "value1"}, {Name: "key2", Value: "value2"}},
 				isDeleteSupervisordVolumes: false,
-				dcRollOutWaitCond: func(*appsv1.DeploymentConfig) bool {
+				dcRollOutWaitCond: func(*appsv1.DeploymentConfig, int64) bool {
 					return true
 				},
 			},
@@ -4277,7 +4277,7 @@ func TestUpdateDCToSupervisor(t *testing.T) {
 					ResourceLimits: corev1.ResourceRequirements{},
 					EnvVars:        tt.args.envVars,
 					ExistingDC:     &(tt.args.dc),
-					DcRollOutWaitCond: func(e *appsv1.DeploymentConfig) bool {
+					DcRollOutWaitCond: func(e *appsv1.DeploymentConfig, i int64) bool {
 						return true
 					},
 				},
@@ -4861,7 +4861,7 @@ func TestWaitAndGetDC(t *testing.T) {
 				return true, fkWatch, nil
 			})
 			// Run function WaitAndGetDC
-			_, err := fakeClient.WaitAndGetDC(tt.args.name, tt.args.timeout, func(*appsv1.DeploymentConfig) bool {
+			_, err := fakeClient.WaitAndGetDC(tt.args.name, 0, tt.args.timeout, func(*appsv1.DeploymentConfig, int64) bool {
 				return !tt.wantErr
 			})
 			// Error checking WaitAndGetDC

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -22,49 +22,6 @@ type CommonImageMeta struct {
 	Ports     []corev1.ContainerPort
 }
 
-// getDeploymentCondition returns the condition with the provided type.
-// Borrowed from https://github.com/openshift/origin/blob/64349ed036ed14808124c5b4d8538b3856783b54/pkg/oc/originpolymorphichelpers/deploymentconfigs/status.go
-func getDeploymentCondition(status appsv1.DeploymentConfigStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
-	for i := range status.Conditions {
-		c := status.Conditions[i]
-		if c.Type == condType {
-			return &c
-		}
-	}
-	return nil
-}
-
-// IsDCRolledOut indicates whether the deployment config is rolled out or not
-// Borrowed from https://github.com/openshift/origin/blob/64349ed036ed14808124c5b4d8538b3856783b54/pkg/oc/originpolymorphichelpers/deploymentconfigs/status.go
-func IsDCRolledOut(config *appsv1.DeploymentConfig) bool {
-	cond := getDeploymentCondition(config.Status, appsv1.DeploymentProgressing)
-	if config.Generation <= config.Status.ObservedGeneration {
-		switch {
-		case cond != nil && cond.Reason == "NewReplicationControllerAvailable":
-			return true
-
-		case cond != nil && cond.Reason == "ProgressDeadlineExceeded":
-			return true
-
-		case cond != nil && cond.Reason == "RolloutCancelled":
-			return true
-
-		case cond != nil && cond.Reason == "DeploymentConfigPaused":
-			return true
-
-		case config.Status.UpdatedReplicas < config.Spec.Replicas:
-			return false
-
-		case config.Status.Replicas > config.Status.UpdatedReplicas:
-			return false
-
-		case config.Status.AvailableReplicas < config.Status.UpdatedReplicas:
-			return false
-		}
-	}
-	return false
-}
-
 // generateSupervisordDeploymentConfig generates dc for local and binary components
 // Parameters:
 //	commonObjectMeta: Contains annotations and labels for dc

--- a/pkg/occlient/utils.go
+++ b/pkg/occlient/utils.go
@@ -34,7 +34,6 @@ func getDeploymentCondition(status appsv1.DeploymentConfigStatus, condType appsv
 func IsDCRolledOut(config *appsv1.DeploymentConfig, desiredRevision int64) bool {
 
 	latestRevision := config.Status.LatestVersion
-	glog.V(4).Infof("Current revision %s, we want: %s", latestRevision, desiredRevision)
 
 	if latestRevision == 0 {
 		switch {

--- a/pkg/occlient/utils.go
+++ b/pkg/occlient/utils.go
@@ -1,9 +1,85 @@
 package occlient
 
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	appsv1 "github.com/openshift/api/apps/v1"
+	appsutil "github.com/openshift/origin/pkg/apps/util"
+)
+
 func hasTag(tags []string, requiredTag string) bool {
 	for _, tag := range tags {
 		if tag == requiredTag {
 			return true
+		}
+	}
+	return false
+}
+
+// getDeploymentCondition returns the condition with the provided type.
+// Borrowed from https://github.com/openshift/origin/blob/64349ed036ed14808124c5b4d8538b3856783b54/pkg/oc/originpolymorphichelpers/deploymentconfigs/status.go
+func getDeploymentCondition(status appsv1.DeploymentConfigStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
+// IsDCRolledOut indicates whether the deployment config is rolled out or not
+// Borrowed from https://github.com/openshift/origin/blob/64349ed036ed14808124c5b4d8538b3856783b54/pkg/oc/originpolymorphichelpers/deploymentconfigs/status.go
+func IsDCRolledOut(config *appsv1.DeploymentConfig, desiredRevision int64) bool {
+
+	latestRevision := config.Status.LatestVersion
+	glog.V(4).Infof("Current revision %s, we want: %s", latestRevision, desiredRevision)
+
+	if latestRevision == 0 {
+		switch {
+		case appsutil.HasImageChangeTrigger(config):
+			glog.V(4).Infof("Deployment config %q waiting on image update", config.Name)
+			return false
+
+		case len(config.Spec.Triggers) == 0:
+			fmt.Printf("Deployment config %q waiting on manual update (use 'oc rollout latest %s')", config.Name, config.Name)
+			return false
+		}
+	}
+
+	if desiredRevision > 0 && latestRevision != desiredRevision {
+		glog.V(4).Infof("desired revision (%d) is different from the running revision (%d)", desiredRevision, latestRevision)
+		return false
+	}
+
+	// Check the current condition of the deployment config
+	cond := getDeploymentCondition(config.Status, appsv1.DeploymentProgressing)
+	if config.Generation <= config.Status.ObservedGeneration {
+		switch {
+		case cond != nil && cond.Reason == "NewReplicationControllerAvailable":
+			return true
+
+		case cond != nil && cond.Reason == "ProgressDeadlineExceeded":
+			return true
+
+		case cond != nil && cond.Reason == "RolloutCancelled":
+			return true
+
+		case cond != nil && cond.Reason == "DeploymentConfigPaused":
+			return true
+
+		case config.Status.UpdatedReplicas < config.Spec.Replicas:
+			glog.V(4).Infof("Waiting for rollout to finish: %d out of %d new replicas have been updated...", config.Status.UpdatedReplicas, config.Spec.Replicas)
+			return false
+
+		case config.Status.Replicas > config.Status.UpdatedReplicas:
+			glog.V(4).Infof("Waiting for rollout to finish: %d old replicas are pending termination...", config.Status.Replicas-config.Status.UpdatedReplicas)
+			return false
+
+		case config.Status.AvailableReplicas < config.Status.UpdatedReplicas:
+			glog.V(4).Infof("Waiting for rollout to finish: %d of %d updated replicas are available...", config.Status.AvailableReplicas, config.Status.UpdatedReplicas)
+			return false
 		}
 	}
 	return false

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -521,6 +521,18 @@ var _ = Describe("odoe2e", func() {
 				Expect(getLogging).To(ContainSubstring("Building component"))
 			})
 
+			It("should be able to spam odo push without anything breaking", func() {
+				// Iteration 1
+				runCmdShouldPass("odo push --show-log --context " + tmpDir + "/nodejs-ex")
+
+				// Iteration 2
+				runCmdShouldPass("odo push --show-log --context " + tmpDir + "/nodejs-ex")
+
+				// Iteration 3
+				runCmdShouldPass("odo push --show-log --context " + tmpDir + "/nodejs-ex")
+
+			})
+
 			It("should create a component and push using the --ignore flag", func() {
 				// runCmdShouldPass("odo create " + curProj + "/nodejs push-odoignore-flag-example --context " + tmpDir + "/nodejs-ex")
 				runCmdShouldPass("odo create nodejs push-odoignore-flag-example --context " + tmpDir + "/nodejs-ex")


### PR DESCRIPTION
This PR:

- Adds more checks for IsDCRolledOut, including waiting for the new
revision, making sure that DeploymentConfig is actually deployed / has a
new image as well as the desired revision is available.
- More debug information when waiting for deploymentconfig
- Moves the functions from template.go to utils.go (I have no idea why a
utility function was in a templates file...)
- These changes also makes sure that our revision doesn't skip a number
/ goes to the next revision.

Closes https://github.com/openshift/odo/issues/1567