### PR TITLE
Fixes wait for project creation

### DIFF
--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -8,21 +8,18 @@ import (
 	fakeProjClientset "github.com/openshift/client-go/project/clientset/versioned/fake"
 	fakeRouteClientset "github.com/openshift/client-go/route/clientset/versioned/fake"
 	fakeKubeClientset "k8s.io/client-go/kubernetes/fake"
-	clienttesting "k8s.io/client-go/testing"
-	fakeKubeCoreV1set "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake"
 )
 
 // FakeClientset holds fake ClientSets
 // this is returned by FakeNew to access methods of fake client sets
 type FakeClientset struct {
-	Kubernetes                *fakeKubeClientset.Clientset
-	AppsClientset             *fakeAppsClientset.Clientset
-	BuildClientset            *fakeBuildClientset.Clientset
-	ImageClientset            *fakeImageClientset.Clientset
-	RouteClientset            *fakeRouteClientset.Clientset
-	ProjClientset             *fakeProjClientset.Clientset
-	ServiceCatalogClientSet   *fakeServiceCatalogClientSet.Clientset
-	KubernetesCoreV1ClientSet *fakeKubeCoreV1set.FakeCoreV1
+	Kubernetes              *fakeKubeClientset.Clientset
+	AppsClientset           *fakeAppsClientset.Clientset
+	BuildClientset          *fakeBuildClientset.Clientset
+	ImageClientset          *fakeImageClientset.Clientset
+	RouteClientset          *fakeRouteClientset.Clientset
+	ProjClientset           *fakeProjClientset.Clientset
+	ServiceCatalogClientSet *fakeServiceCatalogClientSet.Clientset
 }
 
 // FakeNew creates new fake client for testing
@@ -55,9 +52,6 @@ func FakeNew() (*Client, *FakeClientset) {
 
 	fkclientset.ServiceCatalogClientSet = fakeServiceCatalogClientSet.NewSimpleClientset()
 	client.serviceCatalogClient = fkclientset.ServiceCatalogClientSet.Servicecatalog()
-
-	fkclientset.KubernetesCoreV1ClientSet = &fakeKubeCoreV1set.FakeCoreV1{Fake: &clienttesting.Fake{}}
-	client.kubernetesCoreV1 = fkclientset.KubernetesCoreV1ClientSet
 
 	return &client, &fkclientset
 }

--- a/pkg/occlient/fakeclient.go
+++ b/pkg/occlient/fakeclient.go
@@ -8,18 +8,21 @@ import (
 	fakeProjClientset "github.com/openshift/client-go/project/clientset/versioned/fake"
 	fakeRouteClientset "github.com/openshift/client-go/route/clientset/versioned/fake"
 	fakeKubeClientset "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	fakeKubeCoreV1set "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake"
 )
 
 // FakeClientset holds fake ClientSets
 // this is returned by FakeNew to access methods of fake client sets
 type FakeClientset struct {
-	Kubernetes              *fakeKubeClientset.Clientset
-	AppsClientset           *fakeAppsClientset.Clientset
-	BuildClientset          *fakeBuildClientset.Clientset
-	ImageClientset          *fakeImageClientset.Clientset
-	RouteClientset          *fakeRouteClientset.Clientset
-	ProjClientset           *fakeProjClientset.Clientset
-	ServiceCatalogClientSet *fakeServiceCatalogClientSet.Clientset
+	Kubernetes                *fakeKubeClientset.Clientset
+	AppsClientset             *fakeAppsClientset.Clientset
+	BuildClientset            *fakeBuildClientset.Clientset
+	ImageClientset            *fakeImageClientset.Clientset
+	RouteClientset            *fakeRouteClientset.Clientset
+	ProjClientset             *fakeProjClientset.Clientset
+	ServiceCatalogClientSet   *fakeServiceCatalogClientSet.Clientset
+	KubernetesCoreV1ClientSet *fakeKubeCoreV1set.FakeCoreV1
 }
 
 // FakeNew creates new fake client for testing
