### PR TITLE
Add managed-by labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ else
         GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 endif
 PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor | grep -v $(PROJECT)/tests )
-COMMON_FLAGS := -X $(PROJECT)/pkg/odo/cli/version.GITCOMMIT=$(GITCOMMIT)
+COMMON_FLAGS := -X $(PROJECT)/pkg/version/version.GITCOMMIT=$(GITCOMMIT)
 BUILD_FLAGS := -ldflags="-w $(COMMON_FLAGS)"
 DEBUG_BUILD_FLAGS := -ldflags="$(COMMON_FLAGS)"
 FILES := odo dist

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -427,7 +427,7 @@ To release a new version:
 
 * Updates the version in the following files:
 
-** link:/pkg/odo/cli/version/version.go[`pkg/odo/cli/version/version.go`]
+** link:/pkg/version/version.go[`pkg/version/version.go`]
 ** link:/scripts/installer.sh[`scripts/installer.sh`]
 ** link:/Dockerfile.rhel[`Dockerfile.rhel`]
 ** link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,9 +1,11 @@
 package application
 
 import (
-	"github.com/openshift/odo/pkg/testingutil"
 	"reflect"
 	"testing"
+
+	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/version"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	applabels "github.com/openshift/odo/pkg/application/labels"
@@ -62,6 +64,8 @@ func TestGetMachineReadableFormat(t *testing.T) {
 						applabels.ApplicationLabel:         "myapp",
 						componentlabels.ComponentLabel:     "frontend",
 						componentlabels.ComponentTypeLabel: "nodejs",
+						applabels.OdoManagedBy:             "odo",
+						applabels.OdoVersion:               version.VERSION,
 					},
 					Annotations: map[string]string{
 						component.ComponentSourceTypeAnnotation: "local",
@@ -87,6 +91,8 @@ func TestGetMachineReadableFormat(t *testing.T) {
 						applabels.ApplicationLabel:         "app",
 						componentlabels.ComponentLabel:     "backend",
 						componentlabels.ComponentTypeLabel: "java",
+						applabels.OdoManagedBy:             "odo",
+						applabels.OdoVersion:               version.VERSION,
 					},
 					Annotations: map[string]string{
 						component.ComponentSourceTypeAnnotation: "local",

--- a/pkg/application/labels/labels.go
+++ b/pkg/application/labels/labels.go
@@ -1,15 +1,23 @@
 package labels
 
+import "github.com/openshift/odo/pkg/version"
+
 // ApplicationLabel is label key that is used to group all object that belong to one application
 // It should be save to use just this label to filter application
 const ApplicationLabel = "app.kubernetes.io/part-of"
 
-// AdditionalApplicationLabels additional labels that are applied to all objects belonging to one application
-// Those labels are not used for filtering or grouping, they are used just when creating and they are mend to be used by other tools
-var AdditionalApplicationLabels = []string{
-	// OpenShift Web console uses this label for grouping
-	"app",
-}
+//////////////////////////////
+// ADDITIONALLY USED LABELS
+//////////////////////////////
+
+// App is the default name used when labeling
+const App = "app"
+
+// OdoManagedBy notes that this is managed by odo
+const OdoManagedBy = "app.kubernetes.io/managed-by"
+
+// OdoVersion is a Kubernetes label that adds what version of odo is being ran.
+const OdoVersion = "app.kubernetes.io/managed-by-version"
 
 // GetLabels return labels that identifies given application
 // additional labels are used only when creating object
@@ -21,9 +29,9 @@ func GetLabels(application string, additional bool) map[string]string {
 	}
 
 	if additional {
-		for _, additionalLabel := range AdditionalApplicationLabels {
-			labels[additionalLabel] = application
-		}
+		labels[App] = application
+		labels[OdoVersion] = version.VERSION
+		labels[OdoManagedBy] = "odo"
 	}
 
 	return labels

--- a/pkg/application/labels/labels_test.go
+++ b/pkg/application/labels/labels_test.go
@@ -3,6 +3,8 @@ package labels
 import (
 	"reflect"
 	"testing"
+
+	"github.com/openshift/odo/pkg/version"
 )
 
 func TestGetLabels(t *testing.T) {
@@ -16,7 +18,7 @@ func TestGetLabels(t *testing.T) {
 		want map[string]string
 	}{
 		{
-			name: "everything",
+			name: "Case 1: All labels",
 			args: args{
 				applicationName: "applicationame",
 				additional:      false,
@@ -26,15 +28,17 @@ func TestGetLabels(t *testing.T) {
 			},
 		},
 		{
-			name: "everything with additional",
+			name: "Case 2: All labels including all additional labels",
 			args: args{
 
 				applicationName: "applicationame",
 				additional:      true,
 			},
 			want: map[string]string{
-				ApplicationLabel:               "applicationame",
-				AdditionalApplicationLabels[0]: "applicationame",
+				ApplicationLabel: "applicationame",
+				App:              "applicationame",
+				OdoManagedBy:     "odo",
+				OdoVersion:       version.VERSION,
 			},
 		},
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -127,6 +127,7 @@ func validateSourceType(sourceType string) bool {
 // envVars is the array containing the environment variables
 func CreateFromGit(client *occlient.Client, params occlient.CreateArgs) error {
 
+	// Create the labels
 	labels := componentlabels.GetLabels(params.Name, params.ApplicationName, true)
 
 	// Parse componentImageType before adding to labels
@@ -206,6 +207,8 @@ func GetComponentLinkedSecretNames(client *occlient.Client, componentName string
 // sourceType indicates the source type of the component and can be either local or binary
 // envVars is the array containing the environment variables
 func CreateFromPath(client *occlient.Client, params occlient.CreateArgs) error {
+
+	// Create the labels to be used
 	labels := componentlabels.GetLabels(params.Name, params.ApplicationName, true)
 
 	// Parse componentImageType before adding to labels
@@ -1073,7 +1076,7 @@ func Update(client *occlient.Client, componentConfig config.LocalConfigInfo, new
 		return errors.Wrap(err, "unable to parse image name")
 	}
 
-	// Retrieve labels
+	// Create labels for the component
 	// Save component type as label
 	labels := componentlabels.GetLabels(componentName, applicationName, true)
 	labels[componentlabels.ComponentTypeLabel] = imageName

--- a/pkg/component/labels/labels_test.go
+++ b/pkg/component/labels/labels_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
+	"github.com/openshift/odo/pkg/version"
 )
 
 func TestGetLabels(t *testing.T) {
@@ -37,9 +38,11 @@ func TestGetLabels(t *testing.T) {
 				additional:      true,
 			},
 			want: map[string]string{
-				applabels.ApplicationLabel:               "applicationame",
-				applabels.AdditionalApplicationLabels[0]: "applicationame",
-				ComponentLabel:                           "componentname",
+				applabels.ApplicationLabel: "applicationame",
+				applabels.App:              "applicationame",
+				applabels.OdoManagedBy:     "odo",
+				applabels.OdoVersion:       version.VERSION,
+				ComponentLabel:             "componentname",
 			},
 		},
 	}

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -7,22 +7,13 @@ import (
 
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	odoversion "github.com/openshift/odo/pkg/version"
 
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/notify"
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-)
-
-var (
-	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0"
-
-	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
-	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"
-	// HEAD is default indicating that this was not set during build
-	GITCOMMIT = "HEAD"
 )
 
 // RecommendedCommandName is the recommended version command name
@@ -78,7 +69,7 @@ func (o *VersionOptions) Run() (err error) {
 		}
 	}
 
-	fmt.Println("odo " + VERSION + " (" + GITCOMMIT + ")")
+	fmt.Println("odo " + odoversion.VERSION + " (" + odoversion.GITCOMMIT + ")")
 
 	if !o.clientFlag && o.serverInfo != nil {
 		// make sure we only include OpenShift info if we actually have it
@@ -122,7 +113,7 @@ func NewCmdVersion(name, fullName string) *cobra.Command {
 
 // GetLatestReleaseInfo Gets information about the latest release
 func GetLatestReleaseInfo(info chan<- string) {
-	newTag, err := notify.CheckLatestReleaseTag(VERSION)
+	newTag, err := notify.CheckLatestReleaseTag(odoversion.VERSION)
 	if err != nil {
 		// The error is intentionally not being handled because we don't want
 		// to stop the execution of the program because of this failure

--- a/pkg/storage/labels/labels_test.go
+++ b/pkg/storage/labels/labels_test.go
@@ -6,6 +6,7 @@ import (
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/version"
 )
 
 func TestGetLabels(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGetLabels(t *testing.T) {
 		want map[string]string
 	}{
 		{
-			name: "everything filled",
+			name: "Case 1: Everything filled",
 			args: args{
 				storageName:     "storagename",
 				componentName:   "componentname",
@@ -34,7 +35,7 @@ func TestGetLabels(t *testing.T) {
 				StorageLabel:                   "storagename",
 			},
 		}, {
-			name: "no storage name",
+			name: "Case 2: No storage name",
 			args: args{
 				storageName:     "",
 				componentName:   "componentname",
@@ -47,7 +48,7 @@ func TestGetLabels(t *testing.T) {
 				StorageLabel:                   "",
 			},
 		}, {
-			name: "everything with additional",
+			name: "Case 3: Everything with additional",
 			args: args{
 				storageName:     "storagename",
 				componentName:   "componentname",
@@ -55,10 +56,12 @@ func TestGetLabels(t *testing.T) {
 				additional:      true,
 			},
 			want: map[string]string{
-				applabels.ApplicationLabel:               "applicationame",
-				applabels.AdditionalApplicationLabels[0]: "applicationame",
-				componentlabels.ComponentLabel:           "componentname",
-				StorageLabel:                             "storagename",
+				applabels.ApplicationLabel:     "applicationame",
+				applabels.App:                  "applicationame",
+				applabels.OdoManagedBy:         "odo",
+				applabels.OdoVersion:           version.VERSION,
+				componentlabels.ComponentLabel: "componentname",
+				StorageLabel:                   "storagename",
 			},
 		},
 	}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,14 +1,16 @@
 package storage
 
 import (
-	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/testingutil"
-	"github.com/openshift/odo/pkg/util"
 	"reflect"
 	"testing"
 
+	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/util"
+	"github.com/openshift/odo/pkg/version"
+
 	v1 "github.com/openshift/api/apps/v1"
-	appLabels "github.com/openshift/odo/pkg/application/labels"
+	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentLabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/storage/labels"
 	storageLabels "github.com/openshift/odo/pkg/storage/labels"
@@ -275,7 +277,7 @@ func TestCreate(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "case 1: with valid values",
+			name: "Case 1: With valid values",
 			args: args{
 				name:            "storage-0",
 				size:            "100Mi",
@@ -285,7 +287,9 @@ func TestCreate(t *testing.T) {
 			wantLabels: map[string]string{
 				"app":                          "app-ex",
 				labels.StorageLabel:            "storage-0",
-				appLabels.ApplicationLabel:     "app-ex",
+				applabels.ApplicationLabel:     "app-ex",
+				applabels.OdoManagedBy:         "odo",
+				applabels.OdoVersion:           version.VERSION,
 				componentLabels.ComponentLabel: "nodejs-ex",
 			},
 			wantErr: false,

--- a/pkg/url/labels/labels_test.go
+++ b/pkg/url/labels/labels_test.go
@@ -6,6 +6,7 @@ import (
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/version"
 )
 
 func TestGetLabels(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGetLabels(t *testing.T) {
 		want map[string]string
 	}{
 		{
-			name: "everything filled",
+			name: "Case 1: Everything filled",
 			args: args{
 				urlName:         "urlname",
 				componentName:   "componentname",
@@ -34,7 +35,7 @@ func TestGetLabels(t *testing.T) {
 				URLLabel:                       "urlname",
 			},
 		}, {
-			name: "no storage name",
+			name: "Case 2: No URL name",
 			args: args{
 				urlName:         "",
 				componentName:   "componentname",
@@ -47,7 +48,7 @@ func TestGetLabels(t *testing.T) {
 				URLLabel:                       "",
 			},
 		}, {
-			name: "everything with additional",
+			name: "Case 3: Everything with additional",
 			args: args{
 				urlName:         "urlname",
 				componentName:   "componentname",
@@ -55,10 +56,12 @@ func TestGetLabels(t *testing.T) {
 				additional:      true,
 			},
 			want: map[string]string{
-				applabels.ApplicationLabel:               "applicationame",
-				applabels.AdditionalApplicationLabels[0]: "applicationame",
-				componentlabels.ComponentLabel:           "componentname",
-				URLLabel:                                 "urlname",
+				applabels.ApplicationLabel:     "applicationame",
+				applabels.App:                  "applicationame",
+				applabels.OdoManagedBy:         "odo",
+				applabels.OdoVersion:           version.VERSION,
+				componentlabels.ComponentLabel: "componentname",
+				URLLabel:                       "urlname",
 			},
 		},
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -45,7 +45,7 @@ func Delete(client *occlient.Client, urlName string, applicationName string) err
 // Create creates a URL and returns url string and error if any
 // portNumber is the target port number for the route and is -1 in case no port number is specified in which case it is automatically detected for components which expose only one service port)
 func Create(client *occlient.Client, urlName string, portNumber int, componentName, applicationName string) (string, error) {
-	labels := urlLabels.GetLabels(urlName, componentName, applicationName, false)
+	labels := urlLabels.GetLabels(urlName, componentName, applicationName, true)
 
 	serviceName, err := util.NamespaceOpenShiftObject(componentName, applicationName)
 	if err != nil {

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -5,11 +5,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kylelemons/godebug/pretty"
 	routev1 "github.com/openshift/api/route/v1"
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/url/labels"
+	"github.com/openshift/odo/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,7 +33,7 @@ func TestCreate(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name: "case 1: component name same as urlName",
+			name: "Case 1: Component name same as urlName",
 			args: args{
 				componentName:   "nodejs",
 				applicationName: "app",
@@ -44,6 +46,9 @@ func TestCreate(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":  "app",
 						"app.kubernetes.io/instance": "nodejs",
+						applabels.App:                "app",
+						applabels.OdoManagedBy:       "odo",
+						applabels.OdoVersion:         version.VERSION,
 						"odo.openshift.io/url-name":  "nodejs",
 					},
 				},
@@ -61,7 +66,7 @@ func TestCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "case 2: component name different than urlName",
+			name: "Case 2: Component name different than urlName",
 			args: args{
 				componentName:   "nodejs",
 				applicationName: "app",
@@ -74,6 +79,9 @@ func TestCreate(t *testing.T) {
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":  "app",
 						"app.kubernetes.io/instance": "nodejs",
+						applabels.App:                "app",
+						applabels.OdoManagedBy:       "odo",
+						applabels.OdoVersion:         version.VERSION,
 						"odo.openshift.io/url-name":  "example-url",
 					},
 				},
@@ -113,7 +121,7 @@ func TestCreate(t *testing.T) {
 					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Name, createdRoute.Name)
 				}
 				if !reflect.DeepEqual(createdRoute.Labels, tt.returnedRoute.Labels) {
-					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Labels, createdRoute.Labels)
+					t.Errorf("route name not matching, %v", pretty.Compare(tt.returnedRoute.Labels, createdRoute.Labels))
 				}
 				if !reflect.DeepEqual(createdRoute.Spec.Port, tt.returnedRoute.Spec.Port) {
 					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Spec.Port, createdRoute.Spec.Port)
@@ -200,6 +208,8 @@ func TestExists(t *testing.T) {
 							Labels: map[string]string{
 								applabels.ApplicationLabel:     "app",
 								componentlabels.ComponentLabel: "nodejs",
+								applabels.OdoManagedBy:         "odo",
+								applabels.OdoVersion:           version.VERSION,
 								labels.URLLabel:                "nodejs",
 							},
 						},
@@ -219,6 +229,8 @@ func TestExists(t *testing.T) {
 							Labels: map[string]string{
 								applabels.ApplicationLabel:     "app",
 								componentlabels.ComponentLabel: "wildfly",
+								applabels.OdoManagedBy:         "odo",
+								applabels.OdoVersion:           version.VERSION,
 								labels.URLLabel:                "wildfly",
 							},
 						},
@@ -251,6 +263,8 @@ func TestExists(t *testing.T) {
 							Labels: map[string]string{
 								applabels.ApplicationLabel:     "app",
 								componentlabels.ComponentLabel: "nodejs",
+								applabels.OdoManagedBy:         "odo",
+								applabels.OdoVersion:           version.VERSION,
 								labels.URLLabel:                "nodejs",
 							},
 						},
@@ -270,6 +284,8 @@ func TestExists(t *testing.T) {
 							Labels: map[string]string{
 								applabels.ApplicationLabel:     "app",
 								componentlabels.ComponentLabel: "wildfly",
+								applabels.OdoManagedBy:         "odo",
+								applabels.OdoVersion:           version.VERSION,
 								labels.URLLabel:                "wildfly",
 							},
 						},

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+/*
+===================
+=    IMPORTANT    =
+===================
+
+This package is solely for versioning information when releasing odo..
+
+Changing these values will change the versioning information when releasing odo.
+*/
+
+var (
+	// VERSION  is version number that will be displayed when running ./odo version
+	VERSION = "v1.0.0"
+
+	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
+	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"
+	// HEAD is default indicating that this was not set during build
+	GITCOMMIT = "HEAD"
+)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -23,8 +23,8 @@ check_version(){
 
 
 echo "* Bumping version in pkg/odo/cli/version/version.go"
-sed -i "s/\(VERSION = \)\"v[0-9]*\.[0-9]*\.[0-9]*\(?:-\w+\)\?\"/\1\"${NEW_VERSION}\"/g" pkg/odo/cli/version/version.go
-check_version pkg/odo/cli/version/version.go
+sed -i "s/\(VERSION = \)\"v[0-9]*\.[0-9]*\.[0-9]*\(?:-\w+\)\?\"/\1\"${NEW_VERSION}\"/g" pkg/version/version.go
+check_version pkg/version/version.go
 
 echo "* Bumping version in scripts/installer.sh"
 sed -i "s/\(LATEST_VERSION=\)\"v[0-9]*\.[0-9]*\.[0-9]*\(?:-\w+\)\?\"/\1\"${NEW_VERSION}\"/g" scripts/installer.sh

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -141,6 +141,14 @@ func (oc *OcRunner) VerifyCmpExists(cmpName string, appName string, prjName stri
 	CmdShouldPass(oc.path, "get", "dc", cmpDCName, "--namespace", prjName)
 }
 
+// VerifyLabelExistsOfComponent verifies app name of component
+func (oc *OcRunner) VerifyLabelExistsOfComponent(cmpName string, namespace string, labelName string) {
+	dcName := oc.GetDcName(cmpName, namespace)
+	session := CmdShouldPass(oc.path, "get", "dc", dcName, "--namespace", namespace,
+		"--template={{.metadata.labels}}")
+	Expect(session).To(ContainSubstring(labelName))
+}
+
 // VerifyAppNameOfComponent verifies app name of component
 func (oc *OcRunner) VerifyAppNameOfComponent(cmpName string, appName string, namespace string) {
 	session := CmdShouldPass(oc.path, "get", "dc", cmpName+"-"+appName, "--namespace", namespace,


### PR DESCRIPTION
This PR:
  - Moves versioning information to `pkg/version/version.go` so other
  parts of odo is able to use the versioning information (namely
  `pkg/component/labels/labels.go`.
  - Updates documentation on the versioning move
  - Adds `app.kubernetes.io/managed-by-version` label
  - Adds `app.kubernetes.io/managed-by` label

See example below of the changes:

```yaml
apiVersion: apps.openshift.io/v1
kind: DeploymentConfig
metadata:
  annotations:
    app.kubernetes.io/component-source-type: local
    app.openshift.io/vcs-uri: file://./
  creationTimestamp: 2019-10-10T21:15:55Z
  generation: 2
  labels:
    app: app
    app.kubernetes.io/instance: foobar
    app.kubernetes.io/managed-by: odo
    app.kubernetes.io/managed-by-version: v1.0.0-beta6
    app.kubernetes.io/name: nodejs
    app.kubernetes.io/part-of: app
    app.openshift.io/runtime-version: latest
  name: foobar-app
  namespace: foo
  resourceVersion: "526665225"
  selfLink: /apis/apps.openshift.io/v1/namespaces/foo/deploymentconfigs/foobar-app
  uid: 25e6bf2c-eba3-11e9-98ab-123dee44c1c5
```

Closes https://github.com/openshift/odo/issues/2017