### PR TITLE
Bumps version to v1.0.0-beta4

### DIFF
--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -1,4 +1,4 @@
-= Overview of the Odo (OpenShift Do) CLI Structure
+= Overview of the odo (OpenShift Do) CLI Structure
 
 ___________________
 Example application
@@ -629,6 +629,12 @@ _________________
 
 Modifies odo specific configuration settings within the global preference file. 
 
+[NOTE]
+====
+By default the path to the global preference file is `~/.odo/preferece.yaml`, it is stored in in the environment variable `GLOBALODOCONFIG`. You can set up a custom path by setting the value of the environment variable to a new preference path, for example `GLOBALODOCONFIG="new_path/preference.yaml"`
+
+Run `echo "$GLOBALODOCONFIG"` to display the current value of the variable. 
+====
 
 Available Parameters:
 NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix

--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -1,4 +1,4 @@
-= Overview of the odo (OpenShift Do) CLI Structure
+= Overview of the Odo (OpenShift Do) CLI Structure
 
 ___________________
 Example application
@@ -10,12 +10,12 @@ ___________________
   git clone https://github.com/openshift/nodejs-ex && cd nodejs-ex
   odo create nodejs
   odo push
-
+  
   # Accessing your Node.js component
-  odo url create
+  odo url create 
 ----
 
-(OpenShift Do) odo is a CLI tool for running OpenShift applications in a fast and automated matter. Reducing the complexity of deployment, odo adds iterative development without the worry of deploying your source code.
+(OpenShift Do) odo is a CLI tool for running OpenShift applications in a fast and automated matter. Reducing the complexity of deployment, odo adds iterative development without the worry of deploying your source code. 
 
 Find more information at https://github.com/openshift/odo
 
@@ -90,7 +90,7 @@ Syntax
 | Expose component to the outside world (create, delete, list)
 
 | link:#utils[utils]
-| Utilities for terminal commands and modifying Odo configurations (terminal)
+| Utilities for terminal commands and modifying odo configurations (terminal)
 
 | link:#version[version]
 | Print the client version information
@@ -106,11 +106,11 @@ CLI Structure
 
 [source,sh]
 ----
-odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connection-check --stderrthreshold --v --vmodule : odo (OpenShift Do) (app, catalog, component, config, create, delete, describe, link, list, log, login, logout, preference, project, push, service, storage, unlink, update, url, utils, version, watch)
+odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --skip-connection-check --stderrthreshold --v --vmodule : odo (OpenShift Do) (app, catalog, component, config, create, delete, describe, link, list, log, login, logout, preference, project, push, service, storage, unlink, update, url, utils, version, watch)
     app : Perform application operations (delete, describe, list)
-        delete --force --output --project : Delete the given application
-        describe --output --project : Describe the given application
-        list --output --project : List all applications in the current project
+        delete --force --project : Delete the given application
+        describe --project : Describe the given application
+        list --project : List all applications in the current project
     catalog : Catalog related operations (describe, list, search)
         describe : Describe catalog item (service)
             service : Describe a service
@@ -121,14 +121,14 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connecti
             component : Search component type in catalog
             service : Search service type in catalog
     component --app --context --project --short : Components of an application (create, delete, describe, link, list, log, push, unlink, update, watch)
-        create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --port --project --ref : Create a new component
+        create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --now --port --project --ref : Create a new component
         delete --all --app --context --force --project : Delete an existing component
-        describe --app --context --output --project : Describe the given component
+        describe --app --context --project : Describe the given component
         get --app --context --project --short : Get currently active component
         link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
-        list --app --context --output --path --project : List all components in the current application
+        list --all --app --context --path --project : List all components in the current application
         log --app --context --follow --project : Retrieve the log for the given component
-        push --config --context --ignore --show-log --source : Push source code to a component
+        push --config --context --force-build --ignore --show-log --source : Push source code to a component
         unlink --app --component --context --port --project --wait : Unlink component to a service or component
         update --app --context --git --local --project --ref : Update the source code path of a component
         watch --app --context --delay --ignore --project --show-log : Watch for changes, update component on change
@@ -136,11 +136,11 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connecti
         set --context --env --force : Set a value in odo config file
         unset --context --env --force : Unset a value in odo config file
         view --context : View current configuration values
-    create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --port --project --ref : Create a new component
+    create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --now --port --project --ref : Create a new component
     delete --all --app --context --force --project : Delete an existing component
-    describe --app --context --output --project : Describe the given component
+    describe --app --context --project : Describe the given component
     link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
