### PR TITLE
fix infinite wait in CreateNewProject

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2565,8 +2565,6 @@ func TestCreateNewProject(t *testing.T) {
 			wait:     true,
 			wantErr:  false,
 		},
-
-		// TODO: Currently fails. Enable once fixed.
 		// {
 		// 	name:     "Case 2: empty project name",
 		// 	projName: "",
@@ -2578,6 +2576,15 @@ func TestCreateNewProject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fkclient, fkclientset := FakeNew()
 
+			fkclientset.ProjClientset.PrependReactor("create", "projectrequests", func(action ktesting.Action) (bool, runtime.Object, error) {
+				proj := projectv1.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.projName,
+					},
+				}
+				return true, &proj, nil
+			})
+
 			if tt.wait {
 				fkWatch := watch.NewFake()
 				// Change the status
@@ -2588,7 +2595,7 @@ func TestCreateNewProject(t *testing.T) {
 						},
 					})
 				}()
-				fkclientset.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				fkclientset.ProjClientset.AddWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 					if len(tt.projName) == 0 {
 						return true, nil, fmt.Errorf("error watching project")
 					}
@@ -2596,31 +2603,22 @@ func TestCreateNewProject(t *testing.T) {
 				})
 			}
 
-			fkclientset.ProjClientset.PrependReactor("create", "projectrequests", func(action ktesting.Action) (bool, runtime.Object, error) {
-				proj := projectv1.Project{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: tt.projName,
-					},
-				}
-				return true, &proj, nil
-			})
-
 			err := fkclient.CreateNewProject(tt.projName, tt.wait)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("client.CreateNewProject(string) unexpected error %v, wantErr %v", err, tt.wantErr)
 			}
 
 			actions := fkclientset.ProjClientset.Actions()
-			actionsNb := len(actions)
-			if !tt.wait && actionsNb != 1 {
+			actionsLen := len(actions)
+			if !tt.wait && actionsLen != 1 {
 				t.Errorf("expected 1 action in CreateNewProject got: %v", actions)
 			}
-			if tt.wait && actionsNb != 2 {
+			if tt.wait && actionsLen != 2 {
 				t.Errorf("expected 2 actions in CreateNewProject when waiting for project creation got: %v", actions)
 			}
 
 			if err == nil {
-				createdProj := actions[0].(ktesting.CreateAction).GetObject().(*projectv1.ProjectRequest)
+				createdProj := actions[actionsLen-1].(ktesting.CreateAction).GetObject().(*projectv1.ProjectRequest)
 
 				if createdProj.Name != tt.projName {
 					t.Errorf("project name does not match the expected name, expected: %s, got: %s", tt.projName, createdProj.Name)
@@ -2628,7 +2626,7 @@ func TestCreateNewProject(t *testing.T) {
 
 				if tt.wait {
 					expectedFields := fields.OneTermEqualSelector("metadata.name", tt.projName)
-					gotFields := actions[1].(ktesting.WatchAction).GetWatchRestrictions().Fields
+					gotFields := actions[0].(ktesting.WatchAction).GetWatchRestrictions().Fields
 
 					if !reflect.DeepEqual(expectedFields, gotFields) {
 						t.Errorf("Fields not matching: expected: %s, got %s", expectedFields, gotFields)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
fixes situation when odo waited forever for a project that was already created

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1707
<!-- Please do Link issues here. -->

## How to test changes?
No easy way to test the fix. 
The only way to that I know how to reproduce the previous bug was by using the debugger. 
I had to comment out the `ProjectRequests().Create` call and then create the project manually right before stepping to water creation.

Creating watcher before the project we make sure that we watcher gets the create even in the go channel.


Due to the nature of the bug, it is almost impossible to write a test to cover this situation :-/


