### PR TITLE
Switch to using string-based formatting for time elapsed

### DIFF
--- a/pkg/log/fidget/spinner.go
+++ b/pkg/log/fidget/spinner.go
@@ -121,12 +121,18 @@ func (s *Spinner) Stop() {
 }
 
 // TimeSpent returns the seconds spent since the spinner first started
-func (s *Spinner) TimeSpent() time.Duration {
+func (s *Spinner) TimeSpent() string {
 	currentTime := time.Now()
+	timeElapsed := currentTime.Sub(s.start)
 
-	if currentTime.Sub(s.start) < time.Second {
-		return currentTime.Sub(s.start).Round(time.Millisecond)
+	// Print ms if less than a second
+	// else print out minutes if more than 1 minute
+	// else print the default (seconds)
+	if timeElapsed < time.Second {
+		return fmt.Sprintf("%dms", timeElapsed.Nanoseconds()/int64(time.Millisecond))
+	} else if timeElapsed > time.Minute {
+		return fmt.Sprintf("%.0fm", timeElapsed.Minutes())
 	}
 
-	return currentTime.Sub(s.start).Round(time.Second)
+	return fmt.Sprintf("%.0fs", timeElapsed.Seconds())
 }

--- a/pkg/log/fidget/spinner.go
+++ b/pkg/log/fidget/spinner.go
@@ -77,6 +77,7 @@ func NewSpinner(w io.Writer) *Spinner {
 		ticker: time.NewTicker(time.Millisecond * 200),
 		mu:     &sync.Mutex{},
 		writer: w,
+		start:  time.Now(),
 	}
 }
 
@@ -96,7 +97,6 @@ func (s *Spinner) SetSuffix(suffix string) {
 
 // Start starts the spinner running
 func (s *Spinner) Start() {
-	s.start = time.Now()
 	go func() {
 		for {
 			for _, frame := range s.frames {
@@ -128,11 +128,13 @@ func (s *Spinner) TimeSpent() string {
 	// Print ms if less than a second
 	// else print out minutes if more than 1 minute
 	// else print the default (seconds)
-	if timeElapsed < time.Second {
-		return fmt.Sprintf("%dms", timeElapsed.Nanoseconds()/int64(time.Millisecond))
-	} else if timeElapsed > time.Minute {
+	if timeElapsed > time.Minute {
 		return fmt.Sprintf("%.0fm", timeElapsed.Minutes())
+	} else if timeElapsed < time.Minute && timeElapsed > time.Second {
+		return fmt.Sprintf("%.0fs", timeElapsed.Seconds())
+	} else if timeElapsed < time.Second && timeElapsed > time.Millisecond {
+		return fmt.Sprintf("%dms", timeElapsed.Nanoseconds()/int64(time.Millisecond))
 	}
 
-	return fmt.Sprintf("%.0fs", timeElapsed.Seconds())
+	return fmt.Sprintf("%dns", timeElapsed.Nanoseconds())
 }

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -142,10 +142,10 @@ func (s *Status) End(success bool) {
 
 	if success {
 		green := color.New(color.FgGreen).SprintFunc()
-		fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%v]\n", green(getSuccessString()), s.status, s.spinner.TimeSpent())
+		fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%s]\n", green(getSuccessString()), s.status, s.spinner.TimeSpent())
 	} else {
 		red := color.New(color.FgRed).SprintFunc()
-		fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%v]\n", red(getErrString()), s.status, s.spinner.TimeSpent())
+		fmt.Fprintf(s.writer, prefixSpacing+"%s"+suffixSpacing+"%s [%s]\n", red(getErrString()), s.status, s.spinner.TimeSpent())
 	}
 
 	s.status = ""


### PR DESCRIPTION
This PR:
  - Uses string based formatting for the time
  - No longer uses "%v" with time.Duration, so there are no
  false-positives when displaying the time

Closes https://github.com/openshift/odo/issues/1811