### PR TITLE
Fails if user tries to unset invalid environment variable

### DIFF
--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -85,24 +85,29 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
 func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) (EnvVarList, error) {
-	// if no keys are to be removed, just return the existing list without any errors
-	if len(keys) == 0 {
-		return envVarList, nil
+	// convert the envVarList map to an array to easily search for env var(s)
+	// to remove from the component
+	envVarListArray := []string{}
+	for _, env := range envVarList {
+		envVarListArray = append(envVarListArray, env.Name)
 	}
 
-	envVarInList := false
+	// now check if the environment variable(s) requested for removal exists in
+	// the env vars set for the component by odo
+	for _, key := range keys {
+		if !util.In(envVarListArray, key) {
+			return nil, fmt.Errorf("unable to find environment variable %s in the component", key)
+		}
+	}
+
+	// finally, let's remove the environment variables(s) requested by the user
 	newEnvVarList := EnvVarList{}
 	for _, envVar := range envVarList {
 		// if the env is in the keys we skip it
 		if util.In(keys, envVar.Name) {
-			envVarInList = true
 			continue
 		}
-
 		newEnvVarList = append(newEnvVarList, envVar)
 	}
-	if envVarInList {
-		return newEnvVarList, nil
-	}
-	return nil, fmt.Errorf("Cannot find environment variable in the component's configuration.\nCheck `odo config view` to confirm it exists.")
+	return newEnvVarList, nil
 }

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -85,6 +85,11 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
 func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) (EnvVarList, error) {
+	// if no keys are to be removed, just return the existing list without any errors
+	if len(keys) == 0 {
+		return envVarList, nil
+	}
+
 	envVarInList := false
 	newEnvVarList := EnvVarList{}
 	for _, envVar := range envVarList {

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -84,15 +84,20 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
-func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {
+func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) (EnvVarList, error) {
+	envVarInList := false
 	newEnvVarList := EnvVarList{}
 	for _, envVar := range envVarList {
 		// if the env is in the keys we skip it
 		if util.In(keys, envVar.Name) {
+			envVarInList = true
 			continue
 		}
 
 		newEnvVarList = append(newEnvVarList, envVar)
 	}
-	return newEnvVarList
+	if envVarInList {
+		return newEnvVarList, nil
+	}
+	return nil, errors.New(fmt.Sprintf("Cannot find environment variable in the component's configuration.\nCheck `odo config view` to confirm it exists."))
 }

--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -104,5 +104,5 @@ func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) (EnvVarList, er
 	if envVarInList {
 		return newEnvVarList, nil
 	}
-	return nil, errors.New(fmt.Sprintf("Cannot find environment variable in the component's configuration.\nCheck `odo config view` to confirm it exists."))
+	return nil, fmt.Errorf("Cannot find environment variable in the component's configuration.\nCheck `odo config view` to confirm it exists.")
 }

--- a/pkg/config/env_var_test.go
+++ b/pkg/config/env_var_test.go
@@ -135,6 +135,7 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 		envVarList EnvVarList
 		expected   EnvVarList
 		keys       []string
+		wantErr    bool
 	}{
 		{
 			envVarList: EnvVarList{
@@ -205,15 +206,29 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 			expected: EnvVarList{},
 			keys:     []string{"foo"},
 		},
+		{
+			envVarList: EnvVarList{},
+			expected:   nil,
+			keys:       []string{"nosuchenv"},
+			wantErr:    true,
+		},
 	}
 
 	for _, testCase := range cases {
 
-		envVarList := RemoveEnvVarsFromList(testCase.envVarList, testCase.keys)
+		envVarList, err := RemoveEnvVarsFromList(testCase.envVarList, testCase.keys)
 		// expected an error
-
-		if !reflect.DeepEqual(envVarList, testCase.expected) {
-			t.Errorf("the %+v and %+v are not equal", envVarList, testCase.expected)
+		if testCase.wantErr {
+			if envVarList != nil || err == nil {
+				t.Errorf("expected error for %s", testCase.envVarList)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(envVarList, testCase.expected) {
+				t.Errorf("the %+v and %+v are not equal", envVarList, testCase.expected)
+			}
 		}
 	}
 

--- a/pkg/config/env_var_test.go
+++ b/pkg/config/env_var_test.go
@@ -132,12 +132,14 @@ func TestNewEnvVarListFromSlice(t *testing.T) {
 
 func TestRemoveEnvVarsFromList(t *testing.T) {
 	cases := []struct {
+		name       string
 		envVarList EnvVarList
 		expected   EnvVarList
 		keys       []string
 		wantErr    bool
 	}{
 		{
+			name: "Case 1: Check removing one environment variable",
 			envVarList: EnvVarList{
 				EnvVar{
 					Name:  "foo",
@@ -157,6 +159,7 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 			keys: []string{"fizz"},
 		},
 		{
+			name: "Case 2: Check removing two environment variables",
 			envVarList: EnvVarList{
 				EnvVar{
 					Name:  "foo",
@@ -171,6 +174,7 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 			keys:     []string{"fizz", "foo"},
 		},
 		{
+			name: "Case 3: Check passing in nothing",
 			envVarList: EnvVarList{
 				EnvVar{
 					Name:  "foo",
@@ -193,6 +197,7 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 			},
 		},
 		{
+			name: "Case 4: Check passing for single environment variable",
 			envVarList: EnvVarList{
 				EnvVar{
 					Name:  "foo",
@@ -207,6 +212,55 @@ func TestRemoveEnvVarsFromList(t *testing.T) {
 			keys:     []string{"foo"},
 		},
 		{
+			name: "Case 5: Check failing with foo=bar (invalid variable.. should error out)",
+			envVarList: EnvVarList{
+				EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+			expected: EnvVarList{},
+			keys:     []string{"foo=bar", "hi=hello"},
+			wantErr:  true,
+		},
+		{
+			name: "Case 6: Check failing when passing in multiple vals but one is valid",
+			envVarList: EnvVarList{
+				EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				EnvVar{
+					Name:  "hi",
+					Value: "hello",
+				},
+			},
+			expected: EnvVarList{},
+			keys:     []string{"foo=bar", "hi"},
+			wantErr:  true,
+		},
+		{
+			name: "Case 7: Check failing when passing in nothing",
+			envVarList: EnvVarList{
+				EnvVar{
+					Name:  "foo",
+					Value: "bar",
+				},
+				EnvVar{
+					Name:  "hi",
+					Value: "hello",
+				},
+			},
+			expected: EnvVarList{},
+			keys:     []string{""},
+			wantErr:  true,
+		},
+		{
+			name:       "Case 8: Check failing when there are no environment variables set",
 			envVarList: EnvVarList{},
 			expected:   nil,
 			keys:       []string{"nosuchenv"},

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -84,12 +84,17 @@ func (o *UnsetOptions) Run() (err error) {
 	if o.envArray != nil {
 
 		envList := o.lci.GetEnvVars()
-		newEnvList := config.RemoveEnvVarsFromList(envList, o.envArray)
-		if err := o.lci.SetEnvVars(newEnvList); err != nil {
+		newEnvList, err := config.RemoveEnvVarsFromList(envList, o.envArray)
+		if err != nil {
+			return err
+		}
+
+		if err = o.lci.SetEnvVars(newEnvList); err != nil {
 			return err
 		}
 
 		log.Info("Environment variables were successfully updated.")
+		log.Info("Run `odo push --config` command to apply changes to the cluster.")
 		return nil
 	}
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -262,6 +262,17 @@ var _ = Describe("odo preference and config command tests", func() {
 			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
 			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
 		})
+		It("should check for existence of environment variable in config before unset'ing it", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
+
+			// unset a valid env var
+			helper.CmdShouldPass("odo", "config", "unset", "--env", "PORT")
+
+			// try to unset an env var that doesn't exist
+			stdOut := helper.CmdShouldFail("odo", "config", "unset", "--env", "nosuchenv")
+			Expect(stdOut).To(ContainSubstring("Cannot find environment variable in the component's configuration"))
+		})
 	})
 
 	Context("when viewing local config without logging into the OpenShift cluster", func() {

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -271,7 +271,7 @@ var _ = Describe("odo preference and config command tests", func() {
 
 			// try to unset an env var that doesn't exist
 			stdOut := helper.CmdShouldFail("odo", "config", "unset", "--env", "nosuchenv", "--context", context)
-			Expect(stdOut).To(ContainSubstring("Cannot find environment variable in the component's configuration"))
+			Expect(stdOut).To(ContainSubstring("unable to find environment variable nosuchenv in the component"))
 		})
 	})
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -262,7 +262,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
 			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
 		})
-		It("should check for existence of environment variable in config before unset'ing it", func() {
+		It("should check for existence of environment variable in config before unsetting it", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -267,10 +267,10 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
 
 			// unset a valid env var
-			helper.CmdShouldPass("odo", "config", "unset", "--env", "PORT")
+			helper.CmdShouldPass("odo", "config", "unset", "--env", "PORT", "--context", context)
 
 			// try to unset an env var that doesn't exist
-			stdOut := helper.CmdShouldFail("odo", "config", "unset", "--env", "nosuchenv")
+			stdOut := helper.CmdShouldFail("odo", "config", "unset", "--env", "nosuchenv", "--context", context)
 			Expect(stdOut).To(ContainSubstring("Cannot find environment variable in the component's configuration"))
 		})
 	})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
At the moment, there's no check for the scenario where a user tries to unset an environment variable that doesn't exist in the configuration. This PR aims to fix that and fails the execution.

## Was the change discussed in an issue?
fixes #2274 
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
* Create a component
* Try to unset an environment variable that doesn't exist in component's config: `odo config unset --env nosuchvar`.