### PR TITLE
Update labels to match gorkem/app-labels recommendations

### DIFF
--- a/pkg/application/labels/labels.go
+++ b/pkg/application/labels/labels.go
@@ -2,7 +2,7 @@ package labels
 
 // ApplicationLabel is label key that is used to group all object that belong to one application
 // It should be save to use just this label to filter application
-const ApplicationLabel = "app.kubernetes.io/name"
+const ApplicationLabel = "app.kubernetes.io/part-of"
 
 // AdditionalApplicationLabels additional labels that are applied to all objects belonging to one application
 // Those labels are not used for filtering or grouping, they are used just when creating and they are mend to be used by other tools

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -30,7 +30,7 @@ import (
 
 // componentSourceURLAnnotation is an source url from which component was build
 // it can be also file://
-const componentSourceURLAnnotation = "app.kubernetes.io/url"
+const componentSourceURLAnnotation = "app.openshift.io/vcs-uri"
 const ComponentSourceTypeAnnotation = "app.kubernetes.io/component-source-type"
 const componentRandomNamePartsMaxLen = 12
 const componentNameMaxRetries = 3

--- a/pkg/component/labels/labels.go
+++ b/pkg/component/labels/labels.go
@@ -5,13 +5,13 @@ import (
 )
 
 // ComponentLabel is a label key used to identify the component name
-const ComponentLabel = "app.kubernetes.io/component-name"
+const ComponentLabel = "app.kubernetes.io/instance"
 
 // ComponentTypeLabel is Kubernetes label that identifies the type of a component being used
-const ComponentTypeLabel = "app.kubernetes.io/component-type"
+const ComponentTypeLabel = "app.kubernetes.io/name"
 
 // ComponentTypeVersion is a Kubernetes label that identifies the component version
-const ComponentTypeVersion = "app.kubernetes.io/component-version"
+const ComponentTypeVersion = "app.openshift.io/runtime-version"
 
 // GetLabels return labels that should be applied to every object for given component in active application
 // additional labels are used only for creating object

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -548,9 +548,9 @@ func TestCreateRoute(t *testing.T) {
 			service:    "mailserver",
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA":                        "High",
 				"app.kubernetes.io/instance": "backend",
-				"app.kubernetes.io/name": "python",
+				"app.kubernetes.io/name":     "python",
 			},
 			wantErr: false,
 		},
@@ -561,9 +561,9 @@ func TestCreateRoute(t *testing.T) {
 			service:    "blog",
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
-				"SLA":                              "High",
+				"SLA":                        "High",
 				"app.kubernetes.io/instance": "backend",
-				"app.kubernetes.io/name": "golang",
+				"app.kubernetes.io/name":     "golang",
 			},
 			wantErr: false,
 		},
