### PR TITLE
Fixes path for odo create interactive

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -337,12 +337,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		if selectedSourceType == config.BINARY {
 
 			// We ask for the source of the component context
-			co.componentContext = ui.EnterInputTypePath("context", currentDirectory, currentDirectory)
+			co.componentContext = ui.EnterInputTypePath("context", currentDirectory, ".")
 			glog.V(4).Infof("Context: %s", co.componentContext)
 
 			// If it's a binary, we have to ask where the actual binary in relation
 			// to the context
-			selectedSourcePath = ui.EnterInputTypePath("binary", currentDirectory)
+			selectedSourcePath = ui.EnterInputTypePath("binary", ".")
 
 			// Get the correct source location
 			sourceLocation, err := getSourceLocation(selectedSourcePath, co.componentContext)
@@ -361,7 +361,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		} else if selectedSourceType == config.LOCAL {
 
 			// We ask for the source of the component, in this case the "path"!
-			co.componentContext = ui.EnterInputTypePath("path", currentDirectory, currentDirectory)
+			co.componentContext = ui.EnterInputTypePath("path", currentDirectory, ".")
 
 			// Get the correct source location
 			if co.componentContext == "" {

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -98,12 +98,7 @@ func EnterInputTypePath(inputType string, currentDir string, defaultPath ...stri
 	err := survey.AskOne(prompt, &path, validation.PathValidator)
 	ui.HandleError(err)
 
-	// We handle getting the absolute path here..
-	absPath, err := util.GetAbsPath(path)
-	if err != nil {
-		ui.HandleError(err)
-	}
-	return absPath
+	return path
 }
 
 // we need this because the validator for the component name needs use info from the Context


### PR DESCRIPTION
fixes #2163 

How to test:
Trigger `odo create` in a directory, enter response of `Location of path component, relative to ...` and check if the correct response is stored by `odo config view`