### PR TITLE
Remove required --port within README and Getting Started guides

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -123,7 +123,7 @@ $ odo push
 . Create a URL to access the application and visit it to test it.
 +
 ----
-$ odo url create --port <application port>
+$ odo url create
 $ curl <generated URL>
 ----
 . When finished, remove your component from `Minishift` and stop your `Minishift` cluster.

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -58,7 +58,7 @@ Your component is now deployed to OpenShift.
 . Create a URL and add an entry in the local configuration file as follows:
 +
 ----
-$ odo url create --port 8080
+$ odo url create
 ----
 +
 . Push the changes. This creates a URL on the cluster.


### PR DESCRIPTION
Removes the required `--port` from the README and Getting Started guides
since we now default to the port available on the container/image and if
it's not available, odo will automatically error / prompt you for a
port.