### PR TITLE
Fixes odo list with path flag

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -964,10 +964,12 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 					return err
 				}
 
+				// if the .odo folder doesn't contain a proper config file
 				if data.GetName() == "" || data.GetApplication() == "" || data.GetProject() == "" {
 					return nil
 				}
 
+				// since the config file maybe belong to a component of a different project
 				client.Namespace = data.GetProject()
 				exist, err := Exists(client, data.GetName(), data.GetApplication())
 				if err != nil {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -963,6 +963,12 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 				if err != nil {
 					return err
 				}
+
+				if data.GetName() == "" || data.GetApplication() == "" || data.GetProject() == "" {
+					return nil
+				}
+
+				client.Namespace = data.GetProject()
 				exist, err := Exists(client, data.GetName(), data.GetApplication())
 				if err != nil {
 					return err


### PR DESCRIPTION
fixes #2186 
fixes #2032 

How to test:

- Create two or more odo components belonging to different projects and push all to the cluster
- try `odo list --path <root_of_both_component_folders>`
- check if the states for the components are right or not