### PR TITLE
Implement `--wait` flag for `odo storage delete` (#1942)

### DIFF
--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -29,6 +29,7 @@ type StorageDeleteOptions struct {
 	storageName            string
 	storageForceDeleteFlag bool
 	componentContext       string
+	wait                   bool
 	localConfig            *config.LocalConfigInfo
 	*genericclioptions.Context
 }
@@ -99,6 +100,7 @@ func NewCmdStorageDelete(name, fullName string) *cobra.Command {
 
 	storageDeleteCmd.Flags().BoolVarP(&o.storageForceDeleteFlag, "force", "f", false, "Delete storage without prompting")
 	completion.RegisterCommandHandler(storageDeleteCmd, completion.StorageDeleteCompletionHandler)
+	storageDeleteCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "Wait until the storage is gone")
 
 	genericclioptions.AddContextFlag(storageDeleteCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(storageDeleteCmd, "context", completion.FileCompletionHandler)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
adds --wait flag for odo storage delete cli command

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/1942
## How to test changes?
I was on a oc project default with odo nodejs app pushed
1. build from source
2. `./odo storage create nodestorage --path=/opt/app-root/src/storage/ --size=1G`
3. `./odo push`
4. `oc get pvc`
5. `./odo storage delete nodestorage --wait`
6. `./odo push`
7. `oc get pvc`