### PR TITLE
Updating default bootstrapper image to GA'ed image

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -96,7 +96,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "quay.io/openshiftdo/init:0.13.1"
+	defaultBootstrapperImage = "registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.0.0"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"


### PR DESCRIPTION
registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.0.0

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>
