### PR TITLE
Don't allow user to create a URL name longer than 63 characters

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -63,9 +63,6 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 	if len(args) == 0 {
 		o.urlName = url.GetURLName(o.Component(), o.componentPort)
 	} else {
-		if len(args[0]) > 63 {
-			return fmt.Errorf("url name must be shorter than 63 characters")
-		}
 		o.urlName = args[0]
 	}
 	o.localConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
@@ -83,9 +80,15 @@ func (o *URLCreateOptions) Validate() (err error) {
 		}
 	}
 
+	// Check if url name is more than 63 characters long
+	if len(o.urlName) > 63 {
+		return fmt.Errorf("url name must be shorter than 63 characters")
+	}
+
 	if !util.CheckOutputFlag(o.OutputFlag) {
 		return fmt.Errorf("given output format %s is not supported", o.OutputFlag)
 	}
+
 	return
 }
 

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -63,6 +63,9 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 	if len(args) == 0 {
 		o.urlName = url.GetURLName(o.Component(), o.componentPort)
 	} else {
+		if len(args[0]) > 63 {
+			return fmt.Errorf("url name must be shorter than 63 characters")
+		}
 		o.urlName = args[0]
 	}
 	o.localConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -21,6 +21,7 @@ var _ = Describe("odo generic", func() {
 	var oc helper.OcRunner
 	var err error
 	var testPHPGitURL = "https://github.com/appuio/example-php-sti-helloworld"
+	var testLongURLName = "long-url-name-long-url-name-long-url-name-long-url-name-long-url-name"
 
 	BeforeEach(func() {
 		oc = helper.NewOcRunner("oc")
@@ -214,6 +215,22 @@ var _ = Describe("odo generic", func() {
 			reServerURL := regexp.MustCompile(`Server:\s*https:\/\/(.+\.com|([0-9]+.){3}[0-9]+):[0-9]{4}`)
 			serverURLStringMatch := reServerURL.MatchString(odoVersion)
 			Expect(serverURLStringMatch).Should(BeTrue())
+		})
+	})
+
+	Context("prevent the user from creating a URL with name that has more than 63 characters", func() {
+		JustBeforeEach(func() {
+			project = helper.CreateRandProject()
+		})
+
+		JustAfterEach(func() {
+			helper.DeleteProject(project)
+			os.RemoveAll(".odo")
+		})
+		It("should not allow creating a URL with long name", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs")
+			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
+			Expect(stdOut).To(ContainSubstring("url name must be shorter than 63 characters"))
 		})
 	})
 })

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -219,16 +219,22 @@ var _ = Describe("odo generic", func() {
 	})
 
 	Context("prevent the user from creating a URL with name that has more than 63 characters", func() {
+		var originalDir string
+
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()
+			context = helper.CreateNewContext()
+			originalDir = helper.Getwd()
+			helper.Chdir(context)
 		})
 
 		JustAfterEach(func() {
 			helper.DeleteProject(project)
-			os.RemoveAll(".odo")
+			helper.Chdir(originalDir)
+			helper.DeleteDir(context)
 		})
 		It("should not allow creating a URL with long name", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
 			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
 			Expect(stdOut).To(ContainSubstring("url name must be shorter than 63 characters"))
 		})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR prevents the user from creating URL longer than 63 characters. Long URLs are not allowed by OpenShift. Refer https://github.com/openshift/odo/issues/1213#issuecomment-501201185
## Was the change discussed in an issue?
fixes #1213 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Build the binary.
2. Create a URL with a really long name like:
  ```bash
  $ odo url create frontend-long-long-long-long-long-long-long-long-long-long-long-long-long-long --port 8080
  ```