### PR TITLE
Add newline spacing to odo app --help

### DIFF
--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -32,7 +32,7 @@ func NewCmdApplication(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: "Perform application operations",
 		Long:  `Performs application operations related to your OpenShift project.`,
-		Example: fmt.Sprintf("%s\n%s\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
 			delete.Example,
 			describe.Example,
 			list.Example),


### PR DESCRIPTION
Adds newline spacing to `odo app --help` due to not having `\n\n` within
the help example (spacing was only 1 line)

```sh
Examples:
  # Delete the application
  odo app delete myapp

  # Describe 'webapp' application,
  odo app describe webapp

  # List all applications in the current project
  odo app list

  # List all applications in the specified project
  odo app list --project myproject
```