### PR TITLE
Remove multiple "odo app list" entries

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -7,6 +7,7 @@ import (
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,13 +28,14 @@ func List(client *occlient.Client) ([]string, error) {
 // ListInProject lists all applications in given project by Querying the cluster
 func ListInProject(client *occlient.Client) ([]string, error) {
 
-	// Get applications from cluster
+	// Get all deploymentconfigs with the "app" label
 	appNames, err := client.GetLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list applications")
 	}
 
-	return appNames, nil
+	// Filter out any names, as there could be multiple components but within the same application
+	return util.RemoveDuplicates(appNames), nil
 }
 
 // Exists checks whether the given app exist or not

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -583,3 +583,24 @@ func MachineOutput(outputFlag string, resource interface{}) (string, error) {
 
 	return string(out), err
 }
+
+// RemoveDuplicates goes through a string slice and removes all duplicates.
+// Reference: https://siongui.github.io/2018/04/14/go-remove-duplicates-from-slice-or-array/
+func RemoveDuplicates(s []string) []string {
+
+	// Make a map and go through each value to see if it's a duplicate or not
+	m := make(map[string]bool)
+	for _, item := range s {
+		if _, ok := m[item]; ok {
+		} else {
+			m[item] = true
+		}
+	}
+
+	// Append to the unique string
+	var result []string
+	for item := range m {
+		result = append(result, item)
+	}
+	return result
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -591,8 +591,7 @@ func RemoveDuplicates(s []string) []string {
 	// Make a map and go through each value to see if it's a duplicate or not
 	m := make(map[string]bool)
 	for _, item := range s {
-		if _, ok := m[item]; ok {
-		} else {
+		if _, ok := m[item]; !ok {
 			m[item] = true
 		}
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1034,3 +1034,41 @@ func TestIsGlobExpMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveDuplicate(t *testing.T) {
+	type args struct {
+		input  []string
+		output []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Case 1 - Remove duplicates",
+			args: args{
+				input:  []string{"bar", "bar"},
+				output: []string{"bar"},
+			},
+		},
+		{
+			name: "Case 2 - Remove duplicates, none in array",
+			args: args{
+				input:  []string{"bar", "foo"},
+				output: []string{"bar", "foo"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Run function RemoveDuplicate
+			output := RemoveDuplicates(tt.args.input)
+
+			if !(reflect.DeepEqual(output, tt.args.output)) {
+				t.Errorf("expected %v, got %v", tt.args.output, output)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR puts the app list through a "RemoveDuplicates" function to
remove any duplicate application names.

This is required since we don't have any unique identifies for
applications and thus if we have 2+ components in an application,
multiple deployment config's are returned from OpenShift with the same
application name.

See below for an example of this change:

```sh

▶ odo app list
The project 'foo' has the following applications:
NAME
foobar
app

▶ oc get dc
NAME                 REVISION   DESIRED   CURRENT   TRIGGERED BY
foobar-app           1          1         1         config,image(nodejs:latest)
java-fwwm-app        1          1         1         config,image(java:latest)
nodejs-trym-foobar   1          1         1         config,image(nodejs:latest)

▶ odo app list -o json | jq
{
  "kind": "List",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {},
  "items": [
    {
      "kind": "app",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "foobar",
        "namespace": "foo",
        "creationTimestamp": null
      },
      "spec": {
        "components": [
          "nodejs-trym"
        ]
      },
      "status": {
        "active": false
      }
    },
    {
      "kind": "app",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "app",
        "namespace": "foo",
        "creationTimestamp": null
      },
      "spec": {
        "components": [
          "foobar",
          "java-fwwm"
        ]
      },
      "status": {
        "active": false
      }
    }
  ]
}

```

Closes https://github.com/openshift/odo/issues/1713