### PR TITLE
Dockerfile is used by CI to publish odo artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# This Dockerfile is used by CI to publish openshift/odo:binary-artifacts
+# It builds an image containing the Mac, Win and Linux version of odo binary on the
+# OpenShift golang image.
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11
+RUN mkdir -p /go/src/github.com/openshift/odo
+WORKDIR /go/src/github.com/openshift/odo
+COPY . .
+RUN go get github.com/mitchellh/gox &&\
+    make cross

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile is used by CI to publish openshift/odo:binary-artifacts
+# This Dockerfile is used by CI to publish odo binary artifacts.
 # It builds an image containing the Mac, Win and Linux version of odo binary on the
 # OpenShift golang image.
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/openshift/odo
 RUN go get github.com/mitchellh/gox &&\
     make cross
 
-FROM registry.svc.ci.openshift.org/ocp/4.2:cli
+FROM registry.access.redhat.com/ubi7/ubi
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/linux-amd64/odo /usr/share/openshift/odo/linux/odo

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@
 # It builds an image containing the Mac, Win and Linux version of odo binary on the
 # OpenShift golang image.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11
-RUN mkdir -p /go/src/github.com/openshift/odo
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo
-COPY . .
 RUN go get github.com/mitchellh/gox &&\
     make cross
+
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
+COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
+COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe
+COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/linux-amd64/odo /usr/share/openshift/odo/linux/odo

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,5 @@
-# This Dockerfile is used by CI to publish odo binary artifacts.
-# It builds an image containing the Mac, Win and Linux version of odo binary on the
-# OpenShift golang image.
+# This Dockerfile builds an image containing the Linux, Mac and Windows version of odo
+# layered on top of the ubi7/ubi image.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,12 +6,9 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
 COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo
-RUN go get github.com/mitchellh/gox &&\
-    make cross
+RUN make cross
 
-# For local testing use registry image registry.access.redhat.com/ubi7/ubi instead of
-# registry.svc.ci.openshift.org/ocp/4.2:cli
-FROM registry.svc.ci.openshift.org/ocp/4.2:cli
+FROM registry.access.redhat.com/ubi7/ubi
 LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts
 
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -3,12 +3,20 @@
 # OpenShift golang image.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+LABEL Description="This image is used to build odo(Developer-focused CLI for OpenShift) \
+executables for Windows, macOS and linux" Version="1.0"
+
 COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo
 RUN go get github.com/mitchellh/gox &&\
     make cross
 
-FROM registry.access.redhat.com/ubi7/ubi
+# For local testing use registry image registry.access.redhat.com/ubi7/ubi instead of
+# registry.svc.ci.openshift.org/ocp/4.2:cli
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
+LABEL Description="This image is used to keep odo(Developer-focused CLI for OpenShift) \
+executables for Windows, macOS and linux" Version="1.0"
+
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/linux-amd64/odo /usr/share/openshift/odo/linux/odo

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -9,8 +9,7 @@ WORKDIR /go/src/github.com/openshift/odo
 RUN make cross
 
 FROM registry.access.redhat.com/ubi7/ubi
-LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts
-
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/linux-amd64/odo /usr/share/openshift/odo/linux/odo
+LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -3,8 +3,6 @@
 # OpenShift golang image.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
-LABEL Description="This image is used to build odo(Developer-focused CLI for OpenShift) \
-executables for Windows, macOS and linux" Version="1.0"
 
 COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo
@@ -14,8 +12,7 @@ RUN go get github.com/mitchellh/gox &&\
 # For local testing use registry image registry.access.redhat.com/ubi7/ubi instead of
 # registry.svc.ci.openshift.org/ocp/4.2:cli
 FROM registry.svc.ci.openshift.org/ocp/4.2:cli
-LABEL Description="This image is used to keep odo(Developer-focused CLI for OpenShift) \
-executables for Windows, macOS and linux" Version="1.0"
+LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts
 
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/openshift/odo
 RUN make cross
 
 FROM registry.access.redhat.com/ubi7/ubi
+LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/linux-amd64/odo /usr/share/openshift/odo/linux/odo
-LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This Dockerfile is a used by CI to publish openshift/odo binary artifacts. It builds an image containing the Mac, Win and Linux version of odo binary on the OpenShift golang image.

## Was the change discussed in an issue?
This is a requirement to publish odo artifacts through ART processes
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
This file is for CI use, however you can build it locally by ```docker build .``` command

Steps:
1. git clone https://github.com/openshift/odo
2. Rename the file Dockerfile.rhel to Dockerfile
2. Use the image registry ```registry.access.redhat.com/ubi7/ubi``` instead of ```registry.svc.ci.openshift.org/ocp/4.2:cli```
3. Run ```docker build .```