@@ -770,7 +770,7 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{
@@ -787,7 +787,7 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "non existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{
@@ -867,14 +867,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with normal correct values",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app":                        "apptmp",
 				"app.kubernetes.io/instance": "ruby",
-				"app.kubernetes.io/name": "ruby",
-				"app.kubernetes.io/part-of":           "apptmp",
+				"app.kubernetes.io/name":     "ruby",
+				"app.kubernetes.io/part-of":  "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -905,10 +905,10 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "wildfly",
-						"app.kubernetes.io/name": "wildfly",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "wildfly",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -929,20 +929,20 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with wrong pvc name",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app":                        "apptmp",
 				"app.kubernetes.io/instance": "ruby",
-				"app.kubernetes.io/name": "ruby",
-				"app.kubernetes.io/part-of":           "apptmp",
+				"app.kubernetes.io/name":     "ruby",
+				"app.kubernetes.io/part-of":  "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -968,10 +968,10 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "wildfly",
-						"app.kubernetes.io/name": "wildfly",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "wildfly",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -992,20 +992,20 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with wrong pvc specs",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app":                        "apptmp",
 				"app.kubernetes.io/instance": "ruby",
-				"app.kubernetes.io/name": "ruby",
-				"app.kubernetes.io/part-of":           "apptmp",
+				"app.kubernetes.io/name":     "ruby",
+				"app.kubernetes.io/part-of":  "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1031,10 +1031,10 @@ func TestSetupForSupervisor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "wildfly",
-						"app.kubernetes.io/name": "wildfly",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "wildfly",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -1054,14 +1054,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with non existing dc",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
-				"app":                              "apptmp",
+				"app":                        "apptmp",
 				"app.kubernetes.io/instance": "ruby",
-				"app.kubernetes.io/name": "ruby",
-				"app.kubernetes.io/part-of":           "apptmp",
+				"app.kubernetes.io/name":     "ruby",
+				"app.kubernetes.io/part-of":  "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1211,7 +1211,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 			buildConfigName: "nodejs",
 			gitURL:          "https://github.com/sclorg/nodejs-ex",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
+				"app.openshift.io/vcs-uri":                "https://github.com/sclorg/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "git",
 			},
 			existingBuildConfig: buildv1.BuildConfig{
@@ -1226,7 +1226,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs",
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1312,13 +1312,13 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1338,13 +1338,13 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1365,13 +1365,13 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1392,13 +1392,13 @@ func TestNewAppS2I(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -2647,13 +2647,13 @@ func TestCreateService(t *testing.T) {
 			commonObjectMeta: metav1.ObjectMeta{
 				Name: "nodejs",
 				Labels: map[string]string{
-					"app":                              "apptmp",
+					"app":                        "apptmp",
 					"app.kubernetes.io/instance": "ruby",
-					"app.kubernetes.io/name": "ruby",
-					"app.kubernetes.io/part-of":           "apptmp",
+					"app.kubernetes.io/name":     "ruby",
+					"app.kubernetes.io/part-of":  "apptmp",
 				},
 				Annotations: map[string]string{
-					"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+					"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 					"app.kubernetes.io/component-source-type": "git",
 				},
 			},
@@ -5078,13 +5078,13 @@ func TestCreateBuildConfig(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5111,13 +5111,13 @@ func TestCreateBuildConfig(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5144,13 +5144,13 @@ func TestCreateBuildConfig(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5178,13 +5178,13 @@ func TestCreateBuildConfig(t *testing.T) {
 				commonObjectMeta: metav1.ObjectMeta{
 					Name: "ruby",
 					Labels: map[string]string{
-						"app":                              "apptmp",
+						"app":                        "apptmp",
 						"app.kubernetes.io/instance": "ruby",
-						"app.kubernetes.io/name": "ruby",
-						"app.kubernetes.io/part-of":           "apptmp",
+						"app.kubernetes.io/name":     "ruby",
+						"app.kubernetes.io/part-of":  "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -45,7 +45,7 @@ func fakeDeploymentConfig(name string, image string, envVars []corev1.EnvVar, en
 	labels[applabels.ApplicationLabel] = name
 
 	// save source path as annotation
-	annotations := map[string]string{"app.kubernetes.io/url": "./",
+	annotations := map[string]string{"app.openshift.io/vcs-uri": "./",
 		"app.kubernetes.io/component-source-type": "local",
 	}
 
@@ -89,7 +89,7 @@ func fakeDeploymentConfigGit(name string, image string, envVars []corev1.EnvVar,
 	labels[componentlabels.ComponentTypeVersion] = "latest"
 
 	// save source path as annotation
-	annotations := map[string]string{"app.kubernetes.io/url": "github.com/foo/bar.git",
+	annotations := map[string]string{"app.openshift.io/vcs-uri": "github.com/foo/bar.git",
 		"app.kubernetes.io/component-source-type": "git",
 	}
 
@@ -549,8 +549,8 @@ func TestCreateRoute(t *testing.T) {
 			portNumber: intstr.FromInt(8080),
 			labels: map[string]string{
 				"SLA":                              "High",
-				"app.kubernetes.io/component-name": "backend",
-				"app.kubernetes.io/component-type": "python",
+				"app.kubernetes.io/instance": "backend",
+				"app.kubernetes.io/name": "python",
 			},
 			wantErr: false,
 		},
@@ -562,8 +562,8 @@ func TestCreateRoute(t *testing.T) {
 			portNumber: intstr.FromInt(9100),
 			labels: map[string]string{
 				"SLA":                              "High",
-				"app.kubernetes.io/component-name": "backend",
-				"app.kubernetes.io/component-type": "golang",
+				"app.kubernetes.io/instance": "backend",
+				"app.kubernetes.io/name": "golang",
 			},
 			wantErr: false,
 		},
@@ -770,13 +770,13 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs",
-					Annotations: map[string]string{"app.kubernetes.io/url": "https://github.com/sclorg/nodejs-ex",
+					Annotations: map[string]string{"app.openshift.io/vcs-uri": "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -787,13 +787,13 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "non existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
-					Annotations: map[string]string{"app.kubernetes.io/url": "https://github.com/sclorg/nodejs-ex",
+					Annotations: map[string]string{"app.openshift.io/vcs-uri": "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -867,19 +867,19 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with normal correct values",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
 				"app":                              "apptmp",
-				"app.kubernetes.io/component-name": "ruby",
-				"app.kubernetes.io/component-type": "ruby",
-				"app.kubernetes.io/name":           "apptmp",
+				"app.kubernetes.io/instance": "ruby",
+				"app.kubernetes.io/name": "ruby",
+				"app.kubernetes.io/part-of":           "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
-					Annotations: map[string]string{"app.kubernetes.io/url": "https://github.com/sclorg/nodejs-ex",
+					Annotations: map[string]string{"app.openshift.io/vcs-uri": "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -906,9 +906,9 @@ func TestSetupForSupervisor(t *testing.T) {
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "wildfly",
-						"app.kubernetes.io/component-type": "wildfly",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "wildfly",
+						"app.kubernetes.io/name": "wildfly",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -929,20 +929,20 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with wrong pvc name",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
 				"app":                              "apptmp",
-				"app.kubernetes.io/component-name": "ruby",
-				"app.kubernetes.io/component-type": "ruby",
-				"app.kubernetes.io/name":           "apptmp",
+				"app.kubernetes.io/instance": "ruby",
+				"app.kubernetes.io/name": "ruby",
+				"app.kubernetes.io/part-of":           "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -969,9 +969,9 @@ func TestSetupForSupervisor(t *testing.T) {
 					Name: "wildfly",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "wildfly",
-						"app.kubernetes.io/component-type": "wildfly",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "wildfly",
+						"app.kubernetes.io/name": "wildfly",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -992,20 +992,20 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with wrong pvc specs",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
 				"app":                              "apptmp",
-				"app.kubernetes.io/component-name": "ruby",
-				"app.kubernetes.io/component-type": "ruby",
-				"app.kubernetes.io/name":           "apptmp",
+				"app.kubernetes.io/instance": "ruby",
+				"app.kubernetes.io/name": "ruby",
+				"app.kubernetes.io/part-of":           "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "wildfly",
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1032,9 +1032,9 @@ func TestSetupForSupervisor(t *testing.T) {
 					Name: fmt.Sprintf("%s-s2idata", "wildfly"),
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "wildfly",
-						"app.kubernetes.io/component-type": "wildfly",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "wildfly",
+						"app.kubernetes.io/name": "wildfly",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
@@ -1054,14 +1054,14 @@ func TestSetupForSupervisor(t *testing.T) {
 			name:   "setup with non existing dc",
 			dcName: "wildfly",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "file:///temp/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			labels: map[string]string{
 				"app":                              "apptmp",
-				"app.kubernetes.io/component-name": "ruby",
-				"app.kubernetes.io/component-type": "ruby",
-				"app.kubernetes.io/name":           "apptmp",
+				"app.kubernetes.io/instance": "ruby",
+				"app.kubernetes.io/name": "ruby",
+				"app.kubernetes.io/part-of":           "apptmp",
 			},
 			existingDc: appsv1.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1211,7 +1211,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 			buildConfigName: "nodejs",
 			gitURL:          "https://github.com/sclorg/nodejs-ex",
 			annotations: map[string]string{
-				"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
+				"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "git",
 			},
 			existingBuildConfig: buildv1.BuildConfig{
@@ -1226,7 +1226,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs",
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/sclorg/nodejs-ex",
+						"app.openshift.io/vcs-uri":                   "https://github.com/sclorg/nodejs-ex",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1313,12 +1313,12 @@ func TestNewAppS2I(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1339,12 +1339,12 @@ func TestNewAppS2I(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1366,12 +1366,12 @@ func TestNewAppS2I(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1393,12 +1393,12 @@ func TestNewAppS2I(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -1420,12 +1420,12 @@ func TestNewAppS2I(t *testing.T) {
 		// 		gitURL:       "https://github.com/openshift/ruby",
 		// 		labels: map[string]string{
 		// 			"app": "apptmp",
-		// 			"app.kubernetes.io/component-name": "ruby",
-		// 			"app.kubernetes.io/component-type": "ruby",
-		// 			"app.kubernetes.io/name":           "apptmp",
+		// 			"app.kubernetes.io/instance": "ruby",
+		// 			"app.kubernetes.io/name": "ruby",
+		// 			"app.kubernetes.io/part-of":           "apptmp",
 		// 		},
 		// 		annotations: map[string]string{
-		// 			"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+		// 			"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 		// 			"app.kubernetes.io/component-source-type": "git",
 		// 		},
 		// 	},
@@ -2648,12 +2648,12 @@ func TestCreateService(t *testing.T) {
 				Name: "nodejs",
 				Labels: map[string]string{
 					"app":                              "apptmp",
-					"app.kubernetes.io/component-name": "ruby",
-					"app.kubernetes.io/component-type": "ruby",
-					"app.kubernetes.io/name":           "apptmp",
+					"app.kubernetes.io/instance": "ruby",
+					"app.kubernetes.io/name": "ruby",
+					"app.kubernetes.io/part-of":           "apptmp",
 				},
 				Annotations: map[string]string{
-					"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+					"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 					"app.kubernetes.io/component-source-type": "git",
 				},
 			},
@@ -2728,17 +2728,17 @@ func TestGetDeploymentConfigsFromSelector(t *testing.T) {
 	}{
 		{
 			name:     "true case",
-			selector: "app.kubernetes.io/name=app",
+			selector: "app.kubernetes.io/part-of=app",
 			label: map[string]string{
-				"app.kubernetes.io/name": "app",
+				"app.kubernetes.io/part-of": "app",
 			},
 			wantErr: false,
 		},
 		{
 			name:     "true case",
-			selector: "app.kubernetes.io/name=app1",
+			selector: "app.kubernetes.io/part-of=app1",
 			label: map[string]string{
-				"app.kubernetes.io/name": "app",
+				"app.kubernetes.io/part-of": "app",
 			},
 			wantErr: false,
 		},
@@ -2749,7 +2749,7 @@ func TestGetDeploymentConfigsFromSelector(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app.kubernetes.io/name": "app",
+						"app.kubernetes.io/part-of": "app",
 					},
 				},
 			},
@@ -3168,14 +3168,14 @@ func TestGetDeploymentConfigLabelValues(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "app",
+									"app.kubernetes.io/part-of": "app",
 								},
 							},
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "app2",
+									"app.kubernetes.io/part-of": "app2",
 								},
 							},
 						},
@@ -3195,14 +3195,14 @@ func TestGetDeploymentConfigLabelValues(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "app2",
+									"app.kubernetes.io/part-of": "app2",
 								},
 							},
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "app",
+									"app.kubernetes.io/part-of": "app",
 								},
 							},
 						},
@@ -3434,7 +3434,7 @@ func TestGetServiceInstanceList(t *testing.T) {
 			name: "test case 1",
 			args: args{
 				Project:  "myproject",
-				Selector: "app.kubernetes.io/component-name=mysql-persistent,app.kubernetes.io/name=app",
+				Selector: "app.kubernetes.io/instance=mysql-persistent,app.kubernetes.io/part-of=app",
 			},
 			serviceList: scv1beta1.ServiceInstanceList{
 				Items: []scv1beta1.ServiceInstance{
@@ -5079,12 +5079,12 @@ func TestCreateBuildConfig(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5112,12 +5112,12 @@ func TestCreateBuildConfig(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5145,12 +5145,12 @@ func TestCreateBuildConfig(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},
@@ -5179,12 +5179,12 @@ func TestCreateBuildConfig(t *testing.T) {
 					Name: "ruby",
 					Labels: map[string]string{
 						"app":                              "apptmp",
-						"app.kubernetes.io/component-name": "ruby",
-						"app.kubernetes.io/component-type": "ruby",
-						"app.kubernetes.io/name":           "apptmp",
+						"app.kubernetes.io/instance": "ruby",
+						"app.kubernetes.io/name": "ruby",
+						"app.kubernetes.io/part-of":           "apptmp",
 					},
 					Annotations: map[string]string{
-						"app.kubernetes.io/url":                   "https://github.com/openshift/ruby",
+						"app.openshift.io/vcs-uri":                   "https://github.com/openshift/ruby",
 						"app.kubernetes.io/component-source-type": "git",
 					},
 				},

--- a/pkg/odo/cli/service/service_test.go
+++ b/pkg/odo/cli/service/service_test.go
@@ -56,7 +56,7 @@ func TestCompletions(t *testing.T) {
 			Items: []v1beta1.ServiceInstance{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"app.kubernetes.io/name": "foo", componentlabels.ComponentLabel: "foo", componentlabels.ComponentTypeLabel: "service"},
+						Labels: map[string]string{"app.kubernetes.io/part-of": "foo", componentlabels.ComponentLabel: "foo", componentlabels.ComponentTypeLabel: "service"},
 					},
 					Status: v1beta1.ServiceInstanceStatus{
 						Conditions: []v1beta1.ServiceInstanceCondition{

--- a/pkg/odo/cli/storage/storage_test.go
+++ b/pkg/odo/cli/storage/storage_test.go
@@ -7,7 +7,7 @@ import (
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/odo/pkg/occlient"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,9 +52,9 @@ func Test_validateStoragePath(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mystorage-app-pvc",
 					Labels: map[string]string{
-						"app.kubernetes.io/instance": "nodejs",
-						"app.kubernetes.io/part-of":           "app",
-						"app.kubernetes.io/storage-name":   "mystorage",
+						"app.kubernetes.io/instance":     "nodejs",
+						"app.kubernetes.io/part-of":      "app",
+						"app.kubernetes.io/storage-name": "mystorage",
 					},
 					Namespace: "myproject",
 				},
@@ -67,9 +67,9 @@ func Test_validateStoragePath(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mystorage-app-pvc",
 			Labels: map[string]string{
-				"app.kubernetes.io/instance": "nodejs",
-				"app.kubernetes.io/part-of":           "app",
-				"app.kubernetes.io/storage-name":   "mystorage",
+				"app.kubernetes.io/instance":     "nodejs",
+				"app.kubernetes.io/part-of":      "app",
+				"app.kubernetes.io/storage-name": "mystorage",
 			},
 			Namespace: "myproject",
 		},
@@ -83,8 +83,8 @@ func Test_validateStoragePath(t *testing.T) {
 					Namespace: "myproject",
 					Labels: map[string]string{
 						"app.kubernetes.io/instance": "nodejs",
-						"app.kubernetes.io/name": "nodejs",
-						"app.kubernetes.io/part-of":           "app",
+						"app.kubernetes.io/name":     "nodejs",
+						"app.kubernetes.io/part-of":  "app",
 					},
 				},
 				Spec: appsv1.DeploymentConfigSpec{

--- a/pkg/odo/cli/storage/storage_test.go
+++ b/pkg/odo/cli/storage/storage_test.go
@@ -52,8 +52,8 @@ func Test_validateStoragePath(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mystorage-app-pvc",
 					Labels: map[string]string{
-						"app.kubernetes.io/component-name": "nodejs",
-						"app.kubernetes.io/name":           "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"app.kubernetes.io/part-of":           "app",
 						"app.kubernetes.io/storage-name":   "mystorage",
 					},
 					Namespace: "myproject",
@@ -67,8 +67,8 @@ func Test_validateStoragePath(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mystorage-app-pvc",
 			Labels: map[string]string{
-				"app.kubernetes.io/component-name": "nodejs",
-				"app.kubernetes.io/name":           "app",
+				"app.kubernetes.io/instance": "nodejs",
+				"app.kubernetes.io/part-of":           "app",
 				"app.kubernetes.io/storage-name":   "mystorage",
 			},
 			Namespace: "myproject",
@@ -82,9 +82,9 @@ func Test_validateStoragePath(t *testing.T) {
 					Name:      "nodejs-app",
 					Namespace: "myproject",
 					Labels: map[string]string{
-						"app.kubernetes.io/component-name": "nodejs",
-						"app.kubernetes.io/component-type": "nodejs",
-						"app.kubernetes.io/name":           "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"app.kubernetes.io/name": "nodejs",
+						"app.kubernetes.io/part-of":           "app",
 					},
 				},
 				Spec: appsv1.DeploymentConfigSpec{
@@ -118,7 +118,7 @@ func Test_validateStoragePath(t *testing.T) {
 		},
 	}
 
-	labelSelector := "app.kubernetes.io/component-name=nodejs,app.kubernetes.io/name=app"
+	labelSelector := "app.kubernetes.io/instance=nodejs,app.kubernetes.io/part-of=app"
 	storageSelector := "app.kubernetes.io/storage-name"
 	client, fakeClientSet := occlient.FakeNew()
 	fakeClientSet.AppsClientset.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -219,7 +219,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 			name: "Case 1: services with various statuses, some bound and some linked",
 			args: args{
 				Project:  "myproject",
-				Selector: "app.kubernetes.io/component-name=mysql-persistent,app.kubernetes.io/name=app",
+				Selector: "app.kubernetes.io/instance=mysql-persistent,app.kubernetes.io/part-of=app",
 			},
 			serviceList: scv1beta1.ServiceInstanceList{
 				Items: []scv1beta1.ServiceInstance{

--- a/pkg/testingutil/deploymentconfigs.go
+++ b/pkg/testingutil/deploymentconfigs.go
@@ -38,13 +38,13 @@ func getDeploymentConfig(namespace string, componentName string, componentType s
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":                              "app",
-				"app.kubernetes.io/component-name": componentName,
-				"app.kubernetes.io/component-type": componentType,
-				"app.kubernetes.io/name":           applicationName,
+				"app.kubernetes.io/instance": componentName,
+				"app.kubernetes.io/name": componentType,
+				"app.kubernetes.io/part-of":           applicationName,
 			},
 			Annotations: map[string]string{ // Convert into separate function when other source types required in tests
 				"app.kubernetes.io/component-source-type": "git",
-				"app.kubernetes.io/url":                   fmt.Sprintf("https://github.com/%s/%s.git", componentName, applicationName),
+				"app.openshift.io/vcs-uri":                   fmt.Sprintf("https://github.com/%s/%s.git", componentName, applicationName),
 			},
 		},
 		Spec: v1.DeploymentConfigSpec{

--- a/pkg/testingutil/deploymentconfigs.go
+++ b/pkg/testingutil/deploymentconfigs.go
@@ -2,6 +2,7 @@ package testingutil
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/util"
 
 	v1 "github.com/openshift/api/apps/v1"
@@ -37,14 +38,14 @@ func getDeploymentConfig(namespace string, componentName string, componentType s
 			Name:      fmt.Sprintf("%v-%v", componentName, applicationName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":                              "app",
+				"app":                        "app",
 				"app.kubernetes.io/instance": componentName,
-				"app.kubernetes.io/name": componentType,
-				"app.kubernetes.io/part-of":           applicationName,
+				"app.kubernetes.io/name":     componentType,
+				"app.kubernetes.io/part-of":  applicationName,
 			},
 			Annotations: map[string]string{ // Convert into separate function when other source types required in tests
 				"app.kubernetes.io/component-source-type": "git",
-				"app.openshift.io/vcs-uri":                   fmt.Sprintf("https://github.com/%s/%s.git", componentName, applicationName),
+				"app.openshift.io/vcs-uri":                fmt.Sprintf("https://github.com/%s/%s.git", componentName, applicationName),
 			},
 		},
 		Spec: v1.DeploymentConfigSpec{

--- a/pkg/url/labels/labels.go
+++ b/pkg/url/labels/labels.go
@@ -6,7 +6,7 @@ import (
 
 // URLLabel is the label key that is applied to all url resources
 // that are created
-const URLLabel = "app.kubernetes.io/url-name"
+const URLLabel = "app.openshift.io/vcs-uri-name"
 
 // GetLabels gets the labels to be applied to the given url besides the
 // component labels and application labels.

--- a/pkg/url/labels/labels.go
+++ b/pkg/url/labels/labels.go
@@ -6,7 +6,7 @@ import (
 
 // URLLabel is the label key that is applied to all url resources
 // that are created
-const URLLabel = "app.openshift.io/vcs-uri-name"
+const URLLabel = "odo.openshift.io/url-name"
 
 // GetLabels gets the labels to be applied to the given url besides the
 // component labels and application labels.

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -43,9 +43,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":     "app",
-						"app.kubernetes.io/instance":    "nodejs",
-						"odo.openshift.io/url-name": "nodejs",
+						"app.kubernetes.io/part-of":  "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"odo.openshift.io/url-name":  "nodejs",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -73,9 +73,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "example-url-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":     "app",
-						"app.kubernetes.io/instance":    "nodejs",
-						"odo.openshift.io/url-name": "example-url",
+						"app.kubernetes.io/part-of":  "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"odo.openshift.io/url-name":  "example-url",
 					},
 				},
 				Spec: routev1.RouteSpec{

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -43,9 +43,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":           "app",
-						"app.kubernetes.io/instance": "nodejs",
-						"app.openshift.io/vcs-uri-name":       "nodejs",
+						"app.kubernetes.io/part-of":     "app",
+						"app.kubernetes.io/instance":    "nodejs",
+						"app.openshift.io/vcs-uri-name": "nodejs",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -73,9 +73,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "example-url-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/part-of":           "app",
-						"app.kubernetes.io/instance": "nodejs",
-						"app.openshift.io/vcs-uri-name":       "example-url",
+						"app.kubernetes.io/part-of":     "app",
+						"app.kubernetes.io/instance":    "nodejs",
+						"app.openshift.io/vcs-uri-name": "example-url",
 					},
 				},
 				Spec: routev1.RouteSpec{

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -43,9 +43,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "nodejs-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/name":           "app",
-						"app.kubernetes.io/component-name": "nodejs",
-						"app.kubernetes.io/url-name":       "nodejs",
+						"app.kubernetes.io/part-of":           "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"app.openshift.io/vcs-uri-name":       "nodejs",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -73,9 +73,9 @@ func TestCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "example-url-app",
 					Labels: map[string]string{
-						"app.kubernetes.io/name":           "app",
-						"app.kubernetes.io/component-name": "nodejs",
-						"app.kubernetes.io/url-name":       "example-url",
+						"app.kubernetes.io/part-of":           "app",
+						"app.kubernetes.io/instance": "nodejs",
+						"app.openshift.io/vcs-uri-name":       "example-url",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -236,7 +236,7 @@ func TestExists(t *testing.T) {
 				},
 			},
 			wantBool:      true,
-			labelSelector: "app.kubernetes.io/component-name=nodejs,app.kubernetes.io/name=app",
+			labelSelector: "app.kubernetes.io/instance=nodejs,app.kubernetes.io/part-of=app",
 			wantErr:       false,
 		},
 		{
@@ -287,7 +287,7 @@ func TestExists(t *testing.T) {
 				},
 			},
 			wantBool:      false,
-			labelSelector: "app.kubernetes.io/component-name=nodejs,app.kubernetes.io/name=app",
+			labelSelector: "app.kubernetes.io/instance=nodejs,app.kubernetes.io/part-of=app",
 			wantErr:       false,
 		},
 	}

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":     "app",
 						"app.kubernetes.io/instance":    "nodejs",
-						"app.openshift.io/vcs-uri-name": "nodejs",
+						"odo.openshift.io/url-name": "nodejs",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -75,7 +75,7 @@ func TestCreate(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":     "app",
 						"app.kubernetes.io/instance":    "nodejs",
-						"app.openshift.io/vcs-uri-name": "example-url",
+						"odo.openshift.io/url-name": "example-url",
 					},
 				},
 				Spec: routev1.RouteSpec{

--- a/tests/e2escenarios/core_beta_flow.go
+++ b/tests/e2escenarios/core_beta_flow.go
@@ -75,10 +75,10 @@ var _ = Describe("Core beta flow", func() {
 		helper.CmdShouldPass(odo, append([]string{"push"}, extraArgs...)...)
 
 		dcSession := oc.GetComponentDC("mycomponent", "myapp", project)
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/component-name: mycomponent"))
+		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/instance: mycomponent"))
 		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/component-source-type: local"))
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/component-type: java"))
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/name: myapp"))
+		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/name: java"))
+		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/part-of: myapp"))
 		Expect(dcSession).Should(ContainSubstring("name: mycomponent-myapp"))
 		// DC should have env variable
 		Expect(dcSession).Should(ContainSubstring("name: FOO"))

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -52,8 +52,8 @@ func (oc *OcRunner) GetCurrentProject() string {
 func (oc *OcRunner) GetFirstURL(component string, app string, project string) string {
 	session := CmdRunner(oc.path, "get", "route",
 		"-n", project,
-		"-l", "app.kubernetes.io/component-name="+component,
-		"-l", "app.kubernetes.io/name="+app,
+		"-l", "app.kubernetes.io/instance="+component,
+		"-l", "app.kubernetes.io/part-of="+app,
 		"-o", "jsonpath={.items[0].spec.host}")
 
 	session.Wait()
@@ -67,8 +67,8 @@ func (oc *OcRunner) GetFirstURL(component string, app string, project string) st
 func (oc *OcRunner) GetComponentRoutes(component string, app string, project string) string {
 	session := CmdRunner(oc.path, "get", "route",
 		"-n", project,
-		"-l", "app.kubernetes.io/component-name="+component,
-		"-l", "app.kubernetes.io/name="+app,
+		"-l", "app.kubernetes.io/instance="+component,
+		"-l", "app.kubernetes.io/part-of="+app,
 		"-o", "yaml")
 
 	session.Wait()
@@ -82,8 +82,8 @@ func (oc *OcRunner) GetComponentRoutes(component string, app string, project str
 func (oc *OcRunner) GetComponentDC(component string, app string, project string) string {
 	session := CmdRunner(oc.path, "get", "dc",
 		"-n", project,
-		"-l", "app.kubernetes.io/component-name="+component,
-		"-l", "app.kubernetes.io/name="+app,
+		"-l", "app.kubernetes.io/instance="+component,
+		"-l", "app.kubernetes.io/part-of="+app,
 		"-o", "yaml")
 
 	session.Wait()
@@ -105,7 +105,7 @@ func (oc *OcRunner) SourceTest(appTestName string, sourceType string, source str
 
 	// checking for source in dc
 	sourceInDc := CmdShouldPass(oc.path, "get", "dc", "wildfly-"+appTestName,
-		"-o", "go-template='{{index .metadata.annotations \"app.kubernetes.io/url\"}}'")
+		"-o", "go-template='{{index .metadata.annotations \"app.openshift.io/vcs-uri\"}}'")
 	Expect(sourceInDc).To(ContainSubstring(source))
 }
 
@@ -152,7 +152,7 @@ func (oc *OcRunner) VerifyCmpName(cmpName string, namespace string) {
 	dcName := oc.GetDcName(cmpName, namespace)
 	session := CmdShouldPass(oc.path, "get", "dc", dcName,
 		"--namespace", namespace,
-		"-L", "app.kubernetes.io/component-name")
+		"-L", "app.kubernetes.io/instance")
 	Expect(session).To(ContainSubstring(cmpName))
 }
 
@@ -217,7 +217,7 @@ func (oc *OcRunner) SourceTypeBC(componentName string, appName string, project s
 // SourceLocationDC returns the source location from the deployment config
 func (oc *OcRunner) SourceLocationDC(componentName string, appName string, project string) string {
 	sourceLocation := CmdShouldPass(oc.path, "get", "dc", componentName+"-"+appName, "--namespace", project,
-		"-o", "go-template='{{index .metadata.annotations \"app.kubernetes.io/url\"}}'")
+		"-o", "go-template='{{index .metadata.annotations \"app.openshift.io/vcs-uri\"}}'")
 	return sourceLocation
 }
 


### PR DESCRIPTION
This updates labels to match  https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc and also to match how those labels are used in OpenShift devconsole.
This is to ensure that components created by odo are correctly displayed in devconsole topology view.


**This breaks compatibility with older odo versions!** 
Release notes will need to include a warning about this.

Components that are already pushed to the cluster using older odo versions will not work. User needs to delete a component from the cluster and push it again.


fixes #599 

