### PR TITLE
Bump odo version to 1.0.0-beta7

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,7 +16,7 @@ LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts-container \
     summary="This image contains the Linux, Mac and Windows version of odo"
 
 # Change version as needed. Note no "-" is allowed
-LABEL version=1.0.0-beta6
+LABEL version=1.0.0-beta7
 
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe

--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -1,4 +1,4 @@
-= Overview of the OpenShift Do (odo) CLI Structure
+= Overview of the Odo (OpenShift Do) CLI Structure
 
 ___________________
 Example application
@@ -10,12 +10,13 @@ ___________________
   git clone https://github.com/openshift/nodejs-ex && cd nodejs-ex
   odo create nodejs
   odo push
-
+  
   # Accessing your Node.js component
-  odo url create
+  odo url create 
 ----
 
-(OpenShift Do) odo is a CLI tool for running OpenShift applications in a fast and automated manner. Reducing the complexity of deployment, odo adds iterative development without the worry of deploying your source code.
+(OpenShift Do) odo is a CLI tool for running OpenShift applications in a fast and automated manner.
+Reducing the complexity of deployment, odo adds iterative development without the worry of deploying your source code.
 
 Find more information at https://github.com/openshift/odo
 
@@ -36,10 +37,10 @@ Syntax
 | Catalog related operations (describe, list, search)
 
 | link:#component[component]
-| Components of an application (create, delete, describe, link, list, log, push, unlink, update, watch)
+| Manage components (create, delete, describe, link, list, log, push, unlink, update, watch)
 
 | link:#config[config]
-| Modifies configuration settings (set, unset, view)
+| Change or view configuration (set, unset, view)
 
 | link:#create[create]
 | Create a new component
@@ -48,10 +49,10 @@ Syntax
 | Debug commands (port-forward)
 
 | link:#delete[delete]
-| Delete an existing component
+| Delete component
 
 | link:#describe[describe]
-| Describe the given component
+| Describe component
 
 | link:#link[link]
 | Link component to a service or component
@@ -123,10 +124,10 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --stderrthr
         search : Search available component & service types. (component, service)
             component : Search component type in catalog
             service : Search service type in catalog
-    component --app --context --project --short : Components of an application (create, delete, describe, link, list, log, push, unlink, update, watch)
+    component --app --context --project --short : Manage components (create, delete, describe, link, list, log, push, unlink, update, watch)
         create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --now --port --project --ref : Create a new component
-        delete --all --app --context --force --project : Delete an existing component
-        describe --app --context --project : Describe the given component
+        delete --all --app --context --force --project : Delete component
+        describe --app --context --project : Describe component
         get --app --context --project --short : Get currently active component
         link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
         list --all --app --context --path --project : List all components in the current application
@@ -135,15 +136,15 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --stderrthr
         unlink --app --component --context --port --project --wait : Unlink component to a service or component
         update --app --context --git --local --project --ref : Update the source code path of a component
         watch --app --context --delay --ignore --project --show-log : Watch for changes, update component on change
-    config : Modifies configuration settings (set, unset, view)
+    config : Change or view configuration (set, unset, view)
         set --context --env --force : Set a value in odo config file
         unset --context --env --force : Unset a value in odo config file
         view --context : View current configuration values
     create --app --binary --context --cpu --env --git --max-cpu --max-memory --memory --min-cpu --min-memory --now --port --project --ref : Create a new component
     debug : Debug commands (port-forward)
         port-forward --context --local-port : Forward one or more local ports to a pod
-    delete --all --app --context --force --project : Delete an existing component
-    describe --app --context --project : Describe the given component
+    delete --all --app --context --force --project : Delete component
+    describe --app --context --project : Describe component
     link --app --component --context --port --project --wait --wait-for-target : Link component to a service or component
     list --all --app --context --path --project : List all components in the current application
     log --app --context --follow --project : Retrieve the log for the given component
@@ -165,15 +166,15 @@ odo --alsologtostderr --log_backtrace_at --log_dir --logtostderr --o --stderrthr
         delete --app --context --force --project : Delete an existing service
         list --app --context --project : List all services in the current application
     storage : Perform storage operations (create, delete, list)
-        create --app --component --context --path --project --size : Create storage and mount to a component
-        delete --app --component --context --force --project : Delete storage from component
-        list --app --component --context --project : List storage attached to a component
+        create --context --path --size : Create storage and mount to a component
+        delete --context --force : Delete storage from component
+        list --context : List storage attached to a component
     unlink --app --component --context --port --project --wait : Unlink component to a service or component
     update --app --context --git --local --project --ref : Update the source code path of a component
     url : Expose component to the outside world (create, delete, list)
