### PR TITLE
Fix Grammar for odo Error for Project Create and Set

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -185,7 +185,7 @@ func resolveProject(command *cobra.Command, client *occlient.Client, lci *config
 		// check that the specified project exists
 		_, err = project.Exists(client, ns)
 		if err != nil {
-			e1 := fmt.Sprintf("You dont have permission to project '%s' or it doesnt exist. Please create or set a different project\n\t", ns)
+			e1 := fmt.Sprintf("You don't have permission to create or set project '%s' or the project doesn't exist. Please create or set a different project\n\t", ns)
 			errFormat := fmt.Sprint(e1, "%s project create|set <project_name>")
 			checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command, errFormat)
 		}


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

Changes the error message grammar for `odo project create` and `odo project set`.

## Was the change discussed in an issue?

Closes #2254 
