### PR TITLE
Errors out if json machine output has not been implemented

### DIFF
--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -112,17 +112,19 @@ func (o *DescribeOptions) Run() (err error) {
 func NewCmdDescribe(name, fullName string) *cobra.Command {
 	o := NewDescribeOptions()
 	command := &cobra.Command{
-		Use:     fmt.Sprintf("%s [application_name]", name),
-		Short:   "Describe the given application",
-		Long:    "Describe the given application",
-		Example: fmt.Sprintf(describeExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         fmt.Sprintf("%s [application_name]", name),
+		Short:       "Describe the given application",
+		Long:        "Describe the given application",
+		Example:     fmt.Sprintf(describeExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
 
 	completion.RegisterCommandHandler(command, completion.AppCompletionHandler)
+
 	project.AddProjectFlag(command)
 	return command
 }

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -108,11 +108,12 @@ func (o *ListOptions) Run() (err error) {
 func NewCmdList(name, fullName string) *cobra.Command {
 	o := NewListOptions()
 	command := &cobra.Command{
-		Use:     name,
-		Short:   "List all applications in the current project",
-		Long:    "List all applications in the current project",
-		Example: fmt.Sprintf(listExample, fullName),
-		Args:    cobra.NoArgs,
+		Use:         name,
+		Short:       "List all applications in the current project",
+		Long:        "List all applications in the current project",
+		Example:     fmt.Sprintf(listExample, fullName),
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -98,10 +98,11 @@ func NewCmdCatalogListComponents(name, fullName string) *cobra.Command {
 	o := NewListComponentsOptions()
 
 	return &cobra.Command{
-		Use:     name,
-		Short:   "List all components",
-		Long:    "List all available component types from OpenShift's Image Builder",
-		Example: fmt.Sprintf(componentsExample, fullName),
+		Use:         name,
+		Short:       "List all components",
+		Long:        "List all available component types from OpenShift's Image Builder",
+		Example:     fmt.Sprintf(componentsExample, fullName),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -67,11 +67,12 @@ func (o *ListServicesOptions) Run() (err error) {
 func NewCmdCatalogListServices(name, fullName string) *cobra.Command {
 	o := NewListServicesOptions()
 	return &cobra.Command{
-		Use:     name,
-		Short:   "Lists all available services",
-		Long:    "Lists all available services",
-		Example: fmt.Sprintf(servicesExample, fullName),
-		Args:    cobra.ExactArgs(0),
+		Use:         name,
+		Short:       "Lists all available services",
+		Long:        "Lists all available services",
+		Example:     fmt.Sprintf(servicesExample, fullName),
+		Args:        cobra.ExactArgs(0),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -140,6 +140,7 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 
 	rootCmd.SetUsageTemplate(rootUsageTemplate)
 	cobra.AddTemplateFunc("CapitalizeFlagDescriptions", odoutil.CapitalizeFlagDescriptions)
+	cobra.AddTemplateFunc("ModifyAdditionalFlags", odoutil.ModifyAdditionalFlags)
 
 	rootCmd.AddCommand(
 		application.NewCmdApplication(application.RecommendedCommandName, util.GetFullName(fullName, application.RecommendedCommandName)),

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -134,6 +134,10 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	pflag.CommandLine.MarkHidden("logtostderr")
 	pflag.CommandLine.MarkHidden("stderrthreshold")
 
+	// We will mark the command as hidden and then re-enable if the command
+	// supports json output
+	pflag.CommandLine.MarkHidden("o")
+
 	// Override the verbosity flag description
 	verbosity := pflag.Lookup("v")
 	verbosity.Usage += ". Level varies from 0 to 9 (default 0)."

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -593,7 +593,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	componentCreateCmd.Flags().StringVar(&co.cpuMax, "max-cpu", "", "Limit maximum amount of cpu to be allocated to the component. ex. 1")
 	componentCreateCmd.Flags().StringSliceVarP(&co.componentPorts, "port", "p", []string{}, "Ports to be used when the component is created (ex. 8080,8100/tcp,9100/udp)")
 	componentCreateCmd.Flags().StringSliceVar(&co.componentEnvVars, "env", []string{}, "Environmental variables for the component. For example --env VariableName=Value")
-	// Add a defined annotation in order to appear in the help menu
+
 	componentCreateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	// Adding `--now` flag

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -571,11 +571,12 @@ func ensureAndLogProperResourceUsage(resource, resourceMin, resourceMax, resourc
 func NewCmdCreate(name, fullName string) *cobra.Command {
 	co := NewCreateOptions()
 	var componentCreateCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s <component_type> [component_name] [flags]", name),
-		Short:   "Create a new component",
-		Long:    createLongDesc,
-		Example: fmt.Sprintf(createExample, fullName),
-		Args:    cobra.RangeArgs(0, 2),
+		Use:         fmt.Sprintf("%s <component_type> [component_name] [flags]", name),
+		Short:       "Create a new component",
+		Long:        createLongDesc,
+		Example:     fmt.Sprintf(createExample, fullName),
+		Args:        cobra.RangeArgs(0, 2),
+		Annotations: map[string]string{"machineoutput": "json", "component": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(co, cmd, args)
 		},
@@ -593,7 +594,6 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	componentCreateCmd.Flags().StringSliceVarP(&co.componentPorts, "port", "p", []string{}, "Ports to be used when the component is created (ex. 8080,8100/tcp,9100/udp)")
 	componentCreateCmd.Flags().StringSliceVar(&co.componentEnvVars, "env", []string{}, "Environmental variables for the component. For example --env VariableName=Value")
 	// Add a defined annotation in order to appear in the help menu
-	componentCreateCmd.Annotations = map[string]string{"command": "component"}
 	componentCreateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	// Adding `--now` flag

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -119,11 +119,12 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	do := NewDeleteOptions()
 
 	var componentDeleteCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s <component_name>", name),
-		Short:   "Delete component",
-		Long:    "Delete component.",
-		Example: fmt.Sprintf(deleteExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         fmt.Sprintf("%s <component_name>", name),
+		Short:       "Delete component",
+		Long:        "Delete component.",
+		Example:     fmt.Sprintf(deleteExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(do, cmd, args)
 		},
@@ -133,7 +134,6 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteAllFlag, "all", "a", false, "Delete component and local config")
 
 	// Add a defined annotation in order to appear in the help menu
-	componentDeleteCmd.Annotations = map[string]string{"command": "component"}
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)
 	//Adding `--context` flag

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -133,7 +133,6 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.componentForceDeleteFlag, "force", "f", false, "Delete component without prompting")
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteAllFlag, "all", "a", false, "Delete component and local config")
 
-	// Add a defined annotation in order to appear in the help menu
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)
 	//Adding `--context` flag

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -88,18 +88,18 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 	do := NewDescribeOptions()
 
 	var describeCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [component_name]", name),
-		Short:   "Describe component",
-		Long:    `Describe component.`,
-		Example: fmt.Sprintf(describeExample, fullName),
-		Args:    cobra.RangeArgs(0, 1),
+		Use:         fmt.Sprintf("%s [component_name]", name),
+		Short:       "Describe component",
+		Long:        `Describe component.`,
+		Example:     fmt.Sprintf(describeExample, fullName),
+		Args:        cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(do, cmd, args)
 		},
 	}
 
 	// Add a defined annotation in order to appear in the help menu
-	describeCmd.Annotations = map[string]string{"command": "component"}
 	describeCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(describeCmd, completion.ComponentNameCompletionHandler)
 	// Adding --context flag

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -99,7 +99,6 @@ func NewCmdDescribe(name, fullName string) *cobra.Command {
 		},
 	}
 
-	// Add a defined annotation in order to appear in the help menu
 	describeCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(describeCmd, completion.ComponentNameCompletionHandler)
 	// Adding --context flag

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -119,11 +119,12 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	o := NewLinkOptions()
 
 	linkCmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s <service> --component [component] OR %s <component> --component [component]", name, name),
-		Short:   "Link component to a service or component",
-		Long:    linkLongDesc,
-		Example: fmt.Sprintf(linkExample, fullName),
-		Args:    cobra.ExactArgs(1),
+		Use:         fmt.Sprintf("%s <service> --component [component] OR %s <component> --component [component]", name, name),
+		Short:       "Link component to a service or component",
+		Long:        linkLongDesc,
+		Example:     fmt.Sprintf(linkExample, fullName),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -134,7 +135,6 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 
 	// Add a defined annotation in order to appear in the help menu
-	linkCmd.Annotations = map[string]string{"command": "component"}
 	linkCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(linkCmd)

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -134,7 +134,6 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 
-	// Add a defined annotation in order to appear in the help menu
 	linkCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(linkCmd)

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -149,17 +149,17 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	o := NewListOptions()
 
 	var componentListCmd = &cobra.Command{
-		Use:     name,
-		Short:   "List all components in the current application",
-		Long:    "List all components in the current application.",
-		Example: fmt.Sprintf(listExample, fullName),
-		Args:    cobra.NoArgs,
+		Use:         name,
+		Short:       "List all components in the current application",
+		Long:        "List all components in the current application.",
+		Example:     fmt.Sprintf(listExample, fullName),
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
 	// Add a defined annotation in order to appear in the help menu
-	componentListCmd.Annotations = map[string]string{"command": "component"}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path of the directory to scan for odo component directories")
 	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -159,7 +159,6 @@ func NewCmdList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	// Add a defined annotation in order to appear in the help menu
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path of the directory to scan for odo component directories")
 	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -74,7 +74,6 @@ func NewCmdLog(name, fullName string) *cobra.Command {
 
 	logCmd.Flags().BoolVarP(&o.logFollow, "follow", "f", false, "Follow logs")
 
-	// Add a defined annotation in order to appear in the help menu
 	logCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(logCmd, completion.ComponentNameCompletionHandler)
 	// Adding `--context` flag

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -61,11 +61,12 @@ func NewCmdLog(name, fullName string) *cobra.Command {
 	o := NewLogOptions()
 
 	var logCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [component_name]", name),
-		Short:   "Retrieve the log for the given component",
-		Long:    `Retrieve the log for the given component`,
-		Example: fmt.Sprintf(logExample, fullName),
-		Args:    cobra.RangeArgs(0, 1),
+		Use:         fmt.Sprintf("%s [component_name]", name),
+		Short:       "Retrieve the log for the given component",
+		Long:        `Retrieve the log for the given component`,
+		Example:     fmt.Sprintf(logExample, fullName),
+		Args:        cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -74,7 +75,6 @@ func NewCmdLog(name, fullName string) *cobra.Command {
 	logCmd.Flags().BoolVarP(&o.logFollow, "follow", "f", false, "Follow logs")
 
 	// Add a defined annotation in order to appear in the help menu
-	logCmd.Annotations = map[string]string{"command": "component"}
 	logCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(logCmd, completion.ComponentNameCompletionHandler)
 	// Adding `--context` flag

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -127,7 +127,6 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Flags().BoolVar(&po.pushSource, "source", false, "Use source flag to only push latest source on to cluster")
 	pushCmd.Flags().BoolVarP(&po.forceBuild, "force-build", "f", false, "Use force-build flag to force building the component")
 
-	// Add a defined annotation in order to appear in the help menu
 	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)
 	completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -110,11 +110,12 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	po := NewPushOptions()
 
 	var pushCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [component name]", name),
-		Short:   "Push source code to a component",
-		Long:    `Push source code to a component.`,
-		Example: fmt.Sprintf(pushCmdExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         fmt.Sprintf("%s [component name]", name),
+		Short:       "Push source code to a component",
+		Long:        `Push source code to a component.`,
+		Example:     fmt.Sprintf(pushCmdExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(po, cmd, args)
 		},
@@ -127,7 +128,6 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Flags().BoolVarP(&po.forceBuild, "force-build", "f", false, "Use force-build flag to force building the component")
 
 	// Add a defined annotation in order to appear in the help menu
-	pushCmd.Annotations = map[string]string{"command": "component"}
 	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)
 	completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -87,7 +87,6 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	unlinkCmd.PersistentFlags().StringVar(&o.port, "port", "", "Port of the backend to which to unlink")
 	unlinkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is deleted")
 
-	// Add a defined annotation in order to appear in the help menu
 	unlinkCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(unlinkCmd)

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -73,11 +73,12 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	o := NewUnlinkOptions()
 
 	unlinkCmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s <service> --component [component] OR %s <component> --component [component]", name, name),
-		Short:   "Unlink component to a service or component",
-		Long:    unlinkLongDesc,
-		Example: fmt.Sprintf(unlinkExample, fullName),
-		Args:    cobra.ExactArgs(1),
+		Use:         fmt.Sprintf("%s <service> --component [component] OR %s <component> --component [component]", name, name),
+		Short:       "Unlink component to a service or component",
+		Long:        unlinkLongDesc,
+		Example:     fmt.Sprintf(unlinkExample, fullName),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -87,7 +88,6 @@ func NewCmdUnlink(name, fullName string) *cobra.Command {
 	unlinkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is deleted")
 
 	// Add a defined annotation in order to appear in the help menu
-	unlinkCmd.Annotations = map[string]string{"command": "component"}
 	unlinkCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(unlinkCmd)

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -167,7 +167,7 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 	updateCmd.Flags().StringVarP(&uo.git, "git", "g", "", "git source")
 	updateCmd.Flags().StringVarP(&uo.local, "local", "l", "", "Use local directory as a source for component.")
 	updateCmd.Flags().StringVarP(&uo.ref, "ref", "r", "", "Use a specific ref e.g. commit, branch or tag of the git repository")
-	// Add a defined annotation in order to appear in the help menu
+
 	updateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--application` flag

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -153,11 +153,12 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 	uo := NewUpdateOptions()
 
 	var updateCmd = &cobra.Command{
-		Use:     name,
-		Args:    cobra.MaximumNArgs(1),
-		Short:   "Update the source code path of a component",
-		Long:    "Update the source code path of a component",
-		Example: fmt.Sprintf(updateCmdExample, fullName),
+		Use:         name,
+		Short:       "Update the source code path of a component",
+		Long:        "Update the source code path of a component",
+		Example:     fmt.Sprintf(updateCmdExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(uo, cmd, args)
 		},
@@ -167,7 +168,6 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 	updateCmd.Flags().StringVarP(&uo.local, "local", "l", "", "Use local directory as a source for component.")
 	updateCmd.Flags().StringVarP(&uo.ref, "ref", "r", "", "Use a specific ref e.g. commit, branch or tag of the git repository")
 	// Add a defined annotation in order to appear in the help menu
-	updateCmd.Annotations = map[string]string{"command": "component"}
 	updateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--application` flag

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -162,7 +162,6 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	watchCmd.Flags().StringSliceVar(&wo.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 	watchCmd.Flags().IntVar(&wo.delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 
-	// Add a defined annotation in order to appear in the help menu
 	watchCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	// Adding context flag
 	genericclioptions.AddContextFlag(watchCmd, &wo.componentContext)

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -147,11 +147,12 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	wo := NewWatchOptions()
 
 	var watchCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [component name]", name),
-		Short:   "Watch for changes, update component on change",
-		Long:    watchLongDesc,
-		Example: fmt.Sprintf(watchExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         fmt.Sprintf("%s [component name]", name),
+		Short:       "Watch for changes, update component on change",
+		Long:        watchLongDesc,
+		Example:     fmt.Sprintf(watchExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(wo, cmd, args)
 		},
@@ -162,7 +163,6 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	watchCmd.Flags().IntVar(&wo.delay, "delay", 1, "Time in seconds between a detection of code change and push.delay=0 means changes will be pushed as soon as they are detected which can cause performance issues")
 
 	// Add a defined annotation in order to appear in the help menu
-	watchCmd.Annotations = map[string]string{"command": "component"}
 	watchCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	// Adding context flag
 	genericclioptions.AddContextFlag(watchCmd, &wo.componentContext)

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -93,11 +93,12 @@ func NewCmdProjectCreate(name, fullName string) *cobra.Command {
 	o := NewProjectCreateOptions()
 
 	projectCreateCmd := &cobra.Command{
-		Use:     name,
-		Short:   createShortDesc,
-		Long:    createLongDesc,
-		Example: fmt.Sprintf(createExample, fullName),
-		Args:    cobra.ExactArgs(1),
+		Use:         name,
+		Short:       createShortDesc,
+		Long:        createLongDesc,
+		Example:     fmt.Sprintf(createExample, fullName),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -98,11 +98,12 @@ func NewCmdProjectDelete(name, fullName string) *cobra.Command {
 	o := NewProjectDeleteOptions()
 
 	projectDeleteCmd := &cobra.Command{
-		Use:     name,
-		Short:   deleteShortDesc,
-		Long:    deleteLongDesc,
-		Example: fmt.Sprintf(deleteExample, fullName),
-		Args:    cobra.ExactArgs(1),
+		Use:         name,
+		Short:       deleteShortDesc,
+		Long:        deleteLongDesc,
+		Example:     fmt.Sprintf(deleteExample, fullName),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -81,11 +81,12 @@ func (plo *ProjectListOptions) Run() (err error) {
 func NewCmdProjectList(name, fullName string) *cobra.Command {
 	o := NewProjectListOptions()
 	projectListCmd := &cobra.Command{
-		Use:     name,
-		Short:   listLongDesc,
-		Long:    listLongDesc,
-		Example: fmt.Sprintf(listExample, fullName),
-		Args:    cobra.ExactArgs(0),
+		Use:         name,
+		Short:       listLongDesc,
+		Long:        listLongDesc,
+		Example:     fmt.Sprintf(listExample, fullName),
+		Args:        cobra.ExactArgs(0),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -82,11 +82,12 @@ func (o *ServiceListOptions) Run() (err error) {
 func NewCmdServiceList(name, fullName string) *cobra.Command {
 	o := NewServiceListOptions()
 	serviceListCmd := &cobra.Command{
-		Use:     name,
-		Short:   "List all services in the current application",
-		Long:    listLongDesc,
-		Example: fmt.Sprintf(listExample, fullName),
-		Args:    cobra.NoArgs,
+		Use:         name,
+		Short:       "List all services in the current application",
+		Long:        listLongDesc,
+		Example:     fmt.Sprintf(listExample, fullName),
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -86,11 +86,12 @@ func (o *StorageCreateOptions) Run() (err error) {
 func NewCmdStorageCreate(name, fullName string) *cobra.Command {
 	o := NewStorageCreateOptions()
 	storageCreateCmd := &cobra.Command{
-		Use:     name,
-		Short:   urlCreateShortDesc,
-		Long:    urlCreateLongDesc,
-		Example: fmt.Sprintf(urlCreateExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         name,
+		Short:       urlCreateShortDesc,
+		Long:        urlCreateLongDesc,
+		Example:     fmt.Sprintf(urlCreateExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -102,11 +102,12 @@ func (o *StorageListOptions) Run() (err error) {
 func NewCmdStorageList(name, fullName string) *cobra.Command {
 	o := NewStorageListOptions()
 	storageListCmd := &cobra.Command{
-		Use:     name,
-		Short:   storageListShortDesc,
-		Long:    storageListLongDesc,
-		Example: fmt.Sprintf(storageListExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         name,
+		Short:       storageListShortDesc,
+		Long:        storageListLongDesc,
+		Example:     fmt.Sprintf(storageListExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -99,11 +99,12 @@ func (o *URLListOptions) Run() (err error) {
 func NewCmdURLList(name, fullName string) *cobra.Command {
 	o := NewURLListOptions()
 	urlListCmd := &cobra.Command{
-		Use:     name,
-		Short:   urlListShortDesc,
-		Long:    urlListLongDesc,
-		Example: fmt.Sprintf(urlListExample, fullName),
-		Args:    cobra.NoArgs,
+		Use:         name,
+		Short:       urlListShortDesc,
+		Long:        urlListLongDesc,
+		Example:     fmt.Sprintf(urlListExample, fullName),
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -17,10 +17,6 @@ type Runnable interface {
 }
 
 func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
-	//flag.CommandLine.MarkHidden("o")
-
-	//flag.CommandLine.Lookup("o").Hidden = true
-	cmd.Flag("o").Hidden = true
 
 	// CheckMachineReadableOutput
 	// fixes / checks all related machine readable output functions

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -204,6 +204,28 @@ func VisitCommands(cmd *cobra.Command, f func(*cobra.Command)) {
 	}
 }
 
+// ModifyAdditionalFlags modifies the flags and updates the descriptions
+// as well as changes whether or not machine readable output
+// has been passed in..
+//
+// Return the flag usages for the help outout
+func ModifyAdditionalFlags(cmd *cobra.Command) string {
+
+	// Hide the machine readable output if the command
+	// does not have the annotation.
+	machineOutput := cmd.Annotations["machineoutput"]
+	f := cmd.InheritedFlags()
+
+	f.VisitAll(func(f *pflag.Flag) {
+		// Remove json flag if machineoutput has not been passed in
+		if f.Name == "o" && machineOutput == "" {
+			f.Hidden = true
+		}
+	})
+
+	return CapitalizeFlagDescriptions(f)
+}
+
 // CapitalizeFlagDescriptions adds capitalizations
 func CapitalizeFlagDescriptions(f *pflag.FlagSet) string {
 	f.VisitAll(func(f *pflag.Flag) {
@@ -231,8 +253,8 @@ Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
 Flags:
 {{CapitalizeFlagDescriptions .LocalFlags | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
 
-Global Flags:
-{{CapitalizeFlagDescriptions .InheritedFlags | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+Additional Flags:
+{{ModifyAdditionalFlags . | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -218,8 +218,8 @@ func ModifyAdditionalFlags(cmd *cobra.Command) string {
 
 	f.VisitAll(func(f *pflag.Flag) {
 		// Remove json flag if machineoutput has not been passed in
-		if f.Name == "o" && machineOutput == "" {
-			f.Hidden = true
+		if f.Name == "o" && machineOutput == "json" {
+			f.Hidden = false
 		}
 	})
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -39,6 +39,25 @@ func componentTests(args ...string) {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
+	Context("Generic machine readable output tests", func() {
+
+		It("Command should fail if json is non-existent for a command", func() {
+			output := helper.CmdShouldFail("odo", "version", "-o", "json")
+			Expect(output).To(ContainSubstring("Machine readable output is not yet implemented for this command"))
+		})
+
+		It("Help for odo version should not contain machine output", func() {
+			output := helper.CmdShouldPass("odo", "version", "--help")
+			Expect(output).NotTo(ContainSubstring("Specify output format, supported format: json"))
+		})
+
+		It("Help for odo create should contain machine output", func() {
+			output := helper.CmdShouldPass("odo", "create", "--help")
+			Expect(output).To(ContainSubstring("Specify output format, supported format: json"))
+		})
+
+	})
+
 	Context("Creating component", func() {
 		JustBeforeEach(func() {
 			project = helper.CreateRandProject()


### PR DESCRIPTION
This PR:    
    
 - Moves annotations to `&cobra.Command` struct creation rather than    
 using the command to add it    
 - Errors out if `-o json` has been passed, but json support has not    
 been added    
 - Hides the `-o json` command if it's not impemented    
 - Solves the issue of https://github.com/openshift/odo/issues/2031    
 - Changes "Global Flags" to "Additional Flags"
  
Closes https://github.com/openshift/odo/issues/2031    