### PR TITLE
consistent component name and resolved failing numeric dir push

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -95,7 +95,7 @@ func GetDefaultComponentName(componentPath string, componentPathType config.SrcT
 
 	// Generate unique name for the component using prefix and unique random suffix
 	componentName, err := util.GetRandomName(
-		fmt.Sprintf("%s-%s", prefix, componentType),
+		fmt.Sprintf("%s-%s", componentType, prefix),
 		componentNameMaxLen,
 		existingComponentNames,
 		componentNameMaxRetries,

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -435,7 +435,7 @@ func TestGetDefaultComponentName(t *testing.T) {
 			componentPath:      "./testing",
 			existingComponents: ComponentList{},
 			wantErr:            false,
-			wantRE:             "testing-nodejs-*",
+			wantRE:             "nodejs-testing-*",
 			needPrefix:         true,
 		},
 		{
@@ -445,7 +445,7 @@ func TestGetDefaultComponentName(t *testing.T) {
 			componentPath:      "./testing.war",
 			existingComponents: ComponentList{},
 			wantErr:            false,
-			wantRE:             "testing-wildfly-*",
+			wantRE:             "wildfly-testing-*",
 			needPrefix:         true,
 		},
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -220,8 +220,26 @@ func getSourceLocation(componentContext string, currentDirectory string) (string
 
 func createDefaultComponentName(context *genericclioptions.Context, componentType string, sourceType config.SrcType, sourcePath string) (string, error) {
 	// Retrieve the componentName, if the componentName isn't specified, we will use the default image name
+	var err error
+	finalSourcePath := sourcePath
+	// we only get absolute path for local source type
+	if sourceType == config.LOCAL {
+		if sourcePath == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				return "", err
+			}
+			finalSourcePath = wd
+		} else {
+			finalSourcePath, err = filepath.Abs(sourcePath)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
 	componentName, err := component.GetDefaultComponentName(
-		sourcePath,
+		finalSourcePath,
 		sourceType,
 		componentType,
 		component.ComponentList{},


### PR DESCRIPTION
- Changed the ordering of prefix and component type when creating a default component name.
- Use of absolute path for source path when generating the default component name when source type is local

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1825
<!-- Please do Link issues here. -->

## How to test changes?
```
mkdir nodejs-test
odo create nodejs --context ./nodejs-test
cd nodejs-test
odo create nodejs --context .
```
should give the same component name

also
```
mkdir 1234
odo create nodejs --context ./1234
cd 1234
npm init --yes  #just so it doesn't fail on package.json not found error
odo push 
```
shouldn't fail due to `a DNS-1035 label must consist of lower case alphanumeric characters or '-'` 
