### PR TITLE
Bumps version to v1.0.0-beta3

### DIFF
--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -126,7 +126,7 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connecti
         describe --app --context --output --project : Describe the given component
         get --app --context --project --short : Get currently active component
         link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
-        list --app --context --output --project : List all components in the current application
+        list --app --context --output --path --project : List all components in the current application
         log --app --context --follow --project : Retrieve the log for the given component
         push --config --context --ignore --show-log --source : Push source code to a component
         unlink --app --component --context --port --project --wait : Unlink component to a service or component
@@ -140,7 +140,7 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connecti
     delete --all --app --context --force --project : Delete an existing component
     describe --app --context --output --project : Describe the given component
     link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
-    list --app --context --output --project : List all components in the current application
+    list --app --context --output --path --project : List all components in the current application
     log --app --context --follow --project : Retrieve the log for the given component
     login --certificate-authority --insecure-skip-tls-verify --password --token --username : Login to cluster
     logout : Log out of the current OpenShift session

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0-beta2"
+	VERSION = "v1.0.0-beta3"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ set -e
 ODO_VERSION="latest"
 
 # Latest released odo version
-LATEST_VERSION="v1.0.0-beta2"
+LATEST_VERSION="v1.0.0-beta3"
 
 GITHUB_RELEASES_URL="https://github.com/openshift/odo/releases/download/${LATEST_VERSION}"
 BINTRAY_URL="https://dl.bintray.com/odo/odo/latest"


### PR DESCRIPTION
Release notes draft

So what's new in v1.0.0-beta3?

Enhancements
- Adds a timer to UI / UX output to the odo component creation output. #1795 
- We can now run `odo component describe/delete/list` and `odo app describe/delete/list` outside a directory containing a odo component. #1792 and #1779  
- The problem of wrong path during odo create in interactive mode is fixed. #1764 
- We can now view odo config info from the local config without talking to the server. #1758 
- Adds a "shortcut" section to odo --help. #1763 
- Adds a `path` flag to `odo list` for viewing all components in a directory. #1771 
- Improves URL creation and deletion UI/UX. #1774 
- Rename install.sh to installer.sh and Add Uninstall #1802 
- Fix infinite wait in CreateNewProject #1785 
- Remove multiple "odo app list" entries #1767 
- Create the preference file lazily #1765 
- Add "shortcut" section to odo help #1763 

Breaking changes
- The global preference's default name changes to preference.yaml instead of config.yaml. As this file is present in the ~/.odo folder it will not colide with the config.yaml if someone chooses to create a component in home dir. For backward compatibility, just rename the file to preference.yaml. #1784 