### PR TITLE
Add secrets to `odo describe`

### DIFF
--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -90,7 +90,7 @@ func (o *DescribeOptions) Run() (err error) {
 				for _, currentComponent := range componentList.Items {
 					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, o.Project)
 					util.LogErrorAndExit(err, "")
-					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.Application)
+					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.Application, o.Project)
 					fmt.Println("--------------------------------------")
 				}
 			}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -77,7 +77,7 @@ func (do *DescribeOptions) Run() (err error) {
 		fmt.Println(string(out))
 	} else {
 
-		odoutil.PrintComponentInfo(do.Context.Client, do.componentName, componentDesc, do.Context.Application)
+		odoutil.PrintComponentInfo(do.Context.Client, do.componentName, componentDesc, do.Context.Application, do.Context.Project)
 	}
 
 	return


### PR DESCRIPTION
Adds the "secrets" or environment variables that have been passed into
the component by using the `odo link` feature when connecting to a
database.

Builds upon PR: https://github.com/openshift/odo/pull/2231
Closes: https://github.com/openshift/odo/issues/2232

See the below example of how it now looks like:

```sh
Component Name: nodejs-nodejs-ex-cstb
Type: nodejs
Source: file://./
Environment Variables:
 · foo=bar
 · bar=foo
 · DEBUG_PORT=5858
Storage:
 · mystorage of size 1Gi mounted to /opt/app-root/src/storage/
URLs:
 · http://foobar-app-myproject.192.168.42.79.nip.io exposed via 8080
Linked Components:
 · nodejs2 - Port(s): 8080
Linked Services:
 · mongodb-persistent
   Environment Variables:
    · uri
    · username
    · admin_password
    · database_name
    · password
 · dh-mysql-apb
   Environment Variables:
    · DB_HOST
    · DB_NAME
    · DB_PASSWORD
    · DB_PORT
    · DB_TYPE
    · DB_USER
```