### PR TITLE
removed example for --component from storage

### DIFF
--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -19,9 +19,6 @@ var (
 	storageDeleteLongDesc  = ktemplates.LongDesc(`Delete storage from component`)
 	storageDeleteExample   = ktemplates.Examples(`  # Delete storage mystorage from the currently active component
   %[1]s mystorage
-
-  # Delete storage mystorage from component 'mongodb'
-  %[1]s mystorage --component mongodb
 `)
 )
 

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -18,9 +18,7 @@ var (
 	storageMountLongDesc  = ktemplates.LongDesc(`mount storage to a component`)
 	storageMountExample   = ktemplates.Examples(` # Mount storage 'dbstorage' to current component
   %[1]s dbstorage --path /data
-
-  # Mount storage 'database' to component 'mongodb'
-  %[1]s database --component mongodb --path /data`)
+`)
 )
 
 type StorageMountOptions struct {

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -2,14 +2,15 @@ package storage
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	"os"
-	"strings"
 )
 
 const unMountRecommendedCommandName = "unmount"
@@ -22,14 +23,8 @@ var (
 	storageUnMountExample = ktemplates.Examples(`  # Unmount storage 'dbstorage' from current component
   %[1]s dbstorage
 
-  # Unmount storage 'database' from component 'mongodb'
-  %[1]s database --component mongodb
-
   # Unmount storage mounted to path '/data' from current component
   %[1]s /data
-
-  # Unmount storage mounted to path '/data' from component 'mongodb'
-  %[1]s /data --component mongodb
 `)
 )
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
We removed the `--component`,`--app` and `--project` flag from `odo storage` but the examples are still present, so cleaning them up

## Was the change discussed in an issue?
part of https://github.com/openshift/odo/issues/2243
<!-- Please do Link issues here. -->

## How to test changes?
`odo storage --help`
shouldn't show `--component` examples
