### PR TITLE
Fixing random input applied by ginkgo in test script

### DIFF
--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odo generic", func() {
 		})
 		It("should create the component in default application", func() {
 			helper.CmdShouldPass("odo", "create", "php", "testcmp", "--app", "e2e-xyzk", "--project", project, "--git", testPHPGitURL)
-			helper.CmdShouldPass("odo", "config", "set", "Ports", "8080/TCP")
+			helper.CmdShouldPass("odo", "config", "set", "Ports", "8080/TCP", "-f")
 			helper.CmdShouldPass("odo", "push")
 			oc.VerifyCmpName("testcmp", project)
 			oc.VerifyAppNameOfComponent("testcmp", "e2e-xyzk", project)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
```
[odo] Please use `odo push` command to create the component with source deployed
[odo] 
Running odo with args [odo config set Ports 8080/TCP]
? Ports is already set. Do you want to override it in the config (y/N)                               Aborted by the user.
^[[15;102RDeleting project: oipaimbpmd
Running odo with args [odo project delete oipaimbpmd -f]
```

<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-generic
