### PR TITLE
fail quickly if there is an error while creating service

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -3,11 +3,12 @@ package service
 import (
 	"bytes"
 	"fmt"
+	"strings"
+	"text/template"
+
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	"github.com/pkg/errors"
-	"strings"
-	"text/template"
 
 	"github.com/golang/glog"
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -208,6 +209,9 @@ func (o *ServiceCreateOptions) Run() (err error) {
 	s := log.Spinner("Creating service")
 	defer s.End(false)
 	err = svc.CreateService(o.Client, o.ServiceName, o.ServiceType, o.Plan, o.ParametersMap, o.Application)
+	if err != nil {
+		return err
+	}
 	s.End(true)
 
 	if o.wait {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Due to an ignored error, the creation of service was not checked until the function returned which made the output confusion hence handled the unhandled error.
## Was the change discussed in an issue?
fixes #1989 
<!-- Please do Link issues here. -->

## How to test changes?
```
odo service create dh-prometheus-apb --plan ephemeral 
# then quickly
odo service delete
# then again quickly 
odo service create dh-prometheus-apb --plan ephemeral 
```
this should fail quickly instead of giving odd log like
```odo service create dh-prometheus-apb --plan ephemeral --app myapp
 ✓  Creating service [6ms]
 ✓  Service 'dh-prometheus-apb' was created
Progress of the provisioning will not be reported and might take a long time.
You can see the current status by executing 'odo service list'
 ✗  object is being deleted: serviceinstances.servicecatalog.k8s.io "dh-prometheus-apb" already exists```
<!-- Please describe the steps to test the PR -->
