### PR TITLE
Fixes project wait flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test-cmd-service:
 # Run odo project command tests
 .PHONY: test-cmd-project
 test-cmd-project:
-	ginkgo $(GINKGO_FLAGS) -focus="odo project command tests" tests/integration/
+	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo project command tests" tests/integration/project/
 
 # Run odo app command tests
 .PHONY: test-cmd-app

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -523,8 +523,9 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 	// If watched is created after the project it can lead to situation when the project is created before the watcher.
 	// When this happens, it gets stuck waiting for event that already happened.
 	var watcher watch.Interface
+	var err error
 	if wait {
-		watcher, err := c.projectClient.Projects().Watch(metav1.ListOptions{
+		watcher, err = c.projectClient.Projects().Watch(metav1.ListOptions{
 			FieldSelector: fields.Set{"metadata.name": projectName}.AsSelector().String(),
 		})
 		if err != nil {
@@ -538,7 +539,7 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 			Name: projectName,
 		},
 	}
-	_, err := c.projectClient.ProjectRequests().Create(projectRequest)
+	_, err = c.projectClient.ProjectRequests().Create(projectRequest)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create new project %s", projectName)
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2304,7 +2304,7 @@ func TestCreateNewProject(t *testing.T) {
 						},
 					})
 				}()
-				fkclientset.ProjClientset.AddWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				fkclientset.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 					if len(tt.projName) == 0 {
 						return true, nil, fmt.Errorf("error watching project")
 					}

--- a/tests/integration/cmd_project_test.go
+++ b/tests/integration/cmd_project_test.go
@@ -41,7 +41,6 @@ var _ = Describe("odo project command tests", func() {
 	Context("when running project command app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute list along with machine readable output", func() {
 			helper.CmdRunner("odo", "project", "list")
-			time.Sleep(1 * time.Second)
 			listOutput := helper.CmdShouldPass("odo", "project", "list")
 			Expect(listOutput).To(ContainSubstring(project))
 

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -1,4 +1,4 @@
-package integration
+package project
 
 import (
 	"os"
@@ -40,13 +40,12 @@ var _ = Describe("odo project command tests", func() {
 
 	Context("when running project command app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute list along with machine readable output", func() {
-			helper.CmdRunner("odo", "project", "list")
 			listOutput := helper.CmdShouldPass("odo", "project", "list")
 			Expect(listOutput).To(ContainSubstring(project))
 
 			// project deletion doesn't happen immediately, so we test subset of the string
 			listOutputJson := helper.CmdShouldPass("odo", "project", "list", "-o", "json")
-			Expect(listOutputJson).To(ContainSubstring(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"` + project + `","namespace":"` + project + `","creationTimestamp":null},"spec":{},"status":{"active":false}}`))
+			Expect(listOutputJson).To(ContainSubstring(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"` + project + `","namespace":"` + project + `","creationTimestamp":null},"spec":{},"status":{"active":true}}`))
 		})
 	})
 })

--- a/tests/integration/project/project_suite_test.go
+++ b/tests/integration/project/project_suite_test.go
@@ -1,0 +1,14 @@
+package project
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/tests/helper/reporter"
+)
+
+func TestProject(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+}


### PR DESCRIPTION
fixes #2117 

How to test:
Check if the `odo project create <project-name> -w` works and it waits properly for the project to be ready.