### PR TITLE
Make --output a global parameter, disable logging, fix bug

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -112,6 +112,7 @@ func IsTerminal(w io.Writer) bool {
 // there will be a loading spinner with this status
 func (s *Status) Start(status string, debug bool) {
 	s.End(true)
+
 	// set new status
 	isTerm := IsTerminal(s.writer)
 	s.status = status
@@ -119,7 +120,7 @@ func (s *Status) Start(status string, debug bool) {
 	// If we are in debug mode, don't spin!
 	if !isTerm || debug {
 		fmt.Fprintf(s.writer, prefixSpacing+getSpacingString()+suffixSpacing+"%s  ...\n", s.status)
-	} else {
+	} else if !IsJSON() {
 		s.spinner.SetPrefix(prefixSpacing)
 		s.spinner.SetSuffix(fmt.Sprintf(suffixSpacing+"%s", s.status))
 		s.spinner.Start()
@@ -154,68 +155,90 @@ func (s *Status) End(success bool) {
 // Namef will output the name of the component / application / project in a *bolded* manner
 func Namef(format string, a ...interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
+	}
 }
 
 // Progressf will output in an appropriate "progress" manner
 func Progressf(format string, a ...interface{}) {
-	fmt.Fprintf(GetStdout(), " %s%s\n", prefixSpacing, fmt.Sprintf(format, a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), " %s%s\n", prefixSpacing, fmt.Sprintf(format, a...))
+	}
 }
 
 // Success will output in an appropriate "success" manner
 func Success(a ...interface{}) {
 	green := color.New(color.FgGreen).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s%s%s%s", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintln(a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s%s%s%s", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintln(a...))
+	}
 }
 
 // Successf will output in an appropriate "progress" manner
 func Successf(format string, a ...interface{}) {
 	green := color.New(color.FgGreen).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintf(format, a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintf(format, a...))
+	}
 }
 
 // Warningf will output in an appropriate "progress" manner
 func Warningf(format string, a ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintFunc()
-	fmt.Fprintf(GetStderr(), " %s%s%s\n", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStderr(), " %s%s%s\n", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
+	}
 }
 
 // Warning will output in an appropriate "progress" manner
 func Warning(a ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintFunc()
-	fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, yellow(getWarningString()), suffixSpacing, fmt.Sprintln(a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, yellow(getWarningString()), suffixSpacing, fmt.Sprintln(a...))
+	}
 }
 
 // Errorf will output in an appropriate "progress" manner
 func Errorf(format string, a ...interface{}) {
 	red := color.New(color.FgRed).SprintFunc()
-	fmt.Fprintf(GetStderr(), " %s%s%s\n", red(getErrString()), suffixSpacing, fmt.Sprintf(format, a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStderr(), " %s%s%s\n", red(getErrString()), suffixSpacing, fmt.Sprintf(format, a...))
+	}
 }
 
 // Error will output in an appropriate "progress" manner
 func Error(a ...interface{}) {
 	red := color.New(color.FgRed).SprintFunc()
-	fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, red(getErrString()), suffixSpacing, fmt.Sprintln(a...))
+	if !IsJSON() {
+		fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, red(getErrString()), suffixSpacing, fmt.Sprintln(a...))
+	}
 }
 
 // Info will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Info(a ...interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintln(a...)))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintln(a...)))
+	}
 }
 
 // Infof will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Infof(format string, a ...interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
+	}
 }
 
 // Askf will print out information, but in an "Ask" way (without newline)
 func Askf(format string, a ...interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintf(format, a...)))
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintf(format, a...)))
+	}
 }
 
 // Spinner creates a spinner, sets the prefix then returns it.
