### PR TITLE
Enable bash in Makefile scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BUILD_FLAGS := -ldflags="-w $(COMMON_FLAGS)"
 DEBUG_BUILD_FLAGS := -ldflags="$(COMMON_FLAGS)"
 FILES := odo dist
 TIMEOUT ?= 7200s
+SHELL := /bin/bash
 
 # Env variable TEST_EXEC_NODES is used to pass spec execution type
 # (parallel or sequential) for ginkgo tests. To run the specs sequentially use


### PR DESCRIPTION
Certain bash commands are required in order to execute the `make cross`
command.

See below error:

```sh
github.com/openshift/odo  fix-cross-compiling ✗                                                                                                                                                                                                                          26m ⚑  ⍉
▶ make cross
Cross compiling linux-amd64 and placing binary at dist/bin/linux-amd64/
/bin/sh: 3: [: linux: unexpected operator
Cross compiling darwin-amd64 and placing binary at dist/bin/darwin-amd64/
/bin/sh: 3: [: darwin: unexpected operator
Cross compiling windows-amd64 and placing binary at dist/bin/windows-amd64/
/bin/sh: 3: [: windows: unexpected operator
```

We should be running Makefile as bash rather than sh