### PR TITLE
used default appName as 'app'

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -6,10 +6,7 @@ import (
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	"github.com/openshift/odo/pkg/component"
-	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/preference"
-	"github.com/openshift/odo/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,35 +18,6 @@ const (
 	appKind           = "app"
 	appList           = "List"
 )
-
-// GetDefaultAppName returns randomly generated application name with unique configurable prefix suffixed by a randomly generated string which can be used as a default name in case the user doesn't provide a name.
-func GetDefaultAppName() (string, error) {
-	var appName string
-
-	// Get the desired app name prefix from odo config
-	cfg, err := preference.New()
-	if err != nil {
-		return "", errors.Wrap(err, "unable to fetch config")
-	}
-
-	// If there's no prefix in config file or it is equal to $DIR, use safe default which is the name of current directory
-	if cfg.OdoSettings.NamePrefix == nil || *cfg.OdoSettings.NamePrefix == "" {
-		prefix, err := component.GetComponentDir("", config.NONE)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to generate random app name")
-		}
-		appName, err = util.GetRandomName(prefix, appPrefixMaxLen, []string{}, appNameMaxRetries)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to generate random app name")
-		}
-	} else {
-		appName, err = util.GetRandomName(*cfg.OdoSettings.NamePrefix, appPrefixMaxLen, []string{}, appNameMaxRetries)
-	}
-	if err != nil {
-		return "", errors.Wrap(err, "unable to generate random app name")
-	}
-	return util.GetDNS1123Name(appName), nil
-}
 
 // List all applications in current project
 func List(client *occlient.Client) ([]string, error) {

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,9 +1,7 @@
 package application
 
 import (
-	"os"
 	"reflect"
-	"regexp"
 	"testing"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -11,74 +9,11 @@ import (
 	"github.com/openshift/odo/pkg/component"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/preference"
-	"github.com/openshift/odo/pkg/testingutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
 )
-
-func TestGetDefaultAppName(t *testing.T) {
-	tests := []struct {
-		testName   string
-		wantRE     string
-		needPrefix bool
-		prefix     string
-	}{
-		{
-			testName:   "Case: App prefix not configured",
-			wantRE:     "app-*",
-			needPrefix: false,
-		},
-		{
-			testName:   "Case: App prefix set to testing",
-			wantRE:     "testing-*",
-			needPrefix: true,
-			prefix:     "testing",
-		},
-		{
-			testName:   "Case: App prefix set to empty string",
-			wantRE:     "application-*",
-			needPrefix: true,
-			prefix:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Log("Running test: ", tt.testName)
-		t.Run(tt.testName, func(t *testing.T) {
-
-			odoConfigFile, kubeConfigFile, err := testingutil.SetUp(
-				testingutil.ConfigDetails{
-					FileName:      "odo-test-config",
-					Config:        testingutil.FakeOdoConfig("odo-test-config", tt.needPrefix, tt.prefix),
-					ConfigPathEnv: "GLOBALODOCONFIG",
-				}, testingutil.ConfigDetails{
-					FileName:      "kube-test-config",
-					Config:        testingutil.FakeKubeClientConfig(),
-					ConfigPathEnv: "KUBECONFIG",
-				},
-			)
-			defer testingutil.CleanupEnv([]*os.File{odoConfigFile, kubeConfigFile}, t)
-			if err != nil {
-				t.Errorf("failed setting up the test env. Error: %v", err)
-			}
-
-			name, err := GetDefaultAppName()
-			if err != nil {
-				t.Errorf("failed to setup mock environment. Error: %v", err)
-			}
-
-			r, _ := regexp.Compile(tt.wantRE)
-			match := r.MatchString(name)
-			if !match {
-				fetchedConfig, _ := preference.New()
-				t.Errorf("randomly generated application name %s does not match regexp %s and config is %+v\nthe prefix is %s", name, tt.wantRE, fetchedConfig, *fetchedConfig.OdoSettings.NamePrefix)
-			}
-		})
-	}
-}
 
 func TestGetMachineReadableFormat(t *testing.T) {
 	type args struct {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
@@ -16,6 +15,9 @@ import (
 	"github.com/openshift/odo/pkg/project"
 	pkgUtil "github.com/openshift/odo/pkg/util"
 )
+
+// DefaultAppName is the default name of the application when an application name is not provided
+const DefaultAppName = "app"
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
 func NewContext(command *cobra.Command) *Context {
@@ -194,11 +196,7 @@ func resolveApp(command *cobra.Command, createAppIfNeeded bool, lci *config.Loca
 		app = lci.GetApplication()
 		if app == "" {
 			if createAppIfNeeded {
-				var err error
-				app, err = application.GetDefaultAppName()
-				if err != nil {
-					util.LogErrorAndExit(err, "failed to generate a random app name")
-				}
+				return DefaultAppName
 			}
 		}
 	}

--- a/tests/e2e/component.go
+++ b/tests/e2e/component.go
@@ -66,6 +66,10 @@ func componentTests(componentCmdPrefix string) {
 				appName := runCmdShouldPass("odo app list")
 				Expect(appName).ToNot(BeEmpty())
 
+				// checking if application name is set to "app"
+				applicationName := getConfigValue("Application")
+				Expect(applicationName).To(Equal("app"))
+
 				// clean up
 				runCmdShouldPass("odo component delete " + componentName + " -f")
 				runCmdShouldPass("odo app delete -f")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
To not autogenerate an app name everytime we are using `app` as the default app name from now on.

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1615
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create nodejs
odo config view # verify the Application name to be 'app'
```