### PR TITLE
Fix weird subcommand missing output

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -168,8 +168,8 @@ func ShowSubcommands(cmd *cobra.Command, args []string) error {
 	var strs []string
 	for _, subcmd := range cmd.Commands() {
 		if !subcmd.Hidden {
-			strs = append(strs, subcmd.Use)
+			strs = append(strs, subcmd.Name())
 		}
 	}
-	return fmt.Errorf("Use one of available subcommands: %s", strings.Join(strs, ", "))
+	return fmt.Errorf("Subcommand not found, use one of the available commands: %s", strings.Join(strs, ", "))
 }


### PR DESCRIPTION
Removes the odd missing subcommand output. Now it outputs like so:

```sh
 ✗  Subcommand not found, use one of the available commands: app, catalog, component, config, create, delete, describe, help, link, list, log, login, logout, preference, project, push, service, storage, unlink, update, url, utils, version, watch
```

Closes https://github.com/openshift/odo/issues/1800