### PR TITLE
add json output for `project create`

### DIFF
--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
@@ -53,6 +54,22 @@ func (pco *ProjectCreateOptions) Validate() (err error) {
 
 // Run runs the project create command
 func (pco *ProjectCreateOptions) Run() (err error) {
+
+	if pco.OutputFlag == "json" {
+		err = project.Create(pco.Client, pco.projectName, false)
+		if err != nil {
+			return err
+		}
+		output := project.GetMachineReadableFormat(pco.projectName, false, nil)
+		printableOutput, err := json.Marshal(output)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(printableOutput))
+		return nil
+	}
+
 	if pco.wait {
 		s := log.Spinner("Waiting for project to come up")
 		err = project.Create(pco.Client, pco.projectName, true)
@@ -92,6 +109,7 @@ func NewCmdProjectCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
+	genericclioptions.AddOutputFlag(projectCreateCmd)
 	projectCreateCmd.Flags().BoolVarP(&o.wait, "wait", "w", false, "Wait until the project is ready")
 	return projectCreateCmd
 }

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -16,6 +16,15 @@ var _ = Describe("odojsonoutput", func() {
 		It("Pre-Test Creation: Creating project", func() {
 			odoCreateProject("json-test")
 		})
+		// odo project create newprojectjson -o json
+		It("should be able to create project and show output in json format", func() {
+			actual := runCmdShouldPass("odo project create newprojectjson -o json")
+			desired := `{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"newprojectjson","creationTimestamp":null},"spec":{"apps":null},"status":{"active":false}}`
+			areEqual, _ := compareJSON(desired, actual)
+			Expect(areEqual).To(BeTrue())
+
+		})
+
 		// odo app list -o json
 		It("should be able to return empty list", func() {
 			actual := runCmdShouldPass("odo app list -o json --project json-test")


### PR DESCRIPTION
add -o json flag for project create
which will print output in machine-readable format

## What is the purpose of this change? What does it change?
adds -o json flag for project  create cmd
## Was the change discussed in an issue?
fixes #???
https://github.com/openshift/odo/issues/1381

## How to test changes?
run `odo project create <project name> -o json` 
and validate the json formatted output
