### PR TITLE
Fix typo with wildfly in create command and docs

### DIFF
--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -272,7 +272,7 @@ ____________________
   odo create openshift/nodejs:6 --local /nodejs-ex
 
   # Create new Wildfly component with binary named sample.war in './downloads' directory
-  odo create wildfly wildly --binary ./downloads/sample.war
+  odo create wildfly wildfly --binary ./downloads/sample.war
 
   # Create new Node.js component with the source in current directory and ports 8080-tcp,8100-tcp and 9100-udp exposed
   odo create nodejs --port 8080,8100/tcp,9100/udp

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -78,7 +78,7 @@ var createExample = ktemplates.Examples(`  # Create new Node.js component with t
 %[1]s openshift/nodejs:6 --context /nodejs-ex
 
 # Create new Wildfly component with binary named sample.war in './downloads' directory
-%[1]s wildfly wildly --binary ./downloads/sample.war
+%[1]s wildfly wildfly --binary ./downloads/sample.war
 
 # Create new Node.js component with source from remote git repository
 %[1]s nodejs --git https://github.com/openshift/nodejs-ex.git


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Fixes a typo assuming we are not asking user to create a component named `wildly`
## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
