### PR TITLE
Replace dump-init with go-init

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -95,7 +95,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.10.0"
+	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.11.0"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -83,15 +83,13 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, com
 							Ports: commonImageMeta.Ports,
 							// Run the actual supervisord binary that has been mounted into the container
 							Command: []string{
-								"/opt/odo/bin/dumb-init",
-								"--",
+								"/bin/bash",
+								"-c",
 							},
 							// Using the appropriate configuration file that contains the "run" script for the component.
 							// either from: /usr/libexec/s2i/assemble or /opt/app-root/src/.s2i/bin/assemble
 							Args: []string{
-								"/opt/odo/bin/supervisord",
-								"-c",
-								"/opt/odo/conf/supervisor.conf",
+								"/opt/odo/bin/go-init -main \"/opt/odo/bin/supervisord -c /opt/odo/conf/supervisor.conf\"",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -83,13 +83,13 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, com
 							Ports: commonImageMeta.Ports,
 							// Run the actual supervisord binary that has been mounted into the container
 							Command: []string{
-								"/bin/bash",
-								"-c",
+								"/opt/odo/bin/go-init",
 							},
 							// Using the appropriate configuration file that contains the "run" script for the component.
 							// either from: /usr/libexec/s2i/assemble or /opt/app-root/src/.s2i/bin/assemble
 							Args: []string{
-								"/opt/odo/bin/go-init -main \"/opt/odo/bin/supervisord -c /opt/odo/conf/supervisor.conf\"",
+								"-main",
+								"/opt/odo/bin/supervisord -c /opt/odo/conf/supervisor.conf",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR makes use of go-init instead of dumb-init to avoid having to maintain our own rpm for dumb-init

## How to test changes?
<!-- Please describe the steps to test the PR -->
All standard workflows should pass