### PR TITLE
Create component even in new project

### DIFF
--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -650,4 +650,16 @@ func componentTests(componentCmdPrefix string) {
 
 	})
 
+	Context("Creating Component even in new project", func() {
+
+		It("should create component", func() {
+			runCmdShouldPass("mkdir -p cmp-git")
+			runCmdShouldPass(componentCmdPrefix + " create nodejs cmp-git --git https://github.com/openshift/nodejs-ex --project testproject  --context cmp-git/ --app " + appTestName)
+			runCmdShouldPass("odo push --context cmp-git/ -v4")
+			runCmdShouldPass("rm -rf cmp-git")
+
+		})
+
+	})
+
 }


### PR DESCRIPTION


## What is the purpose of this change? What does it change?

odo should create component even in new project, for example given below, `asdf` don't exist on cluster.

`odo push` will create project and then create component in it



## Was the change discussed in an issue?
fixes #1597
<!-- Please do Link issues here. -->

## How to test changes?

```
odo create nodejs --project asdf

odo push
```
