### PR TITLE
List apps deployed via servers within odo app list

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -44,8 +44,8 @@ func ListInProject(client *occlient.Client) ([]string, error) {
 	// however, we should at least warn the user.
 	serviceInstanceAppNames, err := client.GetServiceInstanceLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {
-		glog.V(4).Infof("Unable to list Service Catalog images: %s", err)
-		log.Warning("Unable to access Service Catalog list, may not be enabled on cluster")
+		glog.V(4).Infof("Unable to list Service Catalog instances: %s", err)
+		log.Warning("Unable to access Service Catalog instances, may not be enabled on cluster")
 	} else {
 		appNames = append(deploymentConfigAppNames, serviceInstanceAppNames...)
 	}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -6,6 +6,7 @@ import (
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/util"
 
@@ -28,10 +29,25 @@ func List(client *occlient.Client) ([]string, error) {
 // ListInProject lists all applications in given project by Querying the cluster
 func ListInProject(client *occlient.Client) ([]string, error) {
 
-	// Get all deploymentconfigs with the "app" label
-	appNames, err := client.GetLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
+	var appNames []string
+
+	// Get all DeploymentConfigs with the "app" label
+	deploymentConfigAppNames, err := client.GetDeploymentConfigLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list applications")
+		return nil, errors.Wrap(err, "unable to list applications from deployment config")
+	}
+
+	appNames = append(appNames, deploymentConfigAppNames...)
+
+	// Get all ServiceInstances with the "app" label
+	// Okay, so there is an edge-case here.. if Service Catalog is *not* enabled in the cluster, we shouldn't error out..
+	// however, we should at least warn the user.
+	serviceInstanceAppNames, err := client.GetServiceInstanceLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
+	if err != nil {
+		glog.V(4).Infof("Unable to list Service Catalog images: %s", err)
+		log.Warning("Unable to access Service Catalog list, may not be enabled on cluster")
+	} else {
+		appNames = append(deploymentConfigAppNames, serviceInstanceAppNames...)
 	}
 
 	// Filter out any names, as there could be multiple components but within the same application

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -855,7 +855,7 @@ func GetComponentType(client *occlient.Client, componentName string, application
 
 	// filter according to component and application name
 	selector := fmt.Sprintf("%s=%s,%s=%s", componentlabels.ComponentLabel, componentName, applabels.ApplicationLabel, applicationName)
-	componentImageTypes, err := client.GetLabelValues(componentlabels.ComponentTypeLabel, selector)
+	componentImageTypes, err := client.GetDeploymentConfigLabelValues(componentlabels.ComponentTypeLabel, selector)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get type of %s component")
 	}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -174,6 +174,18 @@ func Successf(format string, a ...interface{}) {
 	fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintf(format, a...))
 }
 
+// Warningf will output in an appropriate "progress" manner
+func Warningf(format string, a ...interface{}) {
+	yellow := color.New(color.FgYellow).SprintFunc()
+	fmt.Fprintf(GetStderr(), " %s%s%s\n", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
+}
+
+// Warning will output in an appropriate "progress" manner
+func Warning(a ...interface{}) {
+	yellow := color.New(color.FgYellow).SprintFunc()
+	fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, yellow(getWarningString()), suffixSpacing, fmt.Sprintln(a...))
+}
+
 // Errorf will output in an appropriate "progress" manner
 func Errorf(format string, a ...interface{}) {
 	red := color.New(color.FgRed).SprintFunc()
@@ -272,6 +284,16 @@ func getErrString() string {
 		return "X"
 	}
 	return "✗"
+}
+
+// getWarningString returns a certain string based upon the OS.
+// Some Windows terminals do not support unicode and must use ASCII.
+// TODO: Test needs to be added once we get Windows testing available on TravisCI / CI platform.
+func getWarningString() string {
+	if runtime.GOOS == "windows" {
+		return "!"
+	}
+	return "⚠"
 }
 
 // getSuccessString returns a certain string based upon the OS.

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2159,14 +2160,17 @@ func (c *Client) DeleteProject(name string) error {
 	}
 }
 
-// GetLabelValues get label values of given label from objects in project that are matching selector
+// GetDeploymentConfigLabelValues get label values of given label from objects in project that are matching selector
 // returns slice of unique label values
-func (c *Client) GetLabelValues(label string, selector string) ([]string, error) {
+func (c *Client) GetDeploymentConfigLabelValues(label string, selector string) ([]string, error) {
+
 	// List DeploymentConfig according to selectors
 	dcList, err := c.appsClient.DeploymentConfigs(c.Namespace).List(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list DeploymentConfigs")
 	}
+
+	// Grab all the matched strings
 	var values []string
 	for _, elem := range dcList.Items {
 		for key, val := range elem.Labels {
@@ -2175,6 +2179,34 @@ func (c *Client) GetLabelValues(label string, selector string) ([]string, error)
 			}
 		}
 	}
+
+	// Sort alphabetically
+	sort.Strings(values)
+
+	return values, nil
+}
+
+// GetServiceInstanceLabelValues get label values of given label from objects in project that match the selector
+func (c *Client) GetServiceInstanceLabelValues(label string, selector string) ([]string, error) {
+
+	// List ServiceInstance according to given selectors
+	svcList, err := c.serviceCatalogClient.ServiceInstances(c.Namespace).List(metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list ServiceInstances")
+	}
+
+	// Grab all the matched strings
+	var values []string
+	for _, elem := range svcList.Items {
+		for key, val := range elem.Labels {
+			if key == label {
+				values = append(values, val)
+			}
+		}
+	}
+
+	// Sort alphabetically
+	sort.Strings(values)
 
 	return values, nil
 }


### PR DESCRIPTION
This PR:
  - Updates `odo app list` to also include services
  - Adds tests to both GetDeploymentConfigLabelValues as well as
  GetServiceInstanceLabelValues
 - Sorts both functions alphabetically when outputting

To replicate:

```sh
git clone https://github.com/openshift/nodejs-ex
cd nodejs-ex
odo create nodejs --app app
odo service create mysql-persistent --app app2


odo app list
The project 'myproject' has the following applications:
NAME
app
app2
```

Closes https://github.com/openshift/odo/issues/1730