### PR TITLE
Makes update information italic text

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli"
 	"github.com/openshift/odo/pkg/odo/cli/version"
 	"github.com/openshift/odo/pkg/odo/util"
@@ -65,7 +65,7 @@ func main() {
 		util.LogErrorAndExit(root.Execute(), "")
 		select {
 		case message := <-updateInfo:
-			fmt.Println(message)
+			log.Italic(message)
 		default:
 			glog.V(4).Info("Could not get the latest release information in time. Never mind, exiting gracefully :)")
 		}

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -223,6 +223,14 @@ func Error(a ...interface{}) {
 	}
 }
 
+// Italic will simply print out information on a new italic line
+func Italic(a ...interface{}) {
+	italic := color.New(color.Italic).SprintFunc()
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s", italic(fmt.Sprintln(a...)))
+	}
+}
+
 // Info will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Info(a ...interface{}) {

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -133,6 +133,6 @@ func GetLatestReleaseInfo(info chan<- string) {
 			"to update manually, or visit https://github.com/openshift/odo/releases\n" +
 			"---\n" +
 			"If you wish to disable the update notifications, you can disable it by running\n" +
-			"'odo preference set UpdateNotification false'\n"
+			"odo preference set UpdateNotification false"
 	}
 }


### PR DESCRIPTION
Changes the update information to display at italic in order to not get
mixed in with the other output.

Also remove the quotes for `odo preference set UpdateNotification false`
so it's easier to copy-and-paste from the terminal.

To test:

 1. Modify pkg/odo/cli/version/version.go VERSION var to "v1.0.0-beta4"
 or any version previous
 2. Compile
 3. Run a standard create command `odo create nodejs`