### PR TITLE
added --all flag for component deletion and test for it

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,6 +234,11 @@ func (lci *LocalConfigInfo) SetConfiguration(parameter string, value interface{}
 
 }
 
+// DeleteConfigDir Deletes the config directory with the config file
+func (lci *LocalConfigInfo) DeleteConfigDir() error {
+	return os.RemoveAll(filepath.Dir(lci.Filename))
+}
+
 // IsSet uses reflection to get the parameter from the localconfig struct, currently
 // it only searches the componentSettings
 func (lci *LocalConfigInfo) IsSet(parameter string) bool {

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -24,6 +24,7 @@ const DeleteRecommendedCommandName = "delete"
 
 var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'. 
 %[1]s frontend
+%[1]s frontend --all
   `)
 
 // DeleteOptions is a container to attach complete, validate and run pattern

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -79,21 +79,22 @@ func (do *DeleteOptions) Run() (err error) {
 		return fmt.Errorf("Aborting deletion of component: %v", do.componentName)
 	}
 
-	if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete local config for %v?", do.componentName)) {
-		cfg, err := config.NewLocalConfigInfo(do.componentContext)
-		if err != nil {
-			return err
+	if do.componentDeleteAllFlag {
+		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete local config for %v?", do.componentName)) {
+			cfg, err := config.NewLocalConfigInfo(do.componentContext)
+			if err != nil {
+				return err
+			}
+
+			err = cfg.DeleteConfigDir()
+			if err != nil {
+				return err
+			}
+
+			log.Successf("Config for the Component %s has been deleted", do.componentName)
+		} else {
+			return fmt.Errorf("Aborting deletion of config for component: %s", do.componentName)
 		}
-
-		err = cfg.DeleteConfigDir()
-		if err != nil {
-			return err
-		}
-
-		log.Successf("Config for the Component %s has been deleted", do.componentName)
-
-	} else {
-		return fmt.Errorf("Aborting deletion of config for component: %v", do.componentName)
 	}
 
 	return

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -296,5 +296,14 @@ func componentTests(args ...string) {
 			output := helper.CmdShouldFail("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
 			Expect(output).To(ContainSubstring("this directory already contains a component"))
 		})
+
+		It("creates and pushes local nodejs component and then deletes --all", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
+			helper.CmdShouldPass("odo", append(args, "push")...)
+			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f")...)
+
+		})
 	})
+
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Added a `--all` flag for `odo component delete` which deletes the component from the cluster as well as removes the local config file and directory.

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1654
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create nodejs 
odo push
odo delete --all
```
