### PR TITLE
Adds security context / SYS_ADMIN privileges to bootstrap container

### DIFF
--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -323,11 +323,15 @@ func generateBuildConfig(commonObjectMeta metav1.ObjectMeta, gitURL, gitRef, ima
 // dc is the deployment config to be updated
 // dcName is the name of the deployment config
 func addBootstrapVolumeCopyInitContainer(dc *appsv1.DeploymentConfig, dcName string) {
+	addSysAdminContext := corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}},
+	}
 	dc.Spec.Template.Spec.InitContainers = append(dc.Spec.Template.Spec.InitContainers,
 		corev1.Container{
 			Name: "copy-files-to-volume",
 			// Using custom image from bootstrapperImage variable for the initial initContainer
-			Image: dc.Spec.Template.Spec.Containers[0].Image,
+			Image:           dc.Spec.Template.Spec.Containers[0].Image,
+			SecurityContext: &addSysAdminContext,
 			Command: []string{
 				"sh",
 				"-c"},


### PR DESCRIPTION
There are multiple issues in getting volume support / PVC to work inside
of an OpenShift container, such as: https://bugzilla.redhat.com/show_bug.cgi?id=1622670

This PR adds SYS_ADMIN privileges to the boostrap volume copy container, allowing the
container to mount the /tmp folder correctly and thus copy over the files.

During the transition from OpenShift 3.11 to 4.0, SELinux settings (look) to have changed,
I have yet to confirm this however..

Closes https://github.com/openshift/odo/issues/1623