### PR TITLE
Don't check for config file to list components and services

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -138,6 +138,10 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "app" && len(pfs) > 0 {
 			return lci, nil
 		}
+		// Case 4 : Check if fcc is catalog and request is to list
+		if fcc.Name() == "catalog" && p.Name() == "list" {
+			return lci, nil
+		}
 		if fcc.Name() == "component" && len(pfs) > 0 && len(afs) > 0 {
 			return lci, nil
 		}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR excludes the commands `odo catalog list components` and `odo catalog list services` from config file check so that they can be executed from a directory that doesn't have `.odo/config.yaml` file.
## Was the change discussed in an issue?
fixes #1599 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Build the binary, login to the OpenShift cluster, and execute aforementioned commands from a directory that doesn't have `.odo/config.yaml` file.