### PR TITLE
Removes app,project and component flag from storage commands

### DIFF
--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -12,10 +12,6 @@ import (
 	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 )
 
 const createRecommendedCommandName = "create"
@@ -104,10 +100,6 @@ func NewCmdStorageCreate(name, fullName string) *cobra.Command {
 	storageCreateCmd.Flags().StringVar(&o.storagePath, "path", "", "Path to mount the storage on")
 	_ = storageCreateCmd.MarkFlagRequired("path")
 	_ = storageCreateCmd.MarkFlagRequired("size")
-
-	projectCmd.AddProjectFlag(storageCreateCmd)
-	appCmd.AddApplicationFlag(storageCreateCmd)
-	componentCmd.AddComponentFlag(storageCreateCmd)
 
 	genericclioptions.AddContextFlag(storageCreateCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(storageCreateCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -5,9 +5,6 @@ import (
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
@@ -102,10 +99,6 @@ func NewCmdStorageDelete(name, fullName string) *cobra.Command {
 
 	storageDeleteCmd.Flags().BoolVarP(&o.storageForceDeleteFlag, "force", "f", false, "Delete storage without prompting")
 	completion.RegisterCommandHandler(storageDeleteCmd, completion.StorageDeleteCompletionHandler)
-
-	projectCmd.AddProjectFlag(storageDeleteCmd)
-	appCmd.AddApplicationFlag(storageDeleteCmd)
-	componentCmd.AddComponentFlag(storageDeleteCmd)
 
 	genericclioptions.AddContextFlag(storageDeleteCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(storageDeleteCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -12,9 +12,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/openshift/odo/pkg/log"
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
@@ -114,10 +111,6 @@ func NewCmdStorageList(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-
-	projectCmd.AddProjectFlag(storageListCmd)
-	appCmd.AddApplicationFlag(storageListCmd)
-	componentCmd.AddComponentFlag(storageListCmd)
 
 	genericclioptions.AddContextFlag(storageListCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(storageListCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
@@ -89,10 +86,6 @@ func NewCmdStorageMount(name, fullName string) *cobra.Command {
 
 	storageMountCmd.Flags().StringVar(&o.storagePath, "path", "", "Path to mount the storage on")
 	_ = storageMountCmd.MarkFlagRequired("path")
-
-	projectCmd.AddProjectFlag(storageMountCmd)
-	appCmd.AddApplicationFlag(storageMountCmd)
-	componentCmd.AddComponentFlag(storageMountCmd)
 
 	completion.RegisterCommandHandler(storageMountCmd, completion.StorageMountCompletionHandler)
 

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -3,9 +3,6 @@ package storage
 import (
 	"fmt"
 	"github.com/openshift/odo/pkg/log"
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
@@ -108,10 +105,6 @@ func NewCmdStorageUnMount(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-
-	projectCmd.AddProjectFlag(storageUnMountCmd)
-	appCmd.AddApplicationFlag(storageUnMountCmd)
-	componentCmd.AddComponentFlag(storageUnMountCmd)
 
 	completion.RegisterCommandHandler(storageUnMountCmd, completion.StorageUnMountCompletionHandler)
 

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -92,7 +92,7 @@ var _ = Describe("odo storage command tests", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
 			helper.CmdShouldPass("odo", "component", "create", "python", "python", "--app", "pyapp", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
-			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--component", "python", "--app", "pyapp", "--project", project, "--path", "/mnt/pv1", "--size", "5Gi", "--context", context)
+			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "5Gi", "--context", context)
 			Expect(storAdd).To(ContainSubstring("python"))
 			helper.CmdShouldPass("odo", "push", "--context", context)
 


### PR DESCRIPTION
fixes #2203 

How to test:
Try the app,project and component flags with all storage commands. ODO will complain of unknown flags for them.