### PR TITLE
Renamed global preference file to preference.yaml from config.yaml

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	globalConfigEnvName  = "GLOBALODOCONFIG"
-	configFileName       = "config.yaml"
+	configFileName       = "preference.yaml"
 	preferenceKind       = "Preference"
 	preferenceAPIVersion = "odo.openshift.io/v1alpha1"
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
The global preference's default name changes to preference.yaml instead of config.yaml. As this file is present in the ~/.odo folder it will not colide with the config.yaml if someone chooses to create a component in home dir.


<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1766
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
odo preference set Timeout 5 # this should create a ~/.odo/preference.yaml instead of ~/.odo/config.yaml
```

### NOTE - Add this to the ChangeLog as this is a breaking change 