@@ -52,6 +55,9 @@ func FakeNew() (*Client, *FakeClientset) {
 
 	fkclientset.ServiceCatalogClientSet = fakeServiceCatalogClientSet.NewSimpleClientset()
 	client.serviceCatalogClient = fkclientset.ServiceCatalogClientSet.Servicecatalog()
+
+	fkclientset.KubernetesCoreV1ClientSet = &fakeKubeCoreV1set.FakeCoreV1{Fake: &clienttesting.Fake{}}
+	client.kubernetesCoreV1 = fkclientset.KubernetesCoreV1ClientSet
 
 	return &client, &fkclientset
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -532,9 +532,19 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 			if !ok {
 				break
 			}
-			if e, ok := val.Object.(*projectv1.Project); ok {
-				glog.V(4).Infof("Project %s now exists", e.Name)
-				return nil
+			if prj, ok := val.Object.(*projectv1.Project); ok {
+				glog.V(4).Infof("Status of creation of project %s is %s", prj.Name, prj.Status.Phase)
+				switch prj.Status.Phase {
+				//prj.Status.Phase can only be "Terminating" or "Active" or ""
+				case "Active":
+					if val.Type == watch.Added {
+						glog.V(4).Infof("Project %s now exists", prj.Name)
+						return nil
+					}
+					if val.Type == watch.Error {
+						return fmt.Errorf("failed watching the deletion of project %s", prj.Name)
+					}
+				}
 			}
 		}
 	}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -2367,10 +2367,11 @@ func TestCreateNewProject(t *testing.T) {
 				fkWatch := watch.NewFake()
 				// Change the status
 				go func() {
-					fkWatch.Modify(&projectv1.Project{
+					fkWatch.Add(&projectv1.Project{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tt.projName,
 						},
+						Status: projectv1.ProjectStatus{Phase: "Active"},
 					})
 				}()
 				fkclientset.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -5377,3 +5377,57 @@ func TestIsSubDir(t *testing.T) {
 	}
 
 }
+
+func TestWaitForServiceAccountInNamespace(t *testing.T) {
+	tests := []struct {
+		name               string
+		namespace          string
+		serviceAccountName string
+		wantErr            bool
+	}{
+		{
+			name:               "Test case 1: with valid namespace and serviceAccountName",
+			namespace:          "test-1",
+			serviceAccountName: "default",
+			wantErr:            false,
+		},
+		{
+			name:               "Test case 2: with no namespace and serviceAccountName",
+			namespace:          "",
+			serviceAccountName: "",
+			wantErr:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fake the client with the appropriate arguments
+			client, fakeClientSet := FakeNew()
+			fkWatch := watch.NewFake()
+
+			go func() {
+				fkWatch.Add(&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.serviceAccountName,
+					},
+				})
+			}()
+
+			fakeClientSet.Kubernetes.PrependWatchReactor("serviceaccounts", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				return true, fkWatch, nil
+			})
+
+			err := client.WaitForServiceAccountInNamespace(tt.namespace, tt.serviceAccountName)
+			if err == nil && !tt.wantErr {
+				if len(fakeClientSet.Kubernetes.Actions()) != 1 {
+					t.Errorf("expected 1 Kubernetes.Actions() in ServiceAccountName wait, got: %v", len(fakeClientSet.ProjClientset.Actions()))
+				}
+			}
+
+			// Checks for error in positive cases
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -33,6 +33,12 @@ func Create(client *occlient.Client, projectName string, wait bool) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to create new project")
 	}