-        create --app --component --context --port --project : Create a URL for a component
-        delete --app --component --context --force --project : Delete a URL
-        list --app --component --context --project : List URLs
+        create --context --port : Create a URL for a component
+        delete --context --force : Delete a URL
+        list --context : List URLs
     utils : Utilities for terminal commands and modifying odo configurations (terminal)
         terminal : Add odo terminal support to your development environment
     version --client : Print the client version information
@@ -204,7 +205,7 @@ _________________
 
   # List all applications in the current project
   odo app list
-
+  
   # List all applications in the specified project
   odo app list --project myproject
 ----
@@ -297,7 +298,7 @@ _________________
   odo config set MinCPU 0.5
   odo config set MaxCPU 2
   odo config set CPU 1
-
+  
   # Set a env variable in the local config
   odo config set --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
 
@@ -312,12 +313,12 @@ _________________
   odo config unset MinCPU
   odo config unset MaxCPU
   odo config unset CPU
-
+  
   # Unset a env variable in the local config
   odo config unset --env KAFKA_HOST --env KAFKA_PORT
 ----
 
-Modifies odo specific configuration settings within the config file.
+Modifies odo specific configuration settings within the config file. 
 
 
 Available Local Parameters:
@@ -358,53 +359,27 @@ _________________
 ----
   # Create new Node.js component with the source in current directory.
   odo create nodejs
-
-  # A specific image version may also be specified
-  odo create nodejs:latest
-
+  
   # Create new Node.js component named 'frontend' with the source in './frontend' directory
   odo create nodejs frontend --context ./frontend
-
-  # Create a new Node.js component of version 6 from the 'openshift' namespace
-  odo create openshift/nodejs:6 --context /nodejs-ex
-
-  # Create new Wildfly component with binary named sample.war in './downloads' directory
-  odo create wildfly wildfly --binary ./downloads/sample.war
-
+  
+  # Create new Java component with binary named sample.jar in './target' directory
+  odo create java:8  --binary target/sample.jar
+  
   # Create new Node.js component with source from remote git repository
   odo create nodejs --git https://github.com/openshift/nodejs-ex.git
-
-  # Create new Node.js git component while specifying a branch, tag or commit ref
-  odo create nodejs --git https://github.com/openshift/nodejs-ex.git --ref master
-
-  # Create new Node.js git component while specifying a tag
-  odo create nodejs --git https://github.com/openshift/nodejs-ex.git --ref v1.0.1
-
-  # Create new Node.js component with the source in current directory and ports 8080-tcp,8100-tcp and 9100-udp exposed
-  odo create nodejs --port 8080,8100/tcp,9100/udp
-
-  # Create new Node.js component with the source in current directory and env variables key=value and key1=value1 exposed
-  odo create nodejs --env key=value,key1=value1
-
-  # For more examples, visit: https://github.com/openshift/odo/blob/master/docs/examples.adoc
-  odo create python --git https://github.com/openshift/django-ex.git
-
-  # Passing memory limits
-  odo create nodejs --memory 150Mi
-  odo create nodejs --min-memory 150Mi --max-memory 300 Mi
-
-  # Passing cpu limits
-  odo create nodejs --cpu 2
-  odo create nodejs --min-cpu 200m --max-cpu 2
+  
+  # Create new Node.js component with custom ports, additional environment variables and memory and cpu limits
+  odo create nodejs --port 8080,8100/tcp,9100/udp --env key=value,key1=value1 --memory 4Gi --cpu 2
 ----
 
-Create a configuration describing a component to be deployed on OpenShift.
+Create a configuration describing a component. 
 
-If a component name is not provided, it'll be auto-generated.
+If a component name is not provided, it'll be auto-generated. 
 
-By default, builder images will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version If version is not specified by default, latest will be chosen as the version.
+A full list of component types that can be deployed is available using: 'odo catalog list' 
 
-A full list of component types that can be deployed is available using: 'odo catalog list'
+By default, builder images (component type) will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version If version is not specified by default, latest will be chosen as the version.
 
 [[debug]]
 debug
@@ -448,7 +423,7 @@ _________________
   odo delete frontend --all
 ----
 
-Delete an existing component.
+Delete component.
 
 [[describe]]
 describe
@@ -469,7 +444,7 @@ _________________
   odo describe nodejs
 ----
 
-Describe the given component.
+Describe component.
 
 [[link]]
 link
@@ -488,16 +463,16 @@ _________________
 ----
   # Link the current component to the 'my-postgresql' service
   odo link my-postgresql
