### PR TITLE
Update the `odo catalog search component` output

### DIFF
--- a/pkg/odo/cli/catalog/search/component.go
+++ b/pkg/odo/cli/catalog/search/component.go
@@ -2,8 +2,9 @@ package search
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/catalog"
-	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/spf13/cobra"
 )
@@ -46,10 +47,7 @@ func (o *SearchComponentOptions) Validate() (err error) {
 
 // Run contains the logic for the command associated with SearchComponentOptions
 func (o *SearchComponentOptions) Run() (err error) {
-	log.Infof("The following components were found:")
-	for _, component := range o.components {
-		fmt.Printf("- %v\n", component)
-	}
+	util.DisplayComponents(o.components)
 	return
 }
 

--- a/pkg/odo/cli/catalog/util/util.go
+++ b/pkg/odo/cli/catalog/util/util.go
@@ -19,6 +19,16 @@ func DisplayServices(services []occlient.Service) {
 	w.Flush()
 }
 
+// DisplayComponents displays the specified  components
+func DisplayComponents(components []string) {
+	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(w, "NAME")
+	for _, component := range components {
+		fmt.Fprintln(w, component)
+	}
+	w.Flush()
+}
+
 // FilterHiddenServices filters out services that should be hidden from the specified list
 func FilterHiddenServices(input []occlient.Service) []occlient.Service {
 	inputLength := len(input)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -128,8 +128,8 @@ func getValidConfig(command *cobra.Command) (*config.LocalConfigInfo, error) {
 		if fcc.Name() == "app" {
 			return lci, nil
 		}
-		// Case 5 : Check if fcc is catalog and request is to list
-		if fcc.Name() == "catalog" && p.Name() == "list" {
+		// Case 5 : Check if fcc is catalog and request is to list or search
+		if fcc.Name() == "catalog" && (p.Name() == "list" || p.Name() == "search") {
 			return lci, nil
 		}
 		// Check if fcc is component and  request is list

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -52,6 +52,19 @@ var _ = Describe("odo service command tests", func() {
 		})
 	})
 
+	Context("check search functionality", func() {
+
+		It("should pass with searching for part of a service name", func() {
+
+			// We just use "sql" as some catalogs only have postgresql-persistent and
+			// others dh-postgresql-db. So let's just see if there's "any" postgresql to begin
+			// with
+			output := helper.CmdShouldPass("odo", "catalog", "search", "service", "sql")
+			Expect(output).To(ContainSubstring("postgresql"))
+		})
+
+	})
+
 	Context("create service with Env non-interactively", func() {
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()


### PR DESCRIPTION
Updates the output to match the output from `odo catalog search
service`.

See below:

```sh
github.com/openshift/odo  update-search-table ✗                                                                                                                                                                                                                                                                                                                       6m ⚑
▶ ./odo catalog search service rails
NAME                       PLANS
rails-pgsql-persistent     default

github.com/openshift/odo  update-search-table ✗                                                                                                                                                                                                                                                                                                                       6m ⚑
▶ ./odo catalog search component r
NAME
perl
ruby

github.com/openshift/odo  update-search-table ✗                                                                                                                                                                                                                                                                                                                       6m ⚑
▶ ./odo catalog search component ""
NAME
dotnet
httpd
nginx
nodejs
perl
php
python
ruby
wildfly
```