### PR TITLE
Adding now flag to remaining operations

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -75,7 +75,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 	defer s.End(false)
 	isCmpExists, err := component.Exists(cpo.Context.Client, cmpName, appName)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to check if component %s exists or not", cmpName)
+		return errors.Wrapf(err, "failed to check if component %s exists or not", cmpName)
 	}
 	s.End(true)
 

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -47,7 +47,7 @@ func NewCommonPushOptions() *CommonPushOptions {
 }
 
 //EnablePushConfig enables pushing of the config only
-func (cpo *CommonPushOptions) EnablePushConfig()  {
+func (cpo *CommonPushOptions) EnablePushConfig() {
 	cpo.pushConfig = true
 }
 

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -46,6 +46,11 @@ func NewCommonPushOptions() *CommonPushOptions {
 	}
 }
 
+//EnablePushConfig enables pushing of the config only
+func (cpo *CommonPushOptions) EnablePushConfig()  {
+	cpo.pushConfig = true
+}
+
 // ResolveSrcAndConfigFlags sets all pushes if none is asked
 func (cpo *CommonPushOptions) ResolveSrcAndConfigFlags() {
 	// If neither config nor source flag is passed, update both config and source to the component

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -23,7 +23,13 @@ const RecommendedCommandName = "component"
 // ComponentOptions encapsulates basic component options
 type ComponentOptions struct {
 	componentName string
-	*genericclioptions.Context
+	*CommonPushOptions
+}
+
+//NewComponentOptionsWithPushOptions returns empty Component Options with a new
+// CommonPushOptions
+func NewComponentOptionsWithPushOptions() *ComponentOptions {
+	return &ComponentOptions{CommonPushOptions: NewCommonPushOptions()}
 }
 
 // Complete completes component options

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -275,18 +275,18 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.interactive = true
 	}
 
-	co.localConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
+	co.LocalConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}
 
 	// check to see if config file exists or not, if it does that
 	// means we shouldn't allow the user to override the current component
-	if co.localConfigInfo.ConfigFileExists() {
+	if co.LocalConfigInfo.ConfigFileExists() {
 		return errors.New("this directory already contains a component")
 	}
 
-	co.componentSettings = co.localConfigInfo.GetComponentSettings()
+	co.componentSettings = co.LocalConfigInfo.GetComponentSettings()
 
 	co.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 
@@ -481,12 +481,12 @@ func (co *CreateOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run() (err error) {
-	err = co.localConfigInfo.SetComponentSettings(co.componentSettings)
+	err = co.LocalConfigInfo.SetComponentSettings(co.componentSettings)
 	if err != nil {
 		return errors.Wrapf(err, "failed to persist the component settings to config file")
 	}
 	if co.now {
-		co.Context, co.localConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
+		co.Context, co.LocalConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
 
 		if err != nil {
 			return errors.Wrap(err, "unable to retrieve updated local config")
@@ -507,9 +507,9 @@ func (co *CreateOptions) Run() (err error) {
 
 func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) error {
 
-	cmpName := co.localConfigInfo.GetName()
-	appName := co.localConfigInfo.GetApplication()
-	cmpType := co.localConfigInfo.GetType()
+	cmpName := co.LocalConfigInfo.GetName()
+	appName := co.LocalConfigInfo.GetApplication()
+	cmpType := co.LocalConfigInfo.GetType()
 
 	isCmpExists, err := component.Exists(co.Context.Client, cmpName, appName)
 	if err != nil {
@@ -519,7 +519,7 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 	if !isCmpExists {
 		log.Successf("Creating %s component with name %s", cmpType, cmpName)
 		// Classic case of component creation
-		if err = component.CreateComponent(co.Context.Client, *co.localConfigInfo, co.componentContext, stdout); err != nil {
+		if err = component.CreateComponent(co.Context.Client, *co.LocalConfigInfo, co.componentContext, stdout); err != nil {
 			log.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,
@@ -531,7 +531,7 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 	}
 
 	// Apply config
-	err = component.ApplyConfig(co.Context.Client, *co.localConfigInfo, stdout, isCmpExists)
+	err = component.ApplyConfig(co.Context.Client, *co.LocalConfigInfo, stdout, isCmpExists)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
 	}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -29,6 +29,7 @@ var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'.
 
 // DeleteOptions is a container to attach complete, validate and run pattern
 type DeleteOptions struct {
+	now                      bool
 	componentForceDeleteFlag bool
 	componentDeleteAllFlag   bool
 	componentContext         string
@@ -38,7 +39,7 @@ type DeleteOptions struct {
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, "", false, &ComponentOptions{}}
+	return &DeleteOptions{false, false, false, "", NewComponentOptionsWithPushOptions()}
 }
 
 // Complete completes log args
@@ -138,7 +139,8 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)
 	//Adding `--context` flag
 	genericclioptions.AddContextFlag(componentDeleteCmd, &do.componentContext)
-
+	// Adding `--now` flag
+	//	genericclioptions.AddNowFlag(componentDeleteCmd, &do.now)
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentDeleteCmd)
 	//Adding `--application` flag

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -39,7 +39,7 @@ type DeleteOptions struct {
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, false, "", false,NewComponentOptionsWithPushOptions()}
+	return &DeleteOptions{false, false, false, "", false, NewComponentOptionsWithPushOptions()}
 }
 
 // Complete completes log args

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -39,7 +39,7 @@ type DeleteOptions struct {
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, false, "", NewComponentOptionsWithPushOptions()}
+	return &DeleteOptions{false, false, false, "", false,NewComponentOptionsWithPushOptions()}
 }
 
 // Complete completes log args

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -68,7 +68,7 @@ func (do *DescribeOptions) Run() (err error) {
 		return err
 	}
 	if log.IsJSON() {
-		componentDesc.Spec.Ports = do.localConfigInfo.GetPorts()
+		componentDesc.Spec.Ports = do.LocalConfigInfo.GetPorts()
 		out, err := machineoutput.MarshalJSONIndented(componentDesc)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -28,20 +28,19 @@ var describeExample = ktemplates.Examples(`  # Describe nodejs component,
 
 // DescribeOptions is a dummy container to attach complete, validate and run pattern
 type DescribeOptions struct {
-	localConfigInfo  *config.LocalConfigInfo
 	componentContext string
 	*ComponentOptions
 }
 
 // NewDescribeOptions returns new instance of ListOptions
 func NewDescribeOptions() *DescribeOptions {
-	return &DescribeOptions{nil, "", &ComponentOptions{}}
+	return &DescribeOptions{"", NewComponentOptionsWithPushOptions()}
 }
 
 // Complete completes describe args
 func (do *DescribeOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	err = do.ComponentOptions.Complete(name, cmd, args)
-	do.localConfigInfo, err = config.NewLocalConfigInfo(do.componentContext)
+	do.LocalConfigInfo, err = config.NewLocalConfigInfo(do.componentContext)
 	return
 }
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -81,33 +81,19 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Checking component")
 	defer s.End(false)
 
-<<<<<<< HEAD
-	po.isCmpExists, err = component.Exists(po.Context.Client, po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
+	po.isCmpExists, err = component.Exists(po.Context.Client, po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	if err != nil {
-		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
+		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	}
 
 	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
 		s.End(false)
 		log.Info("Run 'odo catalog list components' for a list of supported component types")
-		return fmt.Errorf("Invalid component type %s, %v", *po.localConfigInfo.GetComponentSettings().Type, errors.Cause(err))
+		return fmt.Errorf("Invalid component type %s, %v", *po.LocalConfigInfo.GetComponentSettings().Type, errors.Cause(err))
 	}
 
 	if !po.isCmpExists && po.pushSource && !po.pushConfig {
-		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfigInfo.GetName())
-=======
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), false); err != nil {
-		return err
-	}
-
-	isCmpExists, err := component.Exists(po.Context.Client, po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
-	if err != nil {
-		return err
-	}
-
-	if !isCmpExists && po.pushSource && !po.pushConfig {
 		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.LocalConfigInfo.GetName())
->>>>>>> Updating component as per changes to common push
 	}
 
 	s.End(true)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -86,7 +86,7 @@ func (po *PushOptions) Validate() (err error) {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	}
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
 		s.End(false)
 		log.Info("Run 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *po.LocalConfigInfo.GetComponentSettings().Type, errors.Cause(err))

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -50,7 +50,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	}
 
 	// Set the necessary values within WatchOptions
-	po.localConfigInfo = conf
+	po.LocalConfigInfo = conf
 	err = po.SetSourceInfo()
 	if err != nil {
 		return errors.Wrap(err, "unable to set source information")
@@ -63,7 +63,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 	// Set the correct context
 	po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-	prjName := po.localConfigInfo.GetProject()
+	prjName := po.LocalConfigInfo.GetProject()
 	po.ResolveSrcAndConfigFlags()
 	err = po.ResolveProject(prjName)
 	if err != nil {
@@ -81,6 +81,7 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Checking component")
 	defer s.End(false)
 
+<<<<<<< HEAD
 	po.isCmpExists, err = component.Exists(po.Context.Client, po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
@@ -94,6 +95,19 @@ func (po *PushOptions) Validate() (err error) {
 
 	if !po.isCmpExists && po.pushSource && !po.pushConfig {
 		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfigInfo.GetName())
+=======
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), false); err != nil {
+		return err
+	}
+
+	isCmpExists, err := component.Exists(po.Context.Client, po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
+	if err != nil {
+		return err
+	}
+
+	if !isCmpExists && po.pushSource && !po.pushConfig {
+		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.LocalConfigInfo.GetName())
+>>>>>>> Updating component as per changes to common push
 	}
 
 	s.End(true)

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -72,7 +72,7 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 	}
 	o.LocalConfigInfo = cfg
 	if o.now {
-		o.ResolveSrcAndConfigFlags()
+		o.EnablePushConfig()
 		err = o.ResolveProject(o.Context.Project)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -131,7 +131,7 @@ func (o *SetOptions) Run() (err error) {
 		if o.LocalConfigInfo == nil {
 			fmt.Println("Ooops local config is nil")
 		}
-		glog.V(4).Infof("Reloaded context info %#v" , o)
+		glog.V(4).Infof("Reloaded context info %#v", o)
 
 		if err != nil {
 			return errors.Wrap(err, "unable to retrieve updated local config")

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -2,11 +2,11 @@ package url
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 
-	"github.com/openshift/odo/pkg/odo/genericclioptions/printtemplates"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
-
+	"github.com/openshift/odo/pkg/odo/genericclioptions/printtemplates"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
@@ -115,7 +115,7 @@ func (o *URLCreateOptions) Run() (err error) {
 		if o.LocalConfigInfo == nil {
 			fmt.Println("Ooops local config is nil")
 		}
-		glog.V(4).Infof("Reloaded context info %#v" , o)
+		glog.V(4).Infof("Reloaded context info %#v", o)
 
 		if err != nil {
 			return errors.Wrap(err, "unable to retrieve updated local config")
@@ -150,7 +150,6 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 	urlCreateCmd.Flags().IntVarP(&o.urlPort, "port", "", -1, "port number for the url of the component, required in case of components which expose more than one service port")
 	// Add `--now` flag
 	genericclioptions.AddNowFlag(urlCreateCmd, &o.now)
-	genericclioptions.AddOutputFlag(urlCreateCmd)
 	genericclioptions.AddContextFlag(urlCreateCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(urlCreateCmd, "context", completion.FileCompletionHandler)
 	return urlCreateCmd

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -74,7 +74,7 @@ func (o *URLDeleteOptions) Run() (err error) {
 			return err
 		}
 		log.Successf("URL %s removed from the config file", o.urlName)
-		log.Info("To delete URL on the OpenShift Cluster, please use `odo push`")
+		fmt.Print(printtemplates.PushMessage("delete", "URL", false))
 	} else {
 		return fmt.Errorf("aborting deletion of URL: %v", o.urlName)
 	}

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/openshift/odo/pkg/odo/genericclioptions/printtemplates"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -73,6 +73,7 @@ func (o *URLListOptions) Run() (err error) {
 			return fmt.Errorf("no URLs found for component %v in application %v", o.Component(), o.Application)
 		}
 
+<<<<<<< HEAD
 		log.Infof("Found the following URLs for component %v in application %v:", o.Component(), o.Application)
 		tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(tabWriterURL, "NAME", "\t", "STATE", "\t", "URL", "\t", "PORT")
@@ -83,6 +84,32 @@ func (o *URLListOptions) Run() (err error) {
 			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
 			if u.Status.State != url.StateTypePushed {
 				outOfSync = true
+=======
+			// Now reverse, check urls not in config and print their information
+			// Hence need to be deleted
+			for _, u := range urls.Items {
+				// Search if url is present in local config
+				var found bool
+				for _, i := range localUrls {
+					if i.Name == u.Name {
+						found = true
+						break
+					}
+				}
+				// If not found then we need to print its info but say its not in config
+				if !found {
+					dm = true
+					fmt.Fprintln(tabWriterURL, u.Name, "\t", "Absent", "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
+				}
+			}
+			tabWriterURL.Flush()
+			if cm && dm {
+				fmt.Print(printtemplates.PushMessage("create/delete", "URLs", false))
+			} else if cm {
+				fmt.Print(printtemplates.PushMessage("create", "URLs", false))
+			} else if dm {
+				fmt.Print(printtemplates.PushMessage("delete", "URLs", false))
+>>>>>>> Adding now flag to url operations and config set
 			}
 		}
 		tabWriterURL.Flush()

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -73,7 +73,6 @@ func (o *URLListOptions) Run() (err error) {
 			return fmt.Errorf("no URLs found for component %v in application %v", o.Component(), o.Application)
 		}
 
-<<<<<<< HEAD
 		log.Infof("Found the following URLs for component %v in application %v:", o.Component(), o.Application)
 		tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(tabWriterURL, "NAME", "\t", "STATE", "\t", "URL", "\t", "PORT")
@@ -84,7 +83,6 @@ func (o *URLListOptions) Run() (err error) {
 			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
 			if u.Status.State != url.StateTypePushed {
 				outOfSync = true
-=======
 			// Now reverse, check urls not in config and print their information
 			// Hence need to be deleted
 			for _, u := range urls.Items {
@@ -109,7 +107,6 @@ func (o *URLListOptions) Run() (err error) {
 				fmt.Print(printtemplates.PushMessage("create", "URLs", false))
 			} else if dm {
 				fmt.Print(printtemplates.PushMessage("delete", "URLs", false))
->>>>>>> Adding now flag to url operations and config set
 			}
 		}
 		tabWriterURL.Flush()

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -83,30 +83,6 @@ func (o *URLListOptions) Run() (err error) {
 			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
 			if u.Status.State != url.StateTypePushed {
 				outOfSync = true
-			// Now reverse, check urls not in config and print their information
-			// Hence need to be deleted
-			for _, u := range urls.Items {
-				// Search if url is present in local config
-				var found bool
-				for _, i := range localUrls {
-					if i.Name == u.Name {
-						found = true
-						break
-					}
-				}
-				// If not found then we need to print its info but say its not in config
-				if !found {
-					dm = true
-					fmt.Fprintln(tabWriterURL, u.Name, "\t", "Absent", "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
-				}
-			}
-			tabWriterURL.Flush()
-			if cm && dm {
-				fmt.Print(printtemplates.PushMessage("create/delete", "URLs", false))
-			} else if cm {
-				fmt.Print(printtemplates.PushMessage("create", "URLs", false))
-			} else if dm {
-				fmt.Print(printtemplates.PushMessage("delete", "URLs", false))
 			}
 		}
 		tabWriterURL.Flush()

--- a/pkg/odo/genericclioptions/printtemplates/messages.go
+++ b/pkg/odo/genericclioptions/printtemplates/messages.go
@@ -1,0 +1,15 @@
+package printtemplates
+
+import (
+	"fmt"
+)
+
+// PushMessage tells user to use odo push apply action on specified object (what) on
+// the cluster
+func PushMessage(action string, what string, config bool) string {
+	var c string
+	if config {
+		c = " --config"
+	}
+	return fmt.Sprintf("To %s %s on the OpenShift Cluster, please use `odo push%s` \n", action, what, c)
+}

--- a/pkg/odo/genericclioptions/printtemplates/messages_test.go
+++ b/pkg/odo/genericclioptions/printtemplates/messages_test.go
@@ -1,0 +1,43 @@
+package printtemplates
+
+import (
+	"testing"
+)
+
+func Test_validatePushMessage(t *testing.T) {
+	type args struct {
+		action, what string
+		config  bool
+	}
+	tests := []struct {
+		name     string
+		argl     args
+		expected string
+	}{
+		{
+			name: "create route push message",
+			argl: args{
+				action: "create",
+				what:   "route",
+				config: false,
+			},
+			expected: "To create route on the OpenShift Cluster, please use `odo push` \n",
+		},
+		{
+			name: "create config push message",
+			argl: args{
+				action: "apply",
+				what: "config changes",
+				config: true,
+			},
+			expected: "To apply config changes on the OpenShift Cluster, please use `odo push --config` \n",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := PushMessage(tt.argl.action, tt.argl.what, tt.argl.config)
+		if actual != tt.expected {
+			t.Errorf("Expected : %s Actual %s Mismatch", tt.expected, actual)
+		}
+	}
+}

--- a/pkg/odo/genericclioptions/printtemplates/messages_test.go
+++ b/pkg/odo/genericclioptions/printtemplates/messages_test.go
@@ -7,7 +7,7 @@ import (
 func Test_validatePushMessage(t *testing.T) {
 	type args struct {
 		action, what string
-		config  bool
+		config       bool
 	}
 	tests := []struct {
 		name     string
@@ -27,7 +27,7 @@ func Test_validatePushMessage(t *testing.T) {
 			name: "create config push message",
 			argl: args{
 				action: "apply",
-				what: "config changes",
+				what:   "config changes",
 				config: true,
 			},
 			expected: "To apply config changes on the OpenShift Cluster, please use `odo push --config` \n",

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -52,14 +52,14 @@ func WaitForCmdOut(program string, args []string, timeout int, errOnFail bool, c
 }
 
 // MatchAllInOutput ensures all strings are in output
-func MatchAllInOutput(output string, tomatch []string) {
+func MatchAllInOutput(output string, tomatch... string) {
 	for _, i := range tomatch {
 		Expect(output).To(ContainSubstring(i))
 	}
 }
 
 // DontMatchAllInOutput ensures all strings are not in output
-func DontMatchAllInOutput(output string, tonotmatch []string) {
+func DontMatchAllInOutput(output string, tonotmatch... string) {
 	for _, i := range tonotmatch {
 		Expect(output).ToNot(ContainSubstring(i))
 	}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -52,14 +52,14 @@ func WaitForCmdOut(program string, args []string, timeout int, errOnFail bool, c
 }
 
 // MatchAllInOutput ensures all strings are in output
-func MatchAllInOutput(output string, tomatch... string) {
+func MatchAllInOutput(output string, tomatch ...string) {
 	for _, i := range tomatch {
 		Expect(output).To(ContainSubstring(i))
 	}
 }
 
 // DontMatchAllInOutput ensures all strings are not in output
-func DontMatchAllInOutput(output string, tonotmatch... string) {
+func DontMatchAllInOutput(output string, tonotmatch ...string) {
 	for _, i := range tonotmatch {
 		Expect(output).ToNot(ContainSubstring(i))
 	}

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -51,18 +51,19 @@ var _ = Describe("odo url command tests", func() {
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Not Pushed", url1, "odo push")
 
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Pushed"})
-			helper.DontMatchAllInOutput(stdout, []string{"Not Pushed", "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Pushed")
+			helper.DontMatchAllInOutput(stdout, "Not Pushed", "odo push")
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
 
 			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
+			helper.MatchAllInOutput(stdout, url1, "Locally Deleted", url1, "odo push")
 			helper.MatchAllInOutput(stdout, "<not created on cluster>", "Present", "create URLs", "odo push")
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -67,8 +67,22 @@ var _ = Describe("odo url command tests", func() {
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url2, "Not Pushed", "odo push"})
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url2, "Pushed"})
-			helper.DontMatchAllInOutput(stdout, []string{url1, "Not Pushed", "odo push"})
+			helper.MatchAllInOutput(stdout, url2, "Pushed")
+			helper.DontMatchAllInOutput(stdout, url1, "Not Pushed", "odo push")
+		})
+		It("should list appropriate urls after creation with --now flag", func() {
+			var stdout string
+			url1 := helper.RandString(5)
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			stdout = helper.CmdShouldFail("odo", "url", "list", "--context", context)
+
+			Expect(stdout).To(ContainSubstring("no URLs found"))
+
+			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context, "--now")
+			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			helper.MatchAllInOutput(stdout, url1, "Present")
 		})
 	})
 

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -51,38 +51,24 @@ var _ = Describe("odo url command tests", func() {
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, url1, "Not Pushed", url1, "odo push")
+			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
 
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, url1, "Pushed")
-			helper.DontMatchAllInOutput(stdout, "Not Pushed", "odo push")
+			helper.MatchAllInOutput(stdout, []string{url1, "Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{"Not Pushed", "odo push"})
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
 
 			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
-			helper.MatchAllInOutput(stdout, url1, "Locally Deleted", url1, "odo push")
-			helper.MatchAllInOutput(stdout, "<not created on cluster>", "Present", "create URLs", "odo push")
-			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url2, "Not Pushed", "odo push"})
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, url2, "Pushed")
-			helper.DontMatchAllInOutput(stdout, url1, "Not Pushed", "odo push")
-			helper.MatchAllInOutput(stdout, url1, "Absent", "delete URLs", "odo push")
-
-			// Uncomment once https://github.com/openshift/odo/issues/1832 is fixed
-
-			// helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
-			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			// helper.MatchAllInOutput(stdout, url1, "Absent", url2, "Present", "create/delete URLs", "odo push")
-			// helper.CmdShouldPass("odo", "push", "--context", context)
-			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			// helper.MatchAllInOutput(stdout, url2, "Present")
-			// helper.DontMatchAllInOutput(stdout, url1, "Absent", "odo push")
+			helper.MatchAllInOutput(stdout, []string{url2, "Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{url1, "Not Pushed", "odo push"})
 		})
 		It("should list appropriate urls after creation with --now flag", func() {
 			var stdout string

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -63,12 +63,25 @@ var _ = Describe("odo url command tests", func() {
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
 
 			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
+			helper.MatchAllInOutput(stdout, "<not created on cluster>", "Present", "create URLs", "odo push")
+			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url2, "Not Pushed", "odo push"})
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, url2, "Pushed")
 			helper.DontMatchAllInOutput(stdout, url1, "Not Pushed", "odo push")
+			helper.MatchAllInOutput(stdout, url1, "Absent", "delete URLs", "odo push")
+
+			// Uncomment once https://github.com/openshift/odo/issues/1832 is fixed
+
+			// helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
+			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			// helper.MatchAllInOutput(stdout, url1, "Absent", url2, "Present", "create/delete URLs", "odo push")
+			// helper.CmdShouldPass("odo", "push", "--context", context)
+			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			// helper.MatchAllInOutput(stdout, url2, "Present")
+			// helper.DontMatchAllInOutput(stdout, url1, "Absent", "odo push")
 		})
 		It("should list appropriate urls after creation with --now flag", func() {
 			var stdout string

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -51,24 +51,24 @@ var _ = Describe("odo url command tests", func() {
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Not Pushed", url1, "odo push")
 
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Pushed"})
-			helper.DontMatchAllInOutput(stdout, []string{"Not Pushed", "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Pushed")
+			helper.DontMatchAllInOutput(stdout, "Not Pushed", "odo push")
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Locally Deleted", url1, "odo push")
 
 			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url2, "Not Pushed", "odo push"})
+			helper.MatchAllInOutput(stdout, url1, "Locally Deleted", url2, "Not Pushed", "odo push")
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url2, "Pushed"})
-			helper.DontMatchAllInOutput(stdout, []string{url1, "Not Pushed", "odo push"})
+			helper.MatchAllInOutput(stdout, url2, "Pushed")
+			helper.DontMatchAllInOutput(stdout, url1, "Not Pushed", "odo push")
 		})
 		It("should list appropriate urls after creation with --now flag", func() {
 			var stdout string


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR allows usage of `--now` flag with remaining commands that should have it
## Was the change discussed in an issue?
 #1595 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
run commands with --now flag
```
odo url create --now
odo url delete --now
odo config set --now
```