### PR TITLE
Add benchmark tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,11 @@ test-e2e:
 test-e2e-scenarios:
 	go test -v github.com/openshift/odo/tests/e2escenarios -ginkgo.slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -ginkgo.v -timeout $(TIMEOUT)
 
+# this test shouldn't be in paralel -  it will effect the results
+.PHONY: test-benchmark
+test-benchmark:
+	go test -v github.com/openshift/odo/tests/benchmark -timeout $(TIMEOUT)
+
 # create deb and rpm packages using fpm in ./dist/pkgs/
 # run make cross before this!
 .PHONY: packages

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -206,14 +206,18 @@ func getDefaultBuilderImages(client *occlient.Client) ([]CatalogImage, error) {
 
 			}
 
-			builderImages = append(builderImages,
-				CatalogImage{Name: imageStream.Name, Namespace: imageStream.Namespace,
-					AllTags: allTags, NonHiddenTags: getAllNonHiddenTags(allTags, hiddenTags)})
+			catalogImage := CatalogImage{
+				Name:          imageStream.Name,
+				Namespace:     imageStream.Namespace,
+				AllTags:       allTags,
+				NonHiddenTags: getAllNonHiddenTags(allTags, hiddenTags),
+			}
+			builderImages = append(builderImages, catalogImage)
+			glog.V(5).Infof("Found builder image: %#v", catalogImage)
 		}
 
 	}
 
-	glog.V(4).Infof("Found builder images: %v", builderImages)
 	return builderImages, nil
 }
 

--- a/scripts/openshiftci-presubmit-benchmark.sh
+++ b/scripts/openshiftci-presubmit-benchmark.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+export CI="openshift"
+export TIMEOUT="30m"
+make configure-installer-tests-cluster
+make bin
+mkdir -p $GOPATH/bin
+go get -u github.com/onsi/ginkgo/ginkgo
+export PATH="$PATH:$(pwd):$GOPATH/bin"
+export CUSTOM_HOMEDIR="/tmp/artifacts"
+
+env
+
+make test-benchmark

--- a/tests/benchmark/basic_benchmark.go
+++ b/tests/benchmark/basic_benchmark.go
@@ -1,0 +1,116 @@
+package benchmark
+
+import (
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/odo/tests/helper"
+)
+
+var _ = Describe("Basic benchmark", func() {
+
+	// how many times each benchmark will be executed
+	const numberOfRuns int = 1
+
+	// new clean project and context for each test
+	var project string
+	var context string
+
+	// store current directory and project (before any test is run) so it can restored after all testing is done
+	var originalDir string
+	var originalProject string
+
+	var oc helper.OcRunner
+	// path to odo binary
+	var odo string
+
+	BeforeEach(func() {
+		// Set default timeout for Eventually assertions
+		// commands like odo push, might take a long time
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+
+		// initialize oc runner
+		// right now it uses oc binary, but we should convert it to client-go
+		oc = helper.NewOcRunner("oc")
+		odo = "odo"
+
+		originalProject = oc.GetCurrentProject()
+		originalDir = helper.Getwd()
+
+		project = helper.CreateRandProject()
+		context = helper.CreateNewContext()
+		oc.SwitchProject(project)
+		helper.Chdir(context)
+
+	})
+
+	AfterEach(func() {
+		oc.SwitchProject(originalProject)
+		helper.Chdir(originalDir)
+		helper.DeleteProject(project)
+		helper.DeleteDir(context)
+	})
+
+	Measure("Simple Java (Javalin) component", func(b Benchmarker) {
+		helper.CopyExample(filepath.Join("source", "openjdk"), context)
+		oc.ImportJavaIsToNspace(project)
+
+		b.Time("create component", func() {
+			helper.CmdShouldPass(odo, "component", "create", "java", "javacomponent", "--app", "myapp")
+		})
+		b.Time("crate url", func() {
+			helper.CmdShouldPass(odo, "url", "create", "--port", "8080")
+		})
+		b.Time("first time push", func() {
+			helper.CmdShouldPass(odo, "push")
+		})
+
+		url := oc.GetFirstURL("javacomponent", "myapp", project)
+
+		b.Time("running app after push", func() {
+			helper.HttpWaitFor("http://"+url, "Hello World from Javalin!", 60, 1)
+		})
+
+		helper.ReplaceString("./src/main/java/MessageProducer.java", "Hello World from Javalin!", "UPDATED!")
+
+		b.Time("push after file change", func() {
+			helper.CmdShouldPass(odo, "push")
+		})
+		b.Time("change in app after push", func() {
+			helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
+		})
+	}, numberOfRuns)
+
+	Measure("Simple NodeJS component", func(b Benchmarker) {
+		helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+		b.Time("create component", func() {
+			helper.CmdShouldPass(odo, "component", "create", "nodejs", "nodejscomponent", "--app", "myapp")
+		})
+		b.Time("crate url", func() {
+			helper.CmdShouldPass(odo, "url", "create", "--port", "8080")
+		})
+		b.Time("first time push", func() {
+			helper.CmdShouldPass(odo, "push")
+		})
+
+		url := oc.GetFirstURL("nodejscomponent", "myapp", project)
+
+		b.Time("running app after push", func() {
+			helper.HttpWaitFor("http://"+url, "Hello world from node.js!", 60, 1)
+		})
+
+		helper.ReplaceString("./server.js", "Hello world from node.js!", "UPDATED!")
+
+		b.Time("push after file change", func() {
+			helper.CmdShouldPass(odo, "push")
+		})
+		b.Time("change in app after push", func() {
+			helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
+		})
+	}, numberOfRuns)
+
+})

