### PR TITLE
use more robust project.exists function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,13 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "generic,login,component integration tests"
+      name: "component integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - travis_wait make test-generic
-        - travis_wait make test-odo-login-e2e
-        - travis_wait make test-cmp-e2e
+        - travis_wait make test-e2e
 
     - <<: *base-test
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "component integration tests"
+      name: "generic,login,component integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
         - oc login -u developer
-        - travis_wait make test-e2e
+        - travis_wait make test-generic
+        - travis_wait make test-odo-login-e2e
+        - travis_wait make test-cmp-e2e
 
     - <<: *base-test
       stage: test

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -470,6 +470,10 @@ func (c *Client) GetProjectNames() ([]string, error) {
 	return projectNames, nil
 }
 
+func (c *Client) GetProject(projectName string) (*projectv1.Project, error) {
+	return c.projectClient.Projects().Get(projectName, metav1.GetOptions{})
+}
+
 // CreateNewProject creates project with given projectName
 func (c *Client) CreateNewProject(projectName string, wait bool) error {
 	projectRequest := &projectv1.ProjectRequest{

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -471,6 +471,8 @@ func (c *Client) GetProjectNames() ([]string, error) {
 	return projectNames, nil
 }
 
+// GetProject returns project based on the name of the project.Errors related to
+// project not being found or forbidden are translated to nil project for compatibility
 func (c *Client) GetProject(projectName string) (*projectv1.Project, error) {
 	prj, err := c.projectClient.Projects().Get(projectName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -477,7 +477,8 @@ func (c *Client) GetProject(projectName string) (*projectv1.Project, error) {
 		istatus, ok := err.(kerrors.APIStatus)
 		if ok {
 			status := istatus.Status()
-			if status.Reason == metav1.StatusReasonNotFound {
+			// the
+			if status.Reason == metav1.StatusReasonNotFound || status.Reason == metav1.StatusReasonForbidden {
 				return nil, nil
 			}
 		} else {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -477,7 +477,6 @@ func (c *Client) GetProject(projectName string) (*projectv1.Project, error) {
 		istatus, ok := err.(kerrors.APIStatus)
 		if ok {
 			status := istatus.Status()
-			// the
 			if status.Reason == metav1.StatusReasonNotFound || status.Reason == metav1.StatusReasonForbidden {
 				return nil, nil
 			}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -78,6 +78,7 @@ func Exists(client *occlient.Client, projectName string) (bool, error) {
 	if err != nil || project == nil {
 		return false, err
 	}
+
 	return true, nil
 }
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -69,21 +69,16 @@ func DescribeProjects(client *occlient.Client) (ProjectList, error) {
 	return getMachineReadableFormatForList(projects), nil
 }
 
-// Checks whether a project with the given name exists or not
+// Exists Checks whether a project with the given name exists or not
 // projectName is the project name to perform check for
 // The first returned parameter is a bool indicating if a project with the given name already exists or not
 // The second returned parameter is the error that might occurs while execution
 func Exists(client *occlient.Client, projectName string) (bool, error) {
-	projects, err := client.GetProjectNames()
-	if err != nil {
-		return false, errors.Wrap(err, "unable to get the project list")
+	project, err := client.GetProject(projectName)
+	if err != nil || project == nil {
+		return false, err
 	}
-	for _, project := range projects {
-		if project == projectName {
-			return true, nil
-		}
-	}
-	return false, nil
+	return true, nil
 }
 
 func GetMachineReadableFormat(projectName string, isActive bool, apps []string) Project {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -260,20 +260,22 @@ func componentTests(args ...string) {
 	})
 
 	FContext("Creating Component even in new project", func() {
+		var project string
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()
+			project = helper.RandString(10)
 		})
 
 		JustAfterEach(func() {
 			os.RemoveAll(context)
+			helper.DeleteProject(project)
 		})
 		It("should create component", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", "new-project", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "push", "--context", context, "-v4")
-			oc.SwitchProject("new-project")
+			oc.SwitchProject(project)
 			projectList := helper.CmdShouldPass("odo", "project", "list")
-			Expect(projectList).To(ContainSubstring("new-project"))
-			helper.DeleteProject("new-project")
+			Expect(projectList).To(ContainSubstring(project))
 		})
 	})
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -259,7 +259,7 @@ func componentTests(args ...string) {
 		})
 	})
 
-	Context("Creating Component even in new project", func() {
+	FContext("Creating Component even in new project", func() {
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()
 		})
@@ -277,7 +277,7 @@ func componentTests(args ...string) {
 		})
 	})
 
-	Context("when component is in the current directory and --project flag is used", func() {
+	FContext("when component is in the current directory and --project flag is used", func() {
 
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -259,7 +259,7 @@ func componentTests(args ...string) {
 		})
 	})
 
-	FContext("Creating Component even in new project", func() {
+	Context("Creating Component even in new project", func() {
 		var project string
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()
@@ -279,7 +279,7 @@ func componentTests(args ...string) {
 		})
 	})
 
-	FContext("when component is in the current directory and --project flag is used", func() {
+	Context("when component is in the current directory and --project flag is used", func() {
 
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Currently to check if a project exists or not we used an inefficient List All projects -> match the name approach. This approach becomes quite slow when large number of projects are present. 
Also the `project.Exists` is used at many places and many times which multiplies the slowness. 
This PR addresses this issue by providing a more robust approach of just getting the project.

In my primary cluster which has very less projects I got a 5-7% increase in speed in `project` related commands.

## Was the change discussed in an issue?
This PR possibly resolves the below issue
fixes https://github.com/openshift/odo/issues/1717
<!-- Please do Link issues here. -->

## How to test changes?
`odo project create <name> #twice should fail` 
