### PR TITLE
Added path flag and respective logic

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -898,6 +898,7 @@ func List(client *occlient.Client, applicationName string) (ComponentList, error
 		if err != nil {
 			return ComponentList{}, errors.Wrap(err, "Unable to get component")
 		}
+		component.Status.State = "Pushed"
 		components = append(components, component)
 
 	}
@@ -921,9 +922,13 @@ func ListIfPathGiven(path string, client *occlient.Client) (ComponentList, error
 			}
 			con, _ := filepath.Abs(filepath.Dir(path))
 			a := getMachineReadableFormat(data.GetName(), data.GetType())
-			a.Status.Context = con
-			a.Status.State = exist
 			a.Spec.Source = data.GetSourceLocation()
+			a.Status.Context = con
+			state := "Not Pushed"
+			if exist {
+				state = "Pushed"
+			}
+			a.Status.State = state
 			components = append(components, a)
 		}
 		return nil
@@ -1301,6 +1306,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 	component.Spec.Env = filteredEnv
 	component.Status.LinkedComponents = linkedComponents
 	component.Status.LinkedServices = linkedServices
+	component.Status.State = "Pushed"
 
 	return component, nil
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -908,7 +908,7 @@ func List(client *occlient.Client, applicationName string) (ComponentList, error
 }
 
 // ListIfPathGiven lists all available component in given path directory
