### PR TITLE
use currentDir in when getting source path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -630,10 +630,6 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 	sourceType := lci.GetSourceType()
 	sourceLocation := lci.GetSourceLocation()
 
-	// Get the component context folder
-	// ".odo" is removed as lci.Filename will always return the '.odo' folder.. we don't need that!
-	componentContext := strings.Trim(filepath.Dir(lci.Filename), ".odo")
-
 	if sourceLocation == "" {
 		return "", fmt.Errorf("Blank source location, does the .odo directory exist?")
 	}
@@ -649,10 +645,15 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 		return "", fmt.Errorf("URL %s passed even though source type is: %s", sourceLocation, sourceType)
 	}
 
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
 	// Always piped to "fromslash" so it's correct for the OS..
 	// after retrieving the sourceLocation we will covert it to the
 	// correct source path depending on the OS.
-	absPath, err := util.GetAbsPath(filepath.Join(componentContext, lci.GetSourceLocation()))
+	absPath, err := util.GetAbsPath(filepath.Join(currentDirectory, lci.GetSourceLocation()))
 
 	sourceOSPath := filepath.FromSlash(absPath)
 

--- a/tests/integration/java_test.go
+++ b/tests/integration/java_test.go
@@ -55,8 +55,7 @@ var _ = Describe("odoJavaE2e", func() {
 			helper.CmdShouldPass("odo", "delete", "wo-wait-javaee-git-test", "-f", "--context", context)
 		})
 
-		// https://github.com/openshift/odo/issues/1846
-		/*It("Should be able to deploy a .war file using wildfly", func() {
+		It("Should be able to deploy a .war file using wildfly", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "wildfly"), context)
 			helper.CmdShouldPass("odo", "create", "wildfly", "javaee-war-test", "--project",
 				project, "--binary", filepath.Join(context, "ROOT.war"), "--context", context)
@@ -71,7 +70,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Delete the component
 			helper.CmdShouldPass("odo", "delete", "javaee-war-test", "-f", "--context", context)
-		})*/
+		})
 
 		It("Should be able to deploy a git repo that contains a java uberjar application using openjdk", func() {
 			oc.ImportJavaIsToNspace(project)
@@ -92,8 +91,7 @@ var _ = Describe("odoJavaE2e", func() {
 			helper.CmdShouldPass("odo", "delete", "uberjar-git-test", "-f", "--context", context)
 		})
 
-		// https://github.com/openshift/odo/issues/1846
-		/*It("Should be able to deploy a spring boot uberjar file using openjdk", func() {
+		It("Should be able to deploy a spring boot uberjar file using openjdk", func() {
 			oc.ImportJavaIsToNspace(project)
 
 			helper.CmdShouldPass("odo", "create", "java", "sb-jar-test", "--project",
@@ -109,7 +107,7 @@ var _ = Describe("odoJavaE2e", func() {
 
 			// Delete the component
 			helper.CmdShouldPass("odo", "delete", "sb-jar-test", "-f", "--context", context)
-		})*/
+		})
 
 	})
 })


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
This is an alternate approach to solving https://github.com/openshift/odo/issues/1846. In this approach we join `currentWorkingDirectory` to `SourceLocation` which works because we actually store the `SourceLocation` related to the `currentWorkingDirectory` - here https://github.com/openshift/odo/blob/ad79434c2276eb3166766178c869849c86cd8e57/pkg/odo/cli/component/create.go#L316 and here https://github.com/openshift/odo/blob/ad79434c2276eb3166766178c869849c86cd8e57/pkg/odo/cli/component/create.go#L335

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1846
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
odo create wildfly javaee-war-test --project myproject --binary tests/examples/binary/java/wildfly/ROOT.war --context tests/examples/binary/java/wildfly/
odo push --context tests/examples/binary/java/wildfly/
```