### PR TITLE
Adds the functionality of running some component commands outside a odo directory

### DIFF
--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -48,6 +48,9 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 
 // Validate validates the list parameters
 func (do *DeleteOptions) Validate() (err error) {
+	if do.Context.Project == "" || do.Application == "" {
+		return odoutil.ThrowContextError()
+	}
 	isExists, err := component.Exists(do.Client, do.componentName, do.Application)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -44,6 +44,10 @@ func (do *DescribeOptions) Complete(name string, cmd *cobra.Command, args []stri
 
 // Validate validates the describe parameters
 func (do *DescribeOptions) Validate() (err error) {
+	if do.Context.Project == "" || do.Application == "" {
+		return odoutil.ThrowContextError()
+	}
+
 	isExists, err := component.Exists(do.Context.Client, do.componentName, do.Context.Application)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -47,6 +47,10 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
+	if lo.Context.Project == "" || lo.Application == "" {
+		return odoutil.ThrowContextError()
+	}
+
 	return odoutil.CheckOutputFlag(lo.outputFlag)
 }
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -118,7 +118,6 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		// Gather nessasary info
 		p := command.Parent()
 		r := command.Root()
-		pfs := FlagValueIfSet(command, ProjectFlagName)
 		afs := FlagValueIfSet(command, ApplicationFlagName)
 		// Find the first child of the command. As some groups are allowed even with non existent config
 		fcc := getFirstChildOfCommand(command)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -130,19 +130,24 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if command.Name() == "create" && (p.Name() == "component" || p.Name() == r.Name()) {
 			return lci, nil
 		}
-		// Case 2 : Check if fcc is project. If so, skip validation of context
+		// Case 2 : if command is list,describe or delete and app flag is used just allow it
+		if (fcc.Name() == "list" || fcc.Name() == "describe" || fcc.Name() == "delete") && len(afs) > 0 {
+			return lci, nil
+		}
+		// Case 3 : Check if fcc is project. If so, skip validation of context
 		if fcc.Name() == "project" {
 			return lci, nil
 		}
-		// Case 3 : Check if specific flags are set for specific first child commands
+		// Case 4 : Check if specific flags are set for specific first child commands
 		if fcc.Name() == "app" {
 			return lci, nil
 		}
-		// Case 4 : Check if fcc is catalog and request is to list
+		// Case 5 : Check if fcc is catalog and request is to list
 		if fcc.Name() == "catalog" && p.Name() == "list" {
 			return lci, nil
 		}
-		if fcc.Name() == "component" && len(pfs) > 0 && len(afs) > 0 {
+		// Case 6 : Check if fcc is component and app flag is used
+		if fcc.Name() == "component" && len(afs) > 0 {
 			return lci, nil
 		}
 	} else {

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -151,6 +151,6 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // ThrowContextError prints a context error if application/project is not found
 func ThrowContextError() error {
-	return errors.Errorf("Please specify the application name and project name" +
-		"\n Or use the command from inside a directory containing an odo component.")
+	return errors.Errorf(`Please specify the application name and project name
+Or use the command from inside a directory containing an odo component.`)
 }

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -151,6 +151,6 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // ThrowContextError prints a context error if application/project is not found
 func ThrowContextError() error {
-	return errors.Errorf(`Please specify the application name and project name
-Or use the command from inside a directory containing an odo component.`)
+	return errors.Errorf("Please specify the application name and project name" +
+		"\n Or use the command from inside a directory containing an odo component.")
 }


### PR DESCRIPTION
fixes #1646 (only the component part)

This PR makes the app commands work outside a odo component directory if a project flag is given or the current project is used.

How to test:
Create a odo component and push. Then switch to a different directory containing no odo component. Then run the below commands
```
odo list --app <app-name>
odo delete <cmp-name> --app <app-name>
odo describe <cmp-name> --app <app-name>
```
```
odo component list --app <app-name>
odo component delete <cmp-name> --app <app-name>
odo component describe <cmp-name> --app <app-name>
```
These commands should work outside a odo component directory