### PR TITLE
remove --app, --component and --project from odo url

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -32,9 +32,6 @@ var (
   
 	# Create a URL with a specific name and port
 	%[1]s example --port 8080
-  
-	# Create a URL with a specific name and port for component frontend
-	%[1]s example --port 8080 --component frontend
 	  `)
 )
 

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -3,9 +3,6 @@ package url
 import (
 	"fmt"
 
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
-	componentCmd "github.com/openshift/odo/pkg/odo/cli/component"
-	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
@@ -41,21 +38,6 @@ func NewCmdURL(name, fullName string) *cobra.Command {
 	urlCmd.Annotations = map[string]string{"command": "main"}
 	urlCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	urlCmd.AddCommand(urlCreateCmd, urlDeleteCmd, urlListCmd)
-
-	//Adding `--project` flag
-	projectCmd.AddProjectFlag(urlListCmd)
-	projectCmd.AddProjectFlag(urlCreateCmd)
-	projectCmd.AddProjectFlag(urlDeleteCmd)
-
-	//Adding `--application` flag
-	appCmd.AddApplicationFlag(urlListCmd)
-	appCmd.AddApplicationFlag(urlDeleteCmd)
-	appCmd.AddApplicationFlag(urlCreateCmd)
-
-	//Adding `--component` flag
-	componentCmd.AddComponentFlag(urlDeleteCmd)
-	componentCmd.AddComponentFlag(urlListCmd)
-	componentCmd.AddComponentFlag(urlCreateCmd)
 
 	return urlCmd
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
see $SUBJECT

## Was the change discussed in an issue?
part of https://github.com/openshift/odo/issues/2243
<!-- Please do Link issues here. -->

## How to test changes?
```
odo url create --help
```
shouldn't have the flags
