### PR TITLE
Adds "odo service create --context" feature

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -66,6 +66,8 @@ type ServiceCreateOptions struct {
 	wait bool
 	// generic context options common to all commands
 	*genericclioptions.Context
+	// Context to use when creating service. This will use app and project values from the context
+	componentContext string
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -79,7 +81,11 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.interactive = true
 	}
 
-	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+	if o.componentContext != "" {
+		o.Context = genericclioptions.NewContext(cmd)
+	} else {
+		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+	}
 
 	client := o.Client
 
@@ -250,6 +256,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringSliceVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
 	serviceCreateCmd.Flags().BoolVarP(&o.wait, "wait", "w", false, "Wait until the service is ready")
+	genericclioptions.AddContextFlag(serviceCreateCmd, &o.componentContext)
 	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)
 	completion.RegisterCommandFlagHandler(serviceCreateCmd, "plan", completion.ServicePlanCompletionHandler)
 	completion.RegisterCommandFlagHandler(serviceCreateCmd, "parameters", completion.ServiceParameterCompletionHandler)

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -2,8 +2,9 @@ package service
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"strings"
+
+	"github.com/openshift/odo/pkg/odo/cli/ui"
 
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/log"
@@ -30,6 +31,8 @@ type ServiceDeleteOptions struct {
 	serviceForceDeleteFlag bool
 	serviceName            string
 	*genericclioptions.Context
+	// Context to use when listing service. This will use app and project values from the context
+	componentContext string
 }
 
 // NewServiceDeleteOptions creates a new ServiceDeleteOptions instance
@@ -86,6 +89,7 @@ func NewCmdServiceDelete(name, fullName string) *cobra.Command {
 		},
 	}
 	serviceDeleteCmd.Flags().BoolVarP(&o.serviceForceDeleteFlag, "force", "f", false, "Delete service without prompting")
