### PR TITLE
Machine readable output changes (global changes + error output)

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -89,6 +89,9 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 
 	rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
 
+	// Add the machine readable output flag to all commands
+	rootCmd.PersistentFlags().StringP(genericclioptions.OutputFlagName, "o", "", "Specify output format, supported format: json")
+
 	// Here we add the necessary "logging" flags.. However, we choose to hide some of these from the user
 	// as they are not necessarily needed and more for advanced debugging
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -89,6 +89,6 @@ func NewCmdProjectList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	genericclioptions.AddOutputFlag(projectListCmd)
+	//genericclioptions.AddOutputFlag(projectListCmd)
 	return projectListCmd
 }


### PR DESCRIPTION
This PR:
  - Adds `-o json` as a global parameter
  - Makes sure that NO logging is done when using `-o json` with the
  exception of error out / success output via json