### PR TITLE
[merge after https://github.com/openshift/odo/pull/2009] change .gz to .tar.gz in docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ For more installation options please refer the link:docs/installation.adoc[insta
 In order to correctly use `odo` you must download it and add it
 to your `PATH` environment variable:
 
-. Download the `odo-windows-amd64.exe.gz` file from the
+. Download the `odo-windows-amd64.exe.tar.gz` file from the
 link:https://github.com/openshift/odo/releases[GitHub releases page].
 . Extract the file.
 . Add the location of extracted binary to your `PATH` environment

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -63,7 +63,7 @@ $ brew install kadel/odo/odo
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-darwin-amd64.gz | gzip -d > /usr/local/bin/odo; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-darwin-amd64.tar.gz | tar -xvzf odo-darwin-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 
@@ -109,7 +109,7 @@ $ echo "deb https://dl.bintray.com/odo/odo-deb-releases stretch main" | sudo tee
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.gz | gzip -d > /usr/local/bin/odo; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf odo-linux-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 
@@ -179,7 +179,7 @@ $ dnf install odo
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.gz | gzip -d > /usr/local/bin/odo; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf odo-linux-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -63,7 +63,7 @@ $ brew install kadel/odo/odo
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-darwin-amd64.tar.gz | tar -xvzf odo-darwin-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-darwin-amd64.tar.gz | tar -xvzf - -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 
@@ -109,7 +109,7 @@ $ echo "deb https://dl.bintray.com/odo/odo-deb-releases stretch main" | sudo tee
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf odo-linux-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf - -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 
@@ -179,7 +179,7 @@ $ dnf install odo
 ==== Tarball installation
 
 ----
-# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf odo-linux-amd64.tar.gz -C /usr/local/bin; chmod +x /usr/local/bin/odo'
+# sh -c 'curl -L https://github.com/openshift/odo/releases/latest/download/odo-linux-amd64.tar.gz | tar -xvzf - -C /usr/local/bin; chmod +x /usr/local/bin/odo'
 ----
 
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
change .gz to .tar.gz in docs.
This is a follow up PR after https://github.com/openshift/odo/pull/2009 as it changes the doc references.
As per https://github.com/openshift/odo/pull/2009#issuecomment-523481624


## Was the change discussed in an issue?
part of #1994 
## How to test changes?
check the docs for the change
