### PR TITLE
rename odo-supervisord-image to odo-init-image

### DIFF
--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -423,7 +423,7 @@ For quick deployment of components, odo uses the link:https://github.com/ochinch
 Supervisord is deployed via link:https://docs.openshift.com/container-platform/4.1/nodes/containers/nodes-containers-init.html[Init Container] image. 
 
 `ODO_BOOTSTRAPPER_IMAGE` is an environmental variable which specifies the Init Container image used for Supervisord deployment.  You can modify the value of the variable to use a custom Init Container image.
-The default Init Container image is `quay.io/openshiftdo/supervisord:0.6.0` 
+The default Init Container image is `quay.io/openshiftdo/init` 
 
 . To set a custom Init Container image, run:
 +

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -735,7 +735,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 
 	err = client.ExecCMDInContainer(pod.Name,
 		// We will use the assemble-and-restart script located within the supervisord container we've created
-		[]string{"/var/lib/supervisord/bin/assemble-and-restart"},
+		[]string{"/opt/odo/bin/assemble-and-restart"},
 		pipeWriter, pipeWriter, nil, false)
 
 	if err != nil {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -95,7 +95,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "quay.io/openshiftdo/supervisord:0.8.0"
+	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.9.0"
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"
 

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -83,20 +83,20 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, com
 							Ports: commonImageMeta.Ports,
 							// Run the actual supervisord binary that has been mounted into the container
 							Command: []string{
-								"/var/lib/supervisord/bin/dumb-init",
+								"/opt/odo/bin/dumb-init",
 								"--",
 							},
 							// Using the appropriate configuration file that contains the "run" script for the component.
 							// either from: /usr/libexec/s2i/assemble or /opt/app-root/src/.s2i/bin/assemble
 							Args: []string{
-								"/var/lib/supervisord/bin/supervisord",
+								"/opt/odo/bin/supervisord",
 								"-c",
-								"/var/lib/supervisord/conf/supervisor.conf",
+								"/opt/odo/conf/supervisor.conf",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      supervisordVolumeName,
-									MountPath: "/var/lib/supervisord",
+									MountPath: "/opt/odo/",
 								},
 							},
 							Env:     envVar,
@@ -415,7 +415,7 @@ func addBootstrapSupervisordInitContainer(dc *appsv1.DeploymentConfig, dcName st
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      supervisordVolumeName,
-					MountPath: "/var/lib/supervisord",
+					MountPath: "/opt/odo/",
 				},
 			},
 			Command: []string{
@@ -423,8 +423,8 @@ func addBootstrapSupervisordInitContainer(dc *appsv1.DeploymentConfig, dcName st
 			},
 			Args: []string{
 				"-r",
-				"/opt/supervisord",
-				"/var/lib/",
+				"/opt/odo-init/.",
+				"/opt/odo/",
 			},
 		})
 }


### PR DESCRIPTION
The initContainer image contains more than just  supervisord, this updates naming and paths to be more generic to reflect current use.

The test will fail until  https://github.com/openshift/odo-supervisord-image/pull/29 is merged and new image version is released.