### PR TITLE
Add cross compiling script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,14 +81,7 @@ test-coverage:
 # compile for multiple platforms
 .PHONY: cross
 cross:
-	@for platform in linux darwin windows ; do \
-		echo "Cross compiling $$platform-amd64 and placing binary at dist/bin/$$platform-amd64/"; \
-		if [ $$platform == "windows" ]; then \
-			GOARCH=amd64 GOOS=$$platform go build -o dist/bin/$$platform-amd64/odo.exe $(BUILD_FLAGS) ./cmd/odo/; \
-		else \
-			GOARCH=amd64 GOOS=$$platform go build -o dist/bin/$$platform-amd64/odo $(BUILD_FLAGS) ./cmd/odo/; \
-		fi \
-	done
+	./scripts/cross-compile.sh '$(COMMON_FLAGS)'
 
 .PHONY: generate-cli-structure
 generate-cli-structure:

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This will cross-compile odo for all platforms:
+# Windows, Linux and macOS
+
+
+COMMON_FLAGS=${@}
+
+if [[ -z "${COMMON_FLAGS}" ]]; then
+    echo "Common build flags is missing"
+    exit 1
+fi
+
+for platform in linux darwin windows ; do
+  echo "Cross compiling $platform-amd64 and placing binary at dist/bin/$platform-amd64/"
+  if [ $platform == "windows" ]; then
+    GOARCH=amd64 GOOS=$platform go build -o dist/bin/$platform-amd64/odo.exe -ldflags="$COMMON_FLAGS" ./cmd/odo/
+  else
+    GOARCH=amd64 GOOS=$platform go build -o dist/bin/$platform-amd64/odo -ldflags="$COMMON_FLAGS" ./cmd/odo/
+  fi
+done


### PR DESCRIPTION
Adds a cross-compiling script rather than having it in the Makefile.

To test:

```sh
github.com/openshift/odo  fix-cross ✔                                                                                                                                                                                                                                                                                                                                   0m
▶ make cross
./scripts/cross-compile.sh '-X github.com/openshift/odo/pkg/odo/cli/version.GITCOMMIT=91599ec5'
Cross compiling linux-amd64 and placing binary at dist/bin/linux-amd64/
Cross compiling darwin-amd64 and placing binary at dist/bin/darwin-amd64/
Cross compiling windows-amd64 and placing binary at dist/bin/windows-amd64/
```