-
+  
   # Link component 'nodejs' to the 'my-postgresql' service
   odo link my-postgresql --component nodejs
-
+  
   # Link current component to the 'backend' component (backend must have a single exposed port)
   odo link backend
-
+  
   # Link component 'nodejs' to the 'backend' component
   odo link backend --component nodejs
-
+  
   # Link current component to port 8080 of the 'backend' component (backend must have port 8080 exposed)
   odo link backend --port 8080
 ----
@@ -505,7 +480,7 @@ _________________
 Link component to a service or component
 
 If the source component is not provided, the current active component is assumed.
-In both use cases, link adds the appropriate secret to the environment of the source component.
+In both use cases, link adds the appropriate secret to the environment of the source component. 
 The source component can then consume the entries of the secret as environment variables.
 
 For example:
@@ -590,13 +565,13 @@ _________________
 ----
   # Log in interactively
   odo login
-
+  
   # Log in to the given server with the given certificate authority file
   odo login localhost:8443 --certificate-authority=/path/to/cert.crt
-
+  
   # Log in to the given server with the given credentials (basic auth)
   odo login localhost:8443 --username=myuser --password=mypass
-
+  
   # Log in to the given server with the given credentials (token)
   odo login localhost:8443 --token=xxxxxxxxxxxxxxxxxxxxxxx
 ----
@@ -642,7 +617,7 @@ _________________
 
   # For viewing the current local preference
   odo preference view
-
+  
   # For viewing the current global preference
   odo preference view
 
@@ -657,7 +632,7 @@ _________________
   odo preference unset  Timeout
 ----
 
-Modifies odo specific configuration settings within the global preference file.
+Modifies odo specific configuration settings within the global preference file. 
 
 
 Available Parameters:
@@ -716,10 +691,10 @@ _________________
 ----
   # Push source code to the current component
   odo push
-
+  
   # Push data to the current component from the original source.
   odo push
-
+  
   # Push source code in ~/mycode to component called my-component
   odo push my-component --context ~/mycode
 ----
@@ -772,9 +747,6 @@ _________________
   odo storage create mystorage --path=/opt/app-root/src/storage/ --size=1Gi
   # Delete storage mystorage from the currently active component
   odo storage delete mystorage
-
-  # Delete storage mystorage from component 'mongodb'
-  odo storage delete mystorage --component mongodb
   # List all storage attached or mounted to the current component and
   # all unattached or unmounted storage in the current application
   odo storage list
@@ -799,21 +771,21 @@ _________________
 ----
   # Unlink the 'my-postgresql' service from the current component
   odo unlink my-postgresql
-
+  
   # Unlink the 'my-postgresql' service  from the 'nodejs' component
   odo unlink my-postgresql --component nodejs
-
+  
   # Unlink the 'backend' component from the current component (backend must have a single exposed port)
   odo unlink backend
-
+  
   # Unlink the 'backend' service  from the 'nodejs' component
   odo unlink backend --component nodejs
-
+  
   # Unlink the backend's 8080 port from the current component
   odo unlink backend --port 8080
 ----
 
-Unlink component or service from a component.
+Unlink component or service from a component. 
 For this command to be successful, the service or component needs to have been linked prior to the invocation using 'odo link'
 
 [[update]]
@@ -833,16 +805,16 @@ _________________
 ----
   # Change the source code path of a currently active component to local (use the current directory as a source)
   odo update --local
-
+  
   # Change the source code path of the frontend component to local with source in ./frontend directory
   odo update frontend --local ./frontend
-
+  
   # Change the source code path of a currently active component to git
   odo update --git https://github.com/openshift/nodejs-ex.git
-
+  
   # Change the source code path of the component named node-ex to git
   odo update node-ex --git https://github.com/openshift/nodejs-ex.git
-
+  
   # Change the source code path of the component named wildfly to a binary named sample.war in ./downloads directory
   odo update wildfly --binary ./downloads/sample.war
 ----
@@ -866,22 +838,19 @@ _________________
 ----
   # Create a URL with a specific name by automatically detecting the port used by the component
   odo url create example
-
+  
   # Create a URL for the current component with a specific port
   odo url create --port 8080
-
+  
   # Create a URL with a specific name and port
   odo url create example --port 8080
-
-  # Create a URL with a specific name and port for component frontend
-  odo url create example --port 8080 --component frontend
   # Delete a URL to a component
   odo url delete myurl
   # List the available URLs
   odo url list
 ----
 
-Expose component to the outside world.
+Expose component to the outside world. 
 
 The URLs that are generated using this command, can be used to access the deployed components from outside the cluster.
 
