### PR TITLE
Fix spelling errors in catalog list components

### DIFF
--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -100,7 +100,7 @@ func NewCmdCatalogListComponents(name, fullName string) *cobra.Command {
 	return &cobra.Command{
 		Use:     name,
 		Short:   "List all components",
-		Long:    "List all available component types from OpenShift's Ima",
+		Long:    "List all available component types from OpenShift's Image Builder",
 		Example: fmt.Sprintf(componentsExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)


### PR DESCRIPTION
Updates the spelling errors introduced in:
https://github.com/openshift/odo/pull/2029/files#diff-1898d8a28a2de7aa682a9de52faa269dR96