### PR TITLE
use order less slice comparison in unit tests

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -5402,9 +5403,27 @@ func TestGetPortsFromBuilderImage(t *testing.T) {
 				t.Errorf("Client.GetPortsFromBuilderImage() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !sliceEqual(got, tt.want) {
 				t.Errorf("Client.GetPortsFromBuilderImage() = %v, want %v", got, tt.want)
 			}
 		})
 	}
+}
+
+// sliceEqual checks equality of two slices irrespective of the element ordering
+func sliceEqual(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+
+	xc := make([]string, len(x))
+	yc := make([]string, len(y))
+
+	copy(xc, x)
+	copy(yc, y)
+
+	sort.Strings(xc)
+	sort.Strings(yc)
+
+	return reflect.DeepEqual(xc, yc)
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
There are times when unit test fail due to different ordering of list returned for ports
```
-- FAIL: TestGetPortsFromBuilderImage (0.00s)
    --- FAIL: TestGetPortsFromBuilderImage/component_type:_php (0.00s)
        occlient_test.go:5406: Client.GetPortsFromBuilderImage() = [8443/TCP 8080/TCP], want [8080/TCP 8443/TCP]
FAIL
FAIL    github.com/openshift/odo/pkg/occlient    3.282s
```

So used an order independent comparison for slices

## Was the change discussed in an issue?
No issue
<!-- Please do Link issues here. -->

## How to test changes?
unit tests shouldn't flake out