### PR TITLE
Increasing HTTP timeout for openjdk binary source

### DIFF
--- a/tests/integration/java_test.go
+++ b/tests/integration/java_test.go
@@ -104,7 +104,7 @@ var _ = Describe("odoJavaE2e", func() {
 			routeURL := helper.DetermineRouteURL(context)
 
 			// Ping said URL
-			helper.HttpWaitFor(routeURL, "HTTP Booster", 90, 1)
+			helper.HttpWaitFor(routeURL, "HTTP Booster", 120, 1)
 
 			// Delete the component
 			helper.CmdShouldPass("odo", "delete", "sb-jar-test", "-f", "--context", context)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
Blocking the pr [1]. This pr [1] is responsible to run the test on OpenShift 4.2 cluster

[1] https://github.com/openshift/release/pull/4741

<!-- Please do Link issues here. -->

## How to test changes?
make test-e2e-java
