### PR TITLE
Fixing service test failure

### DIFF
--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -153,15 +153,12 @@ var _ = Describe("odoServiceE2e", func() {
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6",
 				"--app", app, "--project", project)
 
-			odoArgs := []string{"service", "list"}
+			// list the service using app and project flags
+			odoArgs := []string{"service", "list", "--app", app, "--project", project}
 			helper.WaitForCmdOut("odo", odoArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "dh-postgresql-apb") &&
 					strings.Contains(output, "ProvisionedAndBound")
 			})
-
-			// list the service using app and project flags
-			stdOut := helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
-			Expect(stdOut).To(ContainSubstring("dh-postgresql-apb"))
 
 			// delete the service using app and project flags
 			helper.CmdShouldPass("odo", "delete", "-f", "dh-postgresql-apb", "--app", app, "--project", project)

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -126,7 +126,7 @@ var _ = Describe("odoServiceE2e", func() {
 			)
 			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "dh-prometheus-apb")
+				return strings.Contains(output, "Provisioned")
 			})
 
 			// Listing the services should work as expected from within the component directory.
@@ -153,7 +153,7 @@ var _ = Describe("odoServiceE2e", func() {
 
 			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "dh-postgresql-apb")
+				return strings.Contains(output, "Provisioned")
 			})
 
 			// list the service using app and project flags

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -126,7 +126,7 @@ var _ = Describe("odoServiceE2e", func() {
 			)
 			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Provisioned")
+				return strings.Contains(output, "ProvisionedAndBound")
 			})
 
 			// Listing the services should work as expected from within the component directory.
@@ -153,7 +153,7 @@ var _ = Describe("odoServiceE2e", func() {
 
 			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Provisioned")
+				return strings.Contains(output, "ProvisionedAndBound")
 			})
 
 			// list the service using app and project flags

--- a/tests/integration/service_test.go
+++ b/tests/integration/service_test.go
@@ -124,9 +124,11 @@ var _ = Describe("odoServiceE2e", func() {
 			helper.CmdShouldPass("odo", "service", "create", "dh-prometheus-apb", "--plan", "ephemeral",
 				"--app", app, "--project", project,
 			)
-			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "ProvisionedAndBound")
+
+			odoArgs := []string{"service", "list"}
+			helper.WaitForCmdOut("odo", odoArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "dh-prometheus-apb") &&
+					strings.Contains(output, "ProvisionedAndBound")
 			})
 
 			// Listing the services should work as expected from within the component directory.
@@ -151,9 +153,10 @@ var _ = Describe("odoServiceE2e", func() {
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6",
 				"--app", app, "--project", project)
 
-			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "ProvisionedAndBound")
+			odoArgs := []string{"service", "list"}
+			helper.WaitForCmdOut("odo", odoArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "dh-postgresql-apb") &&
+					strings.Contains(output, "ProvisionedAndBound")
 			})
 
 			// list the service using app and project flags


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
helper.WaitForCmdOut is looking for the service name instead of service status in service test file
## Was the change discussed in an issue?
fixes #2019
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-service-e2e