### PR TITLE
Add show parameter to `odo watch`

### DIFF
--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -295,11 +295,11 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				}
 				if fileInfo.IsDir() {
 					glog.V(4).Infof("Copying files %s to pod", changedFiles)
-					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, parameters.Path, out, changedFiles, deletedPaths, false, parameters.FileIgnores, false)
+					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, parameters.Path, out, changedFiles, deletedPaths, false, parameters.FileIgnores, parameters.Show)
 				} else {
 					pathDir := filepath.Dir(parameters.Path)
 					glog.V(4).Infof("Copying file %s to pod", parameters.Path)
-					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, pathDir, out, []string{parameters.Path}, deletedPaths, false, parameters.FileIgnores, false)
+					err = parameters.WatchHandler(client, parameters.ComponentName, parameters.ApplicationName, pathDir, out, []string{parameters.Path}, deletedPaths, false, parameters.FileIgnores, parameters.Show)
 				}
 				if err != nil {
 					// Intentionally not exiting on error here.

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -36,6 +36,7 @@ var watchExample = ktemplates.Examples(`  # Watch for changes in directory for c
 type WatchOptions struct {
 	ignores []string
 	delay   int
+	show    bool
 
 	sourceType       config.SrcType
 	sourcePath       string
@@ -123,6 +124,7 @@ func (wo *WatchOptions) Run() (err error) {
 			StartChan:       nil,
 			ExtChan:         make(chan bool),
 			WatchHandler:    component.PushLocal,
+			Show:            wo.show,
 		},
 	)
 	if err != nil {
@@ -146,6 +148,7 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 		},
 	}
 
+	watchCmd.Flags().BoolVar(&wo.show, "show-log", false, "If enabled, logs will be shown when built")
 	watchCmd.Flags().StringSliceVar(&wo.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 	watchCmd.Flags().IntVar(&wo.delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 


### PR DESCRIPTION
This PR adds the show parameter to `odo watch` in order to watch your
build:

```sh
github.com/openshift/odo  add-show-log-watch ✗                                                                                                                                                                                                                                                                                                                   14h10m ⚑  ⍉
▶ make bin && ./odo watch --context ~/nodejs-ex --show-log true
go build -ldflags="-w -X github.com/openshift/odo/pkg/odo/cli/version.GITCOMMIT=3e7ee8a1" cmd/odo/odo.go
Waiting for something to change in /home/wikus/nodejs-ex
File /home/wikus/nodejs-ex/hi changed
Pushing files...
 ✓  Waiting for component to start
 ✓  Copying files to component
 •  Building component  ...
+ set -eo pipefail
+ '[' '!' -z /opt/app-root/src ']'
+ '[' /tmp '!=' /opt/app-root/src ']'
```

Closes https://github.com/openshift/odo/issues/1589