### PR TITLE
Fixes typo from 'wil' to 'will' in various files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 
 *Prerequisites:*
 
-* OpenShift 3.9.0 and above is required.
+* OpenShift 3.10.0 and above is required.
 * We recommend using link:https://github.com/minishift/minishift[Minishift].
 
 *Procedure:*

--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -291,7 +291,7 @@ If a component name is not provided, it’ll be auto-generated.
 By default, builder images will be used from the current namespace. You
 can explicitly supply a namespace by using: odo create
 namespace/name:version If version is not specified by default, latest
-wil be chosen as the version.
+will be chosen as the version.
 
 A full list of component types that can be deployed is available using:
 `odo catalog list'

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -55,7 +55,7 @@ var createLongDesc = ktemplates.LongDesc(`Create a configuration describing a co
 If a component name is not provided, it'll be auto-generated.
 
 By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version
-If version is not specified by default, latest wil be chosen as the version.
+If version is not specified by default, latest will be chosen as the version.
 
 A full list of component types that can be deployed is available using: 'odo catalog list'`)
 

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -19,7 +19,7 @@ var (
 	// VERSION  is version number that will be displayed when running ./odo version
 	VERSION = "v0.0.20"
 
-	// GITCOMMIT is hash of the commit that wil be displayed when running ./odo version
+	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"
 	// HEAD is default indicating that this was not set during build
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
It simply fixes the typo from `wil` to `will` in a few files in the repo. This PR has been rebased on #1590.
## Was the change discussed in an issue?

<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
