### PR TITLE
Fixes ignore behaviour with Windows

### DIFF
--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -46,6 +46,7 @@ type WatchParameters struct {
 // path is the path of the file or the directory
 // ignores contains the glob rules for matching
 func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string) error {
+
 	file, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -210,7 +211,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				// because its parent is watched, the fsnotify automatically raises an event
 				// for it.
 				matched, err := util.IsGlobExpMatch(event.Name, parameters.FileIgnores)
-				glog.V(4).Infof("Matching %s with %s\n.matched %v, err: %v", event.Name, parameters.FileIgnores, matched, err)
+				glog.V(4).Infof("Matching %s with %s. Matched %v, err: %v", event.Name, parameters.FileIgnores, matched, err)
 				if err != nil {
 					watchError = errors.Wrap(err, "unable to watch changes")
 				}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -532,8 +532,23 @@ func GetContainerPortsFromStrings(ports []string) ([]corev1.ContainerPort, error
 // strToMatch : a string for matching against the rules
 // globExps : a list of glob patterns to match strToMatch with
 // Returns: true if there is any match else false the error (if any)
+// Notes:
+// Source as well as glob expression to match is changed to forward
+// slashes due to supporting Windows as well as support with the
+// "github.com/gobwas/glob" library that we use.
 func IsGlobExpMatch(strToMatch string, globExps []string) (bool, error) {
+
+	// Replace all backslashes with forward slashes in order for
+	// glob / expression matching to work correctly with
+	// the "github.com/gobwas/glob" library
+	strToMatch = strings.Replace(strToMatch, "\\", "/", -1)
+
 	for _, globExp := range globExps {
+
+		// We replace backslashes with forward slashes for
+		// glob expression / matching support
+		globExp = strings.Replace(globExp, "\\", "/", -1)
+
 		pattern, err := glob.Compile(globExp)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This fixes the error occuring with ignore on Windows due to
back slash being used and not forward slash.

With the way that "Glob" programming works as well as the
library that we use, we cannot use back slashes.

Closes https://github.com/openshift/odo/issues/1630