### PR TITLE
using relative filepaths in file indexer and added versioned file index

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -173,7 +173,7 @@ func (cpo *CommonPushOptions) Push() (err error) {
 		}
 
 		// run the indexer and find the modified/added/deleted/renamed files
-		filesChanged, filesDeleted, err := util.Run(cpo.componentContext, absIgnoreRules)
+		filesChanged, filesDeleted, err := util.RunIndexer(cpo.componentContext, absIgnoreRules)
 		spinner.End(true)
 
 		if err != nil {

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -8,10 +8,29 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const fileIndexDirectory = ".odo"
 const fileIndexName = "odo-file-index.json"
+
+// FileIndex holds the file index used for storing local file state change
+type FileIndex struct {
+	metav1.TypeMeta
+	FileMap map[string]FileData
+}
+
+// NewFileIndex returns a fileIndex
+func NewFileIndex() *FileIndex {
+
+	return &FileIndex{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "FileIndex",
+			APIVersion: "v1",
+		},
+		FileMap: make(map[string]FileData),
+	}
+}
 
 type FileData struct {
 	Size             int64
@@ -20,11 +39,11 @@ type FileData struct {
 
 // read tries to read the odo index file from the given location and returns the data from the file
 // if no such file is present, it means the folder hasn't been walked and thus returns a empty list
-func read(filePath string) (map[string]FileData, error) {
+func readFileIndex(filePath string) (*FileIndex, error) {
 	// read operation
-	fileReadMap := make(map[string]FileData)
+	var fi FileIndex
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return map[string]FileData{}, nil
+		return NewFileIndex(), nil
 	}
 
 	byteValue, err := ioutil.ReadFile(filePath)
@@ -32,11 +51,16 @@ func read(filePath string) (map[string]FileData, error) {
 		return nil, err
 	}
 	// unmarshals the byte values and fill up the file read map
-	err = json.Unmarshal(byteValue, &fileReadMap)
+	err = json.Unmarshal(byteValue, &fi)
 	if err != nil {
-		return nil, err
+		// This is added here for backward compatibility because
+		// if the marshalling fails then that means we are trying to
+		// read a very old version of the index and hence we can just
+		// ignore it and reset index
+		// TODO: we need to remove this later
+		return NewFileIndex(), err
 	}
-	return fileReadMap, nil
+	return &fi, nil
 }
 
 // resolveFilePath resolves the filepath of the odo index file in the .odo folder
@@ -72,12 +96,12 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 	}
 
 	// read the odo index file
-	readData, err := read(resolvedPath)
+	existingFileIndex, err := readFileIndex(resolvedPath)
 	if err != nil {
 		return filesChanged, filesDeleted, err
 	}
 
-	filesMap := make(map[string]FileData)
+	newFileMap := make(map[string]FileData)
 	walk := func(fn string, fi os.FileInfo, err error) error {
 		if fi.IsDir() {
 
@@ -106,18 +130,18 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 			return err
 		}
 
-		if _, ok := readData[relFn]; !ok {
+		if _, ok := existingFileIndex.FileMap[relFn]; !ok {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("file added: %s", fn)
-		} else if !fi.ModTime().Equal(readData[relFn].LastModifiedDate) {
+		} else if !fi.ModTime().Equal(existingFileIndex.FileMap[relFn].LastModifiedDate) {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("last modified date changed: %s", fn)
-		} else if fi.Size() != readData[relFn].Size {
+		} else if fi.Size() != existingFileIndex.FileMap[relFn].Size {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("size changed: %s", fn)
 		}
 
-		filesMap[relFn] = FileData{
+		newFileMap[relFn] = FileData{
 			Size:             fi.Size(),
 			LastModifiedDate: fi.ModTime(),
 		}
@@ -130,8 +154,8 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 	}
 
 	// find files which are deleted/renamed
-	for fileName := range readData {
-		if _, ok := filesMap[fileName]; !ok {
+	for fileName := range existingFileIndex.FileMap {
+		if _, ok := newFileMap[fileName]; !ok {
 			glog.V(4).Infof("file deleted: %s", fileName)
 			// we return the absolute path of the files eventhough we store relative
 			filesDeleted = append(filesDeleted, filepath.Join(directory, fileName))
@@ -141,7 +165,9 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 
 	// if there are added/deleted/modified/renamed files or folders, write it to the odo index file
 	if len(filesChanged) > 0 || len(filesDeleted) > 0 {
-		err = write(resolvedPath, filesMap)
+		newfi := NewFileIndex()
+		newfi.FileMap = newFileMap
+		err = write(resolvedPath, newfi)
 		if err != nil {
 			return filesChanged, filesDeleted, err
 		}
@@ -152,8 +178,8 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 
 // writes the map of walked files and info about them, in a file
 // filepath is the location of the file to which it is supposed to be written
-func write(filePath string, writeMap map[string]FileData) error {
-	jsonData, err := json.Marshal(writeMap)
+func write(filePath string, fi *FileIndex) error {
+	jsonData, err := json.Marshal(fi)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -17,7 +17,7 @@ const fileIndexName = "odo-file-index.json"
 // FileIndex holds the file index used for storing local file state change
 type FileIndex struct {
 	metav1.TypeMeta
-	FileMap map[string]FileData
+	Files map[string]FileData
 }
 
 // NewFileIndex returns a fileIndex
@@ -28,7 +28,7 @@ func NewFileIndex() *FileIndex {
 			Kind:       "FileIndex",
 			APIVersion: "v1",
 		},
-		FileMap: make(map[string]FileData),
+		Files: make(map[string]FileData),
 	}
 }
 
@@ -130,13 +130,13 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 			return err
 		}
 
-		if _, ok := existingFileIndex.FileMap[relFn]; !ok {
+		if _, ok := existingFileIndex.Files[relFn]; !ok {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("file added: %s", fn)
-		} else if !fi.ModTime().Equal(existingFileIndex.FileMap[relFn].LastModifiedDate) {
+		} else if !fi.ModTime().Equal(existingFileIndex.Files[relFn].LastModifiedDate) {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("last modified date changed: %s", fn)
-		} else if fi.Size() != existingFileIndex.FileMap[relFn].Size {
+		} else if fi.Size() != existingFileIndex.Files[relFn].Size {
 			filesChanged = append(filesChanged, fn)
 			glog.V(4).Infof("size changed: %s", fn)
 		}
@@ -154,7 +154,7 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 	}
 
 	// find files which are deleted/renamed
-	for fileName := range existingFileIndex.FileMap {
+	for fileName := range existingFileIndex.Files {
 		if _, ok := newFileMap[fileName]; !ok {
 			glog.V(4).Infof("file deleted: %s", fileName)
 			// we return the absolute path of the files eventhough we store relative
@@ -166,7 +166,7 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 	// if there are added/deleted/modified/renamed files or folders, write it to the odo index file
 	if len(filesChanged) > 0 || len(filesDeleted) > 0 {
 		newfi := NewFileIndex()
-		newfi.FileMap = newFileMap
+		newfi.Files = newFileMap
 		err = write(resolvedPath, newfi)
 		if err != nil {
 			return filesChanged, filesDeleted, err

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -58,7 +58,7 @@ func readFileIndex(filePath string) (*FileIndex, error) {
 		// read a very old version of the index and hence we can just
 		// ignore it and reset index
 		// TODO: we need to remove this later
-		return NewFileIndex(), err
+		return NewFileIndex(), nil
 	}
 	return &fi, nil
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
storing relative filepaths in the file index and also storing the file index in a versioned struct called `FileIndex`
Note - This is a breaking change, this will break all the existing file maps. and I think users should remove the older file maps to transition ( or there could be some unexpected behavior )
## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1975
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create
odo push # check the file map to have relative paths
```
<!-- Please describe the steps to test the PR -->
