### PR TITLE
Add notes with regards to no component deployed when using odo describe

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -635,7 +635,7 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 	componentContext := strings.Trim(filepath.Dir(lci.Filename), ".odo")
 
 	if sourceLocation == "" {
-		return "", fmt.Errorf("Blank source location provided")
+		return "", fmt.Errorf("Blank source location, does the .odo directory exist?")
 	}
 
 	if sourceType == GIT {

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -53,7 +53,7 @@ func (do *DescribeOptions) Validate() (err error) {
 		return err
 	}
 	if !existsInCluster {
-		return fmt.Errorf("component %s not found in the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
+		return fmt.Errorf("component %s not pushed to OpenShift cluster, use `odo push` to deploy the component", do.componentName)
 	}
 
 	return odoutil.CheckOutputFlag(do.outputFlag)

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -53,7 +53,7 @@ func (do *DescribeOptions) Validate() (err error) {
 		return err
 	}
 	if !existsInCluster {
-		return fmt.Errorf("component %s not pushed to OpenShift cluster, use `odo push` to deploy the component", do.componentName)
+		return fmt.Errorf("component %s not pushed to the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
 	}
 
 	return odoutil.CheckOutputFlag(do.outputFlag)

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -53,7 +53,7 @@ func (do *DescribeOptions) Validate() (err error) {
 		return err
 	}
 	if !existsInCluster {
-		return fmt.Errorf("component %s does not exist in the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
+		return fmt.Errorf("component %s not found in the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
 	}
 
 	return odoutil.CheckOutputFlag(do.outputFlag)

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -48,12 +48,12 @@ func (do *DescribeOptions) Validate() (err error) {
 		return odoutil.ThrowContextError()
 	}
 
-	isExists, err := component.Exists(do.Context.Client, do.componentName, do.Context.Application)
+	existsInCluster, err := component.Exists(do.Context.Client, do.componentName, do.Context.Application)
 	if err != nil {
 		return err
 	}
-	if !isExists {
-		return fmt.Errorf("component %s does not exist", do.componentName)
+	if !existsInCluster {
+		return fmt.Errorf("component %s does not exist in the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
 	}
 
 	return odoutil.CheckOutputFlag(do.outputFlag)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -165,7 +165,7 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 
 	// If file does not exist at this point, raise an error
 	if !lci.ConfigFileExists() {
-		return nil, fmt.Errorf("The current directory does not represent an odo component. Maybe use 'odo create' to create component here or switch to directory with a component")
+		return nil, fmt.Errorf("The current directory does not represent an odo component. Use 'odo create' to create component here or switch to directory with a component")
 	}
 	// else simply return the local config info
 	return lci, nil


### PR DESCRIPTION
Adds a disclaimer to use `odo push` to push the component if there is no
component deployed.

Closes https://github.com/openshift/odo/issues/1847