### PR TITLE
Change the cases at a few places in help message

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -455,7 +455,7 @@ const (
 	// Memory is the name of the setting controlling the memory a component consumes
 	Memory = "Memory"
 	// MemoryDescription is the name of the setting controlling the min and max memory to same value
-	MemoryDescription = "The minimum and maximum Memory a component can consume"
+	MemoryDescription = "The minimum and maximum memory a component can consume"
 	// Ignore is the name of the setting controlling the min memory a component consumes
 	Ignore = "Ignore"
 	// IgnoreDescription is the name of the setting controlling the use of .odoignore file
@@ -463,11 +463,11 @@ const (
 	// MinCPU is the name of the setting controlling minimum cpu
 	MinCPU = "MinCPU"
 	// MinCPUDescription is the name of the setting controlling the min CPU value
-	MinCPUDescription = "The minimum cpu a component can consume"
+	MinCPUDescription = "The minimum CPU a component can consume"
 	// MaxCPU is the name of the setting controlling the use of .odoignore file
 	MaxCPU = "MaxCPU"
 	//MaxCPUDescription is the name of the setting controlling the max CPU value
-	MaxCPUDescription = "The maximum cpu a component can consume"
+	MaxCPUDescription = "The maximum CPU a component can consume"
 	// CPU is the name of the setting controlling the cpu a component consumes
 	CPU = "CPU"
 	// CPUDescription is the name of the setting controlling the min and max CPU to same value
@@ -499,7 +499,7 @@ const (
 	// Url
 	Url = "Url"
 	// UrlDescription is the description of URL
-	UrlDescription = "Url to access the compoent"
+	UrlDescription = "URL to access the component"
 )
 
 var (

--- a/pkg/odo/cli/config/config.go
+++ b/pkg/odo/cli/config/config.go
@@ -13,7 +13,7 @@ import (
 // RecommendedCommandName is the recommended config command name
 const RecommendedCommandName = "config"
 
-var configLongDesc = ktemplates.LongDesc(`Modifies Odo specific configuration settings within the config file.
+var configLongDesc = ktemplates.LongDesc(`Modifies odo specific configuration settings within the config file.
 
 %[1]s
 `)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
It changes the case of the words at a few places in help message for `odo config -h`.
## Was the change discussed in an issue?
fixes #1661 
## How to test changes?
<!-- Please describe the steps to test the PR -->
