### PR TITLE
Hide "component get" command

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -154,7 +154,9 @@ func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
 
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
-		strs = append(strs, strings.Split(subcmd.Use, " ")[0])
+		if !subcmd.Hidden {
+			strs = append(strs, strings.Split(subcmd.Use, " ")[0])
+		}
 	}
 
 	cmd.Short += " (" + strings.Join(strs, ", ") + ")"
@@ -165,7 +167,9 @@ func reconfigureCmdWithSubcmd(cmd *cobra.Command) {
 func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
-		strs = append(strs, subcmd.Use)
+		if !subcmd.Hidden {
+			strs = append(strs, subcmd.Use)
+		}
 	}
 	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))
 }

--- a/pkg/odo/cli/component/get.go
+++ b/pkg/odo/cli/component/get.go
@@ -76,6 +76,10 @@ func NewCmdGet(name, fullName string) *cobra.Command {
 	}
 
 	componentGetCmd.Flags().BoolVarP(&o.componentShortFlag, "short", "q", false, "If true, display only the component name")
+
+	// Hide component get, as we only use this command for autocompletion
+	componentGetCmd.Hidden = true
+
 	// add --context flag
 	genericclioptions.AddContextFlag(componentGetCmd, &o.componentContext)
 


### PR DESCRIPTION
This PR:
 - Hides the component get command. We do not remove it as `odo
 component get -q` is required for bash/zsh autocompletion support.
 - Updates the "show sub commands" to exclude hidden flags

Closes https://github.com/openshift/odo/issues/1647