### PR TITLE
Add machine readable output for odo project create

### DIFF
--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -33,7 +33,7 @@ var _ = Describe("odojsonoutput", func() {
 	Context("odo machine create project json output", func() {
 		// odo project create newprojectjson -o json
 		It("should be able to create project and show output in json format", func() {
-			actual := helper.CmdShouldPass("odo project create newprojectjson -o json")
+			actual := helper.CmdShouldPass("odo", "project", "create", "newprojectjson", "-o", "json")
 			desired := `{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"newprojectjson","creationTimestamp":null},"spec":{"apps":null},"status":{"active":false}}`
 			Expect(desired).Should(MatchJSON(actual))
 		})

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -30,6 +30,15 @@ var _ = Describe("odojsonoutput", func() {
 		helper.DeleteDir(tmpDir)
 	})
 
+	Context("odo machine create project json output", func() {
+		// odo project create newprojectjson -o json
+		It("should be able to create project and show output in json format", func() {
+			actual := helper.CmdShouldPass("odo project create newprojectjson -o json")
+			desired := `{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"newprojectjson","creationTimestamp":null},"spec":{"apps":null},"status":{"active":false}}`
+			Expect(desired).Should(MatchJSON(actual))
+		})
+	})
+
 	Context("odo machine readable output on empty project", func() {
 		//https://github.com/openshift/odo/issues/1708
 		//odo project list -o json


### PR DESCRIPTION
- Adds machine readable output for `odo project create`
- Added test

To test:

```sh
odo project create foobar -o json
```

Closes https://github.com/openshift/odo/pull/1635
Closes https://github.com/openshift/odo/issues/1381