### PR TITLE
Use local config info for viewing odo config

### DIFF
--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -33,6 +33,11 @@ func NewViewOptions() *ViewOptions {
 
 // Complete completes ViewOptions after they've been created
 func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	cfg, err := config.NewLocalConfigInfo(o.contextDir)
+	if err != nil {
+		return err
+	}
+	o.lci = cfg
 	return
 }
 
@@ -43,13 +48,9 @@ func (o *ViewOptions) Validate() (err error) {
 
 // Run contains the logic for the command
 func (o *ViewOptions) Run() (err error) {
-	cfg, err := config.NewLocalConfigInfo(o.contextDir)
-	if err != nil {
-		return err
-	}
-	cs := cfg.GetComponentSettings()
+	cs := o.lci.GetComponentSettings()
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 2, ' ', tabwriter.TabIndent)
-	envVarList := cfg.GetEnvVars()
+	envVarList := o.lci.GetEnvVars()
 	if len(envVarList) != 0 {
 		fmt.Fprintln(w, "ENVIRONMENT VARIABLES")
 		fmt.Fprintln(w, "------------------------------------------------")

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -23,7 +23,7 @@ var viewExample = ktemplates.Examples(`# For viewing the current local configura
 // ViewOptions encapsulates the options for the command
 type ViewOptions struct {
 	contextDir string
-	context    *genericclioptions.Context
+	lci        *config.LocalConfigInfo
 }
 
 // NewViewOptions creates a new ViewOptions instance
@@ -33,7 +33,6 @@ func NewViewOptions() *ViewOptions {
 
 // Complete completes ViewOptions after they've been created
 func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -209,5 +209,16 @@ var _ = Describe("odo config test", func() {
 			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
 			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
 		})
+
+		It("should list config without logging into the OpenShift cluster", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			helper.CmdShouldPass("odo", "config", "set", "--env", "hello=world")
+			kubeconfigOld := os.Getenv("KUBECONFIG")
+			os.Setenv("KUBECONFIG", "")
+			configValue := helper.CmdShouldPass("odo", "config", "view")
+			Expect(configValue).To(ContainSubstring("hello"))
+			Expect(configValue).To(ContainSubstring("world"))
+			os.Setenv("KUBECONFIG", kubeconfigOld)
+		})
 	})
 })

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -214,7 +214,7 @@ var _ = Describe("odo config test", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "hello=world")
 			kubeconfigOld := os.Getenv("KUBECONFIG")
-			os.Setenv("KUBECONFIG", "")
+			os.Setenv("KUBECONFIG", "/no/such/path")
 			configValue := helper.CmdShouldPass("odo", "config", "view")
 			Expect(configValue).To(ContainSubstring("hello"))
 			Expect(configValue).To(ContainSubstring("world"))


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Using `genericclioptions.Context` required creation of an oc client
connection to the OpenShift server which was not necessary for viewing
the config stored in local config file at `.odo/config.yaml`

## Was the change discussed in an issue?
fixes #1745 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Stop the minishift instance used by `odo`: `minishift stop`
2. Navigate to a directory containing the `.odo/config.yaml` file or don't if you'd like to view the global config stored under `~/.odo/config.yaml`
3. Execute `odo config view`