### PR TITLE
show error when using odo watch on git components

### DIFF
--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -86,16 +86,16 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 // Validate validates the watch parameters
 func (wo *WatchOptions) Validate() (err error) {
 
-	// Validate component path existence and accessibility permissions for odo
-	if _, err := os.Stat(wo.sourcePath); err != nil {
-		return errors.Wrapf(err, "Cannot watch %s", wo.sourcePath)
-	}
-
 	// Validate source of component is either local source or binary path until git watch is supported
 	if wo.sourceType != "binary" && wo.sourceType != "local" {
 		return fmt.Errorf("Watch is supported by binary and local components only and source type of component %s is %s",
 			wo.localConfig.GetName(),
 			wo.sourceType)
+	}
+
+	// Validate component path existence and accessibility permissions for odo
+	if _, err := os.Stat(wo.sourcePath); err != nil {
+		return errors.Wrapf(err, "Cannot watch %s", wo.sourcePath)
 	}
 
 	// Delay interval cannot be -ve

--- a/tests/integration/cmd_watch_test.go
+++ b/tests/integration/cmd_watch_test.go
@@ -49,4 +49,12 @@ var _ = Describe("odo watch command tests", func() {
 			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create you component"))
 		})
 	})
+
+	Context("when executing watch on a git source type component", func() {
+		It("should fail", func() {
+			helper.CmdShouldPass("odo", "create", "--context", context, "nodejs", "--git", "https://github.com/openshift/nodejs-ex.git")
+			output := helper.CmdShouldFail("odo", "watch", "--context", context)
+			Expect(output).To(ContainSubstring("Watch is supported by binary and local components only"))
+		})
+	})
 })


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Currently due to the check of source path existence using `os.Stat` being present before `sourceType` validation - `odo watch` showed `directory doesn't exist` error instead of `watch not supported for git ...` kind.
So resolved that and added a test.

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/2138
<!-- Please do Link issues here. -->

## How to test changes?
```
odo create nodejs --git https://github.com/openshift/nodejs-ex.git
odo watch # should show an error for kind "Watch is supported by binary and local components only...."
```
