### PR TITLE
Fixes double deployment for git components on second push and later

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -3701,8 +3701,8 @@ func TestUpdateDCToGit(t *testing.T) {
 				}
 
 				// Check that the new patch actually has the new "image"
-				if !tt.wantErr == (dc.Spec.Template.Spec.Containers[0].Image != tt.args.newImage) {
-					return true, nil, fmt.Errorf("got %s image, suppose to get %s", dc.Spec.Template.Spec.Containers[0].Image, tt.args.newImage)
+				if !tt.wantErr == (dc.Spec.Template.Spec.Containers[0].Image != "") {
+					return true, nil, fmt.Errorf("got %s image, suppose to get %s", dc.Spec.Template.Spec.Containers[0].Image, "")
 				}
 
 				return true, dc, nil

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -268,7 +268,9 @@ func generateGitDeploymentConfig(commonObjectMeta metav1.ObjectMeta, image strin
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Image: image,
+							// image stream trigger and specifying an image at the same time are mutually exclusive options
+							// thus we put "" into image field as we are specifying an image stream trigger
+							Image: "",
 							Name:  commonObjectMeta.Name,
 							Ports: containerPorts,
 							Env:   envVars,
@@ -277,9 +279,6 @@ func generateGitDeploymentConfig(commonObjectMeta metav1.ObjectMeta, image strin
 				},
 			},
 			Triggers: []appsv1.DeploymentTriggerPolicy{
-				{
-					Type: "ConfigChange",
-				},
 				{
 					Type: "ImageChange",
 					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -42,7 +42,7 @@ var _ = Describe("odo url command tests", func() {
 		It("should list appropriate URLs and push message", func() {
 			var stdout string
 			url1 := helper.RandString(5)
-			//url2 := helper.RandString(5)
+			url2 := helper.RandString(5)
 			componentName := helper.RandString(6)
 			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -62,15 +62,13 @@ var _ = Describe("odo url command tests", func() {
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
 
-			// Uncomment once https://github.com/openshift/odo/issues/1832 is fixed
-
-			// helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
-			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			// helper.MatchAllInOutput(stdout, []string{url1, "Absent", url2, "Present", "create/delete URLs", "odo push"})
-			// helper.CmdShouldPass("odo", "push", "--context", context)
-			// stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
-			// helper.MatchAllInOutput(stdout, []string{url2, "Present"})
-			// helper.DontMatchAllInOutput(stdout, []string{url1, "Absent", "odo push"})
+			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8000", "--context", context)
+			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url2, "Not Pushed", "odo push"})
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url2, "Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{url1, "Not Pushed", "odo push"})
 		})
 	})
 


### PR DESCRIPTION
fixes #1981 

How to test:
1. Trigger `test-cmd-url` on a 4.2 cluster close to 10 times and check if the error described in the issue occurs or not and also if the second push only triggers a single deployment revision.  