### PR TITLE
Removed forgotten focus from integration tests

### DIFF
--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -39,7 +39,7 @@ var _ = Describe("odo project command tests", func() {
 	})
 
 	Context("when running project command app parameter in directory that doesn't contain .odo config directory", func() {
-		FIt("should successfully execute list along with machine readable output", func() {
+		It("should successfully execute list along with machine readable output", func() {
 			listOutput := helper.CmdShouldPass("odo", "project", "list")
 			Expect(listOutput).To(ContainSubstring(project))
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
see $SUBJECT

## Was the change discussed in an issue?
partly https://github.com/openshift/odo/issues/2298
<!-- Please do Link issues here. -->

## How to test changes?
tests shouldn't have `F` (focus) in them
