### PR TITLE
Create, list and edit services using "--app" and "--project" flags (without a context)

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -161,6 +161,10 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "logout" {
 			return lci, nil
 		}
+		// Case 8: Check if fss is service and command is create or delete. Allow it if that's the case
+		if fcc.Name() == "service" && (command.Name() == "create" || command.Name() == "delete") {
+			return lci, nil
+		}
 
 	} else {
 		return lci, nil

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -161,7 +161,7 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "logout" {
 			return lci, nil
 		}
-		// Case 8: Check if fss is service and command is create or delete. Allow it if that's the case
+		// Case 8: Check if fcc is service and command is create or delete. Allow it if that's the case
 		if fcc.Name() == "service" && (command.Name() == "create" || command.Name() == "delete") {
 			return lci, nil
 		}

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -139,5 +139,29 @@ var _ = Describe("odoServiceE2e", func() {
 			stdOut = helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
 			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
 		})
+
+		It("should be able to create, list and delete services without a context and using --app and --project flags instaed", func() {
+			// create a service using only app and project flags
+			// we do Chdir first because originalDir doesn't have a context
+			helper.Chdir(originalDir)
+
+			// create the service
+			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--plan", "dev",
+				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
+				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6",
+				"--app", app, "--project", project)
+
+			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "dh-postgresql-apb")
+			})
+
+			// list the service using app and project flags
+			stdOut := helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
+			Expect(stdOut).To(ContainSubstring("dh-postgresql-apb"))
+
+			// delete the service using app and project flags
+			helper.CmdShouldPass("odo", "delete", "-f", "dh-postgresql-apb", "--app", app, "--project", project)
+		})
 	})
 })


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
So far, `odo service create` has either worked only from within a component directory or by using a `--context` flag (#1997) that points to a valid component directory. This PR makes it possible to create and delete (as listing a service was already taken care of by #1920) a service from outside a component directory using `--app` and `--project` flags in the stead.

## Was the change discussed in an issue?
fixes #1810 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Build the binary
2. Executing below commands should work:
    ```sh
    # make sure that we are not working from a component directory
    $ ls .odo
    ls: cannot access '.odo': No such file or directory 

    $ odo service create dh-postgresql-apb --plan dev -p postgresql_user=luke -p postgresql_password=secret -p postgresql_database=my_data -p postgresql_version=9.6 --app myapp --project myproject
    $ odo service list  --app myapp --project myproject
    $ odo service delete  --app myapp --project myproject
    ```