### PR TITLE
Propagate deleted files to the container

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3217,7 +3217,7 @@ func (c *Client) PropagateDeletes(targetPodName string, delSrcRelPaths []string,
 			rmPaths = append(rmPaths, filepath.Join(s2iPath, delRelPath))
 		}
 	}
-	glog.V(4).Infof("s2ipaths marked  for deletion are %+v", rmPaths)
+	glog.V(4).Infof("s2ipaths marked for deletion are %+v", rmPaths)
 	cmdArr := []string{"rm", "-rf"}
 	cmdArr = append(cmdArr, rmPaths...)
 

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -188,14 +188,13 @@ func (cpo *CommonPushOptions) Push() (err error) {
 			// and ignore the files on which the rules apply and filter them out
 			filesChangedFiltered, filesDeletedFiltered := filterIgnores(filesChanged, filesDeleted, absIgnoreRules)
 
-			glog.V(4).Infof("List of files which have been deleted: +%v", filesDeletedFiltered)
-
-			// Remove the relative file directory
-			deletedFiles, err = removePathFromFiles(filesDeletedFiltered, cpo.sourcePath)
+			// Remove the relative file directory from the list of deleted files
+			// in order to make the changes correctly within the OpenShift pod
+			deletedFiles, err = util.RemoveRelativePathFromFiles(filesDeletedFiltered, cpo.sourcePath)
 			if err != nil {
 				return err
 			}
-			glog.V(4).Infof("List of files to be deleted: +%v", filesDeletedFiltered)
+			glog.V(4).Infof("List of files to be deleted: +%v", deletedFiles)
 
 			if len(filesChangedFiltered) == 0 && len(filesDeletedFiltered) == 0 {
 				// no file was modified/added/deleted/renamed, thus return without building
@@ -287,19 +286,4 @@ func filterIgnores(filesChanged, filesDeleted, absIgnoreRules []string) (filesCh
 		}
 	}
 	return filesChangedFiltered, filesDeletedFiltered
-}
-
-// removePathFromFiles removes a specified path from a file
-func removePathFromFiles(files []string, path string) ([]string, error) {
-
-	removedRelativePathFiles := []string{}
-	for _, file := range files {
-		rel, err := filepath.Rel(path, file)
-		if err != nil {
-			return []string{}, err
-		}
-		removedRelativePathFiles = append(removedRelativePathFiles, rel)
-	}
-
-	return removedRelativePathFiles, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -615,3 +615,18 @@ func RemoveDuplicates(s []string) []string {
 	}
 	return result
 }
+
+// RemoveRelativePathFromFiles removes a specified path from a list of files
+func RemoveRelativePathFromFiles(files []string, path string) ([]string, error) {
+
+	removedRelativePathFiles := []string{}
+	for _, file := range files {
+		rel, err := filepath.Rel(path, file)
+		if err != nil {
+			return []string{}, err
+		}
+		removedRelativePathFiles = append(removedRelativePathFiles, rel)
+	}
+
+	return removedRelativePathFiles, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1077,3 +1077,54 @@ func TestRemoveDuplicate(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveRelativePathFromFiles(t *testing.T) {
+	type args struct {
+		path    string
+		input   []string
+		output  []string
+		wantErr bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Case 1 - Remove the relative path from a list of files",
+			args: args{
+				path:   "/foo/bar",
+				input:  []string{"/foo/bar/1", "/foo/bar/2", "/foo/bar/3/", "/foo/bar/4/5/foo/bar"},
+				output: []string{"1", "2", "3", "4/5/foo/bar"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 2 - Fail on purpose with an invalid path",
+			args: args{
+				path:   `..`,
+				input:  []string{"foo", "bar"},
+				output: []string{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Run function RemoveRelativePathFromFiles
+			output, err := RemoveRelativePathFromFiles(tt.args.input, tt.args.path)
+
+			// Check for error
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !(reflect.DeepEqual(output, tt.args.output)) {
+				t.Errorf("expected %v, got %v", tt.args.output, output)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR propagates and makes sure that all files which were deleted
locally in the source code is *also* deleted within the container on
OpenShift.

To test:

```sh
touch foobar.txt foobar2.txt && odo push && echo "\nPUSHING WITH REMOVING FILE\n" && rm foobar.txt foobar2.txt && odo push -v 4
 ```

Closes:
https://github.com/openshift/odo/issues/1354