### PR TITLE
Refactor machinereadable output

### DIFF
--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -71,3 +71,21 @@ func CatalogListServices(services []occlient.Service) {
 
 	OutputSuccess(data)
 }
+
+// ProjectSuccess outputs a success output that includes
+// project information and namespace
+func ProjectSuccess(projectName string, message string) {
+	machineOutput := GenericSuccess{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Project",
+			APIVersion: "odo.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      projectName,
+			Namespace: projectName,
+		},
+		Message: message,
+	}
+
+	OutputSuccess(machineOutput)
+}

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
 	"github.com/spf13/cobra"
@@ -81,7 +82,7 @@ func (pco *ProjectCreateOptions) Run() (err error) {
 
 	// If -o json has been passed, let's output the approriate json output.
 	if log.IsJSON() {
-		project.MachineReadableSuccessOutput(pco.projectName, successMessage)
+		machineoutput.ProjectSuccess(pco.projectName, successMessage)
 	} else {
 		log.Successf("New project created and now using project : %v", pco.projectName)
 	}

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
@@ -83,7 +84,7 @@ func (pdo *ProjectDeleteOptions) Run() (err error) {
 		}
 
 		if log.IsJSON() {
-			project.MachineReadableSuccessOutput(pdo.projectName, successMessage)
+			machineoutput.ProjectSuccess(pdo.projectName, successMessage)
 		} else {
 			log.Success(successMessage)
 		}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"github.com/openshift/odo/pkg/application"
-	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/odo/pkg/log"
@@ -102,24 +101,6 @@ func GetMachineReadableFormat(projectName string, isActive bool, apps []string) 
 			Active: isActive,
 		},
 	}
-}
-
-// MachineReadableSuccessOutput outputs a success output that includes
-// project information and namespace
-func MachineReadableSuccessOutput(projectName string, message string) {
-	machineOutput := machineoutput.GenericSuccess{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Project",
-			APIVersion: "odo.openshift.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      projectName,
-			Namespace: projectName,
-		},
-		Message: message,
-	}
-
-	machineoutput.OutputSuccess(machineOutput)
 }
 
 // getMachineReadableFormatForList returns application list in machine readable format


### PR DESCRIPTION
Puts the code from project delete / create into `machineoutput/types.go`