### PR TITLE
Making debug command test target in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,7 @@ test-cmd-watch:
 
 # Run odo debug command tests
 test-cmd-debug:
-	ginkgo -v -nodes=$(TEST_EXEC_NODES) -focus="odo debug command tests" \
-	slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -randomizeAllSpecs  tests/integration/ -timeout $(TIMEOUT)
+	ginkgo $(GINKGO_FLAGS) -focus="odo debug command tests" tests/integration/
 
 # Run command's integration tests irrespective of service catalog status in the cluster.
 # Service, link and login/logout command tests are not the part of this test run


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Test target execution method should be in sync with other test target
## Was the change discussed in an issue?
No
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
make test-cmd-debug