### PR TITLE
resolved the consecutive project deletion issue

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -519,6 +519,9 @@ func (c *Client) SetCurrentProject(projectName string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to switch to %s project", projectName)
 	}
+
+	// we set the current namespace to the current project as well
+	c.Namespace = projectName
 	return nil
 }
 

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -61,6 +61,11 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 
 // Run runs the project delete command
 func (pdo *ProjectDeleteOptions) Run() (err error) {
+	// this to set the project in the file and runtime
+	err = project.SetCurrent(pdo.Context.Client, pdo.projectName)
+	if err != nil {
+		return
+	}
 	err = printDeleteProjectInfo(pdo.Context.Client, pdo.projectName)
 	if err != nil {
 		return err

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -155,6 +155,39 @@ var _ = Describe("odo generic", func() {
 		})
 	})
 
+	Context("project deletion", func() {
+		var originalDir string
+
+		JustBeforeEach(func() {
+			context = helper.CreateNewContext()
+			originalDir = helper.Getwd()
+			helper.Chdir(context)
+		})
+
+		JustAfterEach(func() {
+			helper.Chdir(originalDir)
+			os.RemoveAll(context)
+		})
+		It("be able to delete two project one after the other", func() {
+			project1 := helper.CreateRandProject()
+			project2 := helper.CreateRandProject()
+
+			helper.DeleteProject(project2)
+			helper.DeleteProject(project1)
+		})
+
+		It("be able to delete three project one after the other in opposite order", func() {
+			project1 := helper.CreateRandProject()
+			project2 := helper.CreateRandProject()
+			project3 := helper.CreateRandProject()
+
+			helper.DeleteProject(project1)
+			helper.DeleteProject(project2)
+			helper.DeleteProject(project3)
+
+		})
+	})
+
 	Context("validate odo version cmd with other major components version", func() {
 		It("should show the version of odo major components", func() {
 			odoVersion := helper.CmdShouldPass("odo", "version")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
The issue was that the after a project is created it is set as current. But someone deletes the project, the `printDeleteProjectInfo` function takes the consumes the project from the KUBECONFIG rather then 
 the one provided as command line arg.

The resolution was as follows -

1 - set the latest project which we are deleting as current in the file ( so we point to the most recent project ) even though the user has to change the project any way in the future

2 - the SetCurrentProject doesn't actually set the runtime project of the client so I made sure it does, I made this change in the low level function of `occlient` i.e. SetCurrentProject instead of cli's Run() because I felt that SetCurrentProject should do both set the runtime and file project and hence mitigate some future misunderstanding.

<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1503
<!-- Please do Link issues here. -->

## How to test changes?
```
odo project create odo2-1553171170
odo project create prj4

odo project delete -f prj4
odo project delete -f odo2-1553171170
```