### PR TITLE
Remove newline from odo create output

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -496,7 +496,7 @@ func (co *CreateOptions) Run() (err error) {
 			return errors.Wrapf(err, "failed to push the changes")
 		}
 	} else {
-		log.Infof("Please use `odo push` command to create the component with source deployed\n")
+		log.Infof("Please use `odo push` command to create the component with source deployed")
 	}
 	return
 }


### PR DESCRIPTION
Removes an extra newline that was added to the output.

`log.Infof` already adds a newline..