### PR TITLE
create the preference file lazily

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -117,14 +117,16 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get odo config file")
 	}
-	// Check whether directory and file are not present if they aren't then create them
-	if err = util.CreateIfNotExists(configFile); err != nil {
-		return nil, err
-	}
+
 	c := PreferenceInfo{
 		Preference: NewPreference(),
+		Filename:   configFile,
 	}
-	c.Filename = configFile
+	// if the config file doesn't exist then we dont worry about it and return
+	if _, err = os.Stat(configFile); os.IsNotExist(err) {
+		return &c, nil
+	}
+
 	err = util.GetFromFile(&c.Preference, c.Filename)
 	if err != nil {
 		return nil, err

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -403,6 +403,23 @@ func TestIsSupportedParameter(t *testing.T) {
 	}
 }
 
+func TestPreferenceIsntCreatedWhenOdoIsUsed(t *testing.T) {
+	// cleaning up old odo files if any
+	filename, err := getPreferenceFile()
+	if err != nil {
+		t.Error(err)
+	}
+	os.RemoveAll(filename)
+
+	conf, err := NewPreferenceInfo()
+	if err != nil {
+		t.Errorf("error while creating global preference %v", err)
+	}
+	if _, err = os.Stat(conf.Filename); !os.IsNotExist(err) {
+		t.Errorf("preference file shouldn't exist yet")
+	}
+}
+
 func TestMetaTypePopulatedInPreference(t *testing.T) {
 	pi, err := NewPreferenceInfo()
 


### PR DESCRIPTION


## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
recently there was confusion around the global preference file `~/.odo/config.yaml`. some of it was related to why it was present if it was empty. So to reduce this confusion the preference file is created lazily now instead of when NewPreferenceInfo is called.

## Was the change discussed in an issue?
No issue
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
odo preference view # will not create a file
odo preference set Timeout 5000 # will create the file
```
