### PR TITLE
Remove leftover logging

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -135,7 +134,6 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 	// --binary
 	case config.BINARY:
 		cPath, err := filepath.EvalSymlinks(co.componentBinary)
-		glog.V(0).Infof("%s", cPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Removes leftover logging in create.go that was intended for debugging
purposes.

Closes https://github.com/openshift/odo/issues/1653