### PR TITLE
Modifies the PR commit template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,21 @@
-## What is the purpose of this change? What does it change?
-<!-- Describe the changes here, as detailed as needed. -->
+**What kind of PR is this?**
+<!--
+DELETE the kind(s) which are not applicable before opening the PR.
+-->
 
-## Was the change discussed in an issue?
-fixes #???
-<!-- Please do Link issues here. -->
+/kind api-change
+/kind bug
+/kind cleanup
+/kind code refactorting
+/kind docs
+/kind enhancement
+/kind feature
+/kind flake
 
-## How to test changes?
-<!-- Please describe the steps to test the PR -->
+**What does does this PR do / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+Fixes #?
+
+**How to test changes / Special notes to the reviewer**:


### PR DESCRIPTION
**What kind of PR is this?**
/kind docs

**What does does this PR do / why we need it**:

We need this for a few reasons:
  - Our current template has too much "fluff", needing to remove
  multiple lines of comments just to commit..
  - If you use the template from the command-line using `git commit` you
  are actually unable use markdown headers (`#` is a comment in Git...)
  - We should have a way to use `/kind`
  - This template follows the way Kubernetes does it:
  https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
  but simpler

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

View the doc :) The above example is what the new "template" looks like.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>