### PR TITLE
update quay.io/openshiftdo/init image to 0.10.0

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -95,7 +95,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.9.0"
+	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.10.0"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"


### PR DESCRIPTION
Update init image to `quay.io/openshiftdo/init:0.10.0` 

The new version of the image includes custom inner loop scripts, see https://github.com/openshift/odo-init-image/pull/27

To test this just make sure that everything works as before :-)