### PR TITLE
recover from panic to give more graceful error message

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -136,9 +136,19 @@ func fakeResourceRequirements() *corev1.ResourceRequirements {
 }
 
 func fakeResourceConsumption() []util.ResourceRequirementInfo {
+	memoryQuantity, err := util.FetchResourceQuantity(corev1.ResourceMemory, "100Mi", "350Mi", "")
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	cpuQuantity, err := util.FetchResourceQuantity(corev1.ResourceCPU, "100m", "350m", "")
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 	return []util.ResourceRequirementInfo{
-		*util.FetchResourceQuantity(corev1.ResourceMemory, "100Mi", "350Mi", ""),
-		*util.FetchResourceQuantity(corev1.ResourceCPU, "100m", "350m", ""),
+		*memoryQuantity,
+		*cpuQuantity,
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -342,29 +342,41 @@ func OpenBrowser(url string) error {
 }
 
 // FetchResourceQuantity takes passed min, max and requested resource quantities and returns min and max resource requests
-func FetchResourceQuantity(resourceType corev1.ResourceName, min string, max string, request string) *ResourceRequirementInfo {
+func FetchResourceQuantity(resourceType corev1.ResourceName, min string, max string, request string) (*ResourceRequirementInfo, error) {
 	if min == "" && max == "" && request == "" {
-		return nil
+		return nil, nil
 	}
 	// If minimum and maximum both are passed they carry highest priority
 	// Otherwise, use the request as min and max
 	var minResource resource.Quantity
 	var maxResource resource.Quantity
 	if min != "" {
-		minResource = resource.MustParse(min)
+		resourceVal, err := resource.ParseQuantity(min)
+		if err != nil {
+			return nil, err
+		}
+		minResource = resourceVal
 	}
 	if max != "" {
-		maxResource = resource.MustParse(max)
+		resourceVal, err := resource.ParseQuantity(max)
+		if err != nil {
+			return nil, err
+		}
+		maxResource = resourceVal
 	}
 	if request != "" && (min == "" || max == "") {
-		minResource = resource.MustParse(request)
-		maxResource = resource.MustParse(request)
+		resourceVal, err := resource.ParseQuantity(request)
+		if err != nil {
+			return nil, err
+		}
+		minResource = resourceVal
+		maxResource = resourceVal
 	}
 	return &ResourceRequirementInfo{
 		ResourceType: resourceType,
 		MinQty:       minResource,
 		MaxQty:       maxResource,
-	}
+	}, nil
 }
 
 // CheckPathExists checks if a path exists or not

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -532,4 +532,18 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", "push", "--context", context, "-v4")
 		})
 	})
+
+	Context("when creating component with improper memory quantities", func() {
+		JustBeforeEach(func() {
+			project = helper.CreateRandProject()
+		})
+		JustAfterEach(func() {
+			helper.DeleteProject(project)
+		})
+		It("should fail gracefully with proper error message", func() {
+			stdError := helper.CmdShouldFail("odo", append(args, "create", "java", "backend", "--memory", "1GB", "--project", project, "--context", context)...)
+			Expect(stdError).ToNot(ContainSubstring("panic: cannot parse"))
+			Expect(stdError).To(ContainSubstring("quantities must match the regular expression"))
+		})
+	})
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This change prevents a stack trace from being printed when panic() is called. It will generate a more graceful error message for the end user.

A before/after example:

**Before:**
```
[adewey@localhost lab]$ odo create java backend --memory=1GB
panic: cannot parse '1GB': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'

goroutine 1 [running]:
github.com/openshift/odo/vendor/k8s.io/apimachinery/pkg/api/resource.MustParse(0x7fff7e04b75b, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/adewey/go/src/github.com/openshift/odo/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:133 +0x216
github.com/openshift/odo/pkg/util.FetchResourceQuantity(0x196aaa6, 0x6, 0x0, 0x0, 0x0, 0x0, 0x7fff7e04b75b, 0x3, 0x196aa6a)
	/home/adewey/go/src/github.com/openshift/odo/pkg/util/util.go:360 +0x210
github.com/openshift/odo/pkg/odo/cli/component.(*CreateOptions).setResourceLimits(0xc000459200)
	/home/adewey/go/src/github.com/openshift/odo/pkg/odo/cli/component/create.go:265 +0x15f
github.com/openshift/odo/pkg/odo/cli/component.(*CreateOptions).Complete(0xc000459200, 0xc0008a64e0, 0x6, 0xc0008a4b40, 0xc000802510, 0x2, 0x3, 0x2, 0x1969a87)
	/home/adewey/go/src/github.com/openshift/odo/pkg/odo/cli/component/create.go:416 +0x138f
github.com/openshift/odo/pkg/odo/genericclioptions.GenericRun(0x1c32420, 0xc000459200, 0xc0008a4b40, 0xc000802510, 0x2, 0x3)
	/home/adewey/go/src/github.com/openshift/odo/pkg/odo/genericclioptions/runnable.go:15 +0x6e
github.com/openshift/odo/pkg/odo/cli/component.NewCmdCreate.func1(0xc0008a4b40, 0xc000802510, 0x2, 0x3)
	/home/adewey/go/src/github.com/openshift/odo/pkg/odo/cli/component/create.go:559 +0x5e
github.com/openshift/odo/vendor/github.com/spf13/cobra.(*Command).execute(0xc0008a4b40, 0xc0008024e0, 0x3, 0x3, 0xc0008a4b40, 0xc0008024e0)
	/home/adewey/go/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:702 +0x289
github.com/openshift/odo/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0008e6480, 0x1a6e038, 0xc0000453e0, 0x4)
	/home/adewey/go/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:783 +0x2ca
github.com/openshift/odo/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/home/adewey/go/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:736
main.main()
	/home/adewey/go/src/github.com/openshift/odo/cmd/odo/odo.go:65 +0x31f
```

**After:**
```
[adewey@localhost lab]$ odo create java backend --memory=1GB
error: cannot parse '1GB': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

This is also consistent with the error messages produced by oc (4.1). For example:
```
[adewey@localhost lab]$ oc run rhel7 --image=registry.access.redhat.com/rhel7 --limits="memory=1GB" -- /usr/bin/sleep infinity
kubectl run --generator=deploymentconfig/v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

## Was the change discussed in an issue?
Related to #1170. This does not add additional regex, but it does allow calls to panic() to be handled gracefully.

## How to test changes?
<!-- Please describe the steps to test the PR -->
Run a command that will trigger a call to panic(), for example:
```
[adewey@localhost lab]$ odo create java backend --memory=1GB
error: cannot parse '1GB': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```
Notice that it does not print the stack trace.