### PR TITLE
Check that --binary is in --context folder

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -117,10 +117,14 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 		// even when it is not set (empty). In this case filepath.Abs will return current directory.
 		absContext, err := filepath.Abs(co.componentContext)
 		if err != nil {
-			return errors.Wrapf(err, "unable to convert \"%s\" to absolute path", co.componentContext)
+			return err
+		}
+		absPath, err := filepath.Abs(cPath)
+		if err != nil {
+			return err
 		}
 		// we need to store the SourceLocation relative to the componentContext
-		relativePathToSource, err := filepath.Rel(absContext, cPath)
+		relativePathToSource, err := filepath.Rel(absContext, absPath)
 		if err != nil {
 			return err
 		}
@@ -446,7 +450,7 @@ func (co *CreateOptions) Validate() (err error) {
 	s := log.Spinner("Validating component")
 	defer s.End(false)
 
-	if err := component.ValidateComponentCreateRequest(co.Context.Client, co.componentSettings, false, false); err != nil {
+	if err := component.ValidateComponentCreateRequest(co.Context.Client, co.componentSettings, co.componentContext); err != nil {
 		return err
 	}
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
@@ -85,7 +86,7 @@ func (po *PushOptions) Validate() (err error) {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
 	}
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), po.isCmpExists, false); err != nil {
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
 		s.End(false)
 		log.Info("Run 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *po.localConfigInfo.GetComponentSettings().Type, errors.Cause(err))

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -214,8 +214,18 @@ func componentTests(args ...string) {
 
 			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(context, "sb.jar"), "--context", newContext)
-			Expect(output).To(ContainSubstring("inside of the context folder"))
+			Expect(output).To(ContainSubstring("inside of the context directory"))
+		})
 
+		It("binary component is valid if path is relative and includes ../", func() {
+			oc.ImportJavaIS(project)
+			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
+
+			relativeContext := fmt.Sprintf("..%c%s", filepath.Separator, filepath.Base(context))
+			fmt.Printf("relativeContext = %#v\n", relativeContext)
+
+			helper.CmdShouldPass("odo", "create", "java:8", "sb-jar-test", "--project",
+				project, "--binary", filepath.Join(context, "sb.jar"), "--context", relativeContext)
 		})
 
 	})

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -205,6 +205,19 @@ func componentTests(args ...string) {
 				project, "--binary", filepath.Join(context, "sb.jar"))
 		})
 
+		It("binary component should fail when --binary is not in --context folder", func() {
+			oc.ImportJavaIS(project)
+			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
+
+			newContext := helper.CreateNewContext()
+			defer helper.DeleteDir(newContext)
+
+			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--project",
+				project, "--binary", filepath.Join(context, "sb.jar"), "--context", newContext)
+			Expect(output).To(ContainSubstring("inside of the context folder"))
+
+		})
+
 	})
 
 	Context("Test odo push with --source and --config flags", func() {


### PR DESCRIPTION
odo create command should verify that binary is inside the context folder.

how to test:
- When the binary file is outside of the context folder the command should fail.
  - `odo create --binary ../file.jar`
  - `odo create --binary target/file.jar --context my-component`

- When the binary is in the context folder everything should be ok.
  - `odo create --binary target/file.jar`
  - `odo create --binary ../mycomponent/file.jar --context ../mycomponent`

fixes https://github.com/openshift/odo/issues/2266