### PR TITLE
Fixing login flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SLOW_SPEC_THRESHOLD := 120
 # Env variable VERBOSE is the verbose flag. Setting VERBOSE= turns off verbose output.
 VERBOSE=-v
 
-GINKGO_FLAGS_ALL = $(VERBOSE) -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
+GINKGO_FLAGS_ALL = $(VERBOSE) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
 
 # Flags for tests that must not be run in parallel.
 GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SLOW_SPEC_THRESHOLD := 120
 # Env variable VERBOSE is the verbose flag. Setting VERBOSE= turns off verbose output.
 VERBOSE=-v
 
-GINKGO_FLAGS_ALL = $(VERBOSE) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
+GINKGO_FLAGS_ALL = $(VERBOSE) -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
 
 # Flags for tests that must not be run in parallel.
 GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -11,13 +11,11 @@ import (
 var _ = Describe("odo login and logout command tests", func() {
 	// user related constants
 	const loginTestUserForNoProject = "odologinnoproject"
-	const loginTestUserForSingleProject1 = "odologinsingleproject1"
-	const odoTestProjectForSingleProject1 = "odologintestproject1"
 	const loginTestUserPassword = "developer"
 	var session1 string
-	var testUserToken1 string
+	var testUserToken string
 	var oc helper.OcRunner
-	var currentUserToken1 string
+	var currentUserToken string
 
 	BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
@@ -41,7 +39,9 @@ var _ = Describe("odo login and logout command tests", func() {
 
 	Context("when running login tests", func() {
 		It("should successful with correct credentials and fails with incorrect token", func() {
-			currentUserToken1 = oc.GetToken()
+			// Current user login token
+			currentUserToken = oc.GetToken()
+
 			// Login successful without any projects with appropriate message
 			session1 = helper.CmdShouldPass("odo", "login", "-u", loginTestUserForNoProject, "-p", loginTestUserPassword)
 			Expect(session1).To(ContainSubstring("Login successful"))
@@ -50,9 +50,11 @@ var _ = Describe("odo login and logout command tests", func() {
 			session1 = oc.GetLoginUser()
 			Expect(session1).To(ContainSubstring(loginTestUserForNoProject))
 
+			// odologinnoproject user login token
+			testUserToken = oc.GetToken()
+
 			// Login successful with token without any projects with appropriate message
-			testUserToken1 = oc.GetToken()
-			session1 = helper.CmdShouldPass("odo", "login", "-t", testUserToken1)
+			session1 = helper.CmdShouldPass("odo", "login", "-t", testUserToken)
 			Expect(session1).To(ContainSubstring("Logged into"))
 			Expect(session1).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
 			Expect(session1).To(ContainSubstring("odo project create <project-name>"))
@@ -62,7 +64,9 @@ var _ = Describe("odo login and logout command tests", func() {
 			// Login fails on invalid token with appropriate message
 			sessionErr := helper.CmdShouldFail("odo", "login", "-t", "verybadtoken")
 			Expect(sessionErr).To(ContainSubstring("The token provided is invalid or expired"))
-			helper.CmdShouldPass("odo", "login", "--token", currentUserToken1)
+
+			// loging back to current user
+			helper.CmdShouldPass("odo", "login", "--token", currentUserToken)
 		})
 	})
 })

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -39,29 +39,27 @@ var _ = Describe("odo login and logout command tests", func() {
 		})
 	})
 
-	Context("Run login tests with no active projects, having default is also considered as not having active project", func() {
-		It("Should login successfully with username and password without any projects with appropriate message", func() {
+	Context("when running login tests", func() {
+		It("should successful with correct credentials and fails with incorrect token", func() {
 			currentUserToken1 = oc.GetToken()
+			// Login successful without any projects with appropriate message
 			session1 = helper.CmdShouldPass("odo", "login", "-u", loginTestUserForNoProject, "-p", loginTestUserPassword)
 			Expect(session1).To(ContainSubstring("Login successful"))
 			Expect(session1).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
 			Expect(session1).To(ContainSubstring("odo project create <project-name>"))
 			session1 = oc.GetLoginUser()
 			Expect(session1).To(ContainSubstring(loginTestUserForNoProject))
-			// One initialization needs one login, hence it happens here
-			testUserToken1 = oc.GetToken()
-		})
 
-		It("Should login successfully with token without any projects with appropriate message", func() {
+			// Login successful with token without any projects with appropriate message
+			testUserToken1 = oc.GetToken()
 			session1 = helper.CmdShouldPass("odo", "login", "-t", testUserToken1)
 			Expect(session1).To(ContainSubstring("Logged into"))
 			Expect(session1).To(ContainSubstring("You don't have any projects. You can try to create a new project, by running"))
 			Expect(session1).To(ContainSubstring("odo project create <project-name>"))
 			session1 = oc.GetLoginUser()
 			Expect(session1).To(ContainSubstring(loginTestUserForNoProject))
-		})
 
-		It("Should fail login on invalid token with appropriate message", func() {
+			// Login fails on invalid token with appropriate message
 			sessionErr := helper.CmdShouldFail("odo", "login", "-t", "verybadtoken")
 			Expect(sessionErr).To(ContainSubstring("The token provided is invalid or expired"))
 			helper.CmdShouldPass("odo", "login", "--token", currentUserToken1)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Making each login test spec independent.
## Was the change discussed in an issue?
https://github.com/openshift/odo/pull/2162#issuecomment-534467268
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-cmd-login-logout