### PR TITLE
Adds `odo project delete -o json`

### DIFF
--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -61,22 +61,32 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 
 // Run runs the project delete command
 func (pdo *ProjectDeleteOptions) Run() (err error) {
-	// this to set the project in the file and runtime
+
+	// This to set the project in the file and runtime
 	err = project.SetCurrent(pdo.Context.Client, pdo.projectName)
 	if err != nil {
 		return
 	}
+
+	// Prints out what will be deleted
 	err = printDeleteProjectInfo(pdo.Context.Client, pdo.projectName)
 	if err != nil {
 		return err
 	}
-	if pdo.projectForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete project %v", pdo.projectName)) {
+
+	if log.IsJSON() || (pdo.projectForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete project %v", pdo.projectName))) {
+		successMessage := fmt.Sprintf("Deleted project : %v", pdo.projectName)
+
 		err := project.Delete(pdo.Context.Client, pdo.projectName)
 		if err != nil {
 			return err
 		}
 
-		log.Infof("Deleted project : %v", pdo.projectName)
+		if log.IsJSON() {
+			project.MachineReadableSuccessOutput(pdo.projectName, successMessage)
+		} else {
+			log.Success(successMessage)
+		}
 		return nil
 	}
 

--- a/tests/integration/json_test.go
+++ b/tests/integration/json_test.go
@@ -34,6 +34,23 @@ var _ = Describe("odojsonoutput", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
+	Context("Delete the project and output json output", func() {
+		var projectName string
+		JustBeforeEach(func() {
+			projectName = helper.RandString(6)
+		})
+
+		// odo project delete foobar -o json
+		It("should be able to delete project and show output in json format", func() {
+			helper.CmdShouldPass("odo", "project", "create", projectName, "-o", "json")
+
+			actual := helper.CmdShouldPass("odo", "project", "delete", projectName, "-o", "json")
+			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Deleted project : %s"}`, projectName, projectName, projectName)
+			Expect(desired).Should(MatchJSON(actual))
+		})
+
+	})
+
 	// Test machine readable output
 	Context("Pass on creation: odo project create $PROJECT -o json", func() {
 		var projectName string


### PR DESCRIPTION
Adds capability for `odo project create -o json` output.

To test:

```sh
github.com/openshift/odo  json-delete-project ✗                                                                                                                                                                                                                        1h50m ⚑  ⍉
▶ ./odo project create foobar -o json | jq
{
  "kind": "Project",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {
    "name": "foobar",
    "namespace": "foobar",
    "creationTimestamp": null
  },
  "message": "Project 'foobar' is ready for use"
}

github.com/openshift/odo  json-delete-project ✗                                                                                                                                                                                                                         1h50m ⚑
▶ ./odo project delete foobar -o json | jq
{
  "kind": "Project",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {
    "name": "foobar",
    "namespace": "foobar",
    "creationTimestamp": null
  },
  "message": "Deleted project foobar"
}
```