--- a/tests/benchmark/benchmark_test.go
+++ b/tests/benchmark/benchmark_test.go
@@ -1,0 +1,25 @@
+package benchmark
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/odo/tests/helper/reporter"
+)
+
+func TestBenchmark(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	reporters := []Reporter{}
+
+	if os.Getenv("CI") == "openshift" {
+		// If running on OpenShift CI, add reporter that will submit measurements to Google Sheets table
+		// https://docs.google.com/spreadsheets/d/1o-GIoYlZoEyW1F25kAwvvEXzbW4tLck0x3EGCC4_L_A/
+		reporters = append(reporters, reporter.NewHTTPMeasurementReporter("https://script.google.com/macros/s/AKfycbyoeFrEXsrkjWOCCjsLOGY5a31Fsv5RTUvgqQP0E5vPo3YvDGE/exec"))
+	}
+
+	RunSpecsWithDefaultAndCustomReporters(t, "odo benchmark tests", reporters)
+}

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -63,6 +64,19 @@ func FileShouldContainSubstring(file string, subString string) {
 	data, err := ioutil.ReadFile(file)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(string(data)).To(ContainSubstring(subString))
+}
+
+// ReplaceString replaces oldString with newString in text file
+func ReplaceString(filename string, oldString string, newString string) {
+	fmt.Fprintf(GinkgoWriter, "Replacing \"%s\" with \"%s\" in %s\n", oldString, newString, filename)
+
+	f, err := ioutil.ReadFile(filename)
+	Expect(err).NotTo(HaveOccurred())
+
+	newContent := strings.Replace(string(f), oldString, newString, 1)
+
+	err = ioutil.WriteFile(filename, []byte(newContent), 644)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 // copyDir copy one directory to the other

--- a/tests/helper/reporter/httpMeasurementReporter.go
+++ b/tests/helper/reporter/httpMeasurementReporter.go
@@ -1,0 +1,81 @@
+package reporter
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+
+	. "github.com/onsi/ginkgo"
+)
+
+type HTTPMeasurementReporter struct {
+	url string
+}
+
+func NewHTTPMeasurementReporter(url string) *HTTPMeasurementReporter {
+	r := HTTPMeasurementReporter{
+		url: url,
+	}
+	return &r
+}
+
+func (r *HTTPMeasurementReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+}
+
+func (r *HTTPMeasurementReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+func (r *HTTPMeasurementReporter) SpecWillRun(specSummary *types.SpecSummary) {}
+
+func (r *HTTPMeasurementReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	if specSummary.Passed() && specSummary.IsMeasurement {
+		for k, v := range specSummary.Measurements {
+			output := map[string]string{}
+			output["Number of Samples"] = strconv.Itoa(specSummary.NumberOfSamples)
+			output["Measurement"] = k
+			output[v.SmallestLabel] = strconv.FormatFloat(v.Smallest, 'f', -1, 64)
+			output[v.LargestLabel] = strconv.FormatFloat(v.Largest, 'f', -1, 64)
+			output[v.AverageLabel] = strconv.FormatFloat(v.Average, 'f', -1, 64)
+			output["Test"] = strings.Join(specSummary.ComponentTexts, "/")
+			err := r.SubmitMeasurement(output)
+			if err != nil {
+				// Just printing info about error. Error while submiting measurement should cause any failures
+				fmt.Fprintf(GinkgoWriter, "WARNING: error in SubmitMeasurement (%v)\n", err)
+			}
+		}
+	}
+}
+
+func (r *HTTPMeasurementReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+func (r *HTTPMeasurementReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {}
+
+func (r *HTTPMeasurementReporter) SubmitMeasurement(data map[string]string) error {
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", r.url, nil)
+	if err != nil {
+		return err
+	}
+
+	q := req.URL.Query()
+	for k, v := range data {
+		q.Add(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("error while submiting measurement (StatusCode: %d)", resp.StatusCode)
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
Tests are measuring the speed of various odo commands for Java and NodeJS
components.
Results are displayed on the output and also send to the Google Sheet table
https://docs.google.com/spreadsheets/d/1o-GIoYlZoEyW1F25kAwvvEXzbW4tLck0x3EGCC4_L_A/
Results are sent to Google Sheet table only when running on OpenShift CI (`CI=openshift`) 


related to #1726 

Can't be tested on OpenShift CI before it is merged :-(
Once merge I'll update openshift/release to trigger these tests and verify that it is soaking on CI
This can also be executed locally against your cluster `make test-benchmark` or `ginkgo  tests/benchmark`