### PR TITLE
used relative path to SourceLocation for binary

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -142,11 +142,11 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 			return err
 		}
 		// we need to store the SourceLocation relative to the componentContext
-		relcPath, err := filepath.Rel(co.componentContext, cPath)
+		relativePathToSource, err := filepath.Rel(co.componentContext, cPath)
 		if err != nil {
 			return err
 		}
-		co.componentSettings.SourceLocation = &relcPath
+		co.componentSettings.SourceLocation = &relativePathToSource
 
 	// --git
 	case config.GIT:

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -141,7 +141,12 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 		if err != nil {
 			return err
 		}
-		co.componentSettings.SourceLocation = &cPath
+		// we need to store the SourceLocation relative to the componentContext
+		relcPath, err := filepath.Rel(co.componentContext, cPath)
+		if err != nil {
+			return err
+		}
+		co.componentSettings.SourceLocation = &relcPath
 
 	// --git
 	case config.GIT:

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -318,7 +318,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			selectedSourcePath = ui.EnterInputTypePath("binary", currentDirectory)
 
 			// Get the correct source location
-			sourceLocation, err := getSourceLocation(selectedSourcePath, currentDirectory)
+			sourceLocation, err := getSourceLocation(selectedSourcePath, co.componentContext)
 			if err != nil {
 				return errors.Wrapf(err, "unable to get source location")
 			}
@@ -337,11 +337,10 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			co.componentContext = ui.EnterInputTypePath("path", currentDirectory, currentDirectory)
 
 			// Get the correct source location
-			sourceLocation, err := getSourceLocation(co.componentContext, currentDirectory)
-			if err != nil {
-				return errors.Wrapf(err, "unable to get source location")
+			if co.componentContext == "" {
+				co.componentContext = LocalDirectoryDefaultLocation
 			}
-			co.componentSettings.SourceLocation = &sourceLocation
+			co.componentSettings.SourceLocation = &co.componentContext
 
 		}
 

--- a/tests/integration/java_test.go
+++ b/tests/integration/java_test.go
@@ -55,8 +55,7 @@ var _ = Describe("odoJavaE2e", func() {
 			helper.CmdShouldPass("odo", "delete", "wo-wait-javaee-git-test", "-f", "--context", context)
 		})
 
-		// https://github.com/openshift/odo/issues/1846
-		/*It("Should be able to deploy a .war file using wildfly", func() {
+		It("Should be able to deploy a .war file using wildfly", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "wildfly"), context)
 			helper.CmdShouldPass("odo", "create", "wildfly", "javaee-war-test", "--project",
 				project, "--binary", filepath.Join(context, "ROOT.war"), "--context", context)
@@ -71,7 +70,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Delete the component
 			helper.CmdShouldPass("odo", "delete", "javaee-war-test", "-f", "--context", context)
-		})*/
+		})
 
 		It("Should be able to deploy a git repo that contains a java uberjar application using openjdk", func() {
 			oc.ImportJavaIsToNspace(project)
@@ -92,8 +91,7 @@ var _ = Describe("odoJavaE2e", func() {
 			helper.CmdShouldPass("odo", "delete", "uberjar-git-test", "-f", "--context", context)
 		})
 
-		// https://github.com/openshift/odo/issues/1846
-		/*It("Should be able to deploy a spring boot uberjar file using openjdk", func() {
+		It("Should be able to deploy a spring boot uberjar file using openjdk", func() {
 			oc.ImportJavaIsToNspace(project)
 
 			helper.CmdShouldPass("odo", "create", "java", "sb-jar-test", "--project",
@@ -109,7 +107,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Delete the component
 			helper.CmdShouldPass("odo", "delete", "sb-jar-test", "-f", "--context", context)
-		})*/
+		})
 
 	})
 })

--- a/tests/integration/java_test.go
+++ b/tests/integration/java_test.go
@@ -93,9 +93,10 @@ var _ = Describe("odoJavaE2e", func() {
 
 		It("Should be able to deploy a spring boot uberjar file using openjdk", func() {
 			oc.ImportJavaIsToNspace(project)
+			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
 
 			helper.CmdShouldPass("odo", "create", "java", "sb-jar-test", "--project",
-				project, "--binary", "../examples/binary/java/openjdk/sb.jar", "--context", context)
+				project, "--binary", filepath.Join(context, "sb.jar"), "--context", context)
 
 			// Create a URL
 			helper.CmdShouldPass("odo", "url", "create", "uberjaropenjdk", "--port", "8080", "--context", context)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
When using context dir with binary location the `SourceLocation` should be saved as a path relative to componentContext because in the end we are joining them both. Which wasn't happening before and is added as part of this PR


## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1846
fixes https://github.com/openshift/odo/issues/1922
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create wildfly javaee-war-test --project myproject --binary tests/examples/binary/java/wildfly/ROOT.war --context tests/examples/binary/java/wildfly/
odo push --context tests/examples/binary/java/wildfly/
```
should pass now
and
```
odo create wildfly javaee-war-test --project myproject --binary tests/examples/binary/java/wildfly/ROOT.war --context tests/examples/binary/java/wildfly/
cd ..
odo push --context odo/tests/examples/binary/java/wildfly/
```
should also pass
<!-- Please describe the steps to test the PR -->
