### PR TITLE
Uncommenting odo project list -o json in json test file

### DIFF
--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	//. "github.com/Benjamintf1/unmarshalledmatchers"
+	. "github.com/Benjamintf1/unmarshalledmatchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -29,13 +29,12 @@ var _ = Describe("odojsonoutput", func() {
 	})
 
 	Context("odo machine readable output on empty project", func() {
-		//https://github.com/openshift/odo/issues/1708
 		//odo project list -o json
-		/*It("should be able to return project list", func() {
+		It("should be able to return project list", func() {
 			actualProjectListJSON := helper.CmdShouldPass("odo", "project", "list", "-o", "json")
 			desiredProjectListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myproject","creationTimestamp":null},"spec":{"apps":null},"status":{"active":false}},{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","creationTimestamp":null},"spec":{"apps":null},"status":{"active":true}}]}`, project)
 			Expect(desiredProjectListJSON).Should(MatchUnorderedJSON(actualProjectListJSON, WithUnorderedListKeys("items")))
-		})*/
+		})
 
 		// odo app list -o json
 		It("should be able to return empty list", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes - Only on 4.1 OpenShift cluster the scenario passes, however on (CI) 4.0 cluster the same scenario gives weird behaviour. Now prow environment started using 4.1 cluster, so uncommenting those test. But the failure reason on 4.0 cluster of issue #1708 will be investigated.
NOTE:  
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-json-format-output