### PR TITLE
Add capitalization to error messages

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -165,7 +165,7 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 
 	// If file does not exist at this point, raise an error
 	if !lci.ConfigFileExists() {
-		return nil, fmt.Errorf("the current directory does not represent an odo component.\nMaybe use 'odo create' to create component here or switch to directory with a component")
+		return nil, fmt.Errorf("The current directory does not represent an odo component. Maybe use 'odo create' to create component here or switch to directory with a component")
 	}
 	// else simply return the local config info
 	return lci, nil

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -27,7 +27,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 		if context == "" {
 			log.Error(errors.Cause(err))
 		} else {
-			log.Errorf(fmt.Sprintf("%s", context), a...)
+			log.Errorf(fmt.Sprintf("%s", strings.Title(context)), a...)
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
Adds capitalization to error messages since *some* error messages were
lowercase and others capitalized (see context.go file).

Examples:

```sh
github.com/openshift/odo  add-capitalization ✗                                                                                                                                                                              10h10m ⚑
▶ ./odo push
 ✗  Blank source location provided

github.com/openshift/odo  add-capitalization ✗                                                                                                                                                                             10h10m ⚑  ⍉
▶ ./odo list
 ✗  Please specify the application name and project name
Or use the command from inside a directory containing an odo component.

github.com/openshift/odo  add-capitalization ✗                                                                                                                                                                              10h12m ⚑
▶ ./odo component describe
 ✗  The current directory does not represent an odo component. Maybe use 'odo create' to create component here or switch to directory with a component

```

Closes https://github.com/openshift/odo/issues/1855