### PR TITLE
Removed active field for application

### DIFF
--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -151,9 +151,6 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 						Spec: AppSpec{
 							Components: []string{"frontend"},
 						},
-						Status: AppStatus{
-							Active: true,
-						},
 					},
 				},
 			},
@@ -174,9 +171,6 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 						},
 						Spec: AppSpec{
 							Components: []string{"frontend"},
-						},
-						Status: AppStatus{
-							Active: true,
 						},
 					},
 				},

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -8,8 +8,7 @@ import (
 type App struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              AppSpec   `json:"spec,omitempty"`
-	Status            AppStatus `json:"status,omitempty"`
+	Spec              AppSpec `json:"spec,omitempty"`
 }
 
 // AppSpec is list of components present in given application
@@ -22,9 +21,4 @@ type AppList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []App `json:"items"`
-}
-
-// AppStatus shows the application is active or not
-type AppStatus struct {
-	Active bool `json:"active"`
 }

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/log"
@@ -128,9 +129,6 @@ func getMachineReadableFormat(client *occlient.Client, appName string, projectNa
 		},
 		Spec: application.AppSpec{
 			Components: compList,
-		},
-		Status: application.AppStatus{
-			Active: active,
 		},
 	}
 	return appDef

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -74,7 +74,7 @@ var _ = Describe("odoCmdApp", func() {
 				Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 				helper.CmdShouldPass("odo", "app", "describe")
-				desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{},"status":{"active":false}}`, project)
+				desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{}}`, project)
 				actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", "myapp", "-o", "json")
 				Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 
@@ -107,11 +107,11 @@ var _ = Describe("odoCmdApp", func() {
 				Expect(appListOutput).To(ContainSubstring(appName))
 				actualCompListJSON := helper.CmdShouldPass("odo", "app", "list", "-o", "json", "--project", project)
 				//desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
-				desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]},"status":{"active":false}}]}`, project, cmpName)
+				desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}]}`, project, cmpName)
 				Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 				helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project)
-				desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]},"status":{"active":false}}`, appName, project, cmpName)
+				desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}`, appName, project, cmpName)
 				actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project, "-o", "json")
 				Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 


### PR DESCRIPTION

## What is the purpose of this change? What does it change?

Remove `Status.Active` field
## Was the change discussed in an issue?
Fixes #1866
<!-- Please do Link issues here. -->

## How to test changes?

`odo app list -o json` will not show active field