### PR TITLE
Reduces amount of lines in release info / update

### DIFF
--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -28,6 +28,9 @@ var (
 // RecommendedCommandName is the recommended version command name
 const RecommendedCommandName = "version"
 
+// OdoReleasesPage is the GitHub page where we do all our releases
+const OdoReleasesPage = "https://github.com/openshift/odo/releases"
+
 var versionLongDesc = ktemplates.LongDesc("Print the client version information")
 
 var versionExample = ktemplates.Examples(`
@@ -126,13 +129,13 @@ func GetLatestReleaseInfo(info chan<- string) {
 		glog.V(4).Infof("Error checking if newer odo release is available: %v", err)
 	}
 	if len(newTag) > 0 {
-		info <- "---\n" +
-			"A newer version of odo (version: " + fmt.Sprint(newTag) + ") is available.\n" +
-			"Update using your package manager, or run\n" +
-			"curl " + notify.InstallScriptURL + " | sh\n" +
-			"to update manually, or visit https://github.com/openshift/odo/releases\n" +
-			"---\n" +
-			"If you wish to disable the update notifications, you can disable it by running\n" +
-			"odo preference set UpdateNotification false"
+		info <- fmt.Sprintf(`
+---
+A newer version of odo (%s) is available,
+visit %s to update.
+If you wish to disable this notification, run:
+odo preference set UpdateNotification false
+---`, fmt.Sprint(newTag), OdoReleasesPage)
+
 	}
 }


### PR DESCRIPTION
Reduces the amount of output the user is given when prompting that odo
needs to update.

See below:
```sh
github.com/openshift/odo  update-message ✗                                                                                                                                   0h1m ⚑
▶ ./odo list --context ~/nodejs-ex
APP     NAME                      TYPE       SOURCE        STATE
app     nodejs-nodejs-ex-wdfr     nodejs     file://./     Pushed

---
A newer version of odo (v1.0.0-beta5) is available.
Visit https://github.com/openshift/odo/releases to update.
If you wish to disable this notification, run:
odo preference set UpdateNotification false
---
```

fixes #2089

To test:
  1. Change line 20 in `cli/version/version.go` to any other version
  (beta4)
  2. `make bin`
  3. Run any command