### PR TITLE
Fixes the issue of 4 deployments for git components

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -131,7 +131,7 @@ func CreateFromGit(client *occlient.Client, params occlient.CreateArgs) error {
 	labels := componentlabels.GetLabels(params.Name, params.ApplicationName, true)
 
 	// Loading spinner
-	s := log.SpinnerNoSpin("Creating component " + params.Name)
+	s := log.Spinnerf("Creating component %s", params.Name)
 	defer s.End(false)
 
 	// Parse componentImageType before adding to labels
@@ -166,6 +166,8 @@ func CreateFromGit(client *occlient.Client, params occlient.CreateArgs) error {
 		return errors.Wrapf(err, "unable to create git component %s", namespacedOpenShiftObject)
 	}
 
+	s.End(true)
+
 	// Trigger build
 	if err = Build(client, params.Name, params.ApplicationName, params.Wait, params.StdOut, false); err != nil {
 		return errors.Wrapf(err, "failed to build component with args %+v", params)
@@ -177,7 +179,6 @@ func CreateFromGit(client *occlient.Client, params occlient.CreateArgs) error {
 		return errors.Wrapf(err, "failed to deploy component with args %+v", params)
 	}
 
-	s.End(true)
 	return nil
 }
 
@@ -814,6 +815,11 @@ func Build(client *occlient.Client, componentName string, applicationName string
 // Deploy deploys the component
 // desiredRevision is the desired version of the deployment config to wait for
 func Deploy(client *occlient.Client, params occlient.CreateArgs, desiredRevision int64) error {
+
+	// Loading spinner
+	s := log.Spinnerf("Deploying component %s", params.Name)
+	defer s.End(false)
+
 	// Namespace the component
 	namespacedOpenShiftObject, err := util.NamespaceOpenShiftObject(params.Name, params.ApplicationName)
 	if err != nil {
@@ -830,6 +836,9 @@ func Deploy(client *occlient.Client, params occlient.CreateArgs, desiredRevision
 	if err != nil {
 		return errors.Wrapf(err, "unable to wait for DeploymentConfig %s to update", namespacedOpenShiftObject)
 	}
+
+	s.End(true)
+
 	return nil
 }
 
@@ -1053,7 +1062,7 @@ func Update(client *occlient.Client, componentSettings config.LocalConfigInfo, n
 			return errors.Wrapf(err, "unable to update BuildConfig  for %s component", componentName)
 		}
 
-		// we build	as the build needs to happen before the deployment
+		// we build as the build needs to happen before the deployment
 		err = Build(client, componentName, applicationName, true, stdout, false)
 		if err != nil {
 			return errors.Wrapf(err, "unable to build the component %v", componentName)

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -85,7 +85,7 @@ type CreateArgs struct {
 }
 
 const (
-	ocUpdateTimeout    = 5 * time.Minute
+	OcUpdateTimeout    = 5 * time.Minute
 	OpenShiftNameSpace = "openshift"
 
 	// The length of the string to be generated for names of resources
@@ -1402,7 +1402,7 @@ func (c *Client) PatchCurrentDC(dc appsv1.DeploymentConfig, prePatchDCHandler dc
 
 	// Watch / wait for deploymentconfig to update annotations
 	// importing "component" results in an import loop, so we do *not* use the constants here.
-	_, err = c.WaitAndGetDC(name, desiredRevision, ocUpdateTimeout, waitCond)
+	_, err = c.WaitAndGetDC(name, desiredRevision, OcUpdateTimeout, waitCond)
 	if err != nil {
 		return errors.Wrapf(err, "unable to wait for DeploymentConfig %s to update", name)
 	}

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -278,7 +278,9 @@ func generateGitDeploymentConfig(commonObjectMeta metav1.ObjectMeta, image strin
 				{
 					Type: "ImageChange",
 					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
-						Automatic: true,
+						// setting automatic to false so that the trigger is disabled and a new image doesn't trigger deployment
+						// we don't remove this trigger so that we don't face image resolution issues
+						Automatic: false,
 						ContainerNames: []string{
 							commonObjectMeta.Name,
 						},

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -244,15 +244,9 @@ func (po *PushOptions) Run() (err error) {
 			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
 		}
 
-	case config.GIT:
-		err := component.Build(
-			po.Context.Client,
-			cmpName,
-			appName,
-			true,
-			stdout,
-			po.show,
-		)
+		// we don't need a case for building git components
+		// the build happens before deployment
+
 		return errors.Wrapf(err, fmt.Sprintf("failed to push component: %v", cmpName))
 	}
 

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -193,6 +193,34 @@ func (oc *OcRunner) MinCPU(componentName string, appName string, project string)
 	return minMemory
 }
 
+// SourceTypeDC returns the source type from the deployment config
+func (oc *OcRunner) SourceTypeDC(componentName string, appName string, project string) string {
+	sourceType := CmdShouldPass(oc.path, "get", "dc", componentName+"-"+appName, "--namespace", project,
+		"-o", "go-template='{{index .metadata.annotations \"app.kubernetes.io/component-source-type\"}}'")
+	return sourceType
+}
+
+// SourceTypeBC returns the source type from the build config
+func (oc *OcRunner) SourceTypeBC(componentName string, appName string, project string) string {
+	sourceType := CmdShouldPass(oc.path, "get", "bc", componentName+"-"+appName, "--namespace", project,
+		"-o", "go-template='{{.spec.source.type}}'")
+	return sourceType
+}
+
+// SourceLocationDC returns the source location from the deployment config
+func (oc *OcRunner) SourceLocationDC(componentName string, appName string, project string) string {
+	sourceLocation := CmdShouldPass(oc.path, "get", "dc", componentName+"-"+appName, "--namespace", project,
+		"-o", "go-template='{{index .metadata.annotations \"app.kubernetes.io/url\"}}'")
+	return sourceLocation
+}
+
+// SourceLocationBC returns the source location from the build config
+func (oc *OcRunner) SourceLocationBC(componentName string, appName string, project string) string {
+	sourceLocation := CmdShouldPass(oc.path, "get", "bc", componentName+"-"+appName, "--namespace", project,
+		"-o", "go-template='{{index .spec.source.git \"uri\"}}'")
+	return sourceLocation
+}
+
 // ImportJavaIsToNspace import the openjdk image which is used for jars
 func (oc *OcRunner) ImportJavaIsToNspace(project string) {
 	// do nothing if running on OpenShiftCI

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -341,32 +341,36 @@ func componentTests(args ...string) {
 			Expect(getSourceType).To(ContainSubstring("Git"))
 		})
 
-		It("should be able to update a component from git to local", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
-			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
-			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+		/*
+			Enable once https://github.com/openshift/odo/issues/1778 is merged
 
-			// update the component config according to the git component
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "./", "--context", context, "-f")
-			helper.CmdShouldPass("odo", "config", "set", "sourcetype", "local", "--context", context, "-f")
+			It("should be able to update a component from git to local", func() {
+				helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
+				helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
+				getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
+				Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+				getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
+				Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
 
-			// check if the earlier resource requests are still valid
-			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
-			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+				// update the component config according to the git component
+				helper.CopyExample(filepath.Join("source", "nodejs"), context)
+				helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "./", "--context", context, "-f")
+				helper.CmdShouldPass("odo", "config", "set", "sourcetype", "local", "--context", context, "-f")
 
-			// check the source location and type in the deployment config
-			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
-			Expect(getSourceLocation).To(ContainSubstring("file://./"))
-			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
-			Expect(getSourceType).To(ContainSubstring("local"))
-		})
+				// check if the earlier resource requests are still valid
+				helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
+				getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
+				Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+				getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
+				Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+
+				// check the source location and type in the deployment config
+				getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
+				Expect(getSourceLocation).To(ContainSubstring("file://./"))
+				getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
+				Expect(getSourceType).To(ContainSubstring("local"))
+			})
+		*/
 	})
 
 }

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -85,19 +85,6 @@ func componentTests(args ...string) {
 			os.RemoveAll(context)
 		})
 
-		It("should be able to create a component with git source", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.CmdShouldPass("odo", "push", "--context", context)
-			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
-			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
-			Expect(getCPULimit).To(ContainSubstring("2"))
-			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
-			Expect(getCPURequest).To(ContainSubstring("100m"))
-		})
-
 		It("should list the component", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -320,14 +307,10 @@ func componentTests(args ...string) {
 			os.RemoveAll(context)
 		})
 
-		It("should be able to update a component from local to git", func() {
+		It("should be able to create a git component and update it from local to git", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
-			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
 			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
 			Expect(getCPULimit).To(ContainSubstring("2"))
 			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
@@ -339,10 +322,6 @@ func componentTests(args ...string) {
 
 			// check if the earlier resource requests are still valid
 			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
-			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
 			getCPULimit = oc.MaxCPU("cmp-git", "testing", project)
 			Expect(getCPULimit).To(ContainSubstring("2"))
 			getCPURequest = oc.MinCPU("cmp-git", "testing", project)
@@ -363,16 +342,12 @@ func componentTests(args ...string) {
 		})
 
 		It("should be able to update a component from git to local", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
 			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
 			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
-			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
-			Expect(getCPULimit).To(ContainSubstring("2"))
-			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
-			Expect(getCPURequest).To(ContainSubstring("100m"))
 
 			// update the component config according to the git component
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
@@ -385,10 +360,6 @@ func componentTests(args ...string) {
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
 			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
-			getCPULimit = oc.MaxCPU("cmp-git", "testing", project)
-			Expect(getCPULimit).To(ContainSubstring("2"))
-			getCPURequest = oc.MinCPU("cmp-git", "testing", project)
-			Expect(getCPURequest).To(ContainSubstring("100m"))
 
 			// check the source location and type in the deployment config
 			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -323,7 +323,7 @@ func componentTests(args ...string) {
 		It("should be able to update a component from local to git", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
 			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
@@ -338,7 +338,7 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", "config", "set", "sourcetype", "git", "--context", context, "-f")
 
 			// check if the earlier resource requests are still valid
-			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
 			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
@@ -364,7 +364,7 @@ func componentTests(args ...string) {
 
 		It("should be able to update a component from git to local", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
 			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
@@ -380,7 +380,7 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", "config", "set", "sourcetype", "local", "--context", context, "-f")
 
 			// check if the earlier resource requests are still valid
-			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v", "4")
 			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
 			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -309,4 +309,93 @@ func componentTests(args ...string) {
 		})
 	})
 
+	Context("odo component updating", func() {
+		JustBeforeEach(func() {
+			project = helper.CreateRandProject()
+			context = helper.CreateNewContext()
+		})
+
+		JustAfterEach(func() {
+			helper.DeleteProject(project)
+			os.RemoveAll(context)
+		})
+
+		It("should be able to update a component from local to git", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
+			Expect(getCPULimit).To(ContainSubstring("2"))
+			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
+			Expect(getCPURequest).To(ContainSubstring("100m"))
+
+			// update the component config according to the git component
+			helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "https://github.com/openshift/nodejs-ex", "--context", context, "-f")
+			helper.CmdShouldPass("odo", "config", "set", "sourcetype", "git", "--context", context, "-f")
+
+			// check if the earlier resource requests are still valid
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+			getCPULimit = oc.MaxCPU("cmp-git", "testing", project)
+			Expect(getCPULimit).To(ContainSubstring("2"))
+			getCPURequest = oc.MinCPU("cmp-git", "testing", project)
+			Expect(getCPURequest).To(ContainSubstring("100m"))
+
+			// check the source location and type in the deployment config
+			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
+			Expect(getSourceLocation).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
+			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
+			Expect(getSourceType).To(ContainSubstring("git"))
+
+			// since the current component type is git
+			// check the source location and type in the build config
+			getSourceLocation = oc.SourceLocationBC("cmp-git", "testing", project)
+			Expect(getSourceLocation).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
+			getSourceType = oc.SourceTypeBC("cmp-git", "testing", project)
+			Expect(getSourceType).To(ContainSubstring("Git"))
+		})
+
+		It("should be able to update a component from git to local", func() {
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
+			Expect(getCPULimit).To(ContainSubstring("2"))
+			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
+			Expect(getCPURequest).To(ContainSubstring("100m"))
+
+			// update the component config according to the git component
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "./", "--context", context, "-f")
+			helper.CmdShouldPass("odo", "config", "set", "sourcetype", "local", "--context", context, "-f")
+
+			// check if the earlier resource requests are still valid
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+			getCPULimit = oc.MaxCPU("cmp-git", "testing", project)
+			Expect(getCPULimit).To(ContainSubstring("2"))
+			getCPURequest = oc.MinCPU("cmp-git", "testing", project)
+			Expect(getCPURequest).To(ContainSubstring("100m"))
+
+			// check the source location and type in the deployment config
+			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
+			Expect(getSourceLocation).To(ContainSubstring("file://./"))
+			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
+			Expect(getSourceType).To(ContainSubstring("local"))
+		})
+	})
+
 }


### PR DESCRIPTION
It also fixes the issue of update failing during update from local to git.

This PR disables the image trigger for git components. For git components, we start the deployment manually via the client.

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1686
fixes https://github.com/openshift/odo/issues/1682

## How to test changes?
<!-- Please describe the steps to test the PR -->
**Create scenario**
```
odo create <component-type> --git <source-url>
odo push
```
The number of deployments and builds should be 1.

**Update scenario**
```
odo create <component-type> --local <source-location>
odo push
odo config set sourcelocation <git-source-location>
odo config set sourcetype git
odo push
```


