### PR TITLE
Remove / modifies fmt.Errorf for util.LogErrorAndExit

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -741,7 +741,8 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 	if err != nil {
 		// If we fail, log the output
 		s.End(false)
-		return errors.Wrapf(err, "unable to build files\n%v", cmdOutput)
+		log.Errorf("Unable to build files: %v", cmdOutput)
+		return errors.Wrapf(err, "unable to build files")
 	}
 
 	s.End(true)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -740,9 +740,8 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 
 	if err != nil {
 		// If we fail, log the output
-		log.Errorf("Unable to build files\n%v", cmdOutput)
 		s.End(false)
-		return errors.Wrap(err, "unable to execute assemble script")
+		return errors.Wrapf(err, "unable to build files\n%v", cmdOutput)
 	}
 
 	s.End(true)

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/util"
 
 	"github.com/openshift/odo/pkg/occlient"
@@ -177,13 +178,13 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 						// Some of the editors like vim and gedit, generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 						// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
 						// which will terminate the watch
-						glog.Errorf("Failed getting details of the changed file %s. Ignoring the change", event.Name)
+						log.Errorf("Failed getting details of the changed file %s. Ignoring the change", event.Name)
 					}
 					// Some of the editors generate temporary buffer files during update to the file and deletes it soon after exiting from the editor
 					// So, its better to log the error rather than feeding it to error handler via `watchError = errors.Wrap(err, "unable to watch changes")`,
 					// which will terminate the watch
 					if stat == nil {
-						glog.Errorf("Ignoring event for file %s as details about the file couldn't be fetched", event.Name)
+						log.Errorf("Ignoring event for file %s as details about the file couldn't be fetched", event.Name)
 						isIgnoreEvent = true
 					}
 

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -75,12 +75,11 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 
 		// Classic case of component creation
 		if err := component.CreateComponent(cpo.Context.Client, *cpo.localConfigInfo, cpo.componentContext, stdout); err != nil {
-			log.Errorf(
+			odoutil.LogErrorAndExit(fmt.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,
 				err,
-			)
-			os.Exit(1)
+			), "")
 		}
 
 		s.End(true)
@@ -107,10 +106,9 @@ func (cpo *CommonPushOptions) ResolveProject(prjName string) (err error) {
 		log.Successf("Creating project %s", prjName)
 		err = project.Create(cpo.Context.Client, prjName, true)
 		if err != nil {
-			log.Errorf("Failed creating project %s", prjName)
 			return errors.Wrapf(
 				err,
-				"project %s does not exist. Failed creating it.Please try after creating project using `odo project create <project_name>`",
+				"project %s does not exist. Failed creating it. Please try after creating project using `odo project create <project_name>`",
 				prjName,
 			)
 		}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -516,12 +516,11 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 		log.Successf("Creating %s component with name %s", cmpType, cmpName)
 		// Classic case of component creation
 		if err = component.CreateComponent(co.Context.Client, *co.localConfigInfo, co.componentContext, stdout); err != nil {
-			log.Errorf(
+			odoutil.LogErrorAndExit(fmt.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,
 				err,
-			)
-			os.Exit(1)
+			), "")
 		}
 		log.Successf("Successfully created component %s", cmpName)
 	}
