### PR TITLE
Enabled component sub test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-cmp-e2e:
 # Run component subcommands e2e tests
 .PHONY: test-cmp-sub-e2e
 test-cmp-sub-e2e:
-	ginkgo -v -nodes=$(TEST_EXEC_NODES) -focus="odoCmpE2e" slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -randomizeAllSpecs  tests/integration/ -timeout $(TIMEOUT)
+	ginkgo -v -nodes=$(TEST_EXEC_NODES) -focus="odoCmpSubE2e" slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -randomizeAllSpecs  tests/integration/ -timeout $(TIMEOUT)
 
 # Run java e2e tests
 .PHONY: test-java-e2e


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Due to the typo the component sub test was completely missing form the Makefile

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-cmp-sub-e2e