### PR TITLE
Correct odo debug Typo

### DIFF
--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -426,7 +426,7 @@ _________________
 
 Warning - Debug is currently in tech preview and hence is subject to change in future.
 
-Debug allows you to remotely debug you application
+Debug allows you to remotely debug your application
 
 [[delete]]
 delete

--- a/pkg/odo/cli/debug/debug.go
+++ b/pkg/odo/cli/debug/debug.go
@@ -10,7 +10,7 @@ const RecommendedCommandName = "debug"
 
 var DebugLongDesc = `Warning - Debug is currently in tech preview and hence is subject to change in future.
 
-Debug allows you to remotely debug you application`
+Debug allows you to remotely debug your application`
 
 func NewCmdDebug(name, fullName string) *cobra.Command {
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Changes `Debug allows you to remotely debug you application` to `Debug allows you to remotely debug your application`.

## Was the change discussed in an issue?
N/A

## How to test changes?
`odo debug --help` should provide description that shows `Debug allows you to remotely debug your application`