@@ -242,6 +265,18 @@ func SpinnerNoSpin(status string) *Status {
 	s := NewStatus(os.Stdout)
 	s.Start(status, true)
 	return s
+}
+
+// IsJSON returns true if we are in machine output mode..
+// under NO circumstances should we output any logging.. as we are only outputting json
+func IsJSON() bool {
+
+	flag := pflag.Lookup("o")
+	if flag != nil && flag.Changed {
+		return strings.Contains(pflag.Lookup("o").Value.String(), "json")
+	}
+
+	return false
 }
 
 // IsDebug returns true if we are debugging (-v is set to anything but 0)

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -64,7 +64,7 @@ func (o *DeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *DeleteOptions) Run() (err error) {
-	if o.OutputFlag == "json" {
+	if log.IsJSON() {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {
 			return err
@@ -105,7 +105,6 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&o.force, "force", "f", false, "Delete application without prompting")
-	genericclioptions.AddOutputFlag(command)
 
 	project.AddProjectFlag(command)
 	completion.RegisterCommandHandler(command, completion.AppCompletionHandler)

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util"
@@ -62,7 +63,7 @@ func (o *DescribeOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *DescribeOptions) Run() (err error) {
-	if o.outputFormat == "json" {
+	if log.IsJSON() {
 		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.Project)
 		out, err := json.Marshal(appDef)
 		if err != nil {
@@ -121,7 +122,6 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 		},
 	}
 
-	command.Flags().StringVarP(&o.outputFormat, "output", "o", "", "output in json format")
 	completion.RegisterCommandHandler(command, completion.AppCompletionHandler)
 	project.AddProjectFlag(command)
 	return command

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -60,7 +60,7 @@ func (o *ListOptions) Run() (err error) {
 
 	if len(apps) > 0 {
 
-		if o.outputFormat == "json" {
+		if log.IsJSON() {
 			var appList []application.App
 			for _, app := range apps {
 				appDef := application.GetMachineReadableFormat(o.Client, app, o.Project)
@@ -90,7 +90,7 @@ func (o *ListOptions) Run() (err error) {
 			return tabWriter.Flush()
 		}
 	} else {
-		if o.outputFormat == "json" {
+		if log.IsJSON() {
 			out, err := json.Marshal(application.GetMachineReadableFormatForList([]application.App{}))
 			if err != nil {
 				return err
@@ -118,7 +118,6 @@ func NewCmdList(name, fullName string) *cobra.Command {
 		},
 	}
 
-	command.Flags().StringVarP(&o.outputFormat, "output", "o", "", "output in json format")
 	project.AddProjectFlag(command)
 	return command
 }

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -89,6 +89,12 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 
 	rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
 
+	// Add the machine readable output flag to all commands
+	// We use "flag" in order to make this accessible throughtout ALL of odo, rather than the
+	// above traditional "persistentflags" usage that does not make it a pointer within the 'pflag'
+	// package
+	flag.CommandLine.String("o", "json", "Specify output format, supported format: json")
+
 	// Here we add the necessary "logging" flags.. However, we choose to hide some of these from the user
 	// as they are not necessarily needed and more for advanced debugging
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 
 	"github.com/openshift/odo/pkg/component"
@@ -28,14 +29,13 @@ var describeExample = ktemplates.Examples(`  # Describe nodejs component,
 // DescribeOptions is a dummy container to attach complete, validate and run pattern
 type DescribeOptions struct {
 	localConfigInfo  *config.LocalConfigInfo
-	outputFlag       string
 	componentContext string
 	*ComponentOptions
 }
 
 // NewDescribeOptions returns new instance of ListOptions
 func NewDescribeOptions() *DescribeOptions {
-	return &DescribeOptions{nil, "", "", &ComponentOptions{}}
+	return &DescribeOptions{nil, "", &ComponentOptions{}}
 }
 
 // Complete completes describe args
@@ -59,7 +59,7 @@ func (do *DescribeOptions) Validate() (err error) {
 		return fmt.Errorf("component %s not pushed to the OpenShift cluster, use `odo push` to deploy the component", do.componentName)
 	}
 
-	return odoutil.CheckOutputFlag(do.outputFlag)
+	return nil
 }
 
 // Run has the logic to perform the required actions as part of command
@@ -68,7 +68,7 @@ func (do *DescribeOptions) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	if do.outputFlag == "json" {
+	if log.IsJSON() {
 		componentDesc.Spec.Ports = do.localConfigInfo.GetPorts()
 		out, err := json.Marshal(componentDesc)
 		if err != nil {
@@ -102,7 +102,6 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 	describeCmd.Annotations = map[string]string{"command": "component"}
 	describeCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(describeCmd, completion.ComponentNameCompletionHandler)
-	describeCmd.Flags().StringVarP(&do.outputFlag, "output", "o", "", "output in json format")
 	// Adding --context flag
 	genericclioptions.AddContextFlag(describeCmd, &do.componentContext)
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -32,7 +32,6 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
-	outputFlag       string
 	pathFlag         string
 	allFlag          bool
 	componentContext string
@@ -56,17 +55,18 @@ func (lo *ListOptions) Validate() (err error) {
 		return odoutil.ThrowContextError()
 	}
 
-	return odoutil.CheckOutputFlag(lo.outputFlag)
+	return nil
 }
 
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
+
 	if len(lo.pathFlag) != 0 {
 		components, err := component.ListIfPathGiven(lo.Context.Client, filepath.SplitList(lo.pathFlag))
 		if err != nil {
 			return err
 		}
-		if lo.outputFlag == "json" {
+		if log.IsJSON() {
 			out, err := json.Marshal(components)
 			if err != nil {
 				return err
@@ -112,7 +112,7 @@ func (lo *ListOptions) Run() (err error) {
 	}
 	glog.V(4).Infof("the components are %+v", components)
 
-	if lo.outputFlag == "json" {
+	if log.IsJSON() {
 
 		out, err := json.Marshal(components)
 		if err != nil {
@@ -152,7 +152,6 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	// Add a defined annotation in order to appear in the help menu
 	componentListCmd.Annotations = map[string]string{"command": "component"}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
-	componentListCmd.Flags().StringVarP(&o.outputFlag, "output", "o", "", "output in json format")
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path")
 	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")
 	//Adding `--project` flag

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
 	"github.com/spf13/cobra"
@@ -51,7 +52,7 @@ func (plo *ProjectListOptions) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	if plo.OutputFlag == "json" {
+	if log.IsJSON() {
 		out, err := json.Marshal(projects)
 		if err != nil {
 			return err
@@ -89,6 +90,5 @@ func NewCmdProjectList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	genericclioptions.AddOutputFlag(projectListCmd)
 	return projectListCmd
 }

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -122,7 +122,6 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 		},
 	}
 	urlCreateCmd.Flags().IntVarP(&o.urlPort, "port", "", -1, "port number for the url of the component, required in case of components which expose more than one service port")
-	genericclioptions.AddOutputFlag(urlCreateCmd)
 	genericclioptions.AddContextFlag(urlCreateCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(urlCreateCmd, "context", completion.FileCompletionHandler)
 	return urlCreateCmd

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -66,7 +66,7 @@ func (o *URLListOptions) Run() (err error) {
 
 	localUrls := o.localConfigInfo.GetUrl()
 
-	if o.OutputFlag == "json" {
+	if log.IsJSON() {
 		out, err := json.Marshal(urls)
 		if err != nil {
 			return err
@@ -143,7 +143,6 @@ func NewCmdURLList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	genericclioptions.AddOutputFlag(urlListCmd)
 	genericclioptions.AddContextFlag(urlListCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(urlListCmd, "context", completion.FileCompletionHandler)
 

--- a/pkg/odo/genericclioptions/add_flags.go
+++ b/pkg/odo/genericclioptions/add_flags.go
@@ -2,11 +2,6 @@ package genericclioptions
 
 import "github.com/spf13/cobra"
 
-// AddOutputFlag adds a `output` flag to the given cobra command
-func AddOutputFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP(OutputFlagName, "o", "", "Specify output format, supported format: json")
-}
-
 // AddContextFlag adds `context` flag to given cobra command
 func AddContextFlag(cmd *cobra.Command, setValueTo *string) {
 	helpMessage := "Use given context directory as a source for component settings"

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -1,8 +1,13 @@
 package genericclioptions
 
 import (
+	"flag"
+	"os"
+
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type Runnable interface {
@@ -12,7 +17,33 @@ type Runnable interface {
 }
 
 func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
+
+	// CheckMachineReadableOutput
+	// fixes / checks all related machine readable output functions
+	CheckMachineReadableOutputCommand()
+
+	// Run completion, validation and run.
 	util.LogErrorAndExit(o.Complete(cmd.Name(), cmd, args), "")
 	util.LogErrorAndExit(o.Validate(), "")
 	util.LogErrorAndExit(o.Run(), "")
+}
+
+// CheckMachineReadableOutputCommand performs machine-readable output functions required to
+// have it work correctly
+func CheckMachineReadableOutputCommand() {
+
+	// Check that the -o flag has been correctly set as json.
+	outputFlag := pflag.Lookup("o")
+	if outputFlag != nil && outputFlag.Changed && outputFlag.Value.String() != "json" {
+		log.Error("Please input a valid output format for -o, available format: json")
+		os.Exit(1)
+	}
+
+	// Before running anything, we will make sure that no verbose output is made
+	// This is a HACK to manually override `-v 4` to `-v 0` (in which we have no glog.V(0) in our code...
+	// in order to have NO verbose output when combining both `-o json` and `-v 4` so json output
+	// is not malformed / mixed in with normal logging
+	if log.IsJSON() {
+		flag.Set("v", "0")
+	}
 }


### PR DESCRIPTION
This PR:
  - Makes `-o` or `--output` a global parameter
  - Disables logging completely when performing `-o json`, including
  using verbosity `-v`
  - Fixes a minor bug within some commands where `-o json` wasn't
  detected corretly due to a local flag being used `outputFlag` rather
  than `OutputFlag`