### PR TITLE
Adding now flag to component create command and refactoring for common push

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -1,0 +1,167 @@
+package component
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/fatih/color"
+	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
+	"github.com/openshift/odo/pkg/util"
+	"github.com/pkg/errors"
+)
+
+// CommonPushOptions has data needed for all pushes
+type commonPushOptions struct {
+	ignores []string
+	show    bool
+
+	sourceType       config.SrcType
+	sourcePath       string
+	componentContext string
+	client           *occlient.Client
+	localConfig      *config.LocalConfigInfo
+
+	pushConfig bool
+	pushSource bool
+
+	*genericclioptions.Context
+}
+
+// NewCommonPushOptions instantiates a commonPushOptions object
+func NewCommonPushOptions() *commonPushOptions {
+	return &commonPushOptions{
+		show: false,
+	}
+}
+
+func (cpo *commonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) error {
+	if !cpo.pushConfig {
+		// Not the case of component creation or updation(with new config)
+		// So nothing to do here and hence return from here
+		return nil
+	}
+
+	cmpName := cpo.localConfig.GetName()
+	appName := cpo.localConfig.GetApplication()
+	cmpType := cpo.localConfig.GetType()
+
+	isCmpExists, err := component.Exists(cpo.Context.Client, cmpName, appName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if component %s exists or not", cmpName)
+	}
+
+	if !isCmpExists {
+		log.Successf("Creating %s component with name %s", cmpType, cmpName)
+		// Classic case of component creation
+		if err = component.CreateComponent(cpo.Context.Client, *cpo.localConfig, cpo.componentContext, stdout); err != nil {
+			log.Errorf(
+				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
+				cmpName,
+				err,
+			)
+			os.Exit(1)
+		}
+		log.Successf("Successfully created component %s", cmpName)
+	}
+
+	// Apply config
+	err = component.ApplyConfig(cpo.Context.Client, *cpo.localConfig, stdout, isCmpExists)
+	if err != nil {
+		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
+	}
+	log.Successf("Successfully updated component with name: %v", cmpName)
+
+	return nil
+}
+
+// Push pushes changes as per set options
+func (cpo *commonPushOptions) Push() (err error) {
+	stdout := color.Output
+	cmpName := cpo.localConfig.GetName()
+	appName := cpo.localConfig.GetApplication()
+
+	err = cpo.createCmpIfNotExistsAndApplyCmpConfig(stdout)
+	if err != nil {
+		return
+	}
+
+	if !cpo.pushSource {
+		// If source is not requested for update, return
+		return nil
+	}
+
+	log.Successf("Pushing changes to component: %v of type %s", cmpName, cpo.sourceType)
+
+	// Get SourceLocation here...
+	cpo.sourcePath, err = cpo.localConfig.GetOSSourcePath()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve OS source path to source location")
+	}
+
+	switch cpo.sourceType {
+	case config.LOCAL:
+		glog.V(4).Infof("Copying directory %s to pod", cpo.sourcePath)
+		err = component.PushLocal(
+			cpo.Context.Client,
+			cmpName,
+			appName,
+			cpo.sourcePath,
+			os.Stdout,
+			[]string{},
+			[]string{},
+			true,
+			util.GetAbsGlobExps(cpo.sourcePath, cpo.ignores),
+			cpo.show,
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
+		}
+
+	case config.BINARY:
+
+		// We will pass in the directory, NOT filepath since this is a binary..
+		binaryDirectory := filepath.Dir(cpo.sourcePath)
+
+		glog.V(4).Infof("Copying binary file %s to pod", cpo.sourcePath)
+		err = component.PushLocal(
+			cpo.Context.Client,
+			cmpName,
+			appName,
+			binaryDirectory,
+			os.Stdout,
+			[]string{cpo.sourcePath},
+			[]string{},
+			true,
+			util.GetAbsGlobExps(cpo.sourcePath, cpo.ignores),
+			cpo.show,
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
+		}
+
+	case config.GIT:
+		err := component.Build(
+			cpo.Context.Client,
+			cmpName,
+			appName,
+			true,
+			stdout,
+			cpo.show,
+		)
+		return errors.Wrapf(err, fmt.Sprintf("failed to push component: %v", cmpName))
+	}
+
+	log.Successf("Changes successfully pushed to component: %v", cmpName)
+
+	return
+}

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -28,7 +28,7 @@ type CommonPushOptions struct {
 	sourcePath       string
 	componentContext string
 	client           *occlient.Client
-	localConfigInfo      *config.LocalConfigInfo
+	localConfigInfo  *config.LocalConfigInfo
 
 	pushConfig bool
 	pushSource bool

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -28,7 +28,7 @@ type CommonPushOptions struct {
 	sourcePath       string
 	componentContext string
 	client           *occlient.Client
-	localConfig      *config.LocalConfigInfo
+	localConfigInfo      *config.LocalConfigInfo
 
 	pushConfig bool
 	pushSource bool
@@ -59,8 +59,8 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		return nil
 	}
 
-	cmpName := cpo.localConfig.GetName()
-	appName := cpo.localConfig.GetApplication()
+	cmpName := cpo.localConfigInfo.GetName()
+	appName := cpo.localConfigInfo.GetApplication()
 
 	// First off, we check to see if the component exists. This is ran each time we do `odo push`
 	s := log.Spinner("Checking component")
@@ -81,7 +81,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		defer s.End(false)
 
 		// Classic case of component creation
-		if err = component.CreateComponent(cpo.Context.Client, *cpo.localConfig, cpo.componentContext, stdout); err != nil {
+		if err = component.CreateComponent(cpo.Context.Client, *cpo.localConfigInfo, cpo.componentContext, stdout); err != nil {
 			log.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,
@@ -94,7 +94,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 	}
 
 	// Apply config
-	err = component.ApplyConfig(cpo.Context.Client, *cpo.localConfig, stdout, isCmpExists)
+	err = component.ApplyConfig(cpo.Context.Client, *cpo.localConfigInfo, stdout, isCmpExists)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
 	}
@@ -129,12 +129,12 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 
 // SetSourceInfo sets up source information
 func (cpo *CommonPushOptions) SetSourceInfo() (err error) {
-	cpo.sourceType = cpo.localConfig.GetSourceType()
+	cpo.sourceType = cpo.localConfigInfo.GetSourceType()
 
-	glog.V(4).Infof("SourceLocation: %s", cpo.localConfig.GetSourceLocation())
+	glog.V(4).Infof("SourceLocation: %s", cpo.localConfigInfo.GetSourceLocation())
 
 	// Get SourceLocation here...
-	cpo.sourcePath, err = cpo.localConfig.GetOSSourcePath()
+	cpo.sourcePath, err = cpo.localConfigInfo.GetOSSourcePath()
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve absolute path to source location")
 	}
@@ -147,8 +147,8 @@ func (cpo *CommonPushOptions) SetSourceInfo() (err error) {
 func (cpo *CommonPushOptions) Push() (err error) {
 	stdout := color.Output
 
-	cmpName := cpo.localConfig.GetName()
-	appName := cpo.localConfig.GetApplication()
+	cmpName := cpo.localConfigInfo.GetName()
+	appName := cpo.localConfigInfo.GetApplication()
 
 	err = cpo.createCmpIfNotExistsAndApplyCmpConfig(stdout)
 	if err != nil {
@@ -163,7 +163,7 @@ func (cpo *CommonPushOptions) Push() (err error) {
 	log.Infof("\nPushing to component %s of type %s", cmpName, cpo.sourceType)
 
 	// Get SourceLocation here...
-	cpo.sourcePath, err = cpo.localConfig.GetOSSourcePath()
+	cpo.sourcePath, err = cpo.localConfigInfo.GetOSSourcePath()
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve OS source path to source location")
 	}

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -127,6 +127,22 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 	return
 }
 
+// SetSourceInfo sets up source information
+func (cpo *CommonPushOptions) SetSourceInfo() (err error) {
+	cpo.sourceType = cpo.localConfig.GetSourceType()
+
+	glog.V(4).Infof("SourceLocation: %s", cpo.localConfig.GetSourceLocation())
+
+	// Get SourceLocation here...
+	cpo.sourcePath, err = cpo.localConfig.GetOSSourcePath()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve absolute path to source location")
+	}
+
+	glog.V(4).Infof("Source Path: %s", cpo.sourcePath)
+	return
+}
+
 // Push pushes changes as per set options
 func (cpo *CommonPushOptions) Push() (err error) {
 	stdout := color.Output

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -102,7 +102,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 	return nil
 }
 
-// CommonResolve completes the push options as needed
+// ResolveProject completes the push options as needed
 func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 
 	// check if project exist

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -448,7 +448,7 @@ func (co *CreateOptions) Run() (err error) {
 			return errors.Wrapf(err, "failed to push the changes")
 		}
 	} else {
-		log.Infof("Please use `odo push` command to create the component with source deployed")
+		log.Infof("Please use `odo push` command to create the component with source deployed\n")
 	}
 	return
 }

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -434,6 +434,15 @@ func (co *CreateOptions) Run() (err error) {
 		return errors.Wrapf(err, "failed to persist the component settings to config file")
 	}
 	if co.now {
+		co.Context, co.localConfig, err = genericclioptions.UpdatedContext(co.Context)
+
+		if err != nil {
+			return errors.Wrap(err, "unable to retrieve updated local config")
+		}
+		err = co.SetSourceInfo()
+		if err != nil {
+			return errors.Wrap(err, "unable to set source information")
+		}
 		err = co.Push()
 		if err != nil {
 			return errors.Wrapf(err, "failed to push the changes")

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -262,18 +262,18 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.interactive = true
 	}
 
-	co.localConfig, err = config.NewLocalConfigInfo(co.componentContext)
+	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}
 
 	// check to see if config file exists or not, if it does that
 	// means we shouldn't allow the user to override the current component
-	if co.localConfig.ConfigFileExists() {
+	if co.localConfigInfo.ConfigFileExists() {
 		return errors.New("this directory already contains a component")
 	}
 
-	co.componentSettings = co.localConfig.GetComponentSettings()
+	co.componentSettings = co.localConfigInfo.GetComponentSettings()
 
 	co.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 
@@ -429,12 +429,12 @@ func (co *CreateOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run() (err error) {
-	err = co.localConfig.SetComponentSettings(co.componentSettings)
+	err = co.localConfigInfo.SetComponentSettings(co.componentSettings)
 	if err != nil {
 		return errors.Wrapf(err, "failed to persist the component settings to config file")
 	}
 	if co.now {
-		co.Context, co.localConfig, err = genericclioptions.UpdatedContext(co.Context)
+		co.Context, co.localConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
 
 		if err != nil {
 			return errors.Wrap(err, "unable to retrieve updated local config")
@@ -455,9 +455,9 @@ func (co *CreateOptions) Run() (err error) {
 
 func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) error {
 
-	cmpName := co.localConfig.GetName()
-	appName := co.localConfig.GetApplication()
-	cmpType := co.localConfig.GetType()
+	cmpName := co.localConfigInfo.GetName()
+	appName := co.localConfigInfo.GetApplication()
+	cmpType := co.localConfigInfo.GetType()
 
 	isCmpExists, err := component.Exists(co.Context.Client, cmpName, appName)
 	if err != nil {
@@ -467,7 +467,7 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 	if !isCmpExists {
 		log.Successf("Creating %s component with name %s", cmpType, cmpName)
 		// Classic case of component creation
-		if err = component.CreateComponent(co.Context.Client, *co.localConfig, co.componentContext, stdout); err != nil {
+		if err = component.CreateComponent(co.Context.Client, *co.localConfigInfo, co.componentContext, stdout); err != nil {
 			log.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,
@@ -479,7 +479,7 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 	}
 
 	// Apply config
-	err = component.ApplyConfig(co.Context.Client, *co.localConfig, stdout, isCmpExists)
+	err = component.ApplyConfig(co.Context.Client, *co.localConfigInfo, stdout, isCmpExists)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -50,7 +50,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	}
 
 	// Set the necessary values within WatchOptions
-	po.localConfig = conf
+	po.localConfigInfo = conf
 	err = po.SetSourceInfo()
 	if err != nil {
 		return errors.Wrap(err, "unable to set source information")
@@ -63,7 +63,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 	// Set the correct context
 	po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-	prjName := po.localConfig.GetProject()
+	prjName := po.localConfigInfo.GetProject()
 	po.ResolveSrcAndConfigFlags()
 	err = po.ResolveProject(prjName)
 	if err != nil {
@@ -80,17 +80,17 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Validating component")
 	defer s.End(false)
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfig.GetComponentSettings(), false); err != nil {
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), false); err != nil {
 		return err
 	}
 
-	isCmpExists, err := component.Exists(po.Context.Client, po.localConfig.GetName(), po.localConfig.GetApplication())
+	isCmpExists, err := component.Exists(po.Context.Client, po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
 	if err != nil {
 		return err
 	}
 
 	if !isCmpExists && po.pushSource && !po.pushConfig {
-		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfig.GetName())
+		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfigInfo.GetName())
 	}
 
 	s.End(true)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -3,13 +3,13 @@ package component
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -52,18 +51,10 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 	// Set the necessary values within WatchOptions
 	po.localConfig = conf
-	po.sourceType = conf.LocalConfig.GetSourceType()
-
-	glog.V(4).Infof("SourceLocation: %s", po.localConfig.GetSourceLocation())
-
-	// Get SourceLocation here...
-	po.sourcePath, err = conf.GetOSSourcePath()
+	err = po.SetSourceInfo()
 	if err != nil {
-		return errors.Wrap(err, "unable to retrieve absolute path to source location")
+		return errors.Wrap(err, "unable to set source information")
 	}
-
-	glog.V(4).Infof("Source Path: %s", po.sourcePath)
-
 	// Apply ignore information
 	err = genericclioptions.ApplyIgnore(&po.ignores, po.sourcePath)
 	if err != nil {

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -19,7 +19,7 @@ func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
 
 // AddNowFlag adds `now` flag to given cobra command
 func AddNowFlag(cmd *cobra.Command, setValueTo *bool) {
-	helpMessage := "Push changes to cluster right now"
+	helpMessage := "Push changes to the cluster immediately"
 	if setValueTo != nil {
 		cmd.Flags().BoolVar(setValueTo, "now", false, helpMessage)
 	} else {

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -9,9 +9,20 @@ func AddOutputFlag(cmd *cobra.Command) {
 
 // AddContextFlag adds `context` flag to given cobra command
 func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
+	helpMessage := "Use given context directory as a source for component settings"
 	if setValueTo != nil {
-		cmd.Flags().StringVar(setValueTo, "context", "", "Use given context directory as a source for component settings")
+		cmd.Flags().StringVar(setValueTo, ContextFlagName, "", helpMessage)
 	} else {
-		cmd.Flags().String("context", "", "Use given context directory as a source for component settings")
+		cmd.Flags().String(ContextFlagName, "", helpMessage)
+	}
+}
+
+// AddNowFlag adds `now` flag to given cobra command
+func AddNowFlag(cmd *cobra.Command, setValueTo *bool) {
+	helpMessage := "Push changes to cluster right now"
+	if setValueTo != nil {
+		cmd.Flags().BoolVar(setValueTo, "now", false, helpMessage)
+	} else {
+		cmd.Flags().Bool("now", false, helpMessage)
 	}
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -235,6 +235,12 @@ func resolveComponent(command *cobra.Command, lci *config.LocalConfigInfo, conte
 	return cmp
 }
 
+// Update returns a new context updated from config file
+func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error) {
+	lci, err := getValidConfig(context.command)
+	return newContext(context.command, true), lci, err
+}
+
 // newContext creates a new context based on the command flags, creating missing app when requested
 func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 	client := client(command)
@@ -268,6 +274,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 		Project:     ns,
 		Application: app,
 		OutputFlag:  outputFlag,
+		command:     command,
 	}
 
 	// create a context from the internal representation
@@ -300,6 +307,7 @@ type Context struct {
 // This ensures that Context objects are always created properly via NewContext factory functions.
 type internalCxt struct {
 	Client      *occlient.Client
+	command     *cobra.Command
 	Project     string
 	Application string
 	cmp         string

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -235,7 +235,7 @@ func resolveComponent(command *cobra.Command, lci *config.LocalConfigInfo, conte
 	return cmp
 }
 
-// Update returns a new context updated from config file
+// UpdatedContext returns a new context updated from config file
 func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error) {
 	lci, err := getValidConfig(context.command)
 	return newContext(context.command, true), lci, err

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -214,7 +214,7 @@ func componentTests(args ...string) {
 			})
 		})
 
-		Context("Flag --context is used", func() {
+		Context("when --context is used", func() {
 			// don't need to switch to any dir here, as this test should use --context flag
 			It("create local nodejs component and push source and code separately", func() {
 				appName := "nodejs-push-context-test"
@@ -406,7 +406,6 @@ func componentTests(args ...string) {
 	*/
 
 	Context("odo component delete, list and describe", func() {
-
 		appName := "app"
 		cmpName := "nodejs"
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -169,51 +169,6 @@ func componentTests(args ...string) {
 
 		})
 
-		Context("Test odo push with --now flag during creation", func() {
-			var originalDir string
-			BeforeEach(func() {
-				context = helper.CreateNewContext()
-			})
-
-			AfterEach(func() {
-				helper.DeleteProject(project)
-				helper.DeleteDir(context)
-			})
-
-			JustBeforeEach(func() {
-				project = helper.CreateRandProject()
-				originalDir = helper.Getwd()
-				helper.Chdir(context)
-			})
-
-			JustAfterEach(func() {
-				helper.Chdir(originalDir)
-			})
-
-			It("should successfully create config and push code in one create command with --now", func() {
-				appName := "nodejs-create-now-test"
-				cmpName := "nodejs-push-atonce"
-				helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)
-
-				oc.VerifyCmpExists(cmpName, appName, project)
-				remoteCmdExecPass := oc.CheckCmdOpInRemoteCmpPod(
-					cmpName,
-					appName,
-					project,
-					[]string{"ls", "-la", "/tmp/src/package.json"},
-					func(cmdOp string, err error) bool {
-						if err != nil {
-							return false
-						}
-						return true
-					},
-				)
-				Expect(remoteCmdExecPass).To(Equal(true))
-			})
-		})
-
 		Context("when --context is used", func() {
 			// don't need to switch to any dir here, as this test should use --context flag
 			It("create local nodejs component and push source and code separately", func() {
@@ -293,6 +248,51 @@ func componentTests(args ...string) {
 			oc.SwitchProject(project)
 			projectList := helper.CmdShouldPass("odo", "project", "list")
 			Expect(projectList).To(ContainSubstring(project))
+		})
+	})
+
+	Context("Test odo push with --now flag during creation", func() {
+		var originalDir string
+		BeforeEach(func() {
+			context = helper.CreateNewContext()
+		})
+
+		AfterEach(func() {
+			helper.DeleteProject(project)
+			helper.DeleteDir(context)
+		})
+
+		JustBeforeEach(func() {
+			project = helper.CreateRandProject()
+			originalDir = helper.Getwd()
+			helper.Chdir(context)
+		})
+
+		JustAfterEach(func() {
+			helper.Chdir(originalDir)
+		})
+
+		It("should successfully create config and push code in one create command with --now", func() {
+			appName := "nodejs-create-now-test"
+			cmpName := "nodejs-push-atonce"
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)
+
+			oc.VerifyCmpExists(cmpName, appName, project)
+			remoteCmdExecPass := oc.CheckCmdOpInRemoteCmpPod(
+				cmpName,
+				appName,
+				project,
+				[]string{"ls", "-la", "/tmp/src/package.json"},
+				func(cmdOp string, err error) bool {
+					if err != nil {
+						return false
+					}
+					return true
+				},
+			)
+			Expect(remoteCmdExecPass).To(Equal(true))
 		})
 	})
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -191,8 +191,8 @@ func componentTests(args ...string) {
 			})
 
 			It("should successfully create config and push code in one create command with --now", func() {
-				appName := "nodejs-create-push-test-now"
-				cmpName := "nodejs-create-push-atonce-now"
+				appName := "nodejs-create-now-test"
+				cmpName := "nodejs-push-atonce"
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
 				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -166,6 +166,52 @@ func componentTests(args ...string) {
 				)
 				Expect(remoteCmdExecPass).To(Equal(true))
 			})
+
+		})
+
+		Context("Test odo push with --now flag during creation", func() {
+			var originalDir string
+			BeforeEach(func() {
+				context = helper.CreateNewContext()
+			})
+
+			AfterEach(func() {
+				helper.DeleteProject(project)
+				helper.DeleteDir(context)
+			})
+
+			JustBeforeEach(func() {
+				project = helper.CreateRandProject()
+				originalDir = helper.Getwd()
+				helper.Chdir(context)
+			})
+
+			JustAfterEach(func() {
+				helper.Chdir(originalDir)
+			})
+
+			It("should successfully create config and push code in one create command with --now", func() {
+				appName := "nodejs-create-push-test-now"
+				cmpName := "nodejs-create-push-atonce-now"
+				helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)
+
+				oc.VerifyCmpExists(cmpName, appName, project)
+				remoteCmdExecPass := oc.CheckCmdOpInRemoteCmpPod(
+					cmpName,
+					appName,
+					project,
+					[]string{"ls", "-la", "/tmp/src/package.json"},
+					func(cmdOp string, err error) bool {
+						if err != nil {
+							return false
+						}
+						return true
+					},
+				)
+				Expect(remoteCmdExecPass).To(Equal(true))
+			})
 		})
 
 		Context("Flag --context is used", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Adding `--now` flag with `odo create` and `odo component create`
Refactored ush logic into CommonPushOptions to allow reuse as needed and reused
in `create`

## Was the change discussed in an issue?
 #1595 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Now flag now works on component create

```
$ ls
helm  openshift  package.json  README.md  server.js  tests  views

# Without now flag
$ odo create nodejs
 ✓  Checking component
 ✓  Checking component version
Please use `odo push` command to create the component with source deployed

$  odo push
 ✓  Checking component
 ✓  Checking component version
 ✓  Creating nodejs component with name nodejs-dyns
 ✓  Initializing 'nodejs-dyns' component
 ✓  Creating component nodejs-dyns
 ✓  Successfully created component nodejs-dyns
 ✓  Applying component settings to component: nodejs-dyns
 ✓  Successfully updated component with name: nodejs-dyns
 ✓  Pushing changes to component: nodejs-dyns of type local
 ✓  Waiting for component to start
 ✓  Copying files to component
 ✓  Building component
 ✓  Changes successfully pushed to component: nodejs-dyns

# cleanup
$ odo delete nodejs-dyns -f && rm -rf .odo

# With --now flag
$  odo create nodejs --project blah --now
 ✓  Creating project blah
 ✓  Successfully created project blah
 ✓  Checking component
 ✓  Checking component version
 ✓  Creating nodejs component with name nodejs-aqzp
 ✓  Initializing 'nodejs-aqzp' component
 ✓  Creating component nodejs-aqzp
 ✓  Successfully created component nodejs-aqzp
 ✓  Applying component settings to component: nodejs-aqzp
 ✓  Successfully updated component with name: nodejs-aqzp
 ✓  Pushing changes to component: nodejs-aqzp of type local
 ✓  Waiting for component to start
 ✓  Copying files to component
 ✓  Building component
 ✓  Changes successfully pushed to component: nodejs-aqzp

$ oc projects     
You have access to the following projects and can switch between them with 'oc project <projectname>':

    blah
  * myproject - My Project

$  oc get pods
No resources found.

$ oc project blah
Now using project "blah" on server

$  oc get pods
NAME                      READY     STATUS    RESTARTS   AGE
nodejs-aqzp-app-1-nfzn6   1/1       Running   0          2m


```