### PR TITLE
Adds ability to use `odo config unset --env foo=bar`

### DIFF
--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -85,6 +85,8 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
 func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {
+	removeEqualsFromEnvList(&keys)
+
 	newEnvVarList := EnvVarList{}
 	for _, envVar := range envVarList {
 		// if the env is in the keys we skip it
@@ -95,4 +97,16 @@ func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {
 		newEnvVarList = append(newEnvVarList, envVar)
 	}
 	return newEnvVarList
+}
+
+// removeEqualsFromEnvList removes the equal sign from the list of environment variables
+// if (for example) foo=bar was passed in. Since we're only interested in the actual variable name
+// we don't care if foo=bar=foobar has been passed in.. Only the first value.
+func removeEqualsFromEnvList(keys *[]string) {
+
+	// Iterate through, if key contains "=", split it.
+	for index, key := range *keys {
+		(*keys)[index] = strings.Split(key, "=")[0]
+	}
+
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -80,9 +80,8 @@ func (o *UnsetOptions) Validate() (err error) {
 // Run contains the logic for the command
 func (o *UnsetOptions) Run() (err error) {
 
-	// env variables have been provided
+	// Update the environment variables
 	if o.envArray != nil {
-
 		envList := o.lci.GetEnvVars()
 		newEnvList := config.RemoveEnvVarsFromList(envList, o.envArray)
 		if err := o.lci.SetEnvVars(newEnvList); err != nil {
@@ -93,6 +92,7 @@ func (o *UnsetOptions) Run() (err error) {
 		return nil
 	}
 
+	// Update the parameters
 	if isSet := o.lci.IsSet(o.paramName); isSet {
 		if !o.configForceFlag && !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the config", o.paramName)) {
 			fmt.Println("Aborted by the user.")

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -248,6 +248,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			os.Unsetenv("GLOBALODOCONFIG")
 			helper.DeleteDir(context)
 		})
+
 		It("should set and unset env variables", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
@@ -262,6 +263,23 @@ var _ = Describe("odo preference and config command tests", func() {
 			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
 			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
 		})
+
+		It("should be able to unset an environment variable with foo=bar", func() {
+
+			// Create the project
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+
+			// Test out passing in with an equals sign
+			helper.CmdShouldPass("odo", "config", "set", "--env", "FOOBAR=foobar", "--context", context)
+			output := helper.CmdShouldPass("odo", "config", "view", "--context", context)
+			Expect(output).To(ContainSubstring("FOOBAR"))
+
+			// Check that we can remove it
+			helper.CmdShouldPass("odo", "config", "unset", "--env", "FOOBAR=foobar", "--context", context)
+			output = helper.CmdShouldPass("odo", "config", "view", "--context", context)
+			Expect(output).NotTo(ContainSubstring("FOOBAR"))
+		})
+
 	})
 
 	Context("when viewing local config without logging into the OpenShift cluster", func() {


### PR DESCRIPTION
This PR:
- Adds ability to use `foo=bar` when unsetting an environment variable
- Tests have been added

To test:
```sh
git clone https://github.com/openshift/nodejs-ex && cd ~/nodejs-ex
odo create
odo push
odo config set --env foo=bar
odo push  # optional
odo config view
odo config unset --env foo=bar
odo push  # optional
odo config view
```

Closes https://github.com/openshift/odo/issues/2139