### PR TITLE
Set DC as ownerReference for objects created on OpenShift cluster

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1956,12 +1956,6 @@ func (c *Client) Delete(labels map[string]string) error {
 	if err != nil {
 		errorList = append(errorList, "unable to delete deploymentconfig")
 	}
-	// Delete Route
-	glog.V(4).Info("Deleting Routes")
-	err = c.routeClient.Routes(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		errorList = append(errorList, "unable to delete route")
-	}
 	// Delete BuildConfig
 	glog.V(4).Info("Deleting BuildConfigs")
 	err = c.buildClient.BuildConfigs(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
@@ -1973,30 +1967,6 @@ func (c *Client) Delete(labels map[string]string) error {
 	err = c.imageClient.ImageStreams(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		errorList = append(errorList, "unable to delete imagestream")
-	}
-	// Delete Services
-	glog.V(4).Info("Deleting Services")
-	svcList, err := c.kubeClient.CoreV1().Services(c.Namespace).List(metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		errorList = append(errorList, "unable to list services")
-	}
-	for _, svc := range svcList.Items {
-		err = c.kubeClient.CoreV1().Services(c.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
-		if err != nil {
-			errorList = append(errorList, "unable to delete service")
-		}
-	}
-	// PersistentVolumeClaim
-	glog.V(4).Infof("Deleting PersistentVolumeClaims")
-	err = c.kubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		errorList = append(errorList, "unable to delete volume")
-	}
-	// Secret
-	glog.V(4).Infof("Deleting Secret")
-	err = c.kubeClient.CoreV1().Secrets(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		errorList = append(errorList, "unable to delete secret")
 	}
 
 	// Error string

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -545,8 +545,8 @@ func TestCreateRoute(t *testing.T) {
 				"app.kubernetes.io/instance": "backend",
 				"app.kubernetes.io/name":     "python",
 			},
-			wantErr: false,
-			existingDC: *fakeDeploymentConfig("mailserver", "", nil, nil, t),,
+			wantErr:    false,
+			existingDC: *fakeDeploymentConfig("mailserver", "", nil, nil, t),
 		},
 
 		{
@@ -559,14 +559,20 @@ func TestCreateRoute(t *testing.T) {
 				"app.kubernetes.io/instance": "backend",
 				"app.kubernetes.io/name":     "golang",
 			},
-			wantErr: false,
-			existingDC: *fakeDeploymentConfig("blog", "", nil, nil, t),,
+			wantErr:    false,
+			existingDC: *fakeDeploymentConfig("blog", "", nil, nil, t),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// initialising the fakeclient
 			fkclient, fkclientset := FakeNew()
+
+			fkclientset.AppsClientset.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+				dc := &appsv1.DeploymentConfig{}
+				dc.Name = tt.service
+				return true, dc, nil
+			})
 
 			_, err := fkclient.CreateRoute(tt.urlName, tt.service, tt.portNumber, tt.labels)
 

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -533,6 +533,7 @@ func TestCreateRoute(t *testing.T) {
 		portNumber intstr.IntOrString
 		labels     map[string]string
 		wantErr    bool
+		existingDC appsv1.DeploymentConfig
 	}{
 		{
 			name:       "Case : mailserver",
@@ -545,6 +546,7 @@ func TestCreateRoute(t *testing.T) {
 				"app.kubernetes.io/name":     "python",
 			},
 			wantErr: false,
+			existingDC: *fakeDeploymentConfig("mailserver", "", nil, nil, t),,
 		},
 
 		{
@@ -558,6 +560,7 @@ func TestCreateRoute(t *testing.T) {
 				"app.kubernetes.io/name":     "golang",
 			},
 			wantErr: false,
+			existingDC: *fakeDeploymentConfig("blog", "", nil, nil, t),,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/occlient/volumes.go
+++ b/pkg/occlient/volumes.go
@@ -37,10 +37,8 @@ func (c *Client) CreatePVC(name string, size string, labels map[string]string, o
 		},
 	}
 
-	if ownerReference != nil {
-		for _, owRf := range ownerReference {
-			pvc.SetOwnerReferences(append(pvc.GetOwnerReferences(), owRf))
-		}
+	for _, owRf := range ownerReference {
+		pvc.SetOwnerReferences(append(pvc.GetOwnerReferences(), owRf))
 	}
 
 	createdPvc, err := c.kubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).Create(pvc)

--- a/pkg/occlient/volumes.go
+++ b/pkg/occlient/volumes.go
@@ -14,7 +14,7 @@ import (
 
 // CreatePVC creates a PVC resource in the cluster with the given name, size and
 // labels
-func (c *Client) CreatePVC(name string, size string, labels map[string]string) (*corev1.PersistentVolumeClaim, error) {
+func (c *Client) CreatePVC(name string, size string, labels map[string]string, ownerReference ...metav1.OwnerReference) (*corev1.PersistentVolumeClaim, error) {
 	quantity, err := resource.ParseQuantity(size)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse size: %v", size)
@@ -35,6 +35,12 @@ func (c *Client) CreatePVC(name string, size string, labels map[string]string) (
 				corev1.ReadWriteOnce,
 			},
 		},
+	}
+
+	if ownerReference != nil {
+		for _, owRf := range ownerReference {
+			pvc.SetOwnerReferences(append(pvc.GetOwnerReferences(), owRf))
+		}
 	}
 
 	createdPvc, err := c.kubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).Create(pvc)

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -329,7 +329,7 @@ var _ = Describe("odo generic", func() {
 
 			// Delete the deployment config using oc delete
 			dc := oc.GetDcName(componentRandomName, project)
-			helper.CmdShouldPass("oc", "delete", "--wait", "dc", dc)
+			helper.CmdShouldPass("oc", "delete", "--wait", "dc", dc, "--namespace", project)
 
 			// insert sleep because it takes a few seconds to delete *all*
 			// objects owned by DC but we should be able to check if a service
@@ -338,11 +338,11 @@ var _ = Describe("odo generic", func() {
 
 			// now check if the service owned by the DC exists. Service name is
 			// same as DC name for a given component.
-			stdOut := helper.CmdShouldFail("oc", "get", "svc", dc)
+			stdOut := helper.CmdShouldFail("oc", "get", "svc", dc, "--namespace", project)
 			Expect(stdOut).To(ContainSubstring("NotFound"))
 
 			// ensure that the image stream still exists
-			helper.CmdShouldPass("oc", "get", "is", dc)
+			helper.CmdShouldPass("oc", "get", "is", dc, "--namespace", project)
 		})
 	})
 })

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -314,11 +314,13 @@ var _ = Describe("odo generic", func() {
 			componentRandomName = helper.RandString(6)
 			os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 			project = helper.CreateRandProject()
+			originalDir = helper.Getwd()
 			helper.Chdir(context)
 		})
 
 		JustAfterEach(func() {
 			helper.DeleteProject(project)
+			helper.Chdir(originalDir)
 			os.RemoveAll(context)
 			os.Unsetenv("GLOBALODOCONFIG")
 		})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR sets the DC created by `odo push` as the owner of following OpenShift objects of the component:
- Service
- Route
- PVC
- Secret

As a result, doing `oc delete dc/<dc-name>` deletes all the objects from the cluster that belong to the component. The only object it can't remove is an ImageStream

## Was the change discussed in an issue?
fixes #1793 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
- Build the binary
- Create a component and push it
- Not the output of following commands:
  ```sh
  $ oc get all
  $ oc get pvc
  $ oc get secret
  ```
- Do `oc delete dc/<dc-name>` and observe the output of above commands again. Except the ImageStream, all other objects cease to exist on the cluster.