-    list --app --context --output --path --project : List all components in the current application
+    list --all --app --context --path --project : List all components in the current application
     log --app --context --follow --project : Retrieve the log for the given component
     login --certificate-authority --insecure-skip-tls-verify --password --token --username : Login to cluster
     logout : Log out of the current OpenShift session
@@ -152,25 +152,25 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --skip-connecti
         create --wait : Create a new project
         delete --force : Delete a project
         get --short : Get the active project
-        list --output : List all the projects
+        list : List all the projects
         set --short : Set the current active project
-    push --config --context --ignore --show-log --source : Push source code to a component
+    push --config --context --force-build --ignore --show-log --source : Push source code to a component
     service : Perform service catalog operations (create, delete, list)
         create --app --parameters --plan --project --wait : Create a new service from service catalog using the plan defined and deploy it on OpenShift.
         delete --app --force --project : Delete an existing service
         list --app --project : List all services in the current application
     storage : Perform storage operations (create, delete, list)
-        create --app --component --context --output --path --project --size : Create storage and mount to a component
+        create --app --component --context --path --project --size : Create storage and mount to a component
         delete --app --component --context --force --project : Delete storage from component
-        list --app --component --context --output --project : List storage attached to a component
+        list --app --component --context --project : List storage attached to a component
     unlink --app --component --context --port --project --wait : Unlink component to a service or component
     update --app --context --git --local --project --ref : Update the source code path of a component
     url : Expose component to the outside world (create, delete, list)
-        create --app --component --context --output --port --project : Create a URL for a component
+        create --app --component --context --port --project : Create a URL for a component
         delete --app --component --context --force --project : Delete a URL
-        list --app --component --context --output --project : List URLs
+        list --app --component --context --project : List URLs
     utils : Utilities for terminal commands and modifying odo configurations (terminal)
-        terminal : Add odo terminal support to your development environment
+        terminal : Add Odo terminal support to your development environment
     version --client : Print the client version information
     watch --app --context --delay --ignore --project --show-log : Watch for changes, update component on change
 
@@ -193,11 +193,13 @@ _________________
 ----
   # Delete the application
   odo app delete myapp
+
   # Describe 'webapp' application,
   odo app describe webapp
+
   # List all applications in the current project
   odo app list
-
+  
   # List all applications in the specified project
   odo app list --project myproject
 ----
@@ -289,7 +291,7 @@ _________________
   odo config set MinCPU 0.5
   odo config set MaxCPU 2
   odo config set CPU 1
-
+  
   # Set a env variable in the local config
   odo config set --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
 
@@ -303,12 +305,12 @@ _________________
   odo config unset MinCPU
   odo config unset MaxCPU
   odo config unset CPU
-
+  
   # Unset a env variable in the local config
   odo config unset --env KAFKA_HOST --env KAFKA_PORT
 ----
 
-Modifies odo specific configuration settings within the config file.
+Modifies odo specific configuration settings within the config file. 
 
 
 Available Local Parameters:
@@ -348,51 +350,51 @@ _________________
 ----
   # Create new Node.js component with the source in current directory.
   odo create nodejs
-
+  
   # A specific image version may also be specified
   odo create nodejs:latest
-
+  
   # Create new Node.js component named 'frontend' with the source in './frontend' directory
   odo create nodejs frontend --context ./frontend
-
+  
   # Create a new Node.js component of version 6 from the 'openshift' namespace
   odo create openshift/nodejs:6 --context /nodejs-ex
-
+  
   # Create new Wildfly component with binary named sample.war in './downloads' directory
   odo create wildfly wildfly --binary ./downloads/sample.war
-
+  
   # Create new Node.js component with source from remote git repository
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git
-
+  
   # Create new Node.js git component while specifying a branch, tag or commit ref
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git --ref master
-
+  
   # Create new Node.js git component while specifying a tag
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git --ref v1.0.1
-
+  
   # Create new Node.js component with the source in current directory and ports 8080-tcp,8100-tcp and 9100-udp exposed
   odo create nodejs --port 8080,8100/tcp,9100/udp
-
+  
   # Create new Node.js component with the source in current directory and env variables key=value and key1=value1 exposed
   odo create nodejs --env key=value,key1=value1
-
-  # For more examples, visit: https://github.com/openshift/odo/blob/master/docs/examples.md
+  
+  # For more examples, visit: https://github.com/openshift/odo/blob/master/docs/examples.adoc
   odo create python --git https://github.com/openshift/django-ex.git
-
+  
   # Passing memory limits
   odo create nodejs --memory 150Mi
   odo create nodejs --min-memory 150Mi --max-memory 300 Mi
-
+  
   # Passing cpu limits
   odo create nodejs --cpu 2
   odo create nodejs --min-cpu 200m --max-cpu 2
 ----
 
