### PR TITLE
Update OpenShift version because of a forgotten git rebase

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 
 *Prerequisites:*
 
-* OpenShift 3.9.0 and above is required.
+* OpenShift 3.10.0 and above is required.
 * We recommend using link:https://github.com/minishift/minishift[Minishift].
 
 *Procedure:*


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
It modifies the OpenShift version based on what minishift supports. This was already pushed in PR #1538 but PR #1566 got the old state back in due to a forgotten `git rebase` maybe?

## Was the change discussed in an issue?
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
