### PR TITLE
Add 'org.jboss.container.deployments-dir'  to S2IDeploymentsDir

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -197,6 +197,7 @@ type UpdateComponentParams struct {
 var S2IDeploymentsDir = []string{
 	"com.redhat.deployments-dir",
 	"org.jboss.deployments-dir",
+	"org.jboss.container.deployments-dir",
 }
 
 // errorMsg is the message for user when invalid configuration error occurs


### PR DESCRIPTION
Some older images are using this label for deployment dir.
For example java:8 and java:11 builder images  on OCP 4.2 are using this
label.

