### PR TITLE
Disable context / checking for config when using autocompletion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,6 +145,7 @@ func NewLocalConfigInfo(cfgDir string) (*LocalConfigInfo, error) {
 		c.configFileExists = false
 		return &c, nil
 	}
+
 	err = getFromFile(&c.LocalConfig, c.Filename)
 	if err != nil {
 		return nil, err

--- a/pkg/odo/util/completion/completion.go
+++ b/pkg/odo/util/completion/completion.go
@@ -108,7 +108,7 @@ func getCommandFlagCompletionHandlerKey(command *cobra.Command, flag string) han
 func newHandler(cmd *cobra.Command, predictor ContextualizedPredictor) completionHandler {
 	return completionHandler{
 		cmd:       cmd,
-		ctxLoader: genericclioptions.NewContext,
+		ctxLoader: genericclioptions.NewContextCompletion,
 		predictor: predictor,
 	}
 }


### PR DESCRIPTION
**What is the purpose of this change? What does it change?**

There was a change to context that was introduced in commit:
https://github.com/openshift/odo/commit/b800ebc370ee0ed893b3522d323327d36c188847
that made it so odo would error out when there was no configuration.

Previously, there was a boolean value that was passed in to disable
checking for a valid configuration, but that was removed by:
https://github.com/openshift/odo/commit/b800ebc370ee0ed893b3522d323327d36c188847

This re-introduces a boolean value to disable configuration checking
when using context since not always is there a configuration when using
autocompletion / checking parameters.

**Was the change discussed in an issue?**

Closes https://github.com/openshift/odo/issues/1718

**How to test changes?**

Install autocompletion using `odo --complete`

Then try to tab `--context` parameter when using `odo push`.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>