### PR TITLE
Prints environment variables added/removed to a component by doing odo link/unlink

### DIFF
--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/component"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
@@ -114,7 +115,22 @@ func (o *commonLinkOptions) run() (err error) {
 		return err
 	}
 
-	log.Successf("%s %s has been successfully %sed from the component %s", linkType, o.suppliedName, o.operationName, o.Component())
+	log.Successf("%s %s has been successfully %sed from the component %s\n", linkType, o.suppliedName, o.operationName, o.Component())
+
+	secret, err := o.Client.GetSecret(o.secretName, o.Project)
+	if err != nil {
+		return err
+	}
+
+	if o.operationName == "link" {
+		fmt.Printf("Following environment variables were added to %s component:\n", o.Component())
+	} else {
+		fmt.Printf("Following environment variables were removed from %s component:\n", o.Component())
+	}
+
+	for i := range secret.Data {
+		fmt.Printf("- %v\n", i)
+	}
 
 	if o.wait {
 		if err := o.waitForLinkToComplete(); err != nil {

--- a/tests/integration/servicecatalog/cmd_link_unlink_test.go
+++ b/tests/integration/servicecatalog/cmd_link_unlink_test.go
@@ -210,7 +210,7 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
 
 			// first create a service
-			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--plan", "dev",
+			helper.CmdShouldPass("odo", "service", "create", "-w", "dh-postgresql-apb", "--project", project, "--plan", "dev",
 				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6")
 			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}

--- a/tests/integration/servicecatalog/cmd_link_unlink_test.go
+++ b/tests/integration/servicecatalog/cmd_link_unlink_test.go
@@ -175,4 +175,60 @@ var _ = Describe("odoLinkE2e", func() {
 			Expect(envFromOutput).To(Equal("''"))
 		})
 	})
+
+	Context("When linking or unlinking a service or component", func() {
+		JustBeforeEach(func() {
+			context1 = helper.CreateNewContext()
+			context2 = helper.CreateNewContext()
+			originalDir = helper.Getwd()
+		})
+
+		JustAfterEach(func() {
+			helper.Chdir(originalDir)
+			helper.DeleteDir(context1)
+			helper.DeleteDir(context2)
+		})
+
+		It("should print the environment variables being linked/unlinked", func() {
+			helper.CopyExample(filepath.Join("source", "python"), context1)
+			helper.CmdShouldPass("odo", "create", "python", "component1", "--context", context1, "--project", project)
+			helper.CmdShouldPass("odo", "push", "--context", context1)
+			helper.CopyExample(filepath.Join("source", "nodejs"), context2)
+			helper.CmdShouldPass("odo", "create", "nodejs", "component2", "--context", context2, "--project", project)
+			helper.CmdShouldPass("odo", "push", "--context", context2)
+
+			// tests for linking a component to a component
+			stdOut := helper.CmdShouldPass("odo", "link", "component2", "--context", context1)
+			Expect(stdOut).To(ContainSubstring("Following environment variables were added"))
+			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
+			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+
+			// tests for unlinking a component from a component
+			stdOut = helper.CmdShouldPass("odo", "unlink", "component2", "--context", context1)
+			Expect(stdOut).To(ContainSubstring("Following environment variables were removed"))
+			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
+			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+
+			// first create a service
+			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--plan", "dev",
+				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
+				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6")
+			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "dh-postgresql-apb")
+			})
+
+			// tests for linking a service to a component
+			stdOut = helper.CmdShouldPass("odo", "link", "dh-postgresql-apb", "--context", context1)
+			Expect(stdOut).To(ContainSubstring("Following environment variables were added"))
+			Expect(stdOut).To(ContainSubstring("DB_PORT"))
+			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+
+			// tests for unlinking a service to a component
+			stdOut = helper.CmdShouldPass("odo", "unlink", "dh-postgresql-apb", "--context", context1)
+			Expect(stdOut).To(ContainSubstring("Following environment variables were removed"))
+			Expect(stdOut).To(ContainSubstring("DB_PORT"))
+			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+		})
+	})
 })


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR prints the environment variables that are added or removed from a component as a result of `odo link` or `odo unlink` operation.

## Was the change discussed in an issue?
fixes #1964 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
- Build the binary
- Start a service:
  ```sh
  $ odo service create dh-postgresql-apb dh-postgresql-apb --plan dev -p postgresql_database=mydata -p postgresql_password=secret -p postgresql_user=luke -p postgresql_version=10
  ```
- Create a component, push it and link the service created above to the component:
  ```sh
  $ odo link dh-postgresql-apb
  ✓  Service dh-postgresql-apb has been successfully linked from the component nodejs-nodejs-ex-kyvs

  Following environment variables were added to nodejs-nodejs-ex-kyvs component:
  - DB_PORT
  - DB_TYPE
  - DB_USER
  - DB_HOST
  - DB_NAME
  - DB_PASSWORD
  ```
- Similarly, create another component and link the two components
  ```sh
  $ odo link component2
  ```
- Environment variables should be printed on stdout 