### PR TITLE
fix 1503: odo project delete 2nd iteration

### DIFF
--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -61,6 +61,8 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 
 // Run runs the project delete command
 func (pdo *ProjectDeleteOptions) Run() (err error) {
+
+	pdo.Context.Client.Namespace = pdo.projectName
 	err = printDeleteProjectInfo(pdo.Context.Client, pdo.projectName)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

After the deletion of project it's not switching the active project,
this patch will modify the active project in runtime after confirming the existence of given project name.

## Was the change discussed in an issue?

#1503

## How to test changes?

Validate if the scenario mentioned in this issue description works properly
https://github.com/openshift/odo/issues/1503