### PR TITLE
Delete .PHONY openshiftci-presubmit-e2e From Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,9 +248,7 @@ upload-packages:
 vendor-update:
 	glide update --strip-vendor
 
-.PHONY: openshiftci-presubmit-e2e
-openshiftci-presubmit-e2e:
-	./scripts/openshiftci-presubmit-e2e.sh
+
 
 .PHONY: openshiftci-presubmit-unittests
 openshiftci-presubmit-unittests:


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Removed ```.PHONY openshiftci-presubmit-e2e``` from Makefile as it was a dead command.
## Was the change discussed in an issue?
No
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
Nowhere used further, Refer ```https://github.com/openshift/release/tree/master/ci-operator/config/openshift/odo```