### PR TITLE
show warning for unsupported image types

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -235,6 +236,18 @@ func SliceSupportedTags(component ComponentType) ([]string, []string) {
 		}
 	}
 	return supTag, unSupTag
+}
+
+func IsComponentTypeSupported(client *occlient.Client, componentType string) (bool, error) {
+
+	_, componentType, _, componentVersion := util.ParseComponentImageName(componentType)
+
+	imageStream, err := client.GetImageStream("", componentType, componentVersion)
+	if err != nil {
+		return false, err
+	}
+	tagMap := createImageTagMap(imageStream.Spec.Tags)
+	return isSupportedImage(tagMap[componentVersion]), nil
 }
 
 // createImageTagMap takes a list of image TagReferences and creates a map of type tag name => image name e.g. 1.11 => openshift/nodejs-11

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -238,6 +238,8 @@ func SliceSupportedTags(component ComponentType) ([]string, []string) {
 	return supTag, unSupTag
 }
 
+// IsComponentTypeSupported takes the componentType e.g. java:8 and return true if
+// it is fully supported i.e. debug mode and more.
 func IsComponentTypeSupported(client *occlient.Client, componentType string) (bool, error) {
 
 	_, componentType, _, componentVersion := util.ParseComponentImageName(componentType)

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -143,6 +143,31 @@ func TestListComponents(t *testing.T) {
 
 func TestSliceSupportedTags(t *testing.T) {
 
+	imageStream := MockImageStream()
+
+	img := ComponentType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nodejs",
+			Namespace: "openshift",
+		},
+		Spec: ComponentSpec{
+			NonHiddenTags: []string{
+				"10", "8", "6", "latest",
+			},
+			ImageStreamRef: *imageStream,
+		},
+	}
+
+	supTags, unSupTags := SliceSupportedTags(img)
+
+	if !reflect.DeepEqual(supTags, []string{"10", "8", "latest"}) ||
+		!reflect.DeepEqual(unSupTags, []string{"6"}) {
+		t.Fatal("supported or unsupported tags are not as expected")
+	}
+}
+
+func MockImageStream() *imagev1.ImageStream {
+
 	tags := map[string]string{
 		"10": "docker.io/rhoar-nodejs/nodejs-10",
 		"8":  "docker.io/rhoar-nodejs/nodejs-8",
@@ -178,23 +203,5 @@ func TestSliceSupportedTags(t *testing.T) {
 			},
 		})
 
-	img := ComponentType{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nodejs",
-			Namespace: "openshift",
-		},
-		Spec: ComponentSpec{
-			NonHiddenTags: []string{
-				"10", "8", "6", "latest",
-			},
-			ImageStreamRef: *imageStream,
-		},
-	}
-
-	supTags, unSupTags := SliceSupportedTags(img)
-
-	if !reflect.DeepEqual(supTags, []string{"10", "8", "latest"}) ||
-		!reflect.DeepEqual(unSupTags, []string{"6"}) {
-		t.Fatal("supported or unsupported tags are not as expected")
-	}
+	return imageStream
 }

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -460,9 +460,17 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 // Validate validates the create parameters
 func (co *CreateOptions) Validate() (err error) {
+	supported, err := catalog.IsComponentTypeSupported(co.Context.Client, *co.componentSettings.Type)
+	if err != nil {
+		return err
+	}
+
+	if !supported {
+		log.Infof("Warning: %s is not fully supported by odo, and it is not guaranteed to work.", *co.componentSettings.Type)
+	}
+
 	s := log.Spinner("Validating component")
 	defer s.End(false)
-
 	if err := component.ValidateComponentCreateRequest(co.Context.Client, co.componentSettings, co.componentContext); err != nil {
 		return err
 	}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -470,6 +470,18 @@ func componentTests(args ...string) {
 			files := helper.ListFilesInDir(context)
 			Expect(files).NotTo(ContainElement(".odo"))
 		})
+
+		It("creates a local python component and check for unsupported warning", func() {
+			helper.CopyExample(filepath.Join("source", "python"), context)
+			output := helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
+			Expect(output).To(ContainSubstring("Warning: python is not fully supported by odo, and it is not guaranteed to work."))
+		})
+
+		It("creates a local java component and check unsupported warning hasn't occured", func() {
+			helper.CopyExample(filepath.Join("source", "openjdk"), context)
+			output := helper.CmdShouldPass("odo", append(args, "create", "java", componentName, "--app", appName, "--project", project, "--context", context)...)
+			Expect(output).NotTo(ContainSubstring("Warning"))
+		})
 	})
 
 	/*

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -477,9 +477,9 @@ func componentTests(args ...string) {
 			Expect(output).To(ContainSubstring("Warning: python is not fully supported by odo, and it is not guaranteed to work."))
 		})
 
-		It("creates a local java component and check unsupported warning hasn't occured", func() {
-			helper.CopyExample(filepath.Join("source", "openjdk"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "java", componentName, "--app", appName, "--project", project, "--context", context)...)
+		It("creates a local nodejs component and check unsupported warning hasn't occured", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs", componentName, "--app", appName, "--project", project, "--context", context)...)
 			Expect(output).NotTo(ContainSubstring("Warning"))
 		})
 	})


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Show warning for unsupported image types on executing `odo create`

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/2156
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create python # should show the warning
odo create java # shouldn't show the warning
```
