### PR TITLE
Removes unnecessary logging flags

### DIFF
--- a/docs/logging.adoc
+++ b/docs/logging.adoc
@@ -36,3 +36,15 @@ Warning messages can be logged as under:
 ----
 $ glog.Warningf(msg, args...)
 ----
+
+In addition to the above logging, the following hidden flags are available for debugging:
+
+----
+      --alsologtostderr                  log to standard error as well as files
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default false)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs. Level varies from 0 to 9 (default 0).
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+----

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -87,8 +87,16 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
 
 	rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
+
+	// Here we add the necessary "logging" flags.. However, we choose to hide some of these from the user
+	// as they are not necessarily needed and more for advanced debugging
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.Set("logtostderr", "true")
+	pflag.CommandLine.MarkHidden("alsologtostderr")
+	pflag.CommandLine.MarkHidden("log_backtrace_at")
+	pflag.CommandLine.MarkHidden("log_dir")
+	pflag.CommandLine.MarkHidden("logtostderr")
+	pflag.CommandLine.MarkHidden("stderrthreshold")
 
 	// Override the verbosity flag description
 	verbosity := pflag.Lookup("v")


### PR DESCRIPTION
This PR removes unnecessary logging flags that were added as part of
integrating "glog" into odo.

Instead of the following:

```sh
Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default false)
      --skip-connection-check            Skip cluster check
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

Only these flags are now available:

```sh
Global Flags:
      --skip-connection-check   Skip cluster check
  -v, --v Level                 Log level for V logs. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec      Comma-separated list of pattern=N settings for file-filtered logging
```

Thus making `odo --help` / `odo help` a lot cleaner.