### PR TITLE
resolved development docs and bump-version.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ generate-cli-structure:
 
 .PHONY: generate-cli-reference
 generate-cli-reference:
-	go run cmd/cli-doc/cli-doc.go reference > docs/cli-reference.md
+	go run cmd/cli-doc/cli-doc.go reference > docs/cli-reference.adoc
 
 # create gzipped binaries in ./dist/release/
 # for uploading to GitHub release page

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -246,11 +246,10 @@ To release a new version:
 
 * Updates the version in the following files:
 
-** link:/cmd/version.go[`cmd/version.go`]
+** link:/pkg/odo/cli/version/version.go[`cmd/version.go`]
 ** link:/scripts/install.sh[`scripts/install.sh`]
-** link:/README.md[`README.md`]
 +
-There is a helper script link:/scripts/bump-version.sh[scripts/bump-version.sh] that changes version number in all the files listed above (expect `odo.rb`).
+There is a helper script link:/scripts/bump-version.sh[scripts/bump-version.sh] that changes version number in all the files listed above (except `odo.rb`).
 
 * Updates the CLI reference documentation in the `docs/cli-reference.md` file:
 +

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -21,9 +21,6 @@ check_version(){
     echo ""
 }
 
-echo "* Bumping version in README.adoc"
-sed -i "s/v[0-9]*\.[0-9]*\.[0-9]*\(?:-\w+\)\?/${NEW_VERSION}/g" README.adoc
-check_version README.adoc
 
 echo "* Bumping version in pkg/odo/cli/version/version.go"
 sed -i "s/\(VERSION = \)\"v[0-9]*\.[0-9]*\.[0-9]*\(?:-\w+\)\?\"/\1\"${NEW_VERSION}\"/g" pkg/odo/cli/version/version.go


### PR DESCRIPTION
Currently the Readme.adoc doesn't actually show any version for odo but we still try to update that using the bump-version script and also it has been mentioned in the dev docs, so changed that.
Also resolved the extension of the `cli-reference` from `.md` to `.adoc`