### PR TITLE
check if the config file exists for odo config

### DIFF
--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
@@ -28,6 +29,7 @@ type ViewOptions struct {
 
 // NewViewOptions creates a new ViewOptions instance
 func NewViewOptions() *ViewOptions {
+
 	return &ViewOptions{}
 }
 
@@ -43,6 +45,9 @@ func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (
 
 // Validate validates the ViewOptions based on completed values
 func (o *ViewOptions) Validate() (err error) {
+	if !o.lci.ConfigFileExists() {
+		return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
+	}
 	return
 }
 

--- a/tests/e2escenarios/core_beta_flow.go
+++ b/tests/e2escenarios/core_beta_flow.go
@@ -125,10 +125,9 @@ var _ = Describe("Core beta flow", func() {
 			helper.CmdShouldFail("odo", "component", "create", "nodejs", "--context", context, "--project", project)
 		})
 
-		// Uncomment once https://github.com/openshift/odo/issues/1895 is fixed
-		/*It("odo config should fail if there is no .odo dir", func() {
+		It("odo config should fail if there is no .odo dir", func() {
 			helper.CmdShouldFail("odo", "config", "set", "memory", "2Gi", "--context", context)
-		})*/
+		})
 
 		It("create local java component and push code", func() {
 			oc.ImportJavaIsToNspace(project)

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -287,12 +287,13 @@ var _ = Describe("odo config test", func() {
 		})
 
 		It("should set config veriable without logging in", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
 			kubeconfigOld := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
-			helper.CmdShouldPass("odo", "config", "set", "Name", "foobar")
-			configValue := helper.CmdShouldPass("odo", "config", "view")
+			helper.CmdShouldPass("odo", "config", "set", "--force", "--context", context, "Name", "foobar")
+			configValue := helper.CmdShouldPass("odo", "config", "view", "--context", context)
 			Expect(configValue).To(ContainSubstring("foobar"))
-			helper.CmdShouldPass("odo", "config", "unset", "Name")
+			helper.CmdShouldPass("odo", "config", "unset", "--context", context, "Name")
 			os.Setenv("KUBECONFIG", kubeconfigOld)
 		})
 	})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Added checks for checking if config file exists before doing `odo config set, view or unset`. also uncommented the failing test

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1895
<!-- Please do Link issues here. -->

## How to test changes?
the below commands will fail in a non-component dir
```
odo config set memory 2Gi
odo config unset memory
odo config view
```
<!-- Please describe the steps to test the PR -->