@@ -540,16 +539,13 @@ func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer)
 // when the only thing specified is the min or max value, we exit the application
 func ensureAndLogProperResourceUsage(resource, resourceMin, resourceMax, resourceName string) {
 	if strings.HasPrefix(resourceMin, "-") {
-		log.Errorf("min-%s cannot be negative", resource)
-		os.Exit(1)
+		odoutil.LogErrorAndExit(fmt.Errorf("min-%s cannot be negative", resource), "")
 	}
 	if strings.HasPrefix(resourceMax, "-") {
-		log.Errorf("max-%s cannot be negative", resource)
-		os.Exit(1)
+		odoutil.LogErrorAndExit(fmt.Errorf("max-%s cannot be negative", resource), "")
 	}
 	if strings.HasPrefix(resource, "-") {
-		log.Errorf("%s cannot be negative", resource)
-		os.Exit(1)
+		odoutil.LogErrorAndExit(fmt.Errorf("%s cannot be negative", resource), "")
 	}
 	if resourceMin != "" && resourceMax != "" && resource != "" {
 		log.Infof("`--%s` will be ignored as `--min-%s` and `--max-%s` has been passed\n", resourceName, resourceName, resourceName)
@@ -558,8 +554,7 @@ func ensureAndLogProperResourceUsage(resource, resourceMin, resourceMax, resourc
 		log.Infof("Using `--%s` %s for min and max limits.\n", resourceName, resource)
 	}
 	if (resourceMin == "") != (resourceMax == "") && resource == "" {
-		log.Errorf("`--min-%s` should accompany `--max-%s` or pass `--%s` to use same value for both min and max or try not passing any of them\n", resourceName, resourceName, resourceName)
-		os.Exit(1)
+		odoutil.LogErrorAndExit(fmt.Errorf("`--min-%s` should accompany `--max-%s` or pass `--%s` to use same value for both min and max or try not passing any of them\n", resourceName, resourceName, resourceName), "")
 	}
 }
 

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -60,7 +60,7 @@ func (do *DeleteOptions) Validate() (err error) {
 	if do.isCmpExists {
 		do.isCmpExists = true
 	} else {
-		log.Errorf("Component %s does not exist on the cluster", do.ComponentOptions.componentName)
+		return fmt.Errorf("Component %s does not exist on the cluster", do.ComponentOptions.componentName)
 	}
 	return
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -122,8 +122,7 @@ func (lo *ListOptions) Run() (err error) {
 
 	} else {
 		if len(components.Items) == 0 {
-			log.Errorf("There are no components deployed.")
-			return
+			return errors.New("there are no components deployed")
 		}
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -69,7 +69,7 @@ func (o *ServiceDeleteOptions) Run() (err error) {
 		}
 		log.Infof("Service %s from application %s has been deleted", o.serviceName, o.Application)
 	} else {
-		log.Errorf("Aborting deletion of service: %v", o.serviceName)
+		return fmt.Errorf("Aborting deletion of service: %v", o.serviceName)
 	}
 	return
 }

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -2,17 +2,18 @@ package storage
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/openshift/odo/pkg/log"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	"os"
-	"strings"
 )
 
 const unMountRecommendedCommandName = "unmount"
@@ -76,8 +77,7 @@ func (o *StorageUnMountOptions) Validate() (err error) {
 			return fmt.Errorf("unable to check if storage is mounted or not, cause %v", err)
 		}
 		if !exists {
-			log.Errorf("Storage %v does not exist in component %v", o.storageName, o.Component())
-			os.Exit(1)
+			util.LogErrorAndExit(fmt.Errorf("Storage %v does not exist in component %v", o.storageName, o.Component()), "")
 		}
 	}
 	return

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/project"
@@ -315,7 +314,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 		// if we're not specifying a component to resolve, get the current one (resolved in NewContext as cmp)
 		// so nothing to do here unless the calling context doesn't allow no component to be set in which case we exit with error
 		if !allowEmpty && len(o.cmp) == 0 {
-			log.Errorf("No component is set")
+			util.LogErrorAndExit(fmt.Errorf("No component is set"), "")
 			os.Exit(1)
 		}
 	case 1:
@@ -327,8 +326,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 		}
 	default:
 		// safeguard: fail if more than one optional string is passed because it would be a programming error
-		log.Errorf("ComponentAllowingEmpty function only accepts one optional argument, was given: %v", optionalComponent)
-		os.Exit(1)
+		util.LogErrorAndExit(fmt.Errorf("ComponentAllowingEmpty function only accepts one optional argument, was given: %v", optionalComponent), "")
 	}
 
 	return o.cmp
@@ -339,8 +337,7 @@ func (o *Context) checkComponentExistsOrFail(cmp string) {
 	exists, err := component.Exists(o.Client, cmp, o.Application)
 	util.LogErrorAndExit(err, "")
 	if !exists {
-		log.Errorf("Component %v does not exist in application %s", cmp, o.Application)
-		os.Exit(1)
+		util.LogErrorAndExit(fmt.Errorf("Component %v does not exist in application %s", cmp, o.Application), "")
 	}
 }
 


### PR DESCRIPTION
Removes / modifies fmt.Errorf for util.LogErrorAndExit

There have been cases were `odo [COMMAND] -o json` has been blank. This
is due to log.Errorf or fmt.Errorf rather than util.LogErrorAndExit

This modifies that output so errors are properly returned (using
`return`) rather than exiting with logging and then returning a "blank"
`return` statement.