@@ -902,7 +871,7 @@ _________________
 ----
   # Bash terminal PS1 support
   source <(odo utils terminal bash)
-
+  
   # Zsh terminal PS1 support
   source <(odo utils terminal zsh)
 
@@ -948,9 +917,11 @@ _________________
 ----
   # Watch for changes in directory for current component
   odo watch
-
+  
   # Watch for changes in directory for component called frontend
   odo watch frontend
 ----
 
 Watch for changes, update component on change.
+
+

--- a/docs/cli-reference.adoc
+++ b/docs/cli-reference.adoc
@@ -1,4 +1,4 @@
-= Overview of the Odo (OpenShift Do) CLI Structure
+= Overview of the OpenShift Do (odo) CLI Structure
 
 ___________________
 Example application

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.0.0-beta6"
+	VERSION = "v1.0.0-beta7"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -7,7 +7,7 @@ set -e
 ODO_VERSION="latest"
 
 # Latest released odo version
-LATEST_VERSION="v1.0.0-beta6"
+LATEST_VERSION="v1.0.0-beta7"
 
 GITHUB_RELEASES_URL="https://github.com/openshift/odo/releases/download/${LATEST_VERSION}"
 BINTRAY_URL="https://dl.bintray.com/odo/odo/latest"

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -5,7 +5,7 @@ set +ex
 echo "Reading ODO_VERSION, ODO_RELEASE and GIT_COMMIT env, if they are set"
 # Change version as needed. In most cases ODO_RELEASE would not be touched unless
 # we want to do a re-lease of same version as we are not backporting
-export ODO_VERSION=${ODO_VERSION:=1.0.0-beta6}
+export ODO_VERSION=${ODO_VERSION:=1.0.0-beta7}
 export ODO_RELEASE=${ODO_RELEASE:=1}
 
 export GIT_COMMIT=${GIT_COMMIT:=`git rev-parse --short HEAD 2>/dev/null`}


### PR DESCRIPTION
**Enhancements:**
Issue #1672 - Help message is overwhelming for first time users
Issue #2232 - `odo describe` should also show secrets / linked variables from other components and services
#2283 - Updating spec to use `make prepare-release` to create binaries 
#2240 - Adds unit test for project list 
#2268 - Making debug command test target in sync 
#2231 - Updates `odo describe` output 
#2213 - Updates environment variable output 
#2187 - Move dev documentation to /dev 
#2188 - Updates the README formatting and adds crc

**Bug Fixes:**
Issue #2138 - odo watch should fail with error message for git based components
Issue #2156 - show warning for supported and unsupported images when doing odo create/push 
Issue #2192 - "odo push" panics for component created in interactive mode
Issue #2235 - Format json output by default or add an option for that
Issue #2224 - odo link Fails to Link Java Component to Node.js Component 
Issue #2260 - wrong help in odo url
Issue #2243 - Removing --app, --project, --component from subcommands that depends on component dir
Issue #2148 - Should we mention "Supported" / "Unsupported" in components list output for community images?
Issue #2203 - "odo storage create" with "--app" and "--project" flags is broken
Issue #2117 - Project create doesn't wait properly
Issue #1969- --binary flag doesn't work without --context flag while creating component
Issue #2032 - "odo component list --path" shows incorrect "STATE" when components belong to different projects
Issue #2186 - odo list --path <path> fails when not in component directory
Issue #2195 - odo storage commands should mention the need of odo push for changes to take effect
Issue #2163 - odo create interactive generates incorrect config
#2278 - Change Odo Reference to odo for cli-docs 
#2252 - Update test reports path in gitignore file 
#2241 - Correct odo debug Typo 
#2234 - Add crc stop to Deploy Application Section of README
#2230 - ComponentTypeList should be List in machine output 
#2229 - ServiceTypeList should be List in machine output 
#2228 - Machine output for `odo app list` should be `Kind: List` 
#2226 - Edits to Deploying an application using odo Section of README 
#2199 - fix sha256 generation for release 
#2214 - Removing Odo References from CLI 
#2206 - Fix random ginkgo input in test script 
#2205 - Fix typo in `odo debug` help output 
#2190 - log stdout and stderr of tar command 

**Testing:**
Issue #2262 - Link tests are never executed!!
Issue #2184 - Fixing no such file or directory issue

**Documentation**
Issue #2254 - Grammar incorrect for "odo create" project creation.
The downstream documentation has been created and integrated within the OpenShift Container Platform, OpenShift Dedicated and OpenShift Online distribution.

**NOTE:** Remote debugging feature will continue as an experimental in v1.0.0-beta7 release.
