### PR TITLE
Decreasing ginkgo test node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ TIMEOUT ?= 1800s
 
 # Env variable TEST_EXEC_NODES is used to pass spec execution type
 # (parallel or sequential) for ginkgo tests. To run the specs sequentially use
-# TEST_EXEC_NODES=1, otherwise by default the specs are run in parallel on 4 ginkgo test node.
+# TEST_EXEC_NODES=1, otherwise by default the specs are run in parallel on 2 ginkgo test node.
 # NOTE: Any TEST_EXEC_NODES value greater than one runs the spec in parallel
 # on the same number of ginkgo test nodes.
-TEST_EXEC_NODES ?= 4
+TEST_EXEC_NODES ?= 2
 
 # Slow spec threshold for ginkgo tests. After this time (in second), ginkgo marks test as slow
 SLOW_SPEC_THRESHOLD := 120

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -166,7 +166,7 @@ Refer to the odo clean test link:https://github.com/openshift/odo/blob/master/te
 
 Integration tests can be run in the following two ways:
 
-* To run the test in parallel (default: 4 ginkgo test node), on a test cluster:
+* To run the test in parallel (default: 2 ginkgo test node), on a test cluster:
 +
 Run component command integration test
 +
@@ -335,7 +335,7 @@ NOTE: `make test-integration` doesn't honour enviornment variable `TEST_EXEC_NOD
 
 Similarly e2e (end to end) tests can be run in parallel and sequentially separately.
 
-* To run the test in parallel (default: 4 ginkgo test node), on a test cluster:
+* To run the test in parallel (default: 2 ginkgo test node), on a test cluster:
 +
 Run core beta flow e2e test
 +


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
```
[odo]  ✗  Waiting for component to start [4m]
[odo]  ✗  waited 4m0s but couldn't find running pod matching selector: 'deploymentconfig=nodejs-app'
```
Probably running 4 test at a time causing the test flake due to test load. ping @kadel  

## Was the change discussed in an issue?
fixes test flake due to load on cluster
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
