### PR TITLE
Error out when there is a missing environment variable

### DIFF
--- a/pkg/config/env_var.go
+++ b/pkg/config/env_var.go
@@ -84,15 +84,30 @@ func NewEnvVarListFromSlice(envList []string) (EnvVarList, error) {
 
 // RemoveEnvVarsFromList removes the env variables based on the keys provided
 // and returns a new EnvVarList
-func RemoveEnvVarsFromList(envVarList EnvVarList, keys []string) EnvVarList {
+func RemoveEnvVarsFromList(envVarList EnvVarList, envKeysToRemove []string) (EnvVarList, error) {
+
+	// Convert map to list of array for an easier way to search for env names
+	envVarListArray := []string{}
+	for _, env := range envVarList {
+		envVarListArray = append(envVarListArray, env.Name)
+	}
+
+	// Before anything, we check to see if the environment variable actually exists to unset..
+	for _, key := range envKeysToRemove {
+		if !util.In(envVarListArray, key) {
+			return EnvVarList{}, fmt.Errorf("unable to find %s environment variable to unset", key)
+		}
+	}
+
+	// Below we check to see if any of the keys we are removing
+	// match and them remove them.
 	newEnvVarList := EnvVarList{}
 	for _, envVar := range envVarList {
-		// if the env is in the keys we skip it
-		if util.In(keys, envVar.Name) {
+		if util.In(envKeysToRemove, envVar.Name) {
 			continue
 		}
-
 		newEnvVarList = append(newEnvVarList, envVar)
 	}
-	return newEnvVarList
+
+	return newEnvVarList, nil
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -84,8 +84,13 @@ func (o *UnsetOptions) Run() (err error) {
 	if o.envArray != nil {
 
 		envList := o.lci.GetEnvVars()
-		newEnvList := config.RemoveEnvVarsFromList(envList, o.envArray)
-		if err := o.lci.SetEnvVars(newEnvList); err != nil {
+
+		newEnvList, err := config.RemoveEnvVarsFromList(envList, o.envArray)
+		if err != nil {
+			return err
+		}
+
+		if err = o.lci.SetEnvVars(newEnvList); err != nil {
 			return err
 		}
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -262,6 +262,19 @@ var _ = Describe("odo preference and config command tests", func() {
 			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
 			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
 		})
+
+		It("fail when unsetting a variable that isn't there", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldFail("odo", "config", "unset", "--env", helper.RandString(7), "--context", context)
+		})
+
+		It("fail when unsetting a variable that is there, but using key=value, which is incorrect..", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			env := helper.RandString(7) + "=value"
+			helper.CmdShouldPass("odo", "config", "set", "--env", env, "--context", context)
+			helper.CmdShouldFail("odo", "config", "unset", "--env", env, "--context", context)
+		})
+
 	})
 
 	Context("when viewing local config without logging into the OpenShift cluster", func() {


### PR DESCRIPTION
This PR errors out when there is a missing environment variable or an
invalid environment variable has been passed.

To test:

```sh
odo config set --env foo=bar
odo config unset --env testvariable # will error
odo config unset --env foo=bar # will error
odo config unset --env foo # will pass
```

Closes https://github.com/openshift/odo/issues/2139