### PR TITLE
Adds `odo catalog list services -o json`

### DIFF
--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/occlient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,23 +15,23 @@ const Kind = "Error"
 // APIVersion is the current API version we are using
 const APIVersion = "odo.openshift.io/v1alpha1"
 
-// Error for machine readable output error messages
-type Error struct {
+// GenericError for machine readable output error messages
+type GenericError struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Message           string `json:"message"`
 }
 
-// Success same as above, but copy-and-pasted just in case
+// GenericSuccess same as above, but copy-and-pasted just in case
 // we change the output in the future
-type Success struct {
+type GenericSuccess struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Message           string `json:"message"`
 }
 
 // OutputSuccess outputs a "successful" machine-readable output format in json
-func OutputSuccess(machineOutput Success) {
+func OutputSuccess(machineOutput interface{}) {
 	printableOutput, err := json.Marshal(machineOutput)
 
 	// If we error out... there's no way to output it (since we disable logging when using -o json)
@@ -42,7 +43,7 @@ func OutputSuccess(machineOutput Success) {
 }
 
 // OutputError outputs a "successful" machine-readable output format in json
-func OutputError(machineOutput Error) {
+func OutputError(machineOutput interface{}) {
 	printableOutput, err := json.Marshal(machineOutput)
 
 	// If we error out... there's no way to output it (since we disable logging when using -o json)
@@ -51,4 +52,22 @@ func OutputError(machineOutput Error) {
 	} else {
 		fmt.Fprintf(log.GetStderr(), "%s\n", string(printableOutput))
 	}
+}
+
+// CatalogListServices `odo catalog list services` standard machine readable output
+func CatalogListServices(services []occlient.Service) {
+
+	data := struct {
+		metav1.TypeMeta   `json:",inline"`
+		metav1.ObjectMeta `json:"metadata,omitempty"`
+		Items             []occlient.Service `json:"items"`
+	}{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CatalogListServices",
+			APIVersion: "odo.openshift.io/v1alpha1",
+		},
+		Items: services,
+	}
+
+	OutputSuccess(data)
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2365,9 +2365,9 @@ func (c *Client) patchDCOfComponent(componentName, applicationName string, dcPat
 
 // Service struct holds the service name and its corresponding list of plans
 type Service struct {
-	Name     string
-	Hidden   bool
-	PlanList []string
+	Name     string   `json:"name"`
+	Hidden   bool     `json:"hidden"`
+	PlanList []string `json:"planList"`
 }
 
 // GetServiceClassesByCategory retrieves a map associating category name to ClusterServiceClasses matching the category

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -2,6 +2,9 @@ package list
 
 import (
 	"fmt"
+
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -49,7 +52,15 @@ func (o *ListServicesOptions) Validate() (err error) {
 
 // Run contains the logic for the command associated with ListServicesOptions
 func (o *ListServicesOptions) Run() (err error) {
-	util.DisplayServices(o.services)
+	if log.IsJSON() {
+		services, err := svc.ListCatalog(o.Client)
+		if err != nil {
+			return fmt.Errorf("unable to list services because Service Catalog is not enabled in your cluster: %v", err)
+		}
+		machineoutput.CatalogListServices(services)
+	} else {
+		util.DisplayServices(o.services)
+	}
 	return
 }
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -33,7 +33,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 		if log.IsJSON() {
 
 			// Machine readble error output
-			machineOutput := machineoutput.Error{
+			machineOutput := machineoutput.GenericError{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       machineoutput.Kind,
 					APIVersion: machineoutput.APIVersion,

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -107,7 +107,7 @@ func GetMachineReadableFormat(projectName string, isActive bool, apps []string) 
 // MachineReadableSuccessOutput outputs a success output that includes
 // project information and namespace
 func MachineReadableSuccessOutput(projectName string, message string) {
-	machineOutput := machineoutput.Success{
+	machineOutput := machineoutput.GenericSuccess{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Project",
 			APIVersion: "odo.openshift.io/v1alpha1",

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -37,6 +37,14 @@ var _ = Describe("odo service command tests", func() {
 		})
 	})
 
+	Context("checking machine readable output for service catalog", func() {
+		It("should succeed listing catalog components", func() {
+			// Since service catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
+			output := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+			Expect(output).To(ContainSubstring("CatalogListServices"))
+		})
+	})
+
 	Context("create service with Env non-interactively", func() {
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()


### PR DESCRIPTION
Adds the ability to list catalog services and output to json.

The format is as follows:

```json
{
  "kind": "ServiceList",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {
    "creationTimestamp": null
  },
  "items": [
    {
      "name": "cakephp-mysql-persistent",
      "hidden": false,
      "planList": [
        "default"
      ]
    },
  ]
}
```

Closes https://github.com/openshift/odo/issues/1357