### PR TITLE
Added --all flag to odo list

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -903,7 +903,7 @@ func List(client *occlient.Client, applicationName string) (ComponentList, error
 
 	}
 
-	compoList := getMachineReadableFormatForList(components)
+	compoList := GetMachineReadableFormatForList(components)
 	return compoList, nil
 }
 
@@ -924,6 +924,7 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 				}
 				con, _ := filepath.Abs(filepath.Dir(path))
 				a := getMachineReadableFormat(data.GetName(), data.GetType())
+				a.Spec.App = data.GetApplication()
 				a.Spec.Source = data.GetSourceLocation()
 				a.Status.Context = con
 				state := "Not Pushed"
@@ -937,7 +938,7 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 		})
 
 	}
-	return getMachineReadableFormatForList(components), err
+	return GetMachineReadableFormatForList(components), err
 }
 
 // GetComponentSource what source type given component uses
@@ -1304,6 +1305,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 	}
 
 	component = getMachineReadableFormat(componentName, componentType)
+	component.Spec.App = applicationName
 	component.Spec.Source = path
 	component.Spec.URL = urls
 	component.Spec.Storage = storage
@@ -1350,8 +1352,8 @@ func getMachineReadableFormat(componentName, componentType string) Component {
 
 }
 
-// getMachineReadableFormatForList returns list of components in machine readable format
-func getMachineReadableFormatForList(components []Component) ComponentList {
+// GetMachineReadableFormatForList returns list of components in machine readable format
+func GetMachineReadableFormatForList(components []Component) ComponentList {
 	if len(components) == 0 {
 		components = []Component{}
 	}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -346,6 +346,7 @@ func TestList(t *testing.T) {
 						},
 						Spec: ComponentSpec{
 							Type: "nodejs",
+							App:  "app",
 						},
 						Status: ComponentStatus{
 							State:            "Pushed",
@@ -363,6 +364,7 @@ func TestList(t *testing.T) {
 						},
 						Spec: ComponentSpec{
 							Type: "java",
+							App:  "app",
 						},
 						Status: ComponentStatus{
 							State:            "Pushed",
@@ -665,7 +667,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getMachineReadableFormatForList(tt.args.components); !reflect.DeepEqual(got, tt.want) {
+			if got := GetMachineReadableFormatForList(tt.args.components); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getMachineReadableFormatForList() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -15,6 +15,7 @@ type Component struct {
 
 // ComponentSpec is spec of components
 type ComponentSpec struct {
+	App     string          `json:"app,omitempty"`
 	Type    string          `json:"type,omitempty"`
 	Source  string          `json:"source,omitempty"`
 	URL     []string        `json:"url,omitempty"`

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -86,13 +86,14 @@ func (lo *ListOptions) Run() (err error) {
 	var components component.ComponentList
 
 	if lo.allFlag {
+		// retrieve list of application
 		apps, err := application.List(lo.Client)
 		if err != nil {
 			return err
 		}
 
 		var componentList []component.Component
-
+		// interating over list of application and get list of all components
 		for _, app := range apps {
 			comps, err := component.List(lo.Client, app)
 			if err != nil {
@@ -100,6 +101,7 @@ func (lo *ListOptions) Run() (err error) {
 			}
 			componentList = append(componentList, comps.Items...)
 		}
+		// Get machine readable component list format
 		components = component.GetMachineReadableFormatForList(componentList)
 	} else {
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -52,7 +52,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	if lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
+	if !lo.allFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
 		return odoutil.ThrowContextError()
 	}
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/application"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -33,6 +34,7 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 type ListOptions struct {
 	outputFlag       string
 	pathFlag         string
+	allFlag          bool
 	componentContext string
 	*genericclioptions.Context
 }
@@ -72,19 +74,39 @@ func (lo *ListOptions) Run() (err error) {
 			fmt.Println(string(out))
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
 			for _, file := range components.Items {
-				fmt.Fprintln(w, file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
+				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
 
 			}
 			w.Flush()
 		}
 		return nil
 	}
+	var components component.ComponentList
 
-	components, err := component.List(lo.Client, lo.Application)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch components list")
+	if lo.allFlag {
+		apps, err := application.List(lo.Client)
+		if err != nil {
+			return err
+		}
+
+		var componentList []component.Component
+
+		for _, app := range apps {
+			comps, err := component.List(lo.Client, app)
+			if err != nil {
+				return err
+			}
+			componentList = append(componentList, comps.Items...)
+		}
+		components = component.GetMachineReadableFormatForList(componentList)
+	} else {
+
+		components, err = component.List(lo.Client, lo.Application)
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch components list")
+		}
 	}
 	glog.V(4).Infof("the components are %+v", components)
 
@@ -102,9 +124,9 @@ func (lo *ListOptions) Run() (err error) {
 			return
 		}
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
 		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
 		}
 		w.Flush()
 	}
@@ -130,6 +152,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path")
+	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentListCmd)
 	//Adding `--application` flag

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -70,7 +70,7 @@ var _ = Describe("odoCmdApp", func() {
 				appListOutput := helper.CmdShouldPass("odo", "app", "list")
 				Expect(appListOutput).To(ContainSubstring(appName))
 				actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-				desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"file://./"},"status":{"state":"Pushed"}}]}`
+				desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","app":"app","source":"file://./"},"status":{"state":"Pushed"}}]}`
 				Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 				helper.CmdShouldPass("odo", "app", "describe")

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -94,6 +94,13 @@ func componentTests(args ...string) {
 			Expect(cmpList).To(ContainSubstring("cmp-git"))
 			helper.CmdShouldPass("odo", append(args, "delete", "cmp-git", "-f")...)
 		})
+		It("should list the component using --all flag", func() {
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--all")...)
+			Expect(cmpList).To(ContainSubstring("cmp-git"))
+			helper.CmdShouldPass("odo", append(args, "delete", "cmp-git", "-f")...)
+		})
 	})
 
 	Context("Test odo push with --source and --config flags", func() {

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -66,17 +66,18 @@ var _ = Describe("odojsonoutput", func() {
 
 			// odo component list -o json
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}]}`
+			desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","app": "myapp","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}]}`
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			// odo describe component -o json
 			actualDesCompJSON := helper.CmdShouldPass("odo", "describe", "nodejs", "-o", "json")
-			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}`
+			desiredDesCompJSON := `{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","app": "myapp","source":"https://github.com/openshift/nodejs-ex"},"status":{"state":"Pushed"}}`
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			// odo list -o json --path .
 			pwd := helper.Getwd()
-			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
+
+			desired := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null},"spec":{"type":"nodejs","app": "myapp","source":"https://github.com/openshift/nodejs-ex"},"status":{"context":"%s","state":"Pushed"}}]}`, strings.TrimSpace(pwd))
 			helper.Chdir(context)
 			actual := helper.CmdShouldPass("odo", "list", "-o", "json", "--path", pwd)
 			helper.Chdir(pwd)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

this PR adds `--all` flag which will list down all components available in the cluster

## Was the change discussed in an issue?
fixes #1584
<!-- Please do Link issues here. -->

## How to test changes?

```
odo list --all
```