+	if wait {
+		err = client.WaitForDefaultServiceAccountInNamespace(projectName, "default")
+		if err != nil {
+			return errors.Wrap(err, "unable to wait for service account")
+		}
+	}
 	return nil
 }
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -34,7 +34,7 @@ func Create(client *occlient.Client, projectName string, wait bool) error {
 		return errors.Wrap(err, "unable to create new project")
 	}
 	if wait {
-		err = client.WaitForDefaultServiceAccountInNamespace(projectName, "default")
+		err = client.WaitForServiceAccountInNamespace(projectName, "default")
 		if err != nil {
 			return errors.Wrap(err, "unable to wait for service account")
 		}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -66,7 +66,7 @@ func TestCreate(t *testing.T) {
 			})
 
 			go func() {
-				fkWatch.Add(testingutil.FakeProjectStatus(corev1.NamespacePhase(""), tt.projectName))
+				fkWatch.Add(testingutil.FakeProjectStatus(corev1.NamespacePhase("Active"), tt.projectName))
 			}()
 			fakeClientSet.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 				return true, fkWatch, nil

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -82,7 +82,7 @@ func TestCreate(t *testing.T) {
 				})
 			}()
 
-			fakeClientSet.KubernetesCoreV1ClientSet.PrependWatchReactor("serviceaccounts", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+			fakeClientSet.Kubernetes.PrependWatchReactor("serviceaccounts", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 				return true, fkWatch2, nil
 			})
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"reflect"
 	"testing"
@@ -70,6 +71,19 @@ func TestCreate(t *testing.T) {
 			}()
 			fakeClientSet.ProjClientset.PrependWatchReactor("projects", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 				return true, fkWatch, nil
+			})
+
+			fkWatch2 := watch.NewFake()
+			go func() {
+				fkWatch2.Add(&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				})
+			}()
+
+			fakeClientSet.KubernetesCoreV1ClientSet.PrependWatchReactor("serviceaccounts", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
+				return true, fkWatch2, nil
 			})
 
 			// The function we are testing

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -51,7 +51,6 @@ var _ = Describe("odo project command tests", func() {
 
 	Context("when running project command app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute list along with machine readable output", func() {
-			time.Sleep(1 * time.Second)
 			listOutput := helper.CmdShouldPass("odo", "project", "list")
 			Expect(listOutput).To(ContainSubstring(project))
 

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -26,6 +26,8 @@ var _ = Describe("odo project command tests", func() {
 	// Clean up after the test
 	// This is run after every Spec (It)
 	var _ = AfterEach(func() {
+		// remove later
+		helper.CmdRunner("odo", "project", "list", "-o", "json")
 		helper.DeleteProject(project)
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -49,15 +50,21 @@ var _ = Describe("odo project command tests", func() {
 
 	Context("when running project command app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute list along with machine readable output", func() {
-			listOutput := helper.CmdShouldPass("odo", "project", "list")
-			Expect(listOutput).To(ContainSubstring(project))
 
-			// project deletion doesn't happen immediately, so we test subset of the string
-			listOutputJSON, err := helper.Unindented(helper.CmdShouldPass("odo", "project", "list", "-o", "json"))
-			Expect(err).Should(BeNil())
+			helper.WaitForCmdOut("odo", []string{"project", "list"}, 1, true, func(output string) bool {
+				return strings.Contains(output, project)
+			})
+
+			// project deletion doesn't happen immediately and older projects still might exist
+			// so we test subset of the string
 			expected, err := helper.Unindented(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"` + project + `","namespace":"` + project + `","creationTimestamp":null},"spec":{},"status":{"active":true}}`)
 			Expect(err).Should(BeNil())
-			Expect(listOutputJSON).To(ContainSubstring(expected))
+
+			helper.WaitForCmdOut("odo", []string{"project", "list", "-o", "json"}, 1, true, func(output string) bool {
+				listOutputJSON, err := helper.Unindented(output)
+				Expect(err).Should(BeNil())
+				return strings.Contains(listOutputJSON, expected)
+			})
 		})
 	})
 })

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -26,8 +26,6 @@ var _ = Describe("odo project command tests", func() {
 	// Clean up after the test
 	// This is run after every Spec (It)
 	var _ = AfterEach(func() {
-		// remove later
-		helper.CmdRunner("odo", "project", "list", "-o", "json")
 		helper.DeleteProject(project)
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")


### PR DESCRIPTION
fixes #2117 
fixes #2284 

How to test:

- Run `odo project create <name> -w` and check if the command waits properly.
- `make test-cmd-project` should pass.