### PR TITLE
Add `odo catalog list components -o json`

### DIFF
--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -127,14 +127,14 @@ func TestList(t *testing.T) {
 
 			// Check if the output is the same as what's expected (for all tags)
 			// and only if output is more than 0 (something is actually returned)
-			if len(output) > 0 && !(reflect.DeepEqual(output[0].AllTags, tt.wantAllTags)) {
-				t.Errorf("expected all tags: %s, got: %s", tt.wantAllTags, output[0].AllTags)
+			if len(output.Items) > 0 && !(reflect.DeepEqual(output.Items[0].Spec.AllTags, tt.wantAllTags)) {
+				t.Errorf("expected all tags: %s, got: %s", tt.wantAllTags, output.Items[0].Spec.AllTags)
 			}
 
 			// Check if the output is the same as what's expected (for hidden tags)
 			// and only if output is more than 0 (something is actually returned)
-			if len(output) > 0 && !(reflect.DeepEqual(output[0].NonHiddenTags, tt.wantNonHiddenTags)) {
-				t.Errorf("expected non hidden tags: %s, got: %s", tt.wantNonHiddenTags, output[0].NonHiddenTags)
+			if len(output.Items) > 0 && !(reflect.DeepEqual(output.Items[0].Spec.NonHiddenTags, tt.wantNonHiddenTags)) {
+				t.Errorf("expected non hidden tags: %s, got: %s", tt.wantNonHiddenTags, output.Items[0].Spec.NonHiddenTags)
 			}
 
 		})
@@ -178,13 +178,17 @@ func TestSliceSupportedTags(t *testing.T) {
 			},
 		})
 
-	img := CatalogImage{
-		Name:      "nodejs",
-		Namespace: "openshift",
-		NonHiddenTags: []string{
-			"10", "8", "6", "latest",
+	img := Catalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nodejs",
 		},
-		imageStreamRef: *imageStream,
+		Spec: CatalogSpec{
+			Namespace: "openshift",
+			NonHiddenTags: []string{
+				"10", "8", "6", "latest",
+			},
+			ImageStreamRef: *imageStream,
+		},
 	}
 
 	supTags, unSupTags := SliceSupportedTags(img)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -1,0 +1,28 @@
+package catalog
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Catalog ...
+type Catalog struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              CatalogSpec `json:"spec,omitempty"`
+}
+
+// CatalogSpec ...
+type CatalogSpec struct {
+	Namespace      string              `json:"namespace"`
+	AllTags        []string            `json:"allTags"`
+	NonHiddenTags  []string            `json:"nonHiddenTags"`
+	ImageStreamRef imagev1.ImageStream `json:"imageStreamRef"`
+}
+
+// CatalogImageList ...
+type CatalogImageList struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Items             []Catalog `json:"items"`
+}