+	genericclioptions.AddContextFlag(serviceDeleteCmd, &o.componentContext)
 	completion.RegisterCommandHandler(serviceDeleteCmd, completion.ServiceCompletionHandler)
 	return serviceDeleteCmd
 }

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -27,6 +27,8 @@ List all services in the current application
 // ServiceListOptions encapsulates the options for the odo service list command
 type ServiceListOptions struct {
 	*genericclioptions.Context
+	// Context to use when listing service. This will use app and project values from the context
+	componentContext string
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -84,5 +86,6 @@ func NewCmdServiceList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+	genericclioptions.AddContextFlag(serviceListCmd, &o.componentContext)
 	return serviceListCmd
 }

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -140,8 +140,20 @@ var _ = Describe("odoServiceE2e", func() {
 			Expect(stdOut).To(ContainSubstring(serviceName))
 
 			// now check if deleting the service using --context works
-			stdOut = helper.CmdShouldPass("odo", "service", "delete", "--context", context)
+			stdOut = helper.CmdShouldPass("odo", "service", "delete", "-f", "serviceName", "--context", context)
 			Expect(stdOut).To(ContainSubstring(serviceName))
+		})
+
+		It("should fail to create a service when given directory doesn't contain a context", func() {
+			// cd to the originalDir to create service using --context
+			helper.Chdir(originalDir)
+			stdOut := helper.CmdShouldFail("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
+				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
+				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", serviceName,
+				"--context", context,
+			)
+
+			Expect(stdOut).To(ContainSubstring("The current directory does not represent an odo component"))
 		})
 
 		It("should be able to list services in a given app and project combination", func() {

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -153,7 +153,6 @@ var _ = Describe("odoServiceE2e", func() {
 			stdOut := helper.CmdShouldFail("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
 				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", serviceName,
-				"--context", context,
 			)
 
 			Expect(stdOut).To(ContainSubstring("The current directory does not represent an odo component"))

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -115,6 +115,27 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.DeleteDir(context)
 			helper.Chdir(originalDir)
 		})
+
+		It("should be able to create service using a given value for --context", func() {
+			// create a component by copying the example
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--app", app, "--project", project)
+
+			// cd to the originalDir to create service using --context
+			helper.Chdir(originalDir)
+			helper.CmdShouldPass("odo", "service", "create", "dh-prometheus-apb", "--plan", "ephemeral",
+				"--context", context,
+			)
+
+			// now check if listing the service using app & project used above passes
+			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "dh-prometheus-apb")
+			})
+			stdOut := helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
+			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
+		})
+
 		It("should be able to list services in a given app and project combination", func() {
 			// create a component by copying the example
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -147,17 +147,6 @@ var _ = Describe("odoServiceE2e", func() {
 			Expect(stdOut).To(ContainSubstring(serviceName))
 		})
 
-		It("should fail to create a service when given directory doesn't contain a context", func() {
-			// cd to the originalDir to create service using --context
-			helper.Chdir(originalDir)
-			stdOut := helper.CmdShouldFail("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
-				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
-				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", serviceName,
-			)
-
-			Expect(stdOut).To(ContainSubstring("The current directory does not represent an odo component"))
-		})
-
 		It("should be able to list services in a given app and project combination", func() {
 			// create a component by copying the example
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -105,23 +105,26 @@ var _ = Describe("odoServiceE2e", func() {
 
 	Context("When working from outside a component dir", func() {
 		JustBeforeEach(func() {
-			project = helper.CreateRandProject()
 			context = helper.CreateNewContext()
+			os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+			project = helper.CreateRandProject()
 			app = helper.RandString(7)
 			serviceName = "odo-postgres-service"
 			originalDir = helper.Getwd()
 			helper.Chdir(context)
+			SetDefaultConsistentlyDuration(30 * time.Second)
 		})
 		JustAfterEach(func() {
 			helper.DeleteProject(project)
 			helper.DeleteDir(context)
 			helper.Chdir(originalDir)
+			os.Unsetenv("GLOBALODOCONFIG")
 		})
 
 		It("should be able to create, list and delete a service using a given value for --context", func() {
 			// create a component by copying the example
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--app", app, "--project", project)
+			helper.CopyExample(filepath.Join("source", "python"), context)
+			helper.CmdShouldPass("odo", "create", "python", "--app", app, "--project", project)
 
 			// cd to the originalDir to create service using --context
 			helper.Chdir(originalDir)
@@ -140,7 +143,7 @@ var _ = Describe("odoServiceE2e", func() {
 			Expect(stdOut).To(ContainSubstring(serviceName))
 
 			// now check if deleting the service using --context works
-			stdOut = helper.CmdShouldPass("odo", "service", "delete", "-f", "serviceName", "--context", context)
+			stdOut = helper.CmdShouldPass("odo", "service", "delete", "-f", serviceName, "--context", context)
 			Expect(stdOut).To(ContainSubstring(serviceName))
 		})
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR enables the users to create a service with `odo service create --context /path/to/component/dir` command. This allows service creation from anywhere in the system.

## Was the change discussed in an issue?
fixes #1872 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
- Build the binary
- Using [nodejs-ex](https://github.com/sclorg/nodejs-ex) as an example, perform following:
  ```sh
  $ git clone https://github.com/sclorg/nodejs-ex /tmp/nodejs-ex
  $ cd /tmp/nodejs-ex
  $ odo create nodejs
  $ cd # this takes you to home dir
  $ odo service create dh-postgresql-apb --plan dev -p postgresql_user=luke -p postgresql_password=secret -p postgresql_database=my_data -p postgresql_version=9.6 --context /tmp/nodejs-ex

  # Use the --context from /tmp/nodejs-ex/ to list the service
  $ odo service list --context /tmp/nodejs-ex
  
  # Use the --context from /tmp/nodejs-ex/ to delete the service
  $ odo service delete --context /tmp/nodejs-ex
  
  # Bonus points for testing with --app and --project flag along with --context
  # I think the project should exist on the cluster. If app doesn't exist, odo will create it.
  $ odo service create dh-prometheus-apb --plan ephemeral --context /tmp/nodejs-ex --app myapp --project myproject
  ```