### PR TITLE
[Temporary fix] Remove connection check

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/url"
 	"github.com/openshift/odo/pkg/odo/cli/utils"
 	"github.com/openshift/odo/pkg/odo/cli/version"
-	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -86,7 +85,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	// will be global for your application.
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
-	rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
+	//rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -58,7 +58,7 @@ func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient
 		log.Errorf("client function only accepts one optional argument, was given: %v", shouldSkipConnectionCheck)
 		os.Exit(1)
 	}
-
+	skipConnectionCheck = true
 	client, err := occlient.New(skipConnectionCheck)
 	util.LogErrorAndExit(err, "")
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -46,18 +46,18 @@ func ClientWithConnectionCheck(command *cobra.Command, skipConnectionCheck bool)
 // We use varargs to denote the optional status of that boolean.
 func client(command *cobra.Command, shouldSkipConnectionCheck ...bool) *occlient.Client {
 	var skipConnectionCheck bool
-	switch len(shouldSkipConnectionCheck) {
-	case 0:
-		var err error
-		skipConnectionCheck, err = command.Flags().GetBool(SkipConnectionCheckFlagName)
-		util.LogErrorAndExit(err, "")
-	case 1:
-		skipConnectionCheck = shouldSkipConnectionCheck[0]
-	default:
-		// safeguard: fail if more than one optional bool is passed because it would be a programming error
-		log.Errorf("client function only accepts one optional argument, was given: %v", shouldSkipConnectionCheck)
-		os.Exit(1)
-	}
+	//switch len(shouldSkipConnectionCheck) {
+	//case 0:
+	//	var err error
+	//	skipConnectionCheck, err = command.Flags().GetBool(SkipConnectionCheckFlagName)
+	//	util.LogErrorAndExit(err, "")
+	//case 1:
+	//	skipConnectionCheck = shouldSkipConnectionCheck[0]
+	//default:
+	//	// safeguard: fail if more than one optional bool is passed because it would be a programming error
+	//	log.Errorf("client function only accepts one optional argument, was given: %v", shouldSkipConnectionCheck)
+	//	os.Exit(1)
+	//}
 	skipConnectionCheck = true
 	client, err := occlient.New(skipConnectionCheck)
 	util.LogErrorAndExit(err, "")

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -95,6 +95,7 @@ if [ -z $OC_LOGIN_SUCCESS ]; then
 fi
 
 oc whoami
+oc status
 oc new-project myproject
 sleep 4
 oc version

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+set -x
 # Setup to find nessasary data from cluster setup
 ## Constants
 HTPASSWD_FILE="./htpass"
@@ -92,6 +94,7 @@ if [ -z $OC_LOGIN_SUCCESS ]; then
     exit 1
 fi
 
+oc whoami
 oc new-project myproject
 sleep 4
 oc version


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

* remove connection check temporarily for all commands

## Was the change discussed in an issue?
fixes #1588

as @kadel mentioned [here](https://github.com/openshift/odo/issues/1588#issuecomment-482123857), connection check is removed for all commands

## How to test changes?

* run any command 