### PR TITLE
having no components in an app shouldn't be an error

### DIFF
--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/component"
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util"
@@ -82,7 +81,7 @@ func (o *DescribeOptions) Run() (err error) {
 		serviceList, _ := service.ListWithDetailedStatus(o.Client, o.appName)
 
 		if len(componentList.Items) == 0 && len(serviceList) == 0 {
-			log.Errorf("Application %s has no components or services deployed.", o.appName)
+			fmt.Printf("Application %s has no components or services deployed.", o.appName)
 		} else {
 			fmt.Printf("Application Name: %s has %v component(s) and %v service(s):\n--------------------------------------\n",
 				o.appName, len(componentList.Items), len(serviceList))

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -55,9 +55,8 @@ var _ = Describe("odoCmdApp", func() {
 
 				appDelete := helper.CmdShouldFail("odo", "app", "delete", "test", "--project", project, "-f")
 				Expect(appDelete).To(ContainSubstring("test app does not exists"))
-				helper.CmdShouldPass("odo", "app", "describe", "test", "--project", project)
-				// Uncomment once https://github.com/openshift/odo/issues/1803 is fixed
-				// Expect(appDescribe).To(ContainSubstring("Application test has no components or services deployed."))
+				appDescribe := helper.CmdShouldPass("odo", "app", "describe", "test", "--project", project)
+				Expect(appDescribe).To(ContainSubstring("Application test has no components or services deployed."))
 			})
 		})
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
having no components in an app shouldn't be an error

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1803
<!-- Please do Link issues here. -->

## How to test changes?
```
odo app describe test --project myproject > out 2>error
```
check `out` file, now it should have the `Application test has no components or services deployed.` message
