### PR TITLE
Fix source path for windows platform

### DIFF
--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -75,7 +76,13 @@ var _ = Describe("odo app command tests", func() {
 			appListOutput := helper.CmdShouldPass("odo", "app", "list")
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","source":"file://./"},"status":{"state":"Pushed"}}]}`, project)
+			var sourcePath string
+			if runtime.GOOS == "windows" {
+				sourcePath = "file:///./"
+			} else {
+				sourcePath = "file://./"
+			}
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","source":"%s"},"status":{"state":"Pushed"}}]}`, project, sourcePath)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Match machine readable source path in windows platform
## Was the change discussed in an issue?
Quick fix of #2115
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
run ```make test-cmd-app``` and ```make test-cmd-cmp``` on windows platform