### PR TITLE
Release 1.0.0-beta5

### DIFF
--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -1,4 +1,4 @@
-= Overview of the odo (OpenShift Do) CLI Structure
+= Overview of the Odo (OpenShift Do) CLI Structure
 
 ___________________
 Example application
@@ -156,9 +156,9 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --skip-conn
         set --short : Set the current active project
     push --config --context --force-build --ignore --show-log --source : Push source code to a component
     service : Perform service catalog operations (create, delete, list)
-        create --app --parameters --plan --project --wait : Create a new service from service catalog using the plan defined and deploy it on OpenShift.
-        delete --app --force --project : Delete an existing service
-        list --app --project : List all services in the current application
+        create --app --context --parameters --plan --project --wait : Create a new service from service catalog using the plan defined and deploy it on OpenShift.
+        delete --app --context --force --project : Delete an existing service
+        list --app --context --project : List all services in the current application
     storage : Perform storage operations (create, delete, list)
         create --app --component --context --path --project --size : Create storage and mount to a component
         delete --app --component --context --force --project : Delete storage from component
@@ -629,17 +629,11 @@ _________________
 
 Modifies odo specific configuration settings within the global preference file. 
 
-[NOTE]
-====
-By default the path to the global preference file is `~/.odo/preferece.yaml`, it is stored in in the environment variable `GLOBALODOCONFIG`. You can set up a custom path by setting the value of the environment variable to a new preference path, for example `GLOBALODOCONFIG="new_path/preference.yaml"`
-
-Run `echo "$GLOBALODOCONFIG"` to display the current value of the variable. 
-====
 
 Available Parameters:
-NamePrefix - Default prefix is the current directory name. Use this value to set a default name prefix
-Timeout - Timeout (in seconds) for OpenShift server connection check
-UpdateNotification - Controls if an update notification is shown or not (true or false)
+NamePrefix - Use this value to set a default name prefix (Default: current directory name)
+Timeout - Timeout (in seconds) for OpenShift server connection check (Default: 1)
+UpdateNotification - Flag to control if an update notification is shown or not (Default: true)
 
 
 [[project]]
@@ -840,14 +834,14 @@ _________________
 
 [source,sh]
 ----
+  # Create a URL with a specific name by automatically detecting the port used by the component
+  odo url create example
+  
   # Create a URL for the current component with a specific port
   odo url create --port 8080
   
   # Create a URL with a specific name and port
   odo url create example --port 8080
-  
-  # Create a URL with a specific name by automatic detection of port (only for components which expose only one service port)
-  odo url create example
   
   # Create a URL with a specific name and port for component frontend
   odo url create example --port 8080 --component frontend

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0-beta4"
+	VERSION = "v1.0.0-beta5"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ set -e
 ODO_VERSION="latest"
 
 # Latest released odo version
-LATEST_VERSION="v1.0.0-beta4"
+LATEST_VERSION="v1.0.0-beta5"
 
 GITHUB_RELEASES_URL="https://github.com/openshift/odo/releases/download/${LATEST_VERSION}"
 BINTRAY_URL="https://dl.bintray.com/odo/odo/latest"


### PR DESCRIPTION
## Enhancements
- Lists all URLs even if they are undeployed or not (https://github.com/openshift/odo/pull/2034)
- Added json output for `odo project delete -o json` (https://github.com/openshift/odo/pull/2037)
- You can now create list and edit services using --app and --project (https://github.com/openshift/odo/pull/2001)
- Added `odo service create --context` functionality (https://github.com/openshift/odo/pull/1997)

## Testing
- Fixed service integration test that was previously failing (https://github.com/openshift/odo/pull/2022)

## Internal
- `odo push` will now only push changed files (https://github.com/openshift/odo/pull/2030)
- We now use relative paths within the file indexer (https://github.com/openshift/odo/pull/2003)
- Deleted files will now propagate to the OpenShift container (https://github.com/openshift/odo/pull/1999)
- Making cross-compile independant of gox vendor package (https://github.com/openshift/odo/pull/2047)
- `odo-supervisord-image` has been renamed to `odo-init-image` (https://github.com/openshift/odo/pull/2027)
- Releases now use .tar.gz (https://github.com/openshift/odo/pull/2009)
- If there is an error creating a service, it will fail quicker (https://github.com/openshift/odo/pull/2008)

## Documentation
- We now have a Google Group! (https://github.com/openshift/odo/pull/2007)
- Added documentation on how to manage environment variables(https://github.com/openshift/odo/pull/2026)
- Badges added to the README (https://github.com/openshift/odo/pull/2060)
- Updated documentation on uninstallation (https://github.com/openshift/odo/pull/2053)
- Added documentation for default parameters (https://github.com/openshift/odo/pull/2038)
- Minor update to help output (https://github.com/openshift/odo/pull/2006)
- Updated documentation regarding bootstrapper image (https://github.com/openshift/odo/pull/1991)