### PR TITLE
Add section for project creation

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -104,6 +104,7 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 		return errors.Wrapf(err, "failed to check if project with name %s exists", prjName)
 	}
 	if !isPrjExists {
+		log.Info("Project creation")
 		log.Successf("Creating project %s", prjName)
 		err = project.Create(cpo.Context.Client, prjName, true)
 		if err != nil {
@@ -114,7 +115,7 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 				prjName,
 			)
 		}
-		log.Successf("Successfully created project %s", prjName)
+		log.Successf("Successfully created project %s\n", prjName)
 	}
 	cpo.Context.Client.Namespace = prjName
 	return


### PR DESCRIPTION
When initially creating a project, the output gets mixed in with
"Validation" which is incorrect.

This PR adds some "log.Info" to help separate between project creation
and validation.

To test:

  1. Delete all your OpenShift projects (so Odo will create one)
  2. `odo create nodejs`
  3. `odo push`

For example:

```sh
~/nodejs-ex  master ✔                                                                                                                                                                                                                                                     323d  ⍉
▶ odo create nodejs
 ✓  Validating component [81ms]
Please use `odo push` command to create the component with source deployed

~/nodejs-ex  master ✗                                                                                                                                                                                                                                                    323d ◒
▶ odo push
Project creation
 ✓  Creating project zkqunauiig
 ✓  Successfully created project zkqunauiig

Validation
 ✓  Checking component [140ms]

Configuration changes
 ✓  Initializing component
 ✓  Creating component [513ms]
 ✓  Applying configuration [33764ns]

Pushing to component nodejs-nodejs-ex-wdfr of type local
 ✓  Checking files for pushing [1ms]
 ◓  Waiting for component to start^C

~/nodejs-ex  master ✗                                                                                                                                                                                                                                                   323d ◒  ⍉
▶
```