### PR TITLE
Updates machine readable output for `odo app`

### DIFF
--- a/docs/machine-output.md
+++ b/docs/machine-output.md
@@ -6,7 +6,7 @@ This document outlines all the machine readable output options and examples.
  
 ```json
 {
-  "kind": "app",
+  "kind": "Application",
   "apiVersion": "odo.openshift.io/v1alpha1",
   "metadata": {
     "name": "app",
@@ -25,12 +25,12 @@ This document outlines all the machine readable output options and examples.
  
 ```json
 {
-  "kind": "List",
+  "kind": "ApplicationList",
   "apiVersion": "odo.openshift.io/v1alpha1",
   "metadata": {},
   "items": [
     {
-      "kind": "app",
+      "kind": "Application",
       "apiVersion": "odo.openshift.io/v1alpha1",
       "metadata": {
         "name": "app",
@@ -55,7 +55,7 @@ This document outlines all the machine readable output options and examples.
  
 ```json
 {
-  "kind": "List",
+  "kind": "ApplicationList",
   "apiVersion": "odo.openshift.io/v1alpha1",
   "metadata": {},
   "items": [

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -16,8 +16,8 @@ const (
 	appPrefixMaxLen   = 12
 	appNameMaxRetries = 3
 	appAPIVersion     = "odo.openshift.io/v1alpha1"
-	appKind           = "app"
-	appList           = "List"
+	appKind           = "Application"
+	appList           = "ApplicationList"
 )
 
 // List all applications in current project

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -50,7 +50,7 @@ var _ = Describe("odo app command tests", func() {
 			appList := helper.CmdShouldPass("odo", "app", "list", "--project", project)
 			Expect(appList).To(ContainSubstring("There are no applications deployed"))
 			actual := helper.CmdShouldPass("odo", "app", "list", "-o", "json", "--project", project)
-			desired := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
+			desired := `{"kind":"ApplicationList","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
 			Expect(desired).Should(MatchJSON(actual))
 
 			appDelete := helper.CmdShouldFail("odo", "app", "delete", "test", "--project", project, "-f")
@@ -86,7 +86,7 @@ var _ = Describe("odo app command tests", func() {
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe")
-			desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{}}`, project)
+			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{}}`, project)
 			actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", "myapp", "-o", "json")
 			Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 
@@ -118,11 +118,11 @@ var _ = Describe("odo app command tests", func() {
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "app", "list", "-o", "json", "--project", project)
 			//desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}]}`, project, cmpName)
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"ApplicationList","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}]}`, project, cmpName)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project)
-			desiredDesAppJSON := fmt.Sprintf(`{"kind":"app","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}`, appName, project, cmpName)
+			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}`, appName, project, cmpName)
 			actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project, "-o", "json")
 			Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 


### PR DESCRIPTION
This PR:
  - Capitalizes the Kind to Application
  - Uses the full name of Application
  - Uses ApplicationList instead of List (which is already taken by `odo
  list`)