### PR TITLE
ComponentTypeList should be List in machine output

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -26,7 +26,7 @@ func ListComponents(client *occlient.Client) (ComponentTypeList, error) {
 
 	return ComponentTypeList{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ComponentTypeList",
+			Kind:       "List",
 			APIVersion: "odo.openshift.io/v1alpha1",
 		},
 		Items: catalogList,

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -194,7 +194,7 @@ func componentTests(args ...string) {
 
 			// Since components catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			Expect(output).To(ContainSubstring("ComponentTypeList"))
+			Expect(output).To(ContainSubstring("List"))
 		})
 
 		It("binary component should not fail when --context is not set", func() {


### PR DESCRIPTION
For `odo catalog list components` machine-readable output for `Kind`
should simply be `List`