### PR TITLE
Remove status from machine output

### DIFF
--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -8,7 +8,7 @@ type Project struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              ProjectSpec   `json:"spec,omitempty"`
-	Status            ProjectStatus `json:"status,omitempty"`
+	Status            ProjectStatus `json:"-"`
 }
 
 type ProjectSpec struct {


### PR DESCRIPTION
Removes the status for machine readable output,

See below example:

```sh
github.com/openshift/odo  remove-status-active-from-application ✔                                                                                                                                                                             11h25m  ⍉
▶ make bin && ./odo project list -o json | jq
go build -ldflags="-w -X github.com/openshift/odo/pkg/odo/cli/version.GITCOMMIT=54b9a583" cmd/odo/odo.go
{
  "kind": "List",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {},
  "items": [
    {
      "kind": "Project",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "foobar",
        "creationTimestamp": null
      },
      "spec": {
        "apps": [
          "app"
        ]
      }
    }
  ]
}

```

See issue: https://github.com/openshift/odo/issues/1739