### PR TITLE
Add tests/reports to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin
 # Ignore coverage report
 coverage.txt
 
+# Ignore test reports
+tests/reports/
+
 #
 # GO SPECIFIC
 #


### PR DESCRIPTION
Ignore these files when committing. These are test reports which are
generated when running tests locally or on CI.