### PR TITLE
Remove connection checks for `odo config`

### DIFF
--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -60,7 +60,6 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 		o.paramName = args[0]
 		o.paramValue = args[1]
 	}
-	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -59,7 +59,6 @@ func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	if o.envArray == nil {
 		o.paramName = args[0]
 	}
-	o.context = genericclioptions.NewContext(cmd)
 	return
 }
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -285,5 +285,15 @@ var _ = Describe("odo config test", func() {
 			Expect(configValue).To(ContainSubstring("world"))
 			os.Setenv("KUBECONFIG", kubeconfigOld)
 		})
+
+		It("should set config veriable without logging in", func() {
+			kubeconfigOld := os.Getenv("KUBECONFIG")
+			os.Setenv("KUBECONFIG", "/no/such/path")
+			helper.CmdShouldPass("odo", "config", "set", "Name", "foobar")
+			configValue := helper.CmdShouldPass("odo", "config", "view")
+			Expect(configValue).To(ContainSubstring("foobar"))
+			helper.CmdShouldPass("odo", "config", "unset", "Name")
+			os.Setenv("KUBECONFIG", kubeconfigOld)
+		})
 	})
 })


### PR DESCRIPTION
Removes the unecessary connection checks when using `odo config`.
See below for an example of the changes:

```sh
github.com/openshift/odo  remove-connection-check-config ✗                                                                                                                                                                             8h36m ⚑ ◒
▶ export KUBECONFIG=/tmp/non-exsisting

github.com/openshift/odo  remove-connection-check-config ✗                                                                                                                                                                             8h36m ⚑ ◒
▶ ./odo config set Name foobar
Local config was successfully updated.
Run `odo push --config` command to apply changes to the cluster.

github.com/openshift/odo  remove-connection-check-config ✗                                                                                                                                                                             8h36m ⚑ ◒
▶ ./odo config unset Name
? Do you want to unset Name in the config Yes
Local config was successfully updated.
```