### PR TITLE
fix --binary  flag when --context is not set

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -490,10 +490,10 @@ func ValidateComponentCreateRequest(client *occlient.Client, componentSettings c
 	// Check to see if the catalog type actually exists
 	exists, err := catalog.ComponentExists(client, componentType, componentVersion)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to check component of type %s", componentType)
+		return errors.Wrapf(err, "failed to check component of type %s", componentType)
 	}
 	if !exists {
-		return fmt.Errorf("Failed to find component of type %s and version%s", componentType, componentVersion)
+		return fmt.Errorf("failed to find component of type %s and version %s", componentType, componentVersion)
 	}
 
 	// Validate component name

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -141,8 +141,14 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 		if err != nil {
 			return err
 		}
+		// Convert componentContext to absolute path, so it can be safely used in filepath.Rel
+		// even when it is not set (empty). In this case filepath.Abs will return current directory.
+		absContext, err := filepath.Abs(co.componentContext)
+		if err != nil {
+			return errors.Wrapf(err, "unable to convert \"%s\" to absolute path", co.componentContext)
+		}
 		// we need to store the SourceLocation relative to the componentContext
-		relativePathToSource, err := filepath.Rel(co.componentContext, cPath)
+		relativePathToSource, err := filepath.Rel(absContext, cPath)
 		if err != nil {
 			return err
 		}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -169,6 +169,14 @@ func componentTests(args ...string) {
 			Expect(output).To(ContainSubstring("ComponentTypeList"))
 		})
 
+		It("binary component should not fail when --context is not set", func() {
+			oc.ImportJavaIS(project)
+			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
+			// Was failing due to https://github.com/openshift/odo/issues/1969
+			helper.CmdShouldPass("odo", "create", "java:8", "sb-jar-test", "--project",
+				project, "--binary", filepath.Join(context, "sb.jar"))
+		})
+
 	})
 
 	Context("Test odo push with --source and --config flags", func() {


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

## Was the change discussed in an issue?
fixes #1969
<!-- Please do Link issues here. -->

## How to test changes?
```
cd /component/path
odo component create java:8 --binary /component/path/target/java.jar
```
should succeed

Previously it was failing. This is a valid command, as binary is inside the context.