-Create a configuration describing a component to be deployed on OpenShift.
+Create a configuration describing a component to be deployed on OpenShift. 
 
-If a component name is not provided, it'll be auto-generated.
+If a component name is not provided, it'll be auto-generated. 
 
-By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version If version is not specified by default, latest will be chosen as the version.
+By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version If version is not specified by default, latest will be chosen as the version. 
 
 A full list of component types that can be deployed is available using: 'odo catalog list'
 
@@ -456,16 +458,16 @@ _________________
 ----
   # Link the current component to the 'my-postgresql' service
   odo link my-postgresql
-
+  
   # Link component 'nodejs' to the 'my-postgresql' service
   odo link my-postgresql --component nodejs
-
+  
   # Link current component to the 'backend' component (backend must have a single exposed port)
   odo link backend
-
+  
   # Link component 'nodejs' to the 'backend' component
   odo link backend --component nodejs
-
+  
   # Link current component to port 8080 of the 'backend' component (backend must have port 8080 exposed)
   odo link backend --port 8080
 ----
@@ -473,7 +475,7 @@ _________________
 Link component to a service or component
 
 If the source component is not provided, the current active component is assumed.
-In both use cases, link adds the appropriate secret to the environment of the source component.
+In both use cases, link adds the appropriate secret to the environment of the source component. 
 The source component can then consume the entries of the secret as environment variables.
 
 For example:
@@ -558,13 +560,13 @@ _________________
 ----
   # Log in interactively
   odo login
-
+  
   # Log in to the given server with the given certificate authority file
   odo login localhost:8443 --certificate-authority=/path/to/cert.crt
-
+  
   # Log in to the given server with the given credentials (basic auth)
   odo login localhost:8443 --username=myuser --password=mypass
-
+  
   # Log in to the given server with the given credentials (token)
   odo login localhost:8443 --token=xxxxxxxxxxxxxxxxxxxxxxx
 ----
@@ -610,7 +612,7 @@ _________________
 
   # For viewing the current local preference
   odo preference view
-
+  
   # For viewing the current global preference
   odo preference view
 
@@ -625,22 +627,14 @@ _________________
   odo preference unset  Timeout
 ----
 
-Modifies odo specific configuration settings within the global preference file.
+Modifies odo specific configuration settings within the global preference file. 
 
-[NOTE]
-====
-By default the path to the global preference file is `~/.odo/preferece.yaml`, it is stored in in the environment variable `GLOBALODOCONFIG`. You can set up a custom path by setting the value of the environment variable to a new preference path, for example `GLOBALODOCONFIG="new_path/preference.yaml"`
-
-Run `echo "$GLOBALODOCONFIG"` to display the current value of the variable. 
-====
 
 Available Parameters:
+NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix
+Timeout - Timeout (in seconds) for OpenShift server connection check
+UpdateNotification - Controls if an update notification is shown or not (true or false)
 
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix.
-
-Timeout - Timeout (in seconds) for OpenShift server connection check.
-
-UpdateNotification - Controls if an update notification is shown or not (true or false).
 
 [[project]]
 project
@@ -692,10 +686,10 @@ _________________
 ----
   # Push source code to the current component
   odo push
-
+  
   # Push data to the current component from the original source.
   odo push
-
+  
   # Push source code in ~/mycode to component called my-component
   odo push my-component --context ~/mycode
 ----
@@ -748,7 +742,7 @@ _________________
   odo storage create mystorage --path=/opt/app-root/src/storage/ --size=1Gi
   # Delete storage mystorage from the currently active component
   odo storage delete mystorage
-
+  
   # Delete storage mystorage from component 'mongodb'
   odo storage delete mystorage --component mongodb
   # List all storage attached or mounted to the current component and
@@ -775,21 +769,21 @@ _________________
 ----
   # Unlink the 'my-postgresql' service from the current component
   odo unlink my-postgresql
-
+  
   # Unlink the 'my-postgresql' service  from the 'nodejs' component
   odo unlink my-postgresql --component nodejs
-
+  
   # Unlink the 'backend' component from the current component (backend must have a single exposed port)
   odo unlink backend
-
+  
   # Unlink the 'backend' service  from the 'nodejs' component
   odo unlink backend --component nodejs
-
+  
   # Unlink the backend's 8080 port from the current component
   odo unlink backend --port 8080
 ----
 
-Unlink component or service from a component.
+Unlink component or service from a component. 
 For this command to be successful, the service or component needs to have been linked prior to the invocation using 'odo link'
 
 [[update]]
@@ -809,16 +803,16 @@ _________________
 ----
   # Change the source code path of a currently active component to local (use the current directory as a source)
   odo update --local