--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -8,6 +8,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/openshift/odo/pkg/catalog"
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/spf13/cobra"
@@ -21,7 +23,7 @@ var componentsExample = `  # Get the supported components
 // ListComponentsOptions encapsulates the options for the odo catalog list components command
 type ListComponentsOptions struct {
 	// list of known images
-	catalogList []catalog.CatalogImage
+	catalogList catalog.CatalogImageList
 	// generic context options common to all commands
 	*genericclioptions.Context
 }
@@ -35,17 +37,18 @@ func NewListComponentsOptions() *ListComponentsOptions {
 func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	o.catalogList, err = catalog.List(o.Client)
+
 	if err != nil {
 		return err
 	}
-	o.catalogList = util.FilterHiddenComponents(o.catalogList)
+	o.catalogList.Items = util.FilterHiddenComponents(o.catalogList.Items)
 
 	return
 }
 
 // Validate validates the ListComponentsOptions based on completed values
 func (o *ListComponentsOptions) Validate() (err error) {
-	if len(o.catalogList) == 0 {
+	if len(o.catalogList.Items) == 0 {
 		return fmt.Errorf("no deployable components found")
 	}
 
@@ -54,35 +57,39 @@ func (o *ListComponentsOptions) Validate() (err error) {
 
 // Run contains the logic for the command associated with ListComponentsOptions
 func (o *ListComponentsOptions) Run() (err error) {
-	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-	var supCatalogList, unsupCatalogList []catalog.CatalogImage
+	if log.IsJSON() {
+		machineoutput.OutputSuccess(o.catalogList)
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		var supCatalogList, unsupCatalogList []catalog.Catalog
 
-	for _, image := range o.catalogList {
-		supported, unsupported := catalog.SliceSupportedTags(image)
+		for _, image := range o.catalogList.Items {
+			supported, unsupported := catalog.SliceSupportedTags(image)
 
-		if len(supported) != 0 {
-			image.NonHiddenTags = supported
-			supCatalogList = append(supCatalogList, image)
+			if len(supported) != 0 {
+				image.Spec.NonHiddenTags = supported
+				supCatalogList = append(supCatalogList, image)
+			}
+			if len(unsupported) != 0 {
+				image.Spec.NonHiddenTags = unsupported
+				unsupCatalogList = append(unsupCatalogList, image)
+			}
 		}
-		if len(unsupported) != 0 {
-			image.NonHiddenTags = unsupported
-			unsupCatalogList = append(unsupCatalogList, image)
+
+		if len(supCatalogList) != 0 {
+			fmt.Fprintln(w, "Odo Supported OpenShift Components:")
+			o.printCatalogList(w, supCatalogList)
+			fmt.Fprintln(w)
+
 		}
+
+		if len(unsupCatalogList) != 0 {
+			fmt.Fprintln(w, "OpenShift Components:")
+			o.printCatalogList(w, unsupCatalogList)
+		}
+
+		w.Flush()
 	}
-
-	if len(supCatalogList) != 0 {
-		fmt.Fprintln(w, "Odo Supported OpenShift Components:")
-		o.printCatalogList(w, supCatalogList)
-		fmt.Fprintln(w)
-
-	}
-
-	if len(unsupCatalogList) != 0 {
-		fmt.Fprintln(w, "OpenShift Components:")
-		o.printCatalogList(w, unsupCatalogList)
-	}
-
-	w.Flush()
 	return
 }
 
@@ -102,7 +109,7 @@ func NewCmdCatalogListComponents(name, fullName string) *cobra.Command {
 
 }
 
-func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []catalog.CatalogImage) {
+func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []catalog.Catalog) {
 	fmt.Fprintln(w, "NAME", "\t", "PROJECT", "\t", "TAGS")
 
 	for _, component := range catalogList {
@@ -115,11 +122,11 @@ func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []cata
 				mark the one from current namespace with (*)
 			*/
 			for _, comp := range catalogList {
-				if comp.Name == component.Name && component.Namespace != comp.Namespace {
-					componentName = fmt.Sprintf("%s (*)", component.Name)
+				if comp.ObjectMeta.Name == component.ObjectMeta.Name && component.Namespace != comp.Namespace {
+					componentName = fmt.Sprintf("%s (*)", component.ObjectMeta.Name)
 				}
 			}
 		}
-		fmt.Fprintln(w, componentName, "\t", component.Namespace, "\t", strings.Join(component.NonHiddenTags, ","))
+		fmt.Fprintln(w, componentName, "\t", component.Spec.Namespace, "\t", strings.Join(component.Spec.NonHiddenTags, ","))
 	}
 }

--- a/pkg/odo/cli/catalog/util/util.go
+++ b/pkg/odo/cli/catalog/util/util.go
@@ -32,12 +32,12 @@ func FilterHiddenServices(input []occlient.Service) []occlient.Service {
 }
 
 // FilterHiddenComponents filters out components that should be hidden from the specified list
-func FilterHiddenComponents(input []catalog.CatalogImage) []catalog.CatalogImage {
+func FilterHiddenComponents(input []catalog.Catalog) []catalog.Catalog {
 	inputLength := len(input)
-	filteredComponents := make([]catalog.CatalogImage, 0, inputLength)
+	filteredComponents := make([]catalog.Catalog, 0, inputLength)
 	for _, component := range input {
 		// we keep the image if it has tags that are no hidden
-		if len(component.NonHiddenTags) > 0 {
+		if len(component.Spec.NonHiddenTags) > 0 {
 			filteredComponents = append(filteredComponents, component)
 		}
 	}

--- a/pkg/odo/cli/catalog/util/util_test.go
+++ b/pkg/odo/cli/catalog/util/util_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/occlient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 )
@@ -64,42 +65,66 @@ func TestFilterHiddenServices(t *testing.T) {
 func TestFilterHiddenComponents(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []catalog.CatalogImage
-		expected []catalog.CatalogImage
+		input    []catalog.Catalog
+		expected []catalog.Catalog
 	}{
 		{
 			name:     "Case 1: empty input",
-			input:    []catalog.CatalogImage{},
-			expected: []catalog.CatalogImage{},
+			input:    []catalog.Catalog{},
+			expected: []catalog.Catalog{},
 		},
 		{
 			name: "Case 2: non empty input",
-			input: []catalog.CatalogImage{
+			input: []catalog.Catalog{
 				{
-					Name:          "n1",
-					NonHiddenTags: []string{"1", "latest"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{"1", "latest"},
+					},
 				},
 				{
-					Name:          "n2",
-					NonHiddenTags: []string{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{},
+					},
 				},
 				{
-					Name:          "n3",
-					NonHiddenTags: []string{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n3",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{},
+					},
 				},
 				{
-					Name:          "n4",
-					NonHiddenTags: []string{"10"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n4",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{"10"},
+					},
 				},
 			},
-			expected: []catalog.CatalogImage{
+			expected: []catalog.Catalog{
 				{
-					Name:          "n1",
-					NonHiddenTags: []string{"1", "latest"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{"1", "latest"},
+					},
 				},
 				{
-					Name:          "n4",
-					NonHiddenTags: []string{"10"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n4",
+					},
+					Spec: catalog.CatalogSpec{
+						NonHiddenTags: []string{"10"},
+					},
 				},
 			},
 		},

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -312,11 +312,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	if co.interactive {
 		client := co.Client
 
-		componentTypeCandidates, err := catalog.List(client)
+		catalogList, err := catalog.List(client)
 		if err != nil {
 			return err
 		}
-		componentTypeCandidates = catalogutil.FilterHiddenComponents(componentTypeCandidates)
+
+		componentTypeCandidates := catalogutil.FilterHiddenComponents(catalogList.Items)
 		selectedComponentType := ui.SelectComponentType(componentTypeCandidates)
 		selectedImageTag := ui.SelectImageTag(componentTypeCandidates, selectedComponentType)
 		componentType := selectedComponentType + ":" + selectedImageTag

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SelectComponentType lets the user to select the builder image (name only) in the prompt
-func SelectComponentType(options []catalog.CatalogImage) string {
+func SelectComponentType(options []catalog.Catalog) string {
 	var componentType string
 	prompt := &survey.Select{
 		Message: "Which component type do you wish to create",
@@ -28,7 +28,7 @@ func SelectComponentType(options []catalog.CatalogImage) string {
 	return componentType
 }
 
-func getComponentTypeNameCandidates(options []catalog.CatalogImage) []string {
+func getComponentTypeNameCandidates(options []catalog.Catalog) []string {
 	result := make([]string, len(options))
 	for i, option := range options {
 		result[i] = option.Name
@@ -38,7 +38,7 @@ func getComponentTypeNameCandidates(options []catalog.CatalogImage) []string {
 }
 
 // SelectImageTag lets the user to select a specific tag for the previously selected builder image in a prompt
-func SelectImageTag(options []catalog.CatalogImage, selectedComponentType string) string {
+func SelectImageTag(options []catalog.Catalog, selectedComponentType string) string {
 	var tag string
 	prompt := &survey.Select{
 		Message: fmt.Sprintf("Which version of '%s' component type do you wish to create", selectedComponentType),
@@ -49,11 +49,11 @@ func SelectImageTag(options []catalog.CatalogImage, selectedComponentType string
 	return tag
 }
 
-func getTagCandidates(options []catalog.CatalogImage, selectedComponentType string) []string {
+func getTagCandidates(options []catalog.Catalog, selectedComponentType string) []string {
 	for _, option := range options {
 		if option.Name == selectedComponentType {
-			sort.Strings(option.NonHiddenTags)
-			return option.NonHiddenTags
+			sort.Strings(option.Spec.NonHiddenTags)
+			return option.Spec.NonHiddenTags
 		}
 	}
 	glog.V(4).Infof("Selected component type %s was not part of the catalog images", selectedComponentType)

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -275,7 +275,7 @@ var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 		return completions
 	}
 
-	for _, builder := range catalogList {
+	for _, builder := range catalogList.Items {
 		// we found the builder name in the list which means
 		// that the builder name has been already selected by the user so no need to suggest more
 		if args.commands[builder.Name] {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -118,6 +118,13 @@ func componentTests(args ...string) {
 			Expect(cmpAllList).To(ContainSubstring("cmp-git"))
 			helper.CmdShouldPass("odo", append(args, "delete", "cmp-git", "-f")...)
 		})
+
+		It("should succeed listing catalog components", func() {
+
+			// Since components catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
+			Expect(output).To(ContainSubstring("CatalogList"))
+		})
 	})
 
 	Context("Test odo push with --source and --config flags", func() {


### PR DESCRIPTION
Adds json output for listing catalog components. For example:

```sh
odo catalog list components -o json
```

Example:

```json
{
  "kind": "ComponentTypeList",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {
    "creationTimestamp": null
  },
  "items": [
    {
      "kind": "ComponentType",
      "metadata": {
        "name": "dotnet",
        "creationTimestamp": null
      },
      "spec": {
        "namespace": "openshift",
        "allTags": [
          "2.0",
          "latest"
        ],
        "nonHiddenTags": [
          "2.0",
          "latest"
        ],
        "imageStreamRef": {
...

          }
        }
      }
    },
  ],
}
```

Closes https://github.com/openshift/odo/issues/1357