### PR TITLE
Change Odo Reference to odo for cli-docs

### DIFF
--- a/cmd/cli-doc/cli-doc.go
+++ b/cmd/cli-doc/cli-doc.go
@@ -81,7 +81,7 @@ func referencePrinter(command *cobra.Command, level int) string {
 	}
 
 	// The main markdown "template" for everything
-	return fmt.Sprintf(`= Overview of the Odo (OpenShift Do) CLI Structure
+	return fmt.Sprintf(`= Overview of the OpenShift Do (odo) CLI Structure
 
 ___________________
 Example application
@@ -89,7 +89,7 @@ ___________________
 
 [source,sh]
 ----
-%s 
+%s
 ----
 
 %s
@@ -157,7 +157,7 @@ func commandPrinter(command *cobra.Command, level int) string {
 func main() {
 	var clidoc = &cobra.Command{
 		Use:   "cli-doc",
-		Short: "Generate CLI reference for Odo",
+		Short: "Generate CLI reference for odo",
 
 		Example: `  # Generate a markdown-formatted CLI reference page for Odo
   cli-doc reference > docs/cli-reference.md


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
When running `make generate-cli-reference`, changes from #2214 are changed back to original format with `Odo` for cli-reference doc. This pr changes `cli-doc.go` to keep the the cli-reference doc title consistent with other references to `odo` throughout the CLI.

## Was the change discussed in an issue?
N/A