-
+  
   # Change the source code path of the frontend component to local with source in ./frontend directory
   odo update frontend --local ./frontend
-
+  
   # Change the source code path of a currently active component to git
   odo update --git https://github.com/openshift/nodejs-ex.git
-
+  
   # Change the source code path of the component named node-ex to git
   odo update node-ex --git https://github.com/openshift/nodejs-ex.git
-
+  
   # Change the source code path of the component named wildfly to a binary named sample.war in ./downloads directory
   odo update wildfly --binary ./downloads/sample.war
 ----
@@ -842,13 +836,13 @@ _________________
 ----
   # Create a URL for the current component with a specific port
   odo url create --port 8080
-
+  
   # Create a URL with a specific name and port
   odo url create example --port 8080
-
+  
   # Create a URL with a specific name by automatic detection of port (only for components which expose only one service port)
   odo url create example
-
+  
   # Create a URL with a specific name and port for component frontend
   odo url create example --port 8080 --component frontend
   # Delete a URL to a component
@@ -857,7 +851,7 @@ _________________
   odo url list
 ----
 
-Expose component to the outside world.
+Expose component to the outside world. 
 
 The URLs that are generated using this command, can be used to access the deployed components from outside the cluster.
 
@@ -878,7 +872,7 @@ _________________
 ----
   # Bash terminal PS1 support
   source <(odo utils terminal bash)
-
+  
   # Zsh terminal PS1 support
   source <(odo utils terminal zsh)
 
@@ -924,9 +918,11 @@ _________________
 ----
   # Watch for changes in directory for current component
   odo watch
-
+  
   # Watch for changes in directory for component called frontend
   odo watch frontend
 ----
 
 Watch for changes, update component on change.
+
+

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0-beta3"
+	VERSION = "v1.0.0-beta4"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ set -e
 ODO_VERSION="latest"
 
 # Latest released odo version
-LATEST_VERSION="v1.0.0-beta3"
+LATEST_VERSION="v1.0.0-beta4"
 
 GITHUB_RELEASES_URL="https://github.com/openshift/odo/releases/download/${LATEST_VERSION}"
 BINTRAY_URL="https://dl.bintray.com/odo/odo/latest"


### PR DESCRIPTION
This PR bumps the odo version to v1.0.0-beta4

# Release Notes Draft

## Breaking Changes
- The openshift labels used internally by odo to identify its components, have been updated to match https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc. This breaks backward compatibility with older versions of odo as components created by older versions will no longer be identified https://github.com/openshift/odo/pull/1959

## Enhancements
 - Removes an extra `exist` call and removes the spinner around it https://github.com/openshift/odo/pull/1965
- Graceful recovery from panic with mesage https://github.com/openshift/odo/pull/1954
- Fixed failing push when numeric directory is given https://github.com/openshift/odo/pull/1933
- Remove error if app does not have component https://github.com/openshift/odo/pull/1919
- `odo config set` no longer creates local config, instead reporting error https://github.com/openshift/odo/pull/1900
- No logs on`--output` flag as it is now global https://github.com/openshift/odo/pull/1898

## Testing
- Added gosec static code analysis https://github.com/openshift/odo/pull/1958
- Fixed `oc describe dc` test flakes https://github.com/openshift/odo/pull/1963
- Enabled component sub test in Makefile https://github.com/openshift/odo/pull/1962
- Add message with program and arguments to helper_run.go output https://github.com/openshift/odo/pull/1948
- Fixed flaky unit tests due to reordering of port lists https://github.com/openshift/odo/pull/1924
- Fixed false positives in `CmdShouldFail` https://github.com/openshift/odo/pull/1902
- All tests except login test now run in parallel

## Internal
- `SourceLocation` of binary when `--context` flag is used is now saved relative to component context https://github.com/openshift/odo/pull/1921
- Optimised `component.Exists` https://github.com/openshift/odo/pull/1905
- Component spec now includes project name https://github.com/openshift/odo/pull/1904 

## Documentation
- Fixed the help message for `--path ` flag in `odo list ` https://github.com/openshift/odo/pull/1973
- Added newline spacing to `odo app --help` https://github.com/openshift/odo/pull/1966
- Updated wildfly source location to https://github.com/wildfly/wildfly-s2i https://github.com/openshift/odo/pull/1906
- Added documentation on the `GLOBALODOCONFIG` environment variable https://github.com/openshift/odo/pull/1939
- Adding minor nodes for new developers https://github.com/openshift/odo/pull/1926
- Fixed backticks and grammatical errors https://github.com/openshift/odo/pull/1901
- Fixed broken links in getting started https://github.com/openshift/odo/pull/1896

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

