### PR TITLE
re-arranged the contexts in template test

### DIFF
--- a/tests/e2e/template_cleantest_test.go
+++ b/tests/e2e/template_cleantest_test.go
@@ -87,18 +87,6 @@ var _ = Describe("Example of a clean test", func() {
 
 	var _ = Context("when --context is used", func() {
 
-		// we will be testing components that are created from the current directory
-		// switch to the clean context dir before each test
-		var _ = JustBeforeEach(func() {
-			originalDir = helper.Getwd()
-			helper.Chdir(context)
-		})
-
-		// go back to original directory after each test
-		var _ = JustAfterEach(func() {
-			helper.Chdir(originalDir)
-		})
-
 		var _ = Context("when project from KUBECONFIG is used", func() {
 			// Set active project for each test spec
 			var _ = JustBeforeEach(func() {

--- a/tests/e2e/template_cleantest_test.go
+++ b/tests/e2e/template_cleantest_test.go
@@ -83,39 +83,52 @@ var _ = Describe("Example of a clean test", func() {
 
 		})
 
-		var _ = Context("when --context is used", func() {
-			var _ = Context("when project from KUBECONFIG is used", func() {
-				// Set active project for each test spec
-				var _ = JustBeforeEach(func() {
-					helper.OcSwitchProject(project)
-				})
-				// go back to original project after each test
-				var _ = JustAfterEach(func() {
-					helper.OcSwitchProject(originalProject)
-				})
+	})
 
-				It("create local nodejs component and push code", func() {
-					helper.CopyExample(filepath.Join("source", "nodejs"), context)
+	var _ = Context("when --context is used", func() {
 
-					helper.CmdShouldPass("odo component create nodejs nodejs --context " + context)
-					//TODO: verify that config was properly created
-					helper.CmdShouldPass("odo push")
-					//TODO: verify resources on cluster
-				})
-
-			})
-
-			var _ = Context("when --project flag is used", func() {
-				It("create local nodejs component and push code", func() {
-					helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-					helper.CmdShouldPass("odo component create nodejs nodejs --project " + project + " --context " + context)
-					//TODO: verify that config was properly created
-					helper.CmdShouldPass("odo push")
-					//TODO: verify resources on cluster
-				})
-			})
+		// we will be testing components that are created from the current directory
+		// switch to the clean context dir before each test
+		var _ = JustBeforeEach(func() {
+			originalDir = helper.Getwd()
+			helper.Chdir(context)
 		})
 
+		// go back to original directory after each test
+		var _ = JustAfterEach(func() {
+			helper.Chdir(originalDir)
+		})
+
+		var _ = Context("when project from KUBECONFIG is used", func() {
+			// Set active project for each test spec
+			var _ = JustBeforeEach(func() {
+				helper.OcSwitchProject(project)
+			})
+			// go back to original project after each test
+			var _ = JustAfterEach(func() {
+				helper.OcSwitchProject(originalProject)
+			})
+
+			It("create local nodejs component and push code", func() {
+				helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+				helper.CmdShouldPass("odo component create nodejs nodejs --context " + context)
+				//TODO: verify that config was properly created
+				helper.CmdShouldPass("odo push")
+				//TODO: verify resources on cluster
+			})
+
+		})
+
+		var _ = Context("when --project flag is used", func() {
+			It("create local nodejs component and push code", func() {
+				helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+				helper.CmdShouldPass("odo component create nodejs nodejs --project " + project + " --context " + context)
+				//TODO: verify that config was properly created
+				helper.CmdShouldPass("odo push")
+				//TODO: verify resources on cluster
+			})
+		})
 	})
 })


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
re-arranged the `Context` in the clean template test so please can refer it.

There should be two high level contexts
- when component is in the current directory
- when --context is used


## Was the change discussed in an issue?
No issue

## How to test changes?
<!-- Please describe the steps to test the PR -->
