### PR TITLE
Add "shortcut" section to odo help

### DIFF
--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -45,7 +45,7 @@ func NewCmdApplication(name, fullName string) *cobra.Command {
 	applicationCmd.AddCommand(delete, describe, list)
 
 	// Add a defined annotation in order to appear in the help menu
-	applicationCmd.Annotations = map[string]string{"command": "other"}
+	applicationCmd.Annotations = map[string]string{"command": "main"}
 	applicationCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return applicationCmd

--- a/pkg/odo/cli/catalog/catalog.go
+++ b/pkg/odo/cli/catalog/catalog.go
@@ -32,7 +32,7 @@ func NewCmdCatalog(name, fullName string) *cobra.Command {
 	catalogCmd.AddCommand(catalogSearchCmd, catalogListCmd, catalogDescribeCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	catalogCmd.Annotations = map[string]string{"command": "other"}
+	catalogCmd.Annotations = map[string]string{"command": "main"}
 	catalogCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return catalogCmd

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -51,10 +51,10 @@ Aliases:
 Examples:
 {{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
 
-Component Commands:{{range .Commands}}{{if eq .Annotations.command "component"}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+Shortcuts:{{range .Commands}}{{if eq .Annotations.command "component"}}
+  {{rpad .Name .NamePadding }} {{.Short}} (shortcut for "component {{.Name}}") {{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
-Other Commands:{{range .Commands}}{{if eq .Annotations.command "other"}}
+Commands:{{range .Commands}}{{if eq .Annotations.command "main"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
 Utility Commands:{{range .Commands}}{{if or (eq .Annotations.command "utility") (eq .Name "help") }}

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -71,7 +71,7 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	componentCmd.AddCommand(componentGetCmd, createCmd, deleteCmd, describeCmd, linkCmd, unlinkCmd, listCmd, logCmd, pushCmd, updateCmd, watchCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	componentCmd.Annotations = map[string]string{"command": "component"}
+	componentCmd.Annotations = map[string]string{"command": "main"}
 	componentCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return componentCmd

--- a/pkg/odo/cli/config/config.go
+++ b/pkg/odo/cli/config/config.go
@@ -38,7 +38,7 @@ func NewCmdConfiguration(name, fullName string) *cobra.Command {
 	configurationCmd.AddCommand(configurationViewCmd, configurationSetCmd)
 	configurationCmd.AddCommand(configurationUnsetCmd)
 	configurationCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	configurationCmd.Annotations = map[string]string{"command": "component"}
+	configurationCmd.Annotations = map[string]string{"command": "main"}
 
 	return configurationCmd
 }

--- a/pkg/odo/cli/preference/preference.go
+++ b/pkg/odo/cli/preference/preference.go
@@ -37,7 +37,7 @@ func NewCmdPreference(name, fullName string) *cobra.Command {
 	preferenceCmd.AddCommand(preferenceViewCmd, preferenceSetCmd)
 	preferenceCmd.AddCommand(preferenceUnsetCmd)
 	preferenceCmd.SetUsageTemplate(util.CmdUsageTemplate)
-	preferenceCmd.Annotations = map[string]string{"command": "other"}
+	preferenceCmd.Annotations = map[string]string{"command": "main"}
 
 	return preferenceCmd
 }

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -60,7 +60,7 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 	projectCmd.AddCommand(projectListCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	projectCmd.Annotations = map[string]string{"command": "other"}
+	projectCmd.Annotations = map[string]string{"command": "main"}
 	projectCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	completion.RegisterCommandHandler(projectSetCmd, completion.ProjectNameCompletionHandler)

--- a/pkg/odo/cli/service/service.go
+++ b/pkg/odo/cli/service/service.go
@@ -32,7 +32,7 @@ func NewCmdService(name, fullName string) *cobra.Command {
 		Args: cobra.RangeArgs(1, 3),
 	}
 	// Add a defined annotation in order to appear in the help menu
-	serviceCmd.Annotations = map[string]string{"command": "other"}
+	serviceCmd.Annotations = map[string]string{"command": "main"}
 	serviceCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	serviceCmd.AddCommand(serviceCreateCmd, serviceDeleteCmd, serviceListCmd)
 

--- a/pkg/odo/cli/storage/storage.go
+++ b/pkg/odo/cli/storage/storage.go
@@ -44,7 +44,7 @@ func NewCmdStorage(name, fullName string) *cobra.Command {
 	//storageCmd.AddCommand(storageMountCmd)
 
 	// Add a defined annotation in order to appear in the help menu
-	storageCmd.Annotations = map[string]string{"command": "other"}
+	storageCmd.Annotations = map[string]string{"command": "main"}
 	storageCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	return storageCmd

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -38,7 +38,7 @@ func NewCmdURL(name, fullName string) *cobra.Command {
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	urlCmd.Annotations = map[string]string{"command": "other"}
+	urlCmd.Annotations = map[string]string{"command": "main"}
 	urlCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	urlCmd.AddCommand(urlCreateCmd, urlDeleteCmd, urlListCmd)
 


### PR DESCRIPTION
Adds a "shortcut" section to `odo --help`.

See below:

```sh

Shortcuts:
  create      Create a new component (shortcut for "component create")
  delete      Delete an existing component (shortcut for "component delete")
  describe    Describe the given component (shortcut for "component describe")
  link        Link component to a service or component (shortcut for "component link")
  list        List all components in the current application (shortcut for "component list")
  log         Retrieve the log for the given component (shortcut for "component log")
  push        Push source code to a component (shortcut for "component push")
  unlink      Unlink component to a service or component (shortcut for "component unlink")
  update      Update the source code path of a component (shortcut for "component update")
  watch       Watch for changes, update component on change (shortcut for "component watch")

Commands:
  app         Perform application operations (delete, describe, list)
  catalog     Catalog related operations (describe, list, search)
  component   Components of an application (create, delete, describe, link, list, log, push, unlink, update, watch)
  config      Modifies configuration settings (set, unset, view)
  preference  Modifies preference settings (set, unset, view)
  project     Perform project operations (create, delete, get, list, set)
  service     Perform service catalog operations (create, delete, list)
  storage     Perform storage operations (create, delete, list)
  url         Expose component to the outside world (create, delete, list)
```

Closes https://github.com/openshift/odo/issues/1673