### PR TITLE
Fixes delete --all flag for not pushed components

### DIFF
--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -152,3 +152,16 @@ func CreateFileWithContent(path string, fileContent string) error {
 	}
 	return nil
 }
+
+// ListFilesInDir lists all the files in the directory
+// directoryName is the name of the directory
+func ListFilesInDir(directoryName string) []string {
+	var filesInDirectory []string
+	files, err := ioutil.ReadDir(directoryName)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	for _, file := range files {
+		filesInDirectory = append(filesInDirectory, file.Name())
+	}
+	return filesInDirectory
+}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -345,6 +345,8 @@ func componentTests(args ...string) {
 		It("creates a local nodejs component without pushing and then deletes it using --all flag", func() {
 			helper.CopyExample(filepath.Join("source", "pyhton"), context)
 			helper.CmdShouldPass("odo", append(args, "create", "python", "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "delete", "--context", context, "-f")
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f", "--context", context)...)
 			files := helper.ListFilesInDir(context)
 			Expect(files).NotTo(ContainElement(".odo"))

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -313,6 +313,9 @@ func componentTests(args ...string) {
 
 	Context("when component is in the current directory and --project flag is used", func() {
 
+		appName := "app"
+		componentName := "my-component"
+
 		JustBeforeEach(func() {
 			context = helper.CreateNewContext()
 			project = helper.CreateRandProject()
@@ -335,19 +338,23 @@ func componentTests(args ...string) {
 
 		It("creates and pushes local nodejs component and then deletes --all", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
-			helper.CmdShouldPass("odo", append(args, "push")...)
-			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", componentName, "--app", appName, "--project", project, "--env", "key=value,key1=value1")...)
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "delete", "--context", context, "-f", "--all", "--app", appName)...)
+			componentList := helper.CmdShouldPass("odo", append(args, "list", "--context", context, "--app", appName, "--project", project)...)
+			Expect(componentList).NotTo(ContainSubstring(componentName))
 			files := helper.ListFilesInDir(context)
 			Expect(files).NotTo(ContainElement(".odo"))
 		})
 
-		It("creates a local nodejs component without pushing and then deletes it using --all flag", func() {
-			helper.CopyExample(filepath.Join("source", "pyhton"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "python", "--project", project, "--context", context)...)
-			helper.CmdShouldPass("odo", "push", "--context", context)
-			helper.CmdShouldPass("odo", "delete", "--context", context, "-f")
+		It("creates a local python component, pushes it and then deletes it using --all flag", func() {
+			helper.CopyExample(filepath.Join("source", "python"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "delete", "--context", context, "-f")...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f", "--context", context)...)
+			componentList := helper.CmdShouldPass("odo", append(args, "list", "--context", context, "--app", appName, "--project", project)...)
+			Expect(componentList).NotTo(ContainSubstring(componentName))
 			files := helper.ListFilesInDir(context)
 			Expect(files).NotTo(ContainElement(".odo"))
 		})

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -340,6 +340,14 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f")...)
 
 		})
+
+		It("creates a local nodejs component without pushing and then deletes it using --all flag", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f", "--context", context)...)
+			files := helper.ListFilesInDir(context)
+			Expect(files).NotTo(ContainElement(".odo"))
+		})
 	})
 
 	/*

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -338,12 +338,13 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
 			helper.CmdShouldPass("odo", append(args, "push")...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f")...)
-
+			files := helper.ListFilesInDir(context)
+			Expect(files).NotTo(ContainElement(".odo"))
 		})
 
 		It("creates a local nodejs component without pushing and then deletes it using --all flag", func() {
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", context)...)
+			helper.CopyExample(filepath.Join("source", "pyhton"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "python", "--project", project, "--context", context)...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f", "--context", context)...)
 			files := helper.ListFilesInDir(context)
 			Expect(files).NotTo(ContainElement(".odo"))


### PR DESCRIPTION
fixes #1925 

How to test
1. Create a component and push it to the cluster
2. Delete it from the cluster without the `all` flag
3. Delete again with the `all` flag and check it deletes the local config file or not