### PR TITLE
add parameter map population in non-interactive service creation

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -128,6 +128,8 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 			o.ServiceName = args[1]
 		}
 
+		// we convert the param list provided in the format of key=value list
+		// to a map
 		o.ParametersMap = make(map[string]string)
 		for _, kv := range o.parameters {
 			kvSlice := strings.Split(kv, "=")

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -127,6 +127,16 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		if len(args) == 2 {
 			o.ServiceName = args[1]
 		}
+
+		o.ParametersMap = make(map[string]string)
+		for _, kv := range o.parameters {
+			kvSlice := strings.Split(kv, "=")
+			// key value not provided in format of key=value
+			if len(kvSlice) != 2 {
+				return errors.New("parameters not provided in key=value format")
+			}
+			o.ParametersMap[kvSlice[0]] = kvSlice[1]
+		}
 	}
 
 	return

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -51,16 +51,11 @@ var _ = Describe("odoServiceE2e", func() {
 		})
 
 		It("should be able to create postgresql with env", func() {
-			oc.ImportJavaIsToNspace(project)
-			helper.CopyExample(filepath.Join("source", "openjdk-sb-postgresql"), context)
-
-			// Local config needs to be present in order to create service https://github.com/openshift/odo/issues/1602
-			helper.CmdShouldPass("odo", "create", "java", "sb-app", "--project", project)
-
-			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--plan", "dev",
-				"-p", "postgresql_user=lukecage", "-p", "postgresql_password=secret",
-				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6")
-			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
+			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--app", app,
+				"--plan", "dev", "-p", "postgresql_usero=lukecage", "-p", "postgresql_password=secret",
+				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", "-w")
+			// there is only a single pod in the project
+			ocArgs := []string{"describe", "pod", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "lukecage")
 			})

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -52,7 +52,7 @@ var _ = Describe("odoServiceE2e", func() {
 
 		It("should be able to create postgresql with env", func() {
 			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--app", app,
-				"--plan", "dev", "-p", "postgresql_usero=lukecage", "-p", "postgresql_password=secret",
+				"--plan", "dev", "-p", "postgresql_user=lukecage", "-p", "postgresql_password=secret",
 				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", "-w")
 			// there is only a single pod in the project
 			ocArgs := []string{"describe", "pod", "-n", project}

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -39,15 +39,10 @@ var _ = Describe("odoServiceE2e", func() {
 	Context("create service with Env non-interactively", func() {
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()
-			context = helper.CreateNewContext()
 			app = helper.RandString(7)
-			originalDir = helper.Getwd()
-			helper.Chdir(context)
 		})
 		JustAfterEach(func() {
 			helper.DeleteProject(project)
-			helper.DeleteDir(context)
-			helper.Chdir(originalDir)
 		})
 
 		It("should be able to create postgresql with env", func() {
@@ -61,7 +56,7 @@ var _ = Describe("odoServiceE2e", func() {
 			})
 
 			// Delete the service
-			helper.CmdShouldPass("odo", "service", "delete", "dh-postgresql-apb", "-f")
+			helper.CmdShouldPass("odo", "service", "delete", "dh-postgresql-apb", "-f", "--app", app, "--project", project)
 		})
 	})
 
@@ -86,22 +81,19 @@ var _ = Describe("odoServiceE2e", func() {
 			// Local config needs to be present in order to create service https://github.com/openshift/odo/issues/1602
 			helper.CmdShouldPass("odo", "create", "java", "sb-app", "--project", project)
 
-			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--plan", "dev",
-				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
-				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6")
-			ocArgs := []string{"get", "serviceinstance", "-o", "name", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "dh-postgresql-apb")
-			})
-
 			// Create a URL
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080")
 
-			// push removes link, this is why link needs to be run alaways after the push https://github.com/openshift/odo/issues/1596
-			helper.CmdShouldPass("odo", "push", "-v", "4")
+			// push
+			helper.CmdShouldPass("odo", "push")
 
-			helper.CmdShouldPass("odo", "link", "dh-postgresql-apb", "-w", "--wait-for-target")
+			// create the postgres service
+			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--plan", "dev",
+				"-p", "postgresql_user=luke", "-p", "postgresql_password=secret",
+				"-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", "-w")
 
+			// link the service
+			helper.CmdShouldPass("odo", "link", "dh-postgresql-apb", "--project", project, "-w", "--wait-for-target")
 			odoArgs := []string{"service", "list"}
 			helper.WaitForCmdOut("odo", odoArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "dh-postgresql-apb") &&

--- a/tests/integration/servicecatalog/service_test.go
+++ b/tests/integration/servicecatalog/service_test.go
@@ -58,6 +58,20 @@ var _ = Describe("odoServiceE2e", func() {
 			// Delete the service
 			helper.CmdShouldPass("odo", "service", "delete", "dh-postgresql-apb", "-f", "--app", app, "--project", project)
 		})
+
+		It("should be able to create postgresql with env multiple times", func() {
+			helper.CmdShouldPass("odo", "service", "create", "dh-postgresql-apb", "--project", project, "--app", app,
+				"--plan", "dev", "-p", "postgresql_user=lukecage", "-p", "postgresql_user=testworker", "-p", "postgresql_password=secret",
+				"-p", "postgresql_password=universe", "-p", "postgresql_database=my_data", "-p", "postgresql_version=9.6", "-w")
+			// there is only a single pod in the project
+			ocArgs := []string{"describe", "pod", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "testworker")
+			})
+
+			// Delete the service
+			helper.CmdShouldPass("odo", "service", "delete", "dh-postgresql-apb", "-f", "--app", app, "--project", project)
+		})
 	})
 
 	Context("When creating with a spring boot application", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
add parameter map population in non-interactive service creation. 

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/2033
<!-- Please do Link issues here. -->

## How to test changes?
confirm that env variables get populated and show correctly
```
$ odo service create dh-postgresql-apb dh-postgresql-apb --plan dev -p postgresql_database=mydata -p postgresql_password=secret -p postgresql_user=luke -p postgresql_version=10

$ oc describe pod/<postgres-pod> | grep -A3 Env
    Environment:
      POSTGRESQL_PASSWORD:  secret
      POSTGRESQL_USER:      luke
      POSTGRESQL_DATABASE:  mydata
```
