### PR TITLE
List all urls even if they are only in local config or only in cluster

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -565,7 +565,7 @@ func ApplyConfig(client *occlient.Client, componentConfig config.LocalConfigInfo
 // ApplyConfigDeleteURL applies url config deletion onto component
 func applyConfigDeleteURL(client *occlient.Client, componentConfig config.LocalConfigInfo) (err error) {
 
-	urlList, err := urlpkg.List(client, componentConfig.GetName(), componentConfig.GetApplication())
+	urlList, err := urlpkg.ListPushed(client, componentConfig.GetName(), componentConfig.GetApplication())
 	if err != nil {
 		return err
 	}
@@ -1230,7 +1230,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 		return component, errors.Wrap(err, "unable to get source path")
 	}
 	// URL
-	urlList, err := urlpkg.List(client, componentName, applicationName)
+	urlList, err := urlpkg.ListPushed(client, componentName, applicationName)
 	if err != nil {
 		return component, errors.Wrap(err, "unable to get url list")
 	}
@@ -1385,7 +1385,7 @@ func getStorageFromConfig(localConfig *config.LocalConfigInfo) storage.StorageLi
 // to the URLs when deploying and returns a true / false
 func checkIfURLChangesWillBeMade(client *occlient.Client, componentConfig config.LocalConfigInfo) (bool, error) {
 
-	urlList, err := urlpkg.List(client, componentConfig.GetName(), componentConfig.GetApplication())
+	urlList, err := urlpkg.ListPushed(client, componentConfig.GetName(), componentConfig.GetApplication())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2513,6 +2513,7 @@ func (c *Client) DeleteRoute(name string) error {
 
 // ListRoutes lists all the routes based on the given label selector
 func (c *Client) ListRoutes(labelSelector string) ([]routev1.Route, error) {
+	glog.V(4).Infof("Listing routes with label selector: %v", labelSelector)
 	routeList, err := c.routeClient.Routes(c.Namespace).List(metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -74,7 +74,7 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 			log.Info("component named", currentComponent.Name)
 
 			if len(componentDesc.Spec.URL) != 0 {
-				ul, err := url.List(client, componentDesc.Name, appName)
+				ul, err := url.ListPushed(client, componentDesc.Name, appName)
 				if err != nil {
 					return errors.Wrap(err, "Could not get url list")
 				}

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/storage"
 
 	"github.com/openshift/odo/pkg/component"
@@ -93,7 +94,7 @@ func printDeleteComponentInfo(client *occlient.Client, componentName string, app
 
 	if len(componentDesc.Spec.URL) != 0 {
 		log.Info("This component has following urls that will be deleted with component")
-		ul, err := url.List(client, componentDesc.Name, appName)
+		ul, err := url.ListPushed(client, componentDesc.Name, appName)
 		if err != nil {
 			return errors.Wrap(err, "Could not get url list")
 		}

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/config"
 
 	"github.com/golang/glog"
@@ -108,7 +109,7 @@ func printDeleteProjectInfo(client *occlient.Client, projectName string) error {
 					log.Info("component named", componentDesc.Name)
 
 					if len(componentDesc.Spec.URL) != 0 {
-						ul, err := url.List(client, componentDesc.Name, app)
+						ul, err := url.ListPushed(client, componentDesc.Name, app)
 						if err != nil {
 							return errors.Wrap(err, "Could not get url list")
 						}

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift/odo/pkg/odo/genericclioptions/printtemplates"
-
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -59,12 +57,10 @@ func (o *URLListOptions) Validate() (err error) {
 // Run contains the logic for the odo url list command
 func (o *URLListOptions) Run() (err error) {
 
-	urls, err := url.List(o.Client, o.Component(), o.Application)
+	urls, err := url.List(o.Client, o.localConfigInfo, o.Component(), o.Application)
 	if err != nil {
 		return err
 	}
-
-	localUrls := o.localConfigInfo.GetUrl()
 
 	if log.IsJSON() {
 		out, err := json.Marshal(urls)
@@ -73,60 +69,28 @@ func (o *URLListOptions) Run() (err error) {
 		}
 		fmt.Println(string(out))
 	} else {
-
-		if len(urls.Items) == 0 && len(localUrls) == 0 {
+		if len(urls.Items) == 0 {
 			return fmt.Errorf("no URLs found for component %v in application %v", o.Component(), o.Application)
-		} else {
-			// cm=create message dm=delete message. If these flags are set then push message needs to be printed
-			var cm, dm bool
-			log.Infof("Found the following URLs for component %v in application %v:", o.Component(), o.Application)
-			tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			//create headers
-			fmt.Fprintln(tabWriterURL, "NAME", "\t", "IN CONFIG", "\t", "URL", "\t", "PORT")
-
-			// Check everything in config and match with URL
-			for _, i := range localUrls {
-				var present bool
-				for _, u := range urls.Items {
-					if i.Name == u.Name {
-						fmt.Fprintln(tabWriterURL, u.Name, "\t", "Present", "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
-						present = true
-					}
-				}
-				if !present {
-					cm = true
-					fmt.Fprintln(tabWriterURL, i.Name, "\t", "Present", "\t", "<not created on cluster>", "\t", i.Port)
-				}
-			}
-
-			// Now reverse, check urls not in config and print their information
-			// Hence need to be deleted
-			for _, u := range urls.Items {
-				// Search if url is present in local config
-				var found bool
-				for _, i := range localUrls {
-					if i.Name == u.Name {
-						found = true
-						break
-					}
-				}
-				// If not found then we need to print its info but say its not in config
-				if !found {
-					dm = true
-					fmt.Fprintln(tabWriterURL, u.Name, "\t", "Absent", "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
-				}
-			}
-			tabWriterURL.Flush()
-			if cm && dm {
-				fmt.Print(printtemplates.PushMessage("create/delete", "URLs"))
-			} else if cm {
-				fmt.Print(printtemplates.PushMessage("create", "URLs"))
-			} else if dm {
-				fmt.Print(printtemplates.PushMessage("delete", "URLs"))
-			}
 		}
 
+		log.Infof("Found the following URLs for component %v in application %v:", o.Component(), o.Application)
+		tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(tabWriterURL, "NAME", "\t", "STATE", "\t", "URL", "\t", "PORT")
+
+		outOfSync := false
+		for _, u := range urls.Items {
+			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
+			if u.Status.State != url.StateTypePushed {
+				outOfSync = true
+			}
+		}
+		tabWriterURL.Flush()
+		if outOfSync {
+			fmt.Fprintf(os.Stdout, "\n")
+			fmt.Fprintf(os.Stdout, "There are local changes. Please run 'odo push'.")
+		}
 	}
+
 	return
 }
 

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -77,6 +77,7 @@ func (o *URLListOptions) Run() (err error) {
 		tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(tabWriterURL, "NAME", "\t", "STATE", "\t", "URL", "\t", "PORT")
 
+		// are there changes between local and cluster states?
 		outOfSync := false
 		for _, u := range urls.Items {
 			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
@@ -87,7 +88,7 @@ func (o *URLListOptions) Run() (err error) {
 		tabWriterURL.Flush()
 		if outOfSync {
 			fmt.Fprintf(os.Stdout, "\n")
-			fmt.Fprintf(os.Stdout, "There are local changes. Please run 'odo push'.")
+			fmt.Fprintf(os.Stdout, "There are local changes. Please run 'odo push'.\n")
 		}
 	}
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/openshift/odo/pkg/config"
-	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/occlient"
 	urlPkg "github.com/openshift/odo/pkg/url"
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/machineoutput"
-
-	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	urlPkg "github.com/openshift/odo/pkg/url"
+
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -101,7 +101,7 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 	// URL
 	if componentDesc.Spec.URL != nil {
 		fmt.Println("\nURLs")
-		urls, err := urlPkg.List(client, currentComponentName, applicationName)
+		urls, err := urlPkg.ListPushed(client, currentComponentName, applicationName)
 		LogErrorAndExit(err, "")
 		for _, componentURL := range componentDesc.Spec.URL {
 			url := urls.Get(componentURL)

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -2,8 +2,9 @@ package completion
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/config"
 	"strings"
+
+	"github.com/openshift/odo/pkg/config"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/odo/pkg/application"
@@ -187,7 +188,7 @@ var ProjectNameCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 var URLCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
 
-	urls, err := url.List(context.Client, context.Component(), context.Application)
+	urls, err := url.ListPushed(context.Client, context.Component(), context.Application)
 	if err != nil {
 		return completions
 	}

--- a/pkg/url/types.go
+++ b/pkg/url/types.go
@@ -8,7 +8,8 @@ import (
 type Url struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              UrlSpec `json:"spec,omitempty"`
+	Spec              UrlSpec   `json:"spec,omitempty"`
+	Status            UrlStatus `json:"status,omitempty"`
 }
 
 // UrlSpec is
@@ -24,3 +25,20 @@ type UrlList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Url `json:"items"`
 }
+
+// UrlStatus is Status of url
+type UrlStatus struct {
+	// "Pushed" or "Not Pushed" or "Locally Delted"
+	State StateType `json:"state"`
+}
+
+type StateType string
+
+const (
+	// StateTypePushed means that Url is present both locally and on cluster
+	StateTypePushed = "Pushed"
+	// StateTypeNotPushed means that Url is only in local config, but not on the cluster
+	StateTypeNotPushed = "Not Pushed"
+	// StateTypeLocallyDeleted means that Url was deleted from the local config, but it is still present on the cluster
+	StateTypeLocallyDeleted = "Locally Deleted"
+)

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -93,9 +93,8 @@ func ListPushed(client *occlient.Client, componentName string, applicationName s
 	return urlList, nil
 }
 
-// List returns all URLs for given component. The results can further be narrowed
-// down if a component name is provided, which will only list URLs for the
-// given component
+// List returns all URLs for given component.
+// If componentName is empty string, it lists all url in a given application.
 func List(client *occlient.Client, localConfig *config.LocalConfigInfo, componentName string, applicationName string) (UrlList, error) {
 
 	labelSelector := fmt.Sprintf("%v=%v", applabels.ApplicationLabel, applicationName)

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -1,10 +1,9 @@
 package url
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
-
-	"fmt"
 
 	routev1 "github.com/openshift/api/route/v1"
 	applabels "github.com/openshift/odo/pkg/application/labels"

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -130,7 +130,7 @@ var _ = Describe("odojsonoutput", func() {
 			actualURLListJSON := helper.CmdShouldPass("odo", "url", "list", "-o", "json")
 			fullURLPath := helper.DetermineRouteURL("")
 			pathNoHTTP := strings.Split(fullURLPath, "//")[1]
-			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"http","port":8080}}]}`, pathNoHTTP)
+			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"http","port":8080},"status":{"state": "Pushed"}}]}`, pathNoHTTP)
 			Expect(desiredURLListJSON).Should(MatchJSON(actualURLListJSON))
 
 			// odo project list -o json

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -47,16 +47,19 @@ var _ = Describe("odoURLIntegration", func() {
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldFail("odo", "url", "list", "--context", context)
 			Expect(stdout).To(ContainSubstring("no URLs found"))
+
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "<not created on cluster>", "Present", "create URLs", "odo push"})
+			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
+
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Present"})
-			helper.DontMatchAllInOutput(stdout, []string{"<not created on cluster>", "odo push"})
+			helper.MatchAllInOutput(stdout, []string{url1, "Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{"Not Pushed", "odo push"})
+
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			helper.MatchAllInOutput(stdout, []string{url1, "Absent", "delete URLs", "odo push"})
+			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
 
 			// Uncomment once https://github.com/openshift/odo/issues/1832 is fixed
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
This PR is adding `State` field into `URL` structs. Url can be in 3 different states:
- Pushed: Url is present in local config and also on the cluster
- Locally Deleted: Url is present on the cluster but not in the local config
- Not Pushed: Url is present in the local config but not on the cluster

This is also reflected in the output

## Was the change discussed in an issue?
fixes #1893
This PR replaces https://github.com/openshift/odo/pull/1978

## How to test changes?
Create some urls, and delete them without pushing.
You should see each url reporting correct state
```
odo create java:8
odo url create url0 --port 8080
odo url create url1 --port 8443
odo push
odo url delete url1
odo url create url2 --port 8778

# now you should see each url in a different state
odo url list
```

```
▶ odo url list
Found the following URLs for component java-spring-boot-yelj in application app:
NAME                           STATE               URL                                                                                       PORT
java-spring-boot-yelj-8080     Pushed              http://java-spring-boot-yelj-8080-app-tkmyproject.apps.tkral.devcluster.openshift.com     8080
java-spring-boot-yelj-8443     Locally Deleted     http://java-spring-boot-yelj-8443-app-tkmyproject.apps.tkral.devcluster.openshift.com     8443
java-spring-boot-yelj-8778     Not Pushed          ://


There are local changes. Please run 'odo push'.%
```

```
▶ odo url list -o json | jq .
{
  "kind": "List",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {},
  "items": [
    {
      "kind": "url",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "java-spring-boot-yelj-8080",
        "creationTimestamp": null
      },
      "spec": {
        "host": "java-spring-boot-yelj-8080-app-tkmyproject.apps.tkral.devcluster.openshift.com",
        "protocol": "http",
        "port": 8080
      },
      "status": {
        "state": "Pushed"
      }
    },
    {
      "kind": "url",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "java-spring-boot-yelj-8443",
        "creationTimestamp": null
      },
      "spec": {
        "host": "java-spring-boot-yelj-8443-app-tkmyproject.apps.tkral.devcluster.openshift.com",
        "protocol": "http",
        "port": 8443
      },
      "status": {
        "state": "Locally Deleted"
      }
    },
    {
      "kind": "url",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "java-spring-boot-yelj-8778",
        "creationTimestamp": null
      },
      "spec": {
        "port": 8778
      },
      "status": {
        "state": "Not Pushed"
      }
    }
  ]
}
```


