### PR TITLE
Change UI Language for Component Prompt

### DIFF
--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -130,7 +130,7 @@ func createComponentNameValidator(context *genericclioptions.Context) survey.Val
 func EnterComponentName(defaultName string, context *genericclioptions.Context) string {
 	var path string
 	prompt := &survey.Input{
-		Message: "How do you wish to name the new component",
+		Message: "What do you wish to name the new component",
 		Default: defaultName,
 	}
 	err := survey.AskOne(prompt, &path, createComponentNameValidator(context))

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -20,7 +20,7 @@ import (
 func SelectComponentType(options []catalog.CatalogImage) string {
 	var componentType string
 	prompt := &survey.Select{
-		Message: "Which component type would wish to create",
+		Message: "Which component type do you wish to create",
 		Options: getComponentTypeNameCandidates(options),
 	}
 	err := survey.AskOne(prompt, &componentType, survey.Required)

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -41,7 +41,7 @@ func getComponentTypeNameCandidates(options []catalog.CatalogImage) []string {
 func SelectImageTag(options []catalog.CatalogImage, selectedComponentType string) string {
 	var tag string
 	prompt := &survey.Select{
-		Message: fmt.Sprintf("Which version of '%s' component type would you wish to create", selectedComponentType),
+		Message: fmt.Sprintf("Which version of '%s' component type do you wish to create", selectedComponentType),
 		Options: getTagCandidates(options, selectedComponentType),
 	}
 	err := survey.AskOne(prompt, &tag, survey.Required)
@@ -69,7 +69,7 @@ func SelectSourceType(sourceTypes []config.SrcType) config.SrcType {
 
 	var selectedSourceType string
 	prompt := &survey.Select{
-		Message: "Which input type would wish to use for the component",
+		Message: "Which input type do you wish to use for the component",
 		Options: options,
 	}
 	err := survey.AskOne(prompt, &selectedSourceType, survey.Required)
@@ -130,7 +130,7 @@ func createComponentNameValidator(context *genericclioptions.Context) survey.Val
 func EnterComponentName(defaultName string, context *genericclioptions.Context) string {
 	var path string
 	prompt := &survey.Input{
-		Message: "How would you wish to name the new component",
+		Message: "How do you wish to name the new component",
 		Default: defaultName,
 	}
 	err := survey.AskOne(prompt, &path, createComponentNameValidator(context))
@@ -161,7 +161,7 @@ func EnterGitInfo() (string, string) {
 func enterGitInputTypePath() string {
 	var path string
 	prompt := &survey.Input{
-		Message: "What is the URL of the git repository you would wish the new component to use",
+		Message: "What is the URL of the git repository you wish the new component to use",
 	}
 	err := survey.AskOne(prompt, &path, survey.Required)
 	ui.HandleError(err)
@@ -171,7 +171,7 @@ func enterGitInputTypePath() string {
 func enterGitRef(defaultRef string) string {
 	var path string
 	prompt := &survey.Input{
-		Message: "What git ref (branch, tag, commit) would you wish to use",
+		Message: "What git ref (branch, tag, commit) do you wish to use",
 		Default: defaultRef,
 	}
 	err := survey.AskOne(prompt, &path, survey.Required)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Closes #1688 

This change updates the the prompt for the `odo component create` command. The current language for the command is `Which component type would wish to create`, which is incorrect English being displayed to the user.

In light of this change, I also updated the other `component` prompts to use similar language. 

## Was the change discussed in an issue?
#1688 

## How to test changes?
Assert that the prompts match the changes in this pull request.

One case would be the following: Verify the language is changed from `Which component type would wish to create` to `Which component type do you wish to create` when running `odo component create`. 