-func ListIfPathGiven(path string, client *occlient.Client) (ComponentList, error) {
+func ListIfPathGiven(client *occlient.Client, path string) (ComponentList, error) {
 	var components []Component
 	err := filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
 		if strings.Contains(f.Name(), ".odo") {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -913,7 +913,7 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 	var err error
 	for _, path := range paths {
 		err = filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
-			if strings.Contains(f.Name(), ".odo") {
+			if f != nil && strings.Contains(f.Name(), ".odo") {
 				data, err := config.NewLocalConfigInfo(filepath.Dir(path))
 				if err != nil {
 					return err

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -348,7 +348,6 @@ func TestList(t *testing.T) {
 							Type: "nodejs",
 						},
 						Status: ComponentStatus{
-							Active:           false,
 							LinkedServices:   []string{},
 							LinkedComponents: map[string][]string{},
 						},
@@ -365,7 +364,6 @@ func TestList(t *testing.T) {
 							Type: "java",
 						},
 						Status: ComponentStatus{
-							Active:           false,
 							LinkedServices:   []string{},
 							LinkedComponents: map[string][]string{},
 						},

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -348,6 +348,7 @@ func TestList(t *testing.T) {
 							Type: "nodejs",
 						},
 						Status: ComponentStatus{
+							State:            "Pushed",
 							LinkedServices:   []string{},
 							LinkedComponents: map[string][]string{},
 						},
@@ -364,6 +365,7 @@ func TestList(t *testing.T) {
 							Type: "java",
 						},
 						Status: ComponentStatus{
+							State:            "Pushed",
 							LinkedServices:   []string{},
 							LinkedComponents: map[string][]string{},
 						},

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -32,7 +32,7 @@ type ComponentList struct {
 // ComponentStatus is Status of components
 type ComponentStatus struct {
 	Context          string              `json:"context,omitempty"`
-	State            bool                `json:"state"`
+	State            string              `json:"state"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
 }

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -33,7 +33,6 @@ type ComponentList struct {
 type ComponentStatus struct {
 	Context          string              `json:"context,omitempty"`
 	State            bool                `json:"state,omitempty"`
-	Active           bool                `json:"active"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
 }

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -31,6 +31,8 @@ type ComponentList struct {
 
 // ComponentStatus is Status of components
 type ComponentStatus struct {
+	Context          string              `json:"context,omitempty"`
+	State            bool                `json:"state,omitempty"`
 	Active           bool                `json:"active"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -32,7 +32,7 @@ type ComponentList struct {
 // ComponentStatus is Status of components
 type ComponentStatus struct {
 	Context          string              `json:"context,omitempty"`
-	State            bool                `json:"state,omitempty"`
+	State            bool                `json:"state"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -101,16 +101,21 @@ func (lo *ListOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-
+		activeMark := " "
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
-
+		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
+		currentComponent := lo.Context.ComponentAllowingEmpty(true)
 		for _, file := range ap {
-			d := "not deployed"
+			d := "not Deployed"
 			if file.Status.State {
-				d = "deployed"
+				d = "Deployed"
 			}
-			fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
+			if file.Name == currentComponent {
+				activeMark = "*"
+			}
+			fmt.Fprintln(w, activeMark, "\t", file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
+			activeMark = " "
+
 		}
 		w.Flush()
 		return nil
@@ -137,13 +142,13 @@ func (lo *ListOptions) Run() (err error) {
 		}
 		activeMark := " "
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE")
+		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
 		currentComponent := lo.Context.ComponentAllowingEmpty(true)
 		for _, comp := range components.Items {
 			if comp.Name == currentComponent {
 				activeMark = "*"
 			}
-			fmt.Fprintln(w, activeMark, "\t", comp.Name, "\t", comp.Spec.Type)
+			fmt.Fprintln(w, activeMark, "\t", comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", "Deployed")
 			activeMark = " "
 		}
 		w.Flush()

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -30,7 +30,7 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
 	outputFlag       string
-	pathFlag         string
+	pathFlag         []string
 	componentContext string
 	*genericclioptions.Context
 }
@@ -57,7 +57,7 @@ func (lo *ListOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
-	if lo.pathFlag != "" {
+	if len(lo.pathFlag) != 0 {
 		components, err := component.ListIfPathGiven(lo.Context.Client, lo.pathFlag)
 		if err != nil {
 			return err
@@ -127,7 +127,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	componentListCmd.Annotations = map[string]string{"command": "component"}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
-	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path")
+	componentListCmd.Flags().StringSliceVar(&o.pathFlag, "path", []string{}, "path")
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentListCmd)
 	//Adding `--application` flag

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -8,6 +8,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
@@ -15,8 +18,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -58,7 +58,7 @@ func (lo *ListOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
 	if lo.pathFlag != "" {
-		components, err := component.ListIfPathGiven(lo.pathFlag, lo.Context.Client)
+		components, err := component.ListIfPathGiven(lo.Context.Client, lo.pathFlag)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -4,18 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
+	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -30,6 +34,7 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
 	outputFlag       string
+	pathFlag         string
 	componentContext string
 	*genericclioptions.Context
 }
@@ -56,6 +61,60 @@ func (lo *ListOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
+	var ap []component.Component
+	if lo.pathFlag != "" {
+		err := filepath.Walk(lo.pathFlag, func(path string, f os.FileInfo, err error) error {
+			if strings.Contains(f.Name(), ".odo") {
+				data, err := config.NewLocalConfigInfo(filepath.Dir(path))
+				if err != nil {
+					return err
+				}
+				exist, err := component.Exists(lo.Context.Client, data.GetName(), data.GetApplication())
+				if err != nil {
+					return err
+				}
+				// context will be filepath.Dir(path)
+				con, _ := filepath.Abs(filepath.Dir(path))
+				a := component.Component{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Component",
+						APIVersion: "odo.openshift.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: data.GetName(),
+					},
+					Spec: component.ComponentSpec{
+						Source: data.GetSourceLocation(),
+						Type:   data.GetType(),
+					},
+					Status: component.ComponentStatus{
+						Context: con,
+						State:   exist,
+					},
+				}
+				ap = append(ap, a)
+
+			}
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
+
+		for _, file := range ap {
+			d := "not deployed"
+			if file.Status.State {
+				d = "deployed"
+			}
+			fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
+		}
+		w.Flush()
+		return nil
+	}
 
 	components, err := component.List(lo.Client, lo.Application)
 	if err != nil {
@@ -110,11 +169,13 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	componentListCmd.Annotations = map[string]string{"command": "component"}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
-
+	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path")
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentListCmd)
 	//Adding `--application` flag
 	appCmd.AddApplicationFlag(componentListCmd)
+
+	completion.RegisterCommandFlagHandler(componentListCmd, "path", completion.FileCompletionHandler)
 
 	return componentListCmd
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/golang/glog"
@@ -30,7 +31,7 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
 	outputFlag       string
-	pathFlag         []string
+	pathFlag         string
 	componentContext string
 	*genericclioptions.Context
 }
@@ -58,7 +59,7 @@ func (lo *ListOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
 	if len(lo.pathFlag) != 0 {
-		components, err := component.ListIfPathGiven(lo.Context.Client, lo.pathFlag)
+		components, err := component.ListIfPathGiven(lo.Context.Client, filepath.SplitList(lo.pathFlag))
 		if err != nil {
 			return err
 		}
@@ -127,7 +128,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	componentListCmd.Annotations = map[string]string{"command": "component"}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
-	componentListCmd.Flags().StringSliceVar(&o.pathFlag, "path", []string{}, "path")
+	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path")
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentListCmd)
 	//Adding `--application` flag

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -101,20 +101,14 @@ func (lo *ListOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		activeMark := " "
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
-		currentComponent := lo.Context.ComponentAllowingEmpty(true)
+		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
 		for _, file := range ap {
 			d := "not Deployed"
 			if file.Status.State {
 				d = "Deployed"
 			}
-			if file.Name == currentComponent {
-				activeMark = "*"
-			}
-			fmt.Fprintln(w, activeMark, "\t", file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
-			activeMark = " "
+			fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
 
 		}
 		w.Flush()
@@ -140,16 +134,10 @@ func (lo *ListOptions) Run() (err error) {
 			log.Errorf("There are no components deployed.")
 			return
 		}
-		activeMark := " "
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "ACTIVE", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
-		currentComponent := lo.Context.ComponentAllowingEmpty(true)
+		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
 		for _, comp := range components.Items {
-			if comp.Name == currentComponent {
-				activeMark = "*"
-			}
-			fmt.Fprintln(w, activeMark, "\t", comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", "Deployed")
-			activeMark = " "
+			fmt.Fprintln(w, comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", "Deployed")
 		}
 		w.Flush()
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -63,15 +63,12 @@ func (lo *ListOptions) Run() (err error) {
 			return err
 		}
 		if lo.outputFlag == "json" {
-
 			out, err := json.Marshal(components)
 			if err != nil {
 				return err
 			}
 			fmt.Println(string(out))
-
 		} else {
-
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
 			for _, file := range components.Items {

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -49,7 +49,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	if lo.Context.Project == "" || lo.Application == "" {
+	if lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
 		return odoutil.ThrowContextError()
 	}
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -72,11 +72,7 @@ func (lo *ListOptions) Run() (err error) {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
 			for _, file := range components.Items {
-				d := "not Deployed"
-				if file.Status.State {
-					d = "Deployed"
-				}
-				fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", d, "\t", file.Status.Context)
+				fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
 
 			}
 			w.Flush()
@@ -106,7 +102,7 @@ func (lo *ListOptions) Run() (err error) {
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
 		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", "Deployed")
+			fmt.Fprintln(w, comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
 		}
 		w.Flush()
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -118,11 +118,9 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		// Gather nessasary info
 		p := command.Parent()
 		r := command.Root()
-		fmt.Println("root is", r.Name(), "parent is", p.Name())
 		afs := FlagValueIfSet(command, ApplicationFlagName)
 		// Find the first child of the command. As some groups are allowed even with non existent config
 		fcc := getFirstChildOfCommand(command)
-		fmt.Println("fcc is", fcc.Name(), "command name is", command.Name())
 		// This should not happen but just to be safe
 		if fcc == nil {
 			return nil, fmt.Errorf("Unable to get first child of command")

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -118,9 +118,11 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		// Gather nessasary info
 		p := command.Parent()
 		r := command.Root()
+		fmt.Println("root is", r.Name(), "parent is", p.Name())
 		afs := FlagValueIfSet(command, ApplicationFlagName)
 		// Find the first child of the command. As some groups are allowed even with non existent config
 		fcc := getFirstChildOfCommand(command)
+		fmt.Println("fcc is", fcc.Name(), "command name is", command.Name())
 		// This should not happen but just to be safe
 		if fcc == nil {
 			return nil, fmt.Errorf("Unable to get first child of command")
@@ -129,8 +131,12 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if command.Name() == "create" && (p.Name() == "component" || p.Name() == r.Name()) {
 			return lci, nil
 		}
-		// Case 2 : if command is list,describe or delete and app flag is used just allow it
-		if (fcc.Name() == "list" || fcc.Name() == "describe" || fcc.Name() == "delete") && len(afs) > 0 {
+		// Case 2 : if command is describe or delete and app flag is used just allow it
+		if (fcc.Name() == "describe" || fcc.Name() == "delete") && len(afs) > 0 {
+			return lci, nil
+		}
+		// Case 2 : if command is list, just allow it
+		if fcc.Name() == "list" {
 			return lci, nil
 		}
 		// Case 3 : Check if fcc is project. If so, skip validation of context
@@ -145,10 +151,15 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "catalog" && p.Name() == "list" {
 			return lci, nil
 		}
+		// Check if fcc is component and  request is list
+		if fcc.Name() == "component" && command.Name() == "list" {
+			return lci, nil
+		}
 		// Case 6 : Check if fcc is component and app flag is used
 		if fcc.Name() == "component" && len(afs) > 0 {
 			return lci, nil
 		}
+
 	} else {
 		return lci, nil
 	}

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -81,9 +81,11 @@ var _ = Describe("odojsonoutput", func() {
 			Expect(desiredSrorageList).Should(MatchJSON(actualSrorageList))
 
 			// odo list -o json --path .
-			pwd := helper.CmdShouldPass("pwd")
+			pwd := helper.Getwd()
 			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
-			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", ".")
+			helper.Chdir("/tmp")
+			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", pwd)
+			helper.Chdir(pwd)
 			Expect(desired).Should(MatchJSON(actual))
 
 		})

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -83,9 +83,11 @@ var _ = Describe("odojsonoutput", func() {
 			// odo list -o json --path .
 			pwd := helper.Getwd()
 			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
-			helper.Chdir("/tmp")
+			tmpDir := helper.CreateNewContext()
+			helper.Chdir(tmpDir)
 			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", pwd)
 			helper.Chdir(pwd)
+			helper.DeleteDir(tmpDir)
 			Expect(desired).Should(MatchJSON(actual))
 
 		})

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -62,12 +62,12 @@ var _ = Describe("odojsonoutput", func() {
 
 			// odo component list -o json
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":false}}]}`
+			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}]}`
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			// odo describe component -o json
 			actualDesCompJSON := helper.CmdShouldPass("odo", "describe", "nodejs", "-o", "json")
-			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":false}}`
+			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}`
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			// odo storage create -o json
@@ -82,7 +82,7 @@ var _ = Describe("odojsonoutput", func() {
 
 			// odo list -o json --path .
 			pwd := helper.CmdShouldPass("pwd")
-			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":true}}]}`, strings.TrimSpace(pwd))
+			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
 			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", ".")
 			Expect(desired).Should(MatchJSON(actual))
 

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 var _ = Describe("odojsonoutput", func() {
-	var project string
+	var project, tmpDir string
 
 	// This is run after every Spec (It)
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		project = helper.CreateRandProject()
+		tmpDir = helper.CreateNewContext()
 	})
 
 	// Clean up after the test
@@ -26,6 +27,7 @@ var _ = Describe("odojsonoutput", func() {
 	var _ = AfterEach(func() {
 		helper.DeleteProject(project)
 		os.RemoveAll(".odo")
+		helper.DeleteDir(tmpDir)
 	})
 
 	Context("odo machine readable output on empty project", func() {
@@ -83,11 +85,9 @@ var _ = Describe("odojsonoutput", func() {
 			// odo list -o json --path .
 			pwd := helper.Getwd()
 			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
-			tmpDir := helper.CreateNewContext()
 			helper.Chdir(tmpDir)
 			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", pwd)
 			helper.Chdir(pwd)
-			helper.DeleteDir(tmpDir)
 			Expect(desired).Should(MatchJSON(actual))
 
 		})

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -79,6 +79,13 @@ var _ = Describe("odojsonoutput", func() {
 			actualSrorageList := helper.CmdShouldPass("odo", "storage", "list", "-o", "json")
 			desiredSrorageList := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi"},"status":{"path":"/opt/app-root/src/storage/"}}]}`
 			Expect(desiredSrorageList).Should(MatchJSON(actualSrorageList))
+
+			// odo list -o json --path .
+			pwd := helper.CmdShouldPass("pwd")
+			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":true}}]}`, strings.TrimSpace(pwd))
+			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", ".")
+			Expect(desired).Should(MatchJSON(actual))
+
 		})
 	})
 

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -62,12 +62,12 @@ var _ = Describe("odojsonoutput", func() {
 
 			// odo component list -o json
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"active":false}}]}`
+			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":false}}]}`
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			// odo describe component -o json
 			actualDesCompJSON := helper.CmdShouldPass("odo", "describe", "nodejs", "-o", "json")
-			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"active":false}}`
+			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":false}}`
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			// odo storage create -o json


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

## Was the change discussed in an issue?
fixes #1587
<!-- Please do Link issues here. -->

## How to test changes?

```
[snarwade@redsuraj github.com]$ odo list --context openshift/nodejs-ex --path openshift
NAME            TYPE       SOURCE     STATE            CONTEXT
php-esgq        php        ./         not deployed     /home/snarwade/go/src/github.com/openshift/cakephp-ex
httpd-nesr      httpd      ./         not deployed     /home/snarwade/go/src/github.com/openshift/httpd-ex
nodejs-rtsc     nodejs     ./         deployed         /home/snarwade/go/src/github.com/openshift/nodejs-ex
ruby-kept       ruby       ./         deployed         /home/snarwade/go/src/github.com/openshift/ruby-ex
```