### PR TITLE
openshiftci-presubmit-unittests: get gox before attemting make cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-coverage:
 # compile for multiple platforms
 .PHONY: cross
 cross:
-	gox -osarch="darwin/amd64 linux/amd64 linux/arm windows/amd64" -output="dist/bin/{{.OS}}-{{.Arch}}/odo" $(BUILD_FLAGS) ./cmd/odo/
+	gox -osarch="darwin/amd64 linux/amd64 windows/amd64" -output="dist/bin/{{.OS}}-{{.Arch}}/odo" $(BUILD_FLAGS) ./cmd/odo/
 
 .PHONY: generate-cli-structure
 generate-cli-structure:

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -10,5 +10,7 @@ export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 make test
 
+# crosscompile and publish artifacts
+go get -u github.com/mitchellh/gox
 make cross
 cp -r dist $ARTIFACTS_DIR


### PR DESCRIPTION
- get gox before running `make cross`
- remove arm from build targets (no one is using it right now, and it is just slowing down builds), it can be added back if needed