### PR TITLE
Adds capitalization to all flags

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/version"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -60,7 +61,7 @@ Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") 
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
 Flags:
-{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+{{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace }}{{end}}{{ if .HasAvailableInheritedFlags}}
 
 Global Flags:
 {{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
@@ -95,6 +96,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	verbosity.Usage += ". Level varies from 0 to 9 (default 0)."
 
 	rootCmd.SetUsageTemplate(rootUsageTemplate)
+	cobra.AddTemplateFunc("CapitalizeFlagDescriptions", odoutil.CapitalizeFlagDescriptions)
 
 	rootCmd.AddCommand(
 		application.NewCmdApplication(application.RecommendedCommandName, util.GetFullName(fullName, application.RecommendedCommandName)),
@@ -122,7 +124,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 		preference.NewCmdPreference(preference.RecommendedCommandName, util.GetFullName(fullName, preference.RecommendedCommandName)),
 	)
 
-	utils.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
+	odoutil.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
 
 	return rootCmd
 }

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/auth"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -27,12 +27,3 @@ func NewCmdUtils(name, fullName string) *cobra.Command {
 	utilsCmd.AddCommand(terminalCmd)
 	return utilsCmd
 }
-
-// VisitCommands visits each command within Cobra.
-// Adapted from: https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cobrautil/misc.go#L23
-func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
-	f(cmd)
-	for _, child := range cmd.Commands() {
-		VisitCommands(child, f)
-	}
-}

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/component"
@@ -12,6 +13,8 @@ import (
 	storagePkg "github.com/openshift/odo/pkg/storage"
 	urlPkg "github.com/openshift/odo/pkg/url"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // LogErrorAndExit prints the cause of the given error and exits the code with an
@@ -40,31 +43,6 @@ func CheckOutputFlag(outputFlag string) error {
 	}
 
 }
-
-var CmdUsageTemplate = `Usage:{{if .Runnable}}
-  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
-
-Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
-
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`
 
 // PrintComponentInfo prints Component Information like path, URL & storage
 func PrintComponentInfo(client *occlient.Client, currentComponentName string, componentDesc component.Component, applicationName string) {
@@ -122,3 +100,48 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 func GetFullName(parentName, name string) string {
 	return parentName + " " + name
 }
+
+// VisitCommands visits each command within Cobra.
+// Adapted from: https://github.com/cppforlife/knctl/blob/612840d3c9729b1c57b20ca0450acab0d6eceeeb/pkg/knctl/cobrautil/misc.go#L23
+func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
+	f(cmd)
+	for _, child := range cmd.Commands() {
+		VisitCommands(child, f)
+	}
+}
+
+// CapitalizeFlagDescriptions adds capitalizations
+func CapitalizeFlagDescriptions(f *pflag.FlagSet) string {
+	f.VisitAll(func(f *pflag.Flag) {
+		cap := []rune(f.Usage)
+		cap[0] = unicode.ToUpper(cap[0])
+		f.Usage = string(cap)
+	})
+	return f.FlagUsages()
+}
+
+// CmdUsageTemplate is the main template used for all command line usage
+var CmdUsageTemplate = `Usage:{{if .Runnable}}
+  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Flags:
+{{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{CapitalizeFlagDescriptions .InheritedFlags | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`


### PR DESCRIPTION
This PR:
  - Adds capitalization to all flags / global flags
  - Moves some of the functions around from utils to cmdutils into
  the appropriate area

Example of the change:
```sh
Flags:
      --alsologtostderr                  Log to standard error as well as files
      --complete                         Install completion for odo command
      --log_backtrace_at traceLocation   When logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      Log to standard error instead of files (default false)
      --skip-connection-check            Skip cluster check
      --stderrthreshold severity         Logs at or above this threshold go to stderr (default 2)
      --uncomplete                       Uninstall completion for odo command
  -v, --v Level                          Log level for V logs. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec               Comma-separated list of pattern=N settings for file-filtered logging
  -y, --y                                Don't prompt user for typing 'yes' when installing completion
```

vs

```sh
Flags:
      --alsologtostderr                  log to standard error as well as files
      --complete                         Install completion for odo command
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default false)
      --skip-connection-check            Skip cluster check
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
      --uncomplete                       Uninstall completion for odo command
  -v, --v Level                          log level for V logs. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
  -y, --y                                Don't prompt user for typing 'yes' when installing completion
```