### PR TITLE
Small update to help.

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -26,14 +26,14 @@ var (
 
 	The created URL can be used to access the specified component from outside the OpenShift cluster.
 	`)
-	urlCreateExample = ktemplates.Examples(`  # Create a URL for the current component with a specific port
+	urlCreateExample = ktemplates.Examples(`  # Create a URL with a specific name by automatically detecting the port used by the component
+	%[1]s example
+
+	# Create a URL for the current component with a specific port
 	%[1]s --port 8080
   
 	# Create a URL with a specific name and port
 	%[1]s example --port 8080
-  
-	# Create a URL with a specific name by automatic detection of port (only for components which expose only one service port) 
-	%[1]s example
   
 	# Create a URL with a specific name and port for component frontend
 	%[1]s example --port 8080 --component frontend


### PR DESCRIPTION
Changes the order of the examples and slightly modifies the output.

```sh
Examples:
  # Create a URL with a specific name by automatically detecting the port used by the image
  odo url create example

  # Create a URL for the current component with a specific port
  odo url create --port 8080

  # Create a URL with a specific name and port
  odo url create example --port 8080

  # Create a URL with a specific name and port for component frontend
  odo url create example --port 8080 --component frontend
```