### PR TITLE
`odo url list -o json` will not return empty list

### DIFF
--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -16,6 +16,8 @@ import (
 	"github.com/openshift/odo/pkg/url"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
 
@@ -67,6 +69,23 @@ func (o *URLListOptions) Run() (err error) {
 	localUrls := o.localConfigInfo.GetUrl()
 
 	if log.IsJSON() {
+		if len(localUrls) != 0 {
+			for _, u := range localUrls {
+				p, err := url.Exists(o.Client, u.Name, o.Component(), o.Application)
+				if err != nil {
+					return err
+				}
+				if !p {
+
+					urls.Items = append(urls.Items, url.Url{
+						TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.openshift.io/v1alpha1"},
+						ObjectMeta: metav1.ObjectMeta{Name: u.Name},
+					})
+				}
+			}
+
+		}
+
 		out, err := json.Marshal(urls)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

`odo url list -o json` will not return empty list

## Was the change discussed in an issue?
fixes #1893
<!-- Please do Link issues here. -->

## How to test changes?

* Create the URL using `odo url create`
* Check `odo url list -o json`, it should give output
