### PR TITLE
ServiceTypeList should be List in machine output

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -81,7 +81,7 @@ func ListServices(client *occlient.Client) (ServiceTypeList, error) {
 
 	return ServiceTypeList{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceTypeList",
+			Kind:       "List",
 			APIVersion: "odo.openshift.io/v1alpha1",
 		},
 		Items: clusterServiceClasses,
@@ -105,7 +105,7 @@ func SearchService(client *occlient.Client, name string) (ServiceTypeList, error
 
 	return ServiceTypeList{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceTypeList",
+			Kind:       "List",
 			APIVersion: "odo.openshift.io/v1alpha1",
 		},
 		Items: result,

--- a/pkg/odo/cli/catalog/util/util_test.go
+++ b/pkg/odo/cli/catalog/util/util_test.go
@@ -28,7 +28,7 @@ func TestFilterHiddenServices(t *testing.T) {
 			name: "Case 2: non empty input",
 			input: catalog.ServiceTypeList{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "ServiceTypeList",
+					Kind:       "List",
 					APIVersion: "odo.openshift.io/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +71,7 @@ func TestFilterHiddenServices(t *testing.T) {
 			},
 			expected: catalog.ServiceTypeList{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "ServiceTypeList",
+					Kind:       "List",
 					APIVersion: "odo.openshift.io/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -49,7 +49,7 @@ var _ = Describe("odo service command tests", func() {
 		It("should succeed listing catalog components", func() {
 			// Since service catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
 			output := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			Expect(output).To(ContainSubstring("ServiceTypeList"))
+			Expect(output).To(ContainSubstring("List"))
 		})
 	})
 


### PR DESCRIPTION
For `odo catalog list services` machine-readable output for `Kind`
should simply be `List`