### PR TITLE
Remove context check for search

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -128,8 +128,8 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "app" {
 			return lci, nil
 		}
-		// Case 5 : Check if fcc is catalog and request is to list
-		if fcc.Name() == "catalog" && p.Name() == "list" {
+		// Case 5 : Check if fcc is catalog and request is to list or search
+		if fcc.Name() == "catalog" && (p.Name() == "list" || p.Name() == "search") {
 			return lci, nil
 		}
 		// Check if fcc is component and  request is list


### PR DESCRIPTION
Removes the check for search.

To test:

```sh
odo catalog search component ruby
```

Closes https://github.com/openshift/odo/issues/2132