### PR TITLE
Adds `odo service list -o json`

### DIFF
--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -100,10 +100,10 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 			log.Info("No services / could not get services")
 			glog.V(4).Info(err.Error())
 		}
-		if len(serviceList) != 0 {
+		if len(serviceList.Items) != 0 {
 			log.Info("This application has following service that will be deleted")
-			for _, ser := range serviceList {
-				log.Info("service named", ser.Name, "of type", ser.Type)
+			for _, ser := range serviceList.Items {
+				log.Info("service named", ser.Spec.Name, "of type", ser.Spec.Type)
 			}
 		}
 

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -103,7 +103,7 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 		if len(serviceList.Items) != 0 {
 			log.Info("This application has following service that will be deleted")
 			for _, ser := range serviceList.Items {
-				log.Info("service named", ser.Spec.Name, "of type", ser.Spec.Type)
+				log.Info("service named", ser.ObjectMeta.Name, "of type", ser.Spec.Type)
 			}
 		}
 

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -81,11 +81,11 @@ func (o *DescribeOptions) Run() (err error) {
 		//we ignore service errors here because it's entirely possible that the service catalog has not been installed
 		serviceList, _ := service.ListWithDetailedStatus(o.Client, o.appName)
 
-		if len(componentList.Items) == 0 && len(serviceList) == 0 {
+		if len(componentList.Items) == 0 && len(serviceList.Items) == 0 {
 			fmt.Printf("Application %s has no components or services deployed.", o.appName)
 		} else {
 			fmt.Printf("Application Name: %s has %v component(s) and %v service(s):\n--------------------------------------\n",
-				o.appName, len(componentList.Items), len(serviceList))
+				o.appName, len(componentList.Items), len(serviceList.Items))
 			if len(componentList.Items) > 0 {
 				for _, currentComponent := range componentList.Items {
 					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, o.Project)
@@ -94,11 +94,11 @@ func (o *DescribeOptions) Run() (err error) {
 					fmt.Println("--------------------------------------")
 				}
 			}
-			if len(serviceList) > 0 {
-				for _, currentService := range serviceList {
-					fmt.Printf("Service Name: %s\n", currentService.Name)
-					fmt.Printf("Type: %s\n", currentService.Type)
-					fmt.Printf("Status: %s\n", currentService.Status)
+			if len(serviceList.Items) > 0 {
+				for _, currentService := range serviceList.Items {
+					fmt.Printf("Service Name: %s\n", currentService.Spec.Name)
+					fmt.Printf("Type: %s\n", currentService.Spec.Type)
+					fmt.Printf("Status: %s\n", currentService.Status.Status)
 					fmt.Println("--------------------------------------")
 				}
 			}

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -96,7 +96,7 @@ func (o *DescribeOptions) Run() (err error) {
 			}
 			if len(serviceList.Items) > 0 {
 				for _, currentService := range serviceList.Items {
-					fmt.Printf("Service Name: %s\n", currentService.Spec.Name)
+					fmt.Printf("Service Name: %s\n", currentService.ObjectMeta.Name)
 					fmt.Printf("Type: %s\n", currentService.Spec.Type)
 					fmt.Printf("Status: %s\n", currentService.Status.Status)
 					fmt.Println("--------------------------------------")

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -140,7 +140,7 @@ func printDeleteProjectInfo(client *occlient.Client, projectName string) error {
 			if len(serviceList.Items) != 0 {
 				log.Info("This application has following service that will be deleted")
 				for _, ser := range serviceList.Items {
-					log.Info("service named", ser.Spec.Name, "of type", ser.Spec.Type)
+					log.Info("service named", ser.ObjectMeta.Name, "of type", ser.Spec.Type)
 				}
 			}
 		}

--- a/pkg/odo/cli/project/project.go
+++ b/pkg/odo/cli/project/project.go
@@ -137,10 +137,10 @@ func printDeleteProjectInfo(client *occlient.Client, projectName string) error {
 				glog.V(4).Info(err.Error())
 			}
 
-			if len(serviceList) != 0 {
+			if len(serviceList.Items) != 0 {
 				log.Info("This application has following service that will be deleted")
-				for _, ser := range serviceList {
-					log.Info("service named", ser.Name, "of type", ser.Type)
+				for _, ser := range serviceList.Items {
+					log.Info("service named", ser.Spec.Name, "of type", ser.Spec.Type)
 				}
 			}
 		}

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -71,7 +71,7 @@ func (o *ServiceListOptions) Run() (err error) {
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "PLAN", "\t", "STATUS")
 		for _, comp := range services.Items {
-			fmt.Fprintln(w, comp.Spec.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Plan, "\t", comp.Status.Status)
+			fmt.Fprintln(w, comp.ObjectMeta.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Plan, "\t", comp.Status.Status)
 		}
 		w.Flush()
 	}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -29,11 +29,11 @@ var ServiceCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context
 		return completions
 	}
 
-	for _, class := range services {
-		if args.commands[class.Name] {
+	for _, class := range services.Items {
+		if args.commands[class.Spec.Name] {
 			return nil
 		}
-		completions = append(completions, class.Name)
+		completions = append(completions, class.Spec.Name)
 	}
 
 	return
@@ -313,13 +313,13 @@ var LinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *g
 		}
 	}
 
-	for _, service := range services {
+	for _, service := range services.Items {
 		// we found the name in the list which means
 		// that the name has been already selected by the user so no need to suggest more
-		if val, ok := args.commands[service.Name]; ok && val {
+		if val, ok := args.commands[service.Spec.Name]; ok && val {
 			return nil
 		}
-		completions = append(completions, service.Name)
+		completions = append(completions, service.Spec.Name)
 	}
 
 	return completions
@@ -364,16 +364,16 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 		}
 	}
 
-	for _, service := range services {
+	for _, service := range services.Items {
 		// we found the name in the list which means
 		// that the name has been already selected by the user so no need to suggest more
-		if val, ok := args.commands[service.Name]; ok && val {
+		if val, ok := args.commands[service.Spec.Name]; ok && val {
 			return nil
 		}
 		// we also need to make sure that this component has been linked to the current component
 		for _, envFromSourceName := range dcOfCurrentComponent.Spec.Template.Spec.Containers[0].EnvFrom {
-			if strings.Contains(envFromSourceName.SecretRef.Name, service.Name) {
-				completions = append(completions, service.Name)
+			if strings.Contains(envFromSourceName.SecretRef.Name, service.Spec.Name) {
+				completions = append(completions, service.Spec.Name)
 			}
 		}
 	}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -30,10 +30,10 @@ var ServiceCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context
 	}
 
 	for _, class := range services.Items {
-		if args.commands[class.Spec.Name] {
+		if args.commands[class.ObjectMeta.Name] {
 			return nil
 		}
-		completions = append(completions, class.Spec.Name)
+		completions = append(completions, class.ObjectMeta.Name)
 	}
 
 	return
@@ -316,10 +316,10 @@ var LinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *g
 	for _, service := range services.Items {
 		// we found the name in the list which means
 		// that the name has been already selected by the user so no need to suggest more
-		if val, ok := args.commands[service.Spec.Name]; ok && val {
+		if val, ok := args.commands[service.ObjectMeta.Name]; ok && val {
 			return nil
 		}
-		completions = append(completions, service.Spec.Name)
+		completions = append(completions, service.ObjectMeta.Name)
 	}
 
 	return completions
@@ -367,13 +367,13 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 	for _, service := range services.Items {
 		// we found the name in the list which means
 		// that the name has been already selected by the user so no need to suggest more
-		if val, ok := args.commands[service.Spec.Name]; ok && val {
+		if val, ok := args.commands[service.ObjectMeta.Name]; ok && val {
 			return nil
 		}
 		// we also need to make sure that this component has been linked to the current component
 		for _, envFromSourceName := range dcOfCurrentComponent.Spec.Template.Spec.Containers[0].EnvFrom {
-			if strings.Contains(envFromSourceName.SecretRef.Name, service.Spec.Name) {
-				completions = append(completions, service.Spec.Name)
+			if strings.Contains(envFromSourceName.SecretRef.Name, service.ObjectMeta.Name) {
+				completions = append(completions, service.ObjectMeta.Name)
 			}
 		}
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -213,7 +213,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 		serviceList scv1beta1.ServiceInstanceList
 		secretList  corev1.SecretList
 		dcList      appsv1.DeploymentConfigList
-		output      []ServiceInfo
+		output      []Service
 	}{
 		{
 			name: "Case 1: services with various statuses, some bound and some linked",
@@ -388,26 +388,62 @@ func TestListWithDetailedStatus(t *testing.T) {
 					},
 				},
 			},
-			output: []ServiceInfo{
-				{
-					Name:   "mysql-persistent",
-					Status: "ProvisionedAndLinked",
-					Type:   "mysql-persistent",
+			output: []Service{
+				Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "odo.openshift.io/v1alpha1",
+					},
+					Spec: ServiceSpec{
+						Name: "mysql-persistent",
+						Type: "mysql-persistent",
+						Plan: "default",
+					},
+					Status: ServiceStatus{
+						Status: "ProvisionedSuccessfully",
+					},
 				},
-				{
-					Name:   "postgresql-ephemeral",
-					Status: "ProvisionedAndBound",
-					Type:   "postgresql-ephemeral",
+				Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "odo.openshift.io/v1alpha1",
+					},
+					Spec: ServiceSpec{
+						Name: "postgresql-ephemeral",
+						Type: "postgresql-ephemeral",
+						Plan: "default",
+					},
+					Status: ServiceStatus{
+						Status: "ProvisionedSuccessfully",
+					},
 				},
-				{
-					Name:   "mongodb",
-					Status: "ProvisionedSuccessfully",
-					Type:   "mongodb",
+				Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "odo.openshift.io/v1alpha1",
+					},
+					Spec: ServiceSpec{
+						Name: "mongodb",
+						Type: "mongodb",
+						Plan: "default",
+					},
+					Status: ServiceStatus{
+						Status: "ProvisionedSuccessfully",
+					},
 				},
-				{
-					Name:   "jenkins-persistent",
-					Status: "Provisioning",
-					Type:   "jenkins-persistent",
+				Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "odo.openshift.io/v1alpha1",
+					},
+					Spec: ServiceSpec{
+						Name: "jenkins-persistent",
+						Type: "jenkins-persistent",
+						Plan: "default",
+					},
+					Status: ServiceStatus{
+						Status: "Provisioning",
+					},
 				},
 			},
 		},
@@ -433,8 +469,8 @@ func TestListWithDetailedStatus(t *testing.T) {
 
 		svcInstanceList, _ := ListWithDetailedStatus(client, "app")
 
-		if !reflect.DeepEqual(tt.output, svcInstanceList) {
-			t.Errorf("expected output: %#v,got: %#v", tt.serviceList, svcInstanceList)
+		if !reflect.DeepEqual(tt.output, svcInstanceList.Items) {
+			t.Errorf("expected output: %#v,got: %#v", tt.output, svcInstanceList.Items)
 		}
 	}
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -394,13 +394,15 @@ func TestListWithDetailedStatus(t *testing.T) {
 						Kind:       "Service",
 						APIVersion: "odo.openshift.io/v1alpha1",
 					},
-					Spec: ServiceSpec{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "mysql-persistent",
+					},
+					Spec: ServiceSpec{
 						Type: "mysql-persistent",
 						Plan: "default",
 					},
 					Status: ServiceStatus{
-						Status: "ProvisionedSuccessfully",
+						Status: "ProvisionedAndLinked",
 					},
 				},
 				Service{
@@ -408,13 +410,15 @@ func TestListWithDetailedStatus(t *testing.T) {
 						Kind:       "Service",
 						APIVersion: "odo.openshift.io/v1alpha1",
 					},
-					Spec: ServiceSpec{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "postgresql-ephemeral",
+					},
+					Spec: ServiceSpec{
 						Type: "postgresql-ephemeral",
 						Plan: "default",
 					},
 					Status: ServiceStatus{
-						Status: "ProvisionedSuccessfully",
+						Status: "ProvisionedAndBound",
 					},
 				},
 				Service{
@@ -422,8 +426,10 @@ func TestListWithDetailedStatus(t *testing.T) {
 						Kind:       "Service",
 						APIVersion: "odo.openshift.io/v1alpha1",
 					},
-					Spec: ServiceSpec{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "mongodb",
+					},
+					Spec: ServiceSpec{
 						Type: "mongodb",
 						Plan: "default",
 					},
@@ -436,8 +442,10 @@ func TestListWithDetailedStatus(t *testing.T) {
 						Kind:       "Service",
 						APIVersion: "odo.openshift.io/v1alpha1",
 					},
-					Spec: ServiceSpec{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "jenkins-persistent",
+					},
+					Spec: ServiceSpec{
 						Type: "jenkins-persistent",
 						Plan: "default",
 					},

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"github.com/openshift/odo/pkg/odo/util/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceInfo holds all important information about one service
+type Service struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              ServiceSpec   `json:"spec,omitempty"`
+	Status            ServiceStatus `json:"status,omitempty"`
+}
+
+// ServiceSpec ...
+type ServiceSpec struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+	Plan string `json:"plan,omitempty"`
+}
+
+// ServiceStatus ...
+type ServiceStatus struct {
+	Status string `json:"status,omitempty"`
+}
+
+// ServiceClass holds the information regarding a service catalog service class
+type ServiceClass struct {
+	Name              string
+	Bindable          bool
+	ShortDescription  string
+	LongDescription   string
+	Tags              []string
+	VersionsAvailable []string
+	ServiceBrokerName string
+}
+
+// ServicePlanParameter holds the information regarding a service catalog plan parameter
+type ServicePlanParameter struct {
+	Name                   string `json:"name"`
+	Title                  string `json:"title,omitempty"`
+	Description            string `json:"description,omitempty"`
+	Default                string `json:"default,omitempty"`
+	validation.Validatable `json:",inline,omitempty"`
+}
+
+type ServiceList struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Items             []Service `json:"items"`
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -15,7 +15,6 @@ type Service struct {
 
 // ServiceSpec ...
 type ServiceSpec struct {
-	Name string `json:"name,omitempty"`
 	Type string `json:"type,omitempty"`
 	Plan string `json:"plan,omitempty"`
 }
@@ -49,4 +48,12 @@ type ServiceList struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Items             []Service `json:"items"`
+}
+
+// ServicePlan holds the information about service catalog plans associated to service classes
+type ServicePlan struct {
+	Name        string
+	DisplayName string
+	Description string
+	Parameters  servicePlanParameters
 }

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -45,6 +45,13 @@ var _ = Describe("odo service command tests", func() {
 		})
 	})
 
+	Context("checking machine readable output for service catalog", func() {
+		It("should succeed listing catalog components", func() {
+			// Since service catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
+			helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+		})
+	})
+
 	Context("create service with Env non-interactively", func() {
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()
@@ -190,7 +197,7 @@ var _ = Describe("odo service command tests", func() {
 			Expect(stdOut).To(ContainSubstring(serviceName))
 		})
 
-		It("should be able to list services in a given app and project combination", func() {
+		It("should be able to list services, as well as json list in a given app and project combination", func() {
 			// create a component by copying the example
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", "create", "nodejs", "--app", app, "--project", project)
@@ -209,10 +216,22 @@ var _ = Describe("odo service command tests", func() {
 			stdOut := helper.CmdShouldPass("odo", "service", "list")
 			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
 
+			// Check json output
+			stdOut = helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
+			Expect(stdOut).To(ContainSubstring("ServiceList"))
+
 			// cd to a non-component directory and list services
 			helper.Chdir(originalDir)
 			stdOut = helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project)
 			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
+
+			// Check json output
+			helper.Chdir(originalDir)
+			stdOut = helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project, "-o", "json")
+			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
+			Expect(stdOut).To(ContainSubstring("ServiceList"))
+
 		})
 
 		It("should be able to create, list and delete services without a context and using --app and --project flags instaed", func() {


### PR DESCRIPTION
Adds `odo service list -o json` support.

To test:

```sh
github.com/openshift/odo  add-service-listing-json ✔                                                                                                                                                                                                                         0m
▶ ./odo service list -o json --context ~/nodejs-ex | jq
```

```json
github.com/openshift/odo  add-service-listing-json ✔                                                                                                                                                                                                                         5m
▶ ./odo service list -o json --context ~/nodejs-ex | jq
{
  "kind": "ServiceList",
  "apiVersion": "odo.openshift.io/v1alpha1",
  "metadata": {
    "creationTimestamp": null
  },
  "items": [
    {
      "kind": "Service",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "foobar",
        "creationTimestamp": null
      },
      "spec": {
        "type": "mysql-persistent",
        "plan": "default"
      },
      "status": {
        "status": "DeprovisionBlockedByExistingCredentials"
      }
    },
    {
      "kind": "Service",
      "apiVersion": "odo.openshift.io/v1alpha1",
      "metadata": {
        "name": "mysql-persistent",
        "creationTimestamp": null
      },
      "spec": {
        "type": "mysql-persistent",
        "plan": "default"
      },
      "status": {
        "status": "ProvisionedAndBound"
      }
    }
  ]
}
```
