### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install:
 
 # run all validation tests
 .PHONY: validate
-validate: gofmt check-vendor vet validate-vendor-licenses #lint
+validate: gofmt check-vendor vet validate-vendor-licenses sec #lint
 
 .PHONY: gofmt
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ lint:
 vet:
 	go vet $(PKGS)
 
+.PHONY: sec
+sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium -confidence medium -exclude G304,G204 -quiet  ./...
+
 .PHONY: clean
 clean:
 	@rm -rf $(FILES)
@@ -67,6 +72,7 @@ goget-tools:
 	go get -u github.com/mitchellh/gox
 	go get github.com/frapposelli/wwhrd
 	go get -u github.com/onsi/ginkgo/ginkgo
+	go get -u github.com/securego/gosec/cmd/gosec
 
 # Run unit tests and collect coverage
 .PHONY: test-coverage

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -16,7 +16,7 @@ import (
 func CreateIfNotExists(configFile string) error {
 	_, err := os.Stat(filepath.Dir(configFile))
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(filepath.Dir(configFile), 0755)
+		err = os.MkdirAll(filepath.Dir(configFile), 0750)
 		if err != nil {
 			return errors.Wrap(err, "unable to create directory")
 		}

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -44,7 +44,7 @@ func Chdir(dir string) {
 
 // MakeDir creates a new dir
 func MakeDir(dir string) {
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0750)
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
@@ -140,7 +140,7 @@ func copyDir(src string, dst string, info os.FileInfo) error {
 // fileContent is the content to be written to the given file
 func CreateFileWithContent(path string, fileContent string) error {
 	// create and open file if not exists
-	var file, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	var file, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/tests/helper/helper_http.go
+++ b/tests/helper/helper_http.go
@@ -21,6 +21,8 @@ func HttpWaitFor(url string, match string, maxRetry int, interval int) {
 	for i := 0; i < maxRetry; i++ {
 		fmt.Fprintf(GinkgoWriter, "try %d of %d\n", i, maxRetry)
 
+		// #nosec
+		// gosec:G107 -> This is safe since it's just used for testing.
 		resp, err := http.Get(url)
 		if err != nil {
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -518,7 +518,7 @@ func componentTests(args ...string) {
 			ts := time.Now().UnixNano()
 			context, err = ioutil.TempDir("", fmt.Sprint(ts))
 			Expect(err).ToNot(HaveOccurred())
-			os.Mkdir(context, 0755)
+			os.Mkdir(context, 0750)
 			project = helper.CreateRandProject()
 			helper.Chdir(context)
 		})


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in
golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile.