### PR TITLE
Fix odo update

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1567,7 +1567,7 @@ func (c *Client) UpdateDCToSupervisor(ucp UpdateComponentParams, isToLocal bool,
 			addDeploymentDirVolumeMount(&dc, s2iPaths.DeploymentDir)
 		}
 
-		ownerReference := generateOwnerReference(&dc)
+		ownerReference := generateOwnerReference(ucp.ExistingDC)
 
 		// Setup PVC
 		_, err = c.CreatePVC(getAppRootVolumeName(ucp.CommonObjectMeta.Name), "1Gi", ucp.CommonObjectMeta.Labels, ownerReference)
@@ -2469,7 +2469,7 @@ func (c *Client) DeleteBuildConfig(commonObjectMeta metav1.ObjectMeta) error {
 
 	// Convert labels to selector
 	selector := util.ConvertLabelsToSelector(commonObjectMeta.Labels)
-	glog.V(4).Infof("DeleteBuldConfig selectors used for deletion: %s", selector)
+	glog.V(4).Infof("DeleteBuildConfig selectors used for deletion: %s", selector)
 
 	// Delete BuildConfig
 	glog.V(4).Info("Deleting BuildConfigs with DeleteBuildConfig")

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -71,7 +71,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		// Classic case of component creation
 		if err := component.CreateComponent(cpo.Context.Client, *cpo.localConfigInfo, cpo.componentContext, stdout); err != nil {
 			log.Errorf(
-				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
+				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %v",
 				cmpName,
 				err,
 			)

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -67,17 +67,10 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 // Validate validates the update parameters
 func (uo *UpdateOptions) Validate() (err error) {
 
-	log.Info("Validation")
-
-	// First off, we check to see if the component exists. This is ran each time we do `odo push`
-	s := log.Spinner("Checking component")
-
 	uo.doesComponentExist, err = component.Exists(uo.Context.Client, uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
 	}
-
-	defer s.End(false)
 
 	checkFlag := 0
 
@@ -148,11 +141,7 @@ func (uo *UpdateOptions) Run() (err error) {
 	}
 
 	cmpName := uo.localConfigInfo.GetName()
-	if uo.sourceType == config.GIT {
-		log.Successf("The component %s was updated successfully", cmpName)
-	} else {
-		log.Successf("The component %s was updated successfully, please use 'odo push' to push your local changes", cmpName)
-	}
+	log.Successf("The component %s was updated successfully", cmpName)
 	return
 }
 

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -71,7 +71,7 @@ func (uo *UpdateOptions) Validate() (err error) {
 	// First off, we check to see if the component exists. This is ran each time we do `odo push`
 	s := log.Spinner("Checking component")
 
-	uo.isCmpExists, err = component.Exists(uo.Context.Client, uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
+	uo.doesComponentExist, err = component.Exists(uo.Context.Client, uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
 	}

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -3,6 +3,8 @@ package component
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -78,6 +80,10 @@ func (uo *UpdateOptions) Validate() (err error) {
 		checkFlag++
 		uo.sourceType = config.BINARY
 		uo.sourcePath = uo.binary
+
+		if strings.HasPrefix(uo.sourcePath, fmt.Sprintf("..%c", filepath.Separator)) {
+			return fmt.Errorf("%s binary needs to be inside of the context directory", uo.sourcePath)
+		}
 	}
 	if len(uo.git) != 0 {
 		checkFlag++
@@ -88,6 +94,13 @@ func (uo *UpdateOptions) Validate() (err error) {
 		checkFlag++
 		uo.sourceType = config.LOCAL
 		uo.sourcePath = uo.local
+		srcLocInfo, err := os.Stat(uo.sourcePath)
+		if err != nil {
+			return fmt.Errorf("error while validating source path: %v", err.Error())
+		}
+		if !srcLocInfo.IsDir() {
+			return fmt.Errorf("source path for component created for local source needs to be a directory")
+		}
 	}
 
 	if len(uo.componentContext) == 0 {

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -39,16 +39,17 @@ var updateCmdExample = ktemplates.Examples(`  # Change the source code path of c
 	  %[1]s --git https://github.com/openshift/nodejs-ex.git
 		
 	  # Change the source code path of of currently active component to a binary named sample.war in ./downloads directory
-	  %[1]s wildfly --binary ./downloads/sample.war
+	  %[1]s --binary ./downloads/sample.war
 		`)
 
 // NewUpdateOptions returns new instance of UpdateOptions
 func NewUpdateOptions() *UpdateOptions {
 	return &UpdateOptions{
 		CommonPushOptions: &CommonPushOptions{
-			pushConfig: true, // we assume if someone updates then the config is only pushed
+			pushConfig: true, // we push everything
+			forceBuild: true,
+			pushSource: true,
 			show:       false,
-			forceBuild: false,
 		}}
 }
 

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -60,16 +60,24 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 		return errors.Wrapf(err, "failed to update component")
 	}
 
-	uo.doesComponentExist, err = component.Exists(uo.Context.Client, uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
-	if err != nil {
-		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
-	}
-
 	return
 }
 
 // Validate validates the update parameters
 func (uo *UpdateOptions) Validate() (err error) {
+
+	log.Info("Validation")
+
+	// First off, we check to see if the component exists. This is ran each time we do `odo push`
+	s := log.Spinner("Checking component")
+
+	uo.isCmpExists, err = component.Exists(uo.Context.Client, uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", uo.localConfigInfo.GetName(), uo.localConfigInfo.GetApplication())
+	}
+
+	defer s.End(false)
+
 	checkFlag := 0
 
 	if len(uo.binary) != 0 {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -510,87 +510,63 @@ func componentTests(args ...string) {
 		})
 	})
 
-	/*
-			Enable once #1782 and #1778 are fixed
-
-				Context("odo component updating", func() {
-					JustBeforeEach(func() {
-						project = helper.CreateRandProject()
-					})
-
-					JustAfterEach(func() {
-						helper.DeleteProject(project)
-					})
-
-					It("should be able to create a git component and update it from local to git", func() {
-						helper.CopyExample(filepath.Join("source", "nodejs"), context)
-						helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-						helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v", "4")...)
-						getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
-						Expect(getCPULimit).To(ContainSubstring("2"))
-						getCPURequest := oc.MinCPU("cmp-git", "testing", project)
-						Expect(getCPURequest).To(ContainSubstring("100m"))
-
-						// update the component config according to the git component
-						helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "https://github.com/openshift/nodejs-ex", "--context", context, "-f")
-						helper.CmdShouldPass("odo", "config", "set", "sourcetype", "git", "--context", context, "-f")
-
-						// check if the earlier resource requests are still valid
-						helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v", "4")...)
-						getCPULimit = oc.MaxCPU("cmp-git", "testing", project)
-						Expect(getCPULimit).To(ContainSubstring("2"))
-						getCPURequest = oc.MinCPU("cmp-git", "testing", project)
-						Expect(getCPURequest).To(ContainSubstring("100m"))
-
-						// check the source location and type in the deployment config
-						getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
-						Expect(getSourceLocation).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
-						getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
-						Expect(getSourceType).To(ContainSubstring("git"))
-
-						// since the current component type is git
-						// check the source location and type in the build config
-						getSourceLocation = oc.SourceLocationBC("cmp-git", "testing", project)
-						Expect(getSourceLocation).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
-						getSourceType = oc.SourceTypeBC("cmp-git", "testing", project)
-						Expect(getSourceType).To(ContainSubstring("Git"))
-					})
-
-					It("should be able to update a component from git to local", func() {
-						helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
-						helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v", "4")...)
-						getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
-						Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-						getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
-						Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
-
-						// update the component config according to the git component
-						helper.CopyExample(filepath.Join("source", "nodejs"), context)
-						helper.CmdShouldPass("odo", "config", "set", "sourcelocation", "./", "--context", context, "-f")
-						helper.CmdShouldPass("odo", "config", "set", "sourcetype", "local", "--context", context, "-f")
-
-						// check if the earlier resource requests are still valid
-						helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v", "4")...)
-						getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
-						Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-						getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
-						Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
-
-						// check the source location and type in the deployment config
-						getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
-						var sourcePath string
-						if runtime.GOOS == "windows" {
-							sourcePath = "file:///./"
-						} else {
-							sourcePath = "file://./"
-						}
-						Expect(getSourceLocation).To(ContainSubstring(sourcePath))
-						getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
-						Expect(getSourceType).To(ContainSubstring("local"))
-					})
-				})
+	Context("odo component updating", func() {
+		JustBeforeEach(func() {
+			project = helper.CreateRandProject()
 		})
-	*/
+
+		JustAfterEach(func() {
+			helper.DeleteProject(project)
+		})
+
+		It("should be able to create a git component and update it from local to git", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
+			Expect(getCPULimit).To(ContainSubstring("2"))
+			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
+			Expect(getCPURequest).To(ContainSubstring("100m"))
+
+			helper.CmdShouldPass("odo", "update", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", context)
+			// check the source location and type in the deployment config
+			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
+			Expect(getSourceLocation).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
+			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
+			Expect(getSourceType).To(ContainSubstring("git"))
+		})
+
+		It("should be able to update a component from git to local", func() {
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+
+			// update the component config according to the git component
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "update", "--local", ".", "--context", context)
+
+			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
+			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
+			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
+			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
+
+			// check the source location and type in the deployment config
+			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
+			var sourcePath string
+			if runtime.GOOS == "windows" {
+				sourcePath = "file:///./"
+			} else {
+				sourcePath = "file://./"
+			}
+			Expect(getSourceLocation).To(ContainSubstring(sourcePath))
+			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
+			Expect(getSourceType).To(ContainSubstring("local"))
+		})
+	})
 
 	Context("odo component delete, list and describe", func() {
 		appName := "app"

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -547,7 +547,7 @@ func componentTests(args ...string) {
 			// update the component config according to the git component
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "update", "--local", ".", "--context", context)
+			helper.CmdShouldPass("odo", "update", "--local", "./", "--context", context)
 
 			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
 			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Use of --context flag in odo update and internally odo update uses common push.

## Was the change discussed in an issue?
fixes https://github.com/openshift/odo/issues/2155
fixes https://github.com/openshift/odo/issues/1778
fixes https://github.com/openshift/odo/issues/1782

for the issues https://github.com/openshift/odo/issues/1782 and https://github.com/openshift/odo/issues/1778. I have uncommented the tests and haven't observed the flake since locally and on CI.
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
```
odo create nodejs
odo push
odo update --git  https://github.com/openshift/nodejs-ex.git 