### PR TITLE
Fixing login, service and link reports path

### DIFF
--- a/tests/integration/loginlogout/loginlogout_suite_test.go
+++ b/tests/integration/loginlogout/loginlogout_suite_test.go
@@ -10,5 +10,5 @@ import (
 
 func TestLoginlogout(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Loginlogout Suite", []Reporter{reporter.JunitReport(t, "../../reports")})
+	RunSpecsWithDefaultAndCustomReporters(t, "Loginlogout Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
 }

--- a/tests/integration/servicecatalog/servicecatalog_suite_test.go
+++ b/tests/integration/servicecatalog/servicecatalog_suite_test.go
@@ -10,5 +10,5 @@ import (
 
 func TestServicecatalog(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Servicecatalog Suite", []Reporter{reporter.JunitReport(t, "../../reports")})
+	RunSpecsWithDefaultAndCustomReporters(t, "Servicecatalog Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
sync with other test ```/reports``` directory
## Was the change discussed in an issue?
no
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
login, service and link test reports should be generated in ```reports/``` directory