### PR TITLE
fix sha256 generation for release

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -45,9 +45,9 @@ function release_sha() {
     release_dir_files=`find $RELEASE_DIR -maxdepth 1 ! -name SHA256_SUM -type f -printf "%f\n"`
     for filename in $release_dir_files; do
         sha_sum=`sha256sum $RELEASE_DIR/${filename}|awk '{ print $1 }'`; echo $sha_sum  $filename;
-    done > ${RELEASE_DIR}SHA256_SUM
+    done > ${RELEASE_DIR}/SHA256_SUM
     echo "The SHA256 SUM for the release packages are:"
-    cat ${RELEASE_DIR}SHA256_SUM
+    cat ${RELEASE_DIR}/SHA256_SUM
 }
 
 release_sha


### PR DESCRIPTION
SHA256_SUM file was generated in the wrong directory, and it was not uploaded to the github release