### PR TITLE
Fix issue with failing NodeJS component after the container gets restarted

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -96,8 +96,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	//TODO(kadel): change to updated released init-image
-	defaultBootstrapperImage = "quay.io/tkral/odo-supervisord-image:fix-dev-scripts"
+	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.13.1"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -96,7 +96,8 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.13.0"
+	//TODO(kadel): change to updated released init-image
+	defaultBootstrapperImage = "quay.io/tkral/odo-supervisord-image:fix-dev-scripts"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -409,6 +409,8 @@ func addBootstrapSupervisordInitContainer(dc *appsv1.DeploymentConfig, dcName st
 		corev1.Container{
 			Name:  "copy-supervisord",
 			Image: getBootstrapperImage(),
+			//TODO(kadel): remove PullAlways, just for testing
+			ImagePullPolicy: corev1.PullAlways,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      supervisordVolumeName,

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -409,8 +409,6 @@ func addBootstrapSupervisordInitContainer(dc *appsv1.DeploymentConfig, dcName st
 		corev1.Container{
 			Name:  "copy-supervisord",
 			Image: getBootstrapperImage(),
-			//TODO(kadel): remove PullAlways, just for testing
-			ImagePullPolicy: corev1.PullAlways,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      supervisordVolumeName,

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -392,4 +393,16 @@ func (oc *OcRunner) GetEnvs(componentName string, appName string, projectName st
 		mapOutput[name] = value
 	}
 	return mapOutput
+}
+
+// WaitForDCRollout wait for DeploymentConfig to finish active rollout
+// timeout is a maximum wait time in seconds
+func (oc *OcRunner) WaitForDCRollout(dcName string, project string, timeout time.Duration) {
+	session := CmdRunner(oc.path, "rollout", "status",
+		"-w",
+		"-n", project,
+		"dc", dcName)
+
+	Eventually(session).Should(gexec.Exit(0), runningCmd(session.Command))
+	session.Wait(timeout)
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?

This fixes the issue where the source code for nodejs was lost after the container was restarted.
This was due to the fact that we removed steps that were coping source files from the /tmp/src directory to /opt/app-root/src.

This updates just the image used by odo, the actual fix is in odo-init-image - https://github.com/openshift/odo-init-image/pull/40

After this is tested. We will release a new odo-init-image, and update this PR to use the released version.



## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/2224
<!-- Please do Link issues here. -->

## How to test changes?
You can download odo binaries build from this PR at https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/pr-logs/pull/openshift_odo/2265/pull-ci-openshift-odo-master-v4.1-unit/407/artifacts/unit/dist/bin/

```
odo component create nodejs
odo url create
odo push
odo config set --env FOO=vv
odo push
# verify that application is still running, previously it did not
```
or 
```
cd frontend
odo component create nodejs frontend
odo url create
odo push

cd backend
odo component create java backend
odo push

cd frontend
odo link backend --port 8080

# verify that the frontend is running, previously it did not
```


TODO:
 - add proper tests