### PR TITLE
Bump odo version to 1.0.0-beta6

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,7 +16,7 @@ LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts-container \
     summary="This image contains the Linux, Mac and Windows version of odo"
 
 # Change version as needed. Note no "-" is allowed
-LABEL version=1.0.0beta5
+LABEL version=1.0.0-beta6
 
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe

--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -44,6 +44,9 @@ Syntax
 | link:#create[create]
 | Create a new component
 
+| link:#debug[debug]
+| Debug commands (port-forward)
+
 | link:#delete[delete]
 | Delete an existing component
 
@@ -106,7 +109,7 @@ CLI Structure
 
 [source,sh]
 ----
-odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --skip-connection-check --stderrthreshold --v --vmodule : odo (OpenShift Do) (app, catalog, component, config, create, delete, describe, link, list, log, login, logout, preference, project, push, service, storage, unlink, update, url, utils, version, watch)
+odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --stderrthreshold --v --vmodule : odo (OpenShift Do) (app, catalog, component, config, create, debug, delete, describe, link, list, log, login, logout, preference, project, push, service, storage, unlink, update, url, utils, version, watch)
     app : Perform application operations (delete, describe, list)
         delete --force --project : Delete the given application
         describe --project : Describe the given application
@@ -115,7 +118,7 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --skip-conn
         describe : Describe catalog item (service)
             service : Describe a service
         list : List all available component & service types. (components, services)
-            components : List all components available.
+            components : List all components
             services : Lists all available services
         search : Search available component & service types. (component, service)
             component : Search component type in catalog
@@ -137,6 +140,8 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --skip-conn
         unset --context --env --force : Unset a value in odo config file
         view --context : View current configuration values
     create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --now --port --project --ref : Create a new component
+    debug : Debug commands (port-forward)
+        port-forward --context --local-port : Forward one or more local ports to a pod
     delete --all --app --context --force --project : Delete an existing component
     describe --app --context --project : Describe the given component
     link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
@@ -287,6 +292,7 @@ _________________
   odo config set MinMemory 50M
   odo config set MaxMemory 500M
   odo config set Memory 250M
+  odo config set DebugPort 4040
   odo config set Ignore false
   odo config set MinCPU 0.5
   odo config set MaxCPU 2
@@ -301,6 +307,7 @@ _________________
   odo config unset MinMemory
   odo config unset MaxMemory
   odo config unset Memory
+  odo config unset DebugPort
   odo config unset Ignore
   odo config unset MinCPU
   odo config unset MaxCPU
@@ -316,6 +323,7 @@ Modifies odo specific configuration settings within the config file.
 Available Local Parameters:
 Application - Application is the name of application the component needs to be part of
 CPU - The minimum and maximum CPU a component can consume
+DebugPort - The port on which the debugger will listen on the component
 Ignore - Consider the .odoignore file for push and watch
 MaxCPU - The maximum CPU a component can consume
 MaxMemory - The maximum memory a component can consume
@@ -397,6 +405,28 @@ If a component name is not provided, it'll be auto-generated.
 By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version If version is not specified by default, latest will be chosen as the version. 
 
 A full list of component types that can be deployed is available using: 'odo catalog list'
+
+[[debug]]
+debug
+~~~~~
+
+[source,sh]
+----
+debug
+----
+
+_________________
+Example using debug
+_________________
+
+[source,sh]
+----
+
+----
+
+Warning - Debug is currently in tech preview and hence is subject to change in future.
+
+Debug allows you to remotely debug you application
 
 [[delete]]
 delete

--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -417,7 +417,7 @@ To release a new version:
 
 * Updates the version in the following files:
 
-** link:/pkg/odo/cli/version/version.go[`cmd/version.go`]
+** link:/pkg/odo/cli/version/version.go[`pkg/odo/cli/version/version.go`]
 ** link:/scripts/installer.sh[`scripts/installer.sh`]
 ** link:/Dockerfile.rhel[`Dockerfile.rhel`]
 ** link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0-beta5"
+	VERSION = "v1.0.0-beta6"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ set -e
 ODO_VERSION="latest"
 
 # Latest released odo version
-LATEST_VERSION="v1.0.0-beta5"
+LATEST_VERSION="v1.0.0-beta6"
 
 GITHUB_RELEASES_URL="https://github.com/openshift/odo/releases/download/${LATEST_VERSION}"
 BINTRAY_URL="https://dl.bintray.com/odo/odo/latest"

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -5,7 +5,7 @@ set +ex
 echo "Reading ODO_VERSION, ODO_RELEASE and GIT_COMMIT env, if they are set"
 # Change version as needed. In most cases ODO_RELEASE would not be touched unless
 # we want to do a re-lease of same version as we are not backporting
-export ODO_VERSION=${ODO_VERSION:=1.0.0-beta5}
+export ODO_VERSION=${ODO_VERSION:=1.0.0-beta6}
 export ODO_RELEASE=${ODO_RELEASE:=1}
 
 export GIT_COMMIT=${GIT_COMMIT:=`git rev-parse --short HEAD 2>/dev/null`}


### PR DESCRIPTION
## Enhancements

* Support for `odo debug`. `odo` now lets users debug the application running in the pod on OpenShift (#2043)
* Add json output for `odo catalog list services`. This helps the consumers of `odo`, i.e., Adapters (#2066)
* Add json output for `odo service list`. This helps the consumers of `odo`, i.e., Adapters (#2098)
* Add RPM spec for odo. Very soon, an RPM for `odo` will be available and `odo` could be installed with `yum/dnf install odo`  (#2107)
* Replace dumb-init with go-init. To avoid having to maintain our own RPM for dumb-init  (#2130)
* Refactor catalog code  (#2133)
* Print environment variables when linking a component with another component/service (#2035)

## Bug Fixes
* Fix populating parameters of service when created in non-interactive mode. `odo service create` didn't pick-up the values provided for parameters with `-p` flag (#2040)
* Fix `odo list` for component that's not pushed. `odo list` output was empty for the components that have not been pushed (#2046)
* Removes overlapping messages for odo git components (#2091)

## Testing
* Fixing e2e vs. integration naming (#1878)
* Run tests on OpenShift 4.2 (#2059)
* Add "pretty" library for testing (#2122)
  This makes debugging less painful to the eyes.

## Documentation
*  Add development doc on machine readable output (#2123)