### PR TITLE
Update Deploying an application using odo Section and Fixing Broken Links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,7 +106,7 @@ https://asciinema.org/a/225717[image:https://asciinema.org/a/225717.svg[asciicas
 After installing `odo`, follow these steps to build, push, and
 deploy a Node.js application. Examples for other supported languages and runtimes can be found link:https://github.com/openshift/odo/blob/master/docs/examples.md[here].
 
-. Start a local OpenShift development cluster by using `Minishift`. More information on how to install and use Minishift can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here], but, if properly set up already, run the following:
+. Start a local OpenShift development cluster by using `Minishift`. More information on how to install and use `Minishift` can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here]. If properly set up already, run the following:
 +
 ----
 $ minishift start

--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ link:https://github.com/openshift/odo/releases[GitHub releases page].
 . Add the location of extracted binary to your PATH environment
 variable by following the steps listed in this link:https://github.com/openshift/odo/wiki/Setting-PATH-variable-on-Windows[Wiki page].
 
-For a list of other methods such as installing the latest binary or specific OS installations, visit the link:/docs/installation.md[installation page].
+For a list of other methods such as installing the latest binary or specific OS installations, visit the link:/docs/installation.adoc[installation page].
 
 [[demonstration]]
 == Demonstration
@@ -103,7 +103,7 @@ https://asciinema.org/a/225717[image:https://asciinema.org/a/225717.svg[asciicas
 == Deploying an application using `odo`
 
 After installing `odo`, follow these steps to build, push, and
-deploy a Node.js application. Examples for other supported languages and runtimes can be found link:https://github.com/openshift/odo/blob/master/docs/examples.md[here].
+deploy a Node.js application. Examples for other supported languages and runtimes can be found link:https://github.com/openshift/odo/blob/master/docs/examples.adoc[here].
 
 These steps recommend using link:https://github.com/minishift/minishift[Minishift] for running an OpenShift 3.10.0 or above cluster locally. More information on how to install and use `Minishift` can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here].
 
@@ -148,22 +148,22 @@ $ minishift stop
 ----
 
 For more in-depth information and advanced use-cases such as adding storage to a component or linking components, see the
-link:https://learn.openshift.com/introduction/developing-with-odo/[interactive tutorial] or the link:/docs/getting-started.md[Getting Started Guide].
+link:https://learn.openshift.com/introduction/developing-with-odo/[interactive tutorial] or the link:/docs/getting-started.adoc[Getting Started Guide].
 
 [[additional-documentation]]
 == Additional documentation
 
 Additional documentation can be found below:
 
-* link:https://github.com/openshift/odo/blob/master/docs/installation.md[Detailed
+* link:https://github.com/openshift/odo/blob/master/docs/installation.adoc[Detailed
 Installation Guide]
-* link:https://github.com/openshift/odo/blob/master/docs/getting-started.md[Getting
+* link:https://github.com/openshift/odo/blob/master/docs/getting-started.adoc[Getting
 Started Guide]
-* link:https://github.com/openshift/odo/blob/master/docs/examples.md[Usage
+* link:https://github.com/openshift/odo/blob/master/docs/examples.adoc[Usage
 Examples for Other Languages and Runtimes]
-* link:https://github.com/openshift/odo/blob/master/docs/cli-reference.md[CLI
+* link:https://github.com/openshift/odo/blob/master/docs/cli-reference.adoc[CLI
 Reference]
-* link:https://github.com/openshift/odo/blob/master/docs/development.md[Development
+* link:https://github.com/openshift/odo/blob/master/docs/development.adoc[Development
 Guide]
 
 [[contributing]]
@@ -175,7 +175,7 @@ chat.openshift.io].
 *Issues:* If you have an issue with `odo`, please link:https://github.com/openshift/odo/issues[file it].
 
 *Contributing:* Want to become a contributor and submit your own code?
-Have a look at our link:https://github.com/openshift/odo/blob/master/docs/development.md[Development Guide].
+Have a look at our link:https://github.com/openshift/odo/blob/master/docs/development.adoc[Development Guide].
 
 [[glossary]]
 == Glossary

--- a/README.adoc
+++ b/README.adoc
@@ -140,6 +140,7 @@ $ odo url create --port <application port>
 $ curl <generated URL>
 ----
 . When finished, remove your component from `Minishift` and stop your `Minishift` cluster.
++
 ----
 $ odo delete <component>
 $ minishift stop

--- a/README.adoc
+++ b/README.adoc
@@ -39,8 +39,7 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 
 *Prerequisites:*
 
-* OpenShift 3.10.0 and above is required.
-* We recommend using link:https://github.com/minishift/minishift[Minishift].
+* OpenShift 3.10.0 or above is required.
 
 *Procedure:*
 
@@ -106,7 +105,9 @@ https://asciinema.org/a/225717[image:https://asciinema.org/a/225717.svg[asciicas
 After installing `odo`, follow these steps to build, push, and
 deploy a Node.js application. Examples for other supported languages and runtimes can be found link:https://github.com/openshift/odo/blob/master/docs/examples.md[here].
 
-. Start a local OpenShift development cluster by using `Minishift`. More information on how to install and use `Minishift` can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here]. If properly set up already, run the following:
+These steps recommend using link:https://github.com/minishift/minishift[Minishift] for running an OpenShift 3.10.0 or above cluster locally. More information on how to install and use `Minishift` can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here].
+
+. Start a local OpenShift development cluster by using `Minishift`.
 +
 ----
 $ minishift start

--- a/README.adoc
+++ b/README.adoc
@@ -106,7 +106,7 @@ https://asciinema.org/a/225717[image:https://asciinema.org/a/225717.svg[asciicas
 After installing `odo`, follow these steps to build, push, and
 deploy a Node.js application. Examples for other supported languages and runtimes can be found link:https://github.com/openshift/odo/blob/master/docs/examples.md[here].
 
-. Start a local OpenShift development cluster by running minishift.
+. Start a local OpenShift development cluster by using `Minishift`. More information on how to install and use Minishift can be found link:https://docs.okd.io/latest/minishift/getting-started/index.html[here], but, if properly set up already, run the following:
 +
 ----
 $ minishift start
@@ -115,12 +115,6 @@ $ minishift start
 +
 ----
 $ odo login -u developer -p developer
-----
-. Create an application. An application in `odo` is an umbrella
-under which you add other components.
-+
-----
-$ odo app create node-example-app
 ----
 . Download the Node.js sample code and change directory to the
 location of the sample code.
@@ -144,6 +138,11 @@ $ odo push
 ----
 $ odo url create --port <application port>
 $ curl <generated URL>
+----
+. When finished, remove your component from `Minishift` and stop your `Minishift` cluster.
+----
+$ odo delete <component>
+$ minishift stop
 ----
 
 For more in-depth information and advanced use-cases such as adding storage to a component or linking components, see the


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
This pull request updates `odo`'s `REAMDME` to fix steps in the [Deploying an application using odo](https://github.com/openshift/odo#deploying-an-application-using-odo) section of the documentation. These updates include the following:

1. Including `Minishift` documentation for Step 1 in case users don't have `Minishift` installed.
2. Removing step 3 `odo app create`, which is no longer used in `v1.0.0-beta1`.
3. Adding a step to delete the component created as part of the tutorial.

This change also addresses broken links in the README as referenced in #1704.

## Was the change discussed in an issue?
fixes #1699
fixes #1704  

## How to test changes?
Go through the new steps listed and verify you are able to create a component, expose its url, access the `nodejs` application, and delete the component. 
