### PR TITLE
Makes it possible to list services outside a component directory

### DIFF
--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -42,6 +42,9 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
+	// Throw error if project and application values are not available.
+	// This will most likely be the case when user does odo service list from outside a component directory and
+	// doesn't provide --app and/or --project flags
 	if o.Context.Project == "" || o.Context.Application == "" {
 		return odoutil.ThrowContextError()
 	}

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -41,6 +42,9 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
+	if o.Context.Project == "" || o.Context.Application == "" {
+		return odoutil.ThrowContextError()
+	}
 	return
 }
 

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -150,7 +150,7 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 			return lci, nil
 		}
 		// Check if fcc is component and  request is list
-		if fcc.Name() == "component" && command.Name() == "list" {
+		if (fcc.Name() == "component" || fcc.Name() == "service") && command.Name() == "list" {
 			return lci, nil
 		}
 		// Case 6 : Check if fcc is component and app flag is used

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.CopyExample(filepath.Join("source", "openjdk-sb-postgresql"), context)
 
 			// Local config needs to be present in order to create service https://github.com/openshift/odo/issues/1602
-			helper.CmdShouldPass("odo", "create", "java", "sb-app")
+			helper.CmdShouldPass("odo", "create", "java", "sb-app", "--project", project)
 
 			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
 				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -60,7 +60,7 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
 				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6")
-			ocArgs := []string{"get", "serviceinstance", "-o", "name"}
+			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "dh-postgresql-apb")
 			})
@@ -124,7 +124,7 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.CmdShouldPass("odo", "service", "create", "dh-prometheus-apb", "--plan", "ephemeral",
 				"--app", app, "--project", project,
 			)
-			ocArgs := []string{"get", "serviceinstance", "-o", "name"}
+			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "dh-prometheus-apb")
 			})

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -121,20 +121,23 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--app", app, "--project", project)
 
 			// create a service from within a component directory
-			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
-				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
-				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6",
+			helper.CmdShouldPass("odo", "service", "create", "dh-prometheus-apb", "--plan", "ephemeral",
 				"--app", app, "--project", project,
 			)
 			ocArgs := []string{"get", "serviceinstance", "-o", "name"}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "dh-postgresql-apb")
+				return strings.Contains(output, "dh-prometheus-apb")
 			})
+
+			// Listing the services should work as expected from within the component directory.
+			// This means, it should not require --app or --project flags
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
 
 			// cd to a non-component directory and list services
 			helper.Chdir(originalDir)
-			stdOut := helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
-			Expect(stdOut).To(ContainSubstring("dh-postgresql-apb"))
+			stdOut = helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
+			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
 		})
 	})
 })


### PR DESCRIPTION
User needs to provide the `app` and `project` for which they would like to list the
services.

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Listing services (`odo service list`) was not possible unless one's working from a component directory. This PR fixes that issue as long as `--app` field is provided. 

## Was the change discussed in an issue?
fixes #1838 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Build the binary
2. Create a service from a component directory (#1810).
3. `cd` into a non-component directory
4. Execute `odo service list --app <app-name> --project <project-name>` where `<app-name>` and `<project-name>` should be same as the used in the component directory mentioned in Step 2.