### PR TITLE
Adds spinner to "Applying component settings" / ApplyConfig function

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -530,7 +530,9 @@ func ValidateComponentCreateRequest(client *occlient.Client, componentSettings c
 // Returns:
 //	err: Errors if any else nil
 func ApplyConfig(client *occlient.Client, componentConfig config.LocalConfigInfo, stdout io.Writer, cmpExist bool) (err error) {
-	log.Successf("Applying component settings to component: %v", componentConfig.GetName())
+	s := log.Spinnerf("Applying component settings to component: %v", componentConfig.GetName())
+	defer s.End(false)
+
 	// if component exist then only call the update function
 	if cmpExist {
 
@@ -548,8 +550,8 @@ func ApplyConfig(client *occlient.Client, componentConfig config.LocalConfigInfo
 	if err != nil {
 		return err
 	}
-	log.Successf("The component %s was updated successfully", componentConfig.GetName())
 
+	s.End(true)
 	return
 }
 


### PR DESCRIPTION
Adds a spinner to the ApplyConfig function due to how long it takes to
apply a new deployment config to an existing component.

Example:

```sh
▶ make bin && ./odo push --context ~/nodejs-ex
go build -ldflags="-w -X github.com/openshift/odo/pkg/odo/cli/version.GITCOMMIT=3e7ee8a1" cmd/odo/odo.go
 ✓  Checking component
 ✓  Checking component version
 ◐  Applying component settings to component: nodejs-ex-nodejs-ujjl
 ```

Closes issue https://github.com/openshift/odo/issues/1570