### PR TITLE
increase ocUpdateTimeout to 5 minutes

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -83,7 +83,7 @@ type CreateArgs struct {
 }
 
 const (
-	ocUpdateTimeout    = 120 * time.Second
+	ocUpdateTimeout    = 5 * time.Minute
 	OpenShiftNameSpace = "openshift"
 
 	// The length of the string to be generated for names of resources


### PR DESCRIPTION
It used to be 2 minutes.

2 minutes is not enough for really slow `minishift`/`oc cluster up` cluster