### PR TITLE
Print appropriate parameter name when trying to set its value again

### DIFF
--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -64,7 +64,7 @@ func (o *SetOptions) Run() (err error) {
 
 	if !o.configForceFlag {
 		if isSet := cfg.IsSet(o.paramName); isSet {
-			if !ui.Proceed("%v is already set. Do you want to override it in the config") {
+			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the config", o.paramName)) {
 				log.Info("Aborted by the user.")
 				return nil
 			}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Prints the name of the parameter whose value the user is trying to set again
## Was the change discussed in an issue?
<!-- Please do Link issues here. -->
fixes #1675 
