### PR TITLE
Use the absolute path when using odo push

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -81,7 +81,7 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Checking component")
 	defer s.End(false)
 
-	po.isCmpExists, err = component.Exists(po.Context.Client, po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
+	po.doesComponentExist, err = component.Exists(po.Context.Client, po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.localConfigInfo.GetName(), po.localConfigInfo.GetApplication())
 	}
@@ -92,7 +92,7 @@ func (po *PushOptions) Validate() (err error) {
 		return fmt.Errorf("Invalid component type %s, %v", *po.localConfigInfo.GetComponentSettings().Type, errors.Cause(err))
 	}
 
-	if !po.isCmpExists && po.pushSource && !po.pushConfig {
+	if !po.doesComponentExist && po.pushSource && !po.pushConfig {
 		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfigInfo.GetName())
 	}
 


### PR DESCRIPTION
This PR fixes the following issues:
  - Deletion not working within windows and using a non-relative path
  command, ex: `odo push --context nodejs-ex/`
  - File changes not working when using a non-relative path command:
  `odo push --context nodejs-ex/`
  - Use forward slashes when storing information into
  odo-file-index.json

To test (on Windows):
```sh
git clone https://github.com/openshift/nodejs-ex
cd nodejs-ex\
odo create nodejs
odo push
cd ..
odo push --context nodejs-ex
type nul > nodejs-ex\foobar.txt
odo push --context nodejs-ex
```

All of these commands should now work as odo will now pass on the
absolute path to the file index functions and commands before deletion /
propagating changed files

Then check the index:
```sh
type nodejs-ex\.odo\odo-file-index.json
```

Which will now have forward slashes.

Closes issue https://github.com/openshift/odo/issues/2301
Closes issue https://github.com/openshift/odo/issues/2217