### PR TITLE
Adds golintCI to travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ jobs:
       go: "1.11.2"
       install:
         - make goget-tools
+        # binary will be $(go env GOPATH)/bin/golangci-lint
+        - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
       script:
         - export PATH="$PATH:$GOPATH/bin"
         - make bin
         - make validate
         - make test-coverage
+        - make golint
       after_success:
         # submit coverage.txt to codecov.io
         - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ check-vendor:
 .PHONY: validate-vendor-licenses
 validate-vendor-licenses:
 	wwhrd check -q
+
+.PHONY: golint
+golint:
+	golangci-lint run ./... --timeout 5m
+
 # golint errors are only recommendations
 .PHONY: lint
 lint:

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -13,11 +13,9 @@ import (
 )
 
 const (
-	appPrefixMaxLen   = 12
-	appNameMaxRetries = 3
-	appAPIVersion     = "odo.openshift.io/v1alpha1"
-	appKind           = "Application"
-	appList           = "List"
+	appAPIVersion = "odo.openshift.io/v1alpha1"
+	appKind       = "Application"
+	appList       = "List"
 )
 
 // List all applications in current project

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -99,7 +99,7 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 // Kindly taken from https://stackoverflow.com/questions/54570268/filtering-the-output-of-a-terminal-output-using-golang
 func copyAndFilter(w io.Writer, r io.Reader) ([]byte, error) {
 	var out []byte
-	buf := make([]byte, 1024, 1024)
+	buf := make([]byte, 1024)
 	for {
 		n, err := r.Read(buf[:])
 		if n > 0 {

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -899,11 +899,11 @@ func TestGetComponentFromConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewLocalConfigInfo("")
+			_, err := NewLocalConfigInfo("")
 			if err != nil {
 				t.Error(err)
 			}
-			cfg = &tt.existingConfig
+			cfg := &tt.existingConfig
 
 			got, _ := GetComponentFromConfig(*cfg)
 

--- a/pkg/component/watch.go
+++ b/pkg/component/watch.go
@@ -98,6 +98,9 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string)
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 	for _, folder := range folders {
 
 		if matched, _ := util.IsGlobExpMatch(folder, ignores); matched {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -664,7 +664,7 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 
 	// Get the component context folder
 	// ".odo" is removed as lci.Filename will always return the '.odo' folder.. we don't need that!
-	componentContext := strings.Trim(filepath.Dir(lci.Filename), ".odo")
+	componentContext := strings.TrimSuffix(filepath.Dir(lci.Filename), ".odo")
 
 	if sourceLocation == "" {
 		return "", fmt.Errorf("Blank source location, does the .odo directory exist?")
@@ -688,5 +688,5 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 
 	sourceOSPath := filepath.FromSlash(absPath)
 
-	return sourceOSPath, nil
+	return sourceOSPath, err
 }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -583,7 +583,10 @@ func addLabelsToArgs(labels map[string]string, args []string) []string {
 // getExposedPortsFromISI parse ImageStreamImage definition and return all exposed ports in form of ContainerPorts structs
 func getExposedPortsFromISI(image *imagev1.ImageStreamImage) ([]corev1.ContainerPort, error) {
 	// file DockerImageMetadata
-	_ = imageWithMetadata(&image.Image)
+	err := imageWithMetadata(&image.Image)
+	if err != nil {
+		return nil, err
+	}
 
 	var ports []corev1.ContainerPort
 
@@ -764,7 +767,7 @@ func (c *Client) GetImageStreamImage(imageStream *imagev1.ImageStream, imageTag 
 	}
 
 	// return error since its an unhandled case if code reaches here
-	return nil, fmt.Errorf("unable to fetch image with tag %s corresponding to imagestream %+v", imageTag, imageStream)
+	return nil, fmt.Errorf("unable to find tag %s for image %s", imageTag, imageName)
 }
 
 // GetImageStreamTags returns all the ImageStreamTag objects in the given namespace

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -23,7 +23,6 @@ import (
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/testingutil"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,23 +132,6 @@ func fakeResourceRequirements() *corev1.ResourceRequirements {
 	resReq.Requests = requests
 
 	return &resReq
-}
-
-func fakeResourceConsumption() []util.ResourceRequirementInfo {
-	memoryQuantity, err := util.FetchResourceQuantity(corev1.ResourceMemory, "100Mi", "350Mi", "")
-	if err != nil {
-		fmt.Println(err)
-		return nil
-	}
-	cpuQuantity, err := util.FetchResourceQuantity(corev1.ResourceCPU, "100m", "350m", "")
-	if err != nil {
-		fmt.Println(err)
-		return nil
-	}
-	return []util.ResourceRequirementInfo{
-		*memoryQuantity,
-		*cpuQuantity,
-	}
 }
 
 // fakeImageStream gets imagestream for the reactor

--- a/pkg/occlient/volumes.go
+++ b/pkg/occlient/volumes.go
@@ -91,10 +91,7 @@ func (c *Client) DeletePVC(name string) error {
 
 // IsAppSupervisorDVolume checks if the volume is a supervisorD volume
 func (c *Client) IsAppSupervisorDVolume(volumeName, dcName string) bool {
-	if volumeName == getAppRootVolumeName(dcName) {
-		return true
-	}
-	return false
+	return volumeName == getAppRootVolumeName(dcName)
 }
 
 // getVolumeNamesFromPVC returns the name of the volume associated with the given

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -17,7 +16,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/service"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // RecommendedCommandName is the recommended app command name
@@ -109,27 +107,4 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 
 	}
 	return nil
-}
-
-// getMachineReadableFormat returns resource information in machine readable format
-func getMachineReadableFormat(client *occlient.Client, appName string, projectName string, active bool) application.App {
-	componentList, _ := component.List(client, appName, nil)
-	var compList []string
-	for _, component := range componentList.Items {
-		compList = append(compList, component.Name)
-	}
-	appDef := application.App{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "app",
-			APIVersion: "odo.openshift.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      appName,
-			Namespace: projectName,
-		},
-		Spec: application.AppSpec{
-			Components: compList,
-		},
-	}
-	return appDef
 }

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -59,7 +59,7 @@ func (o *DeleteOptions) Validate() (err error) {
 	if !exist {
 		return fmt.Errorf("%s app does not exists", o.appName)
 	}
-	return nil
+	return err
 }
 
 // Run contains the logic for the odo command

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -127,16 +127,16 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 	// Here we add the necessary "logging" flags.. However, we choose to hide some of these from the user
 	// as they are not necessarily needed and more for advanced debugging
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.CommandLine.Set("logtostderr", "true")
-	pflag.CommandLine.MarkHidden("alsologtostderr")
-	pflag.CommandLine.MarkHidden("log_backtrace_at")
-	pflag.CommandLine.MarkHidden("log_dir")
-	pflag.CommandLine.MarkHidden("logtostderr")
-	pflag.CommandLine.MarkHidden("stderrthreshold")
+	_ = pflag.CommandLine.Set("logtostderr", "true")
+	_ = pflag.CommandLine.MarkHidden("alsologtostderr")
+	_ = pflag.CommandLine.MarkHidden("log_backtrace_at")
+	_ = pflag.CommandLine.MarkHidden("log_dir")
+	_ = pflag.CommandLine.MarkHidden("logtostderr")
+	_ = pflag.CommandLine.MarkHidden("stderrthreshold")
 
 	// We will mark the command as hidden and then re-enable if the command
 	// supports json output
-	pflag.CommandLine.MarkHidden("o")
+	_ = pflag.CommandLine.MarkHidden("o")
 
 	// Override the verbosity flag description
 	verbosity := pflag.Lookup("v")
@@ -231,6 +231,6 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	cmd.Help()
+	_ = cmd.Help()
 	return fmt.Errorf("Invalid command - see available commands/subcommands above")
 }

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/project"
@@ -28,7 +27,6 @@ type CommonPushOptions struct {
 	sourceType       config.SrcType
 	sourcePath       string
 	componentContext string
-	client           *occlient.Client
 	localConfigInfo  *config.LocalConfigInfo
 
 	pushConfig  bool
@@ -141,7 +139,7 @@ func (cpo *CommonPushOptions) Push() (err error) {
 	appName := cpo.localConfigInfo.GetApplication()
 
 	if cpo.componentContext == "" {
-		cpo.componentContext = strings.Trim(filepath.Dir(cpo.localConfigInfo.Filename), ".odo")
+		cpo.componentContext = strings.TrimSuffix(filepath.Dir(cpo.localConfigInfo.Filename), ".odo")
 	}
 
 	err = cpo.createCmpIfNotExistsAndApplyCmpConfig(stdout)

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -2,7 +2,6 @@ package component
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,6 @@ type CreateOptions struct {
 	cpuMax            string
 	cpuMin            string
 	cpu               string
-	wait              bool
 	interactive       bool
 	now               bool
 	*CommonPushOptions
@@ -503,41 +501,6 @@ func (co *CreateOptions) Run() (err error) {
 		log.Infof("Please use `odo push` command to create the component with source deployed")
 	}
 	return
-}
-
-func (co *CreateOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) error {
-
-	cmpName := co.localConfigInfo.GetName()
-	appName := co.localConfigInfo.GetApplication()
-	cmpType := co.localConfigInfo.GetType()
-
-	isCmpExists, err := component.Exists(co.Context.Client, cmpName, appName)
-	if err != nil {
-		return errors.Wrapf(err, "failed to check if component %s exists or not", cmpName)
-	}
-
-	if !isCmpExists {
-		log.Successf("Creating %s component with name %s", cmpType, cmpName)
-		// Classic case of component creation
-		if err = component.CreateComponent(co.Context.Client, *co.localConfigInfo, co.componentContext, stdout); err != nil {
-			log.Errorf(
-				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
-				cmpName,
-				err,
-			)
-			os.Exit(1)
-		}
-		log.Successf("Successfully created component %s", cmpName)
-	}
-
-	// Apply config
-	err = component.ApplyConfig(co.Context.Client, *co.localConfigInfo, stdout, isCmpExists)
-	if err != nil {
-		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
-	}
-	log.Successf("Successfully updated component with name: %v", cmpName)
-
-	return nil
 }
 
 // The general cpu/memory is used as a fallback when it's set and both min-cpu/memory max-cpu/memory are not set

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -41,8 +41,11 @@ func NewDescribeOptions() *DescribeOptions {
 // Complete completes describe args
 func (do *DescribeOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	err = do.ComponentOptions.Complete(name, cmd, args)
+	if err != nil {
+		return err
+	}
 	do.localConfigInfo, err = config.NewLocalConfigInfo(do.componentContext)
-	return
+	return err
 }
 
 // Validate validates the describe parameters

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -73,7 +73,7 @@ func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []st
 
 	o.StopChannel = make(chan struct{}, 1)
 	o.ReadyChannel = make(chan struct{})
-	return nil
+	return err
 }
 
 // Validate validates all the required options for port-forward cmd.

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -11,7 +11,7 @@ import (
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
 
-const mountRecommendedCommandName = "mount"
+//const mountRecommendedCommandName = "mount"
 
 var (
 	storageMountShortDesc = `mount storage to a component`

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -13,7 +13,7 @@ import (
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 )
 
-const unMountRecommendedCommandName = "unmount"
+//const unMountRecommendedCommandName = "unmount"
 
 var (
 	storageUnMountShortDesc = `Unmount storage from the given path or identified by its name, from the current component`

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -239,9 +239,8 @@ func newContext(command *cobra.Command, createAppIfNeeded bool) *Context {
 	// Get details from config file
 	configFileName := FlagValueIfSet(command, ContextFlagName)
 	if configFileName != "" {
-		fAbs, err := pkgUtil.GetAbsPath(configFileName)
+		_, err := pkgUtil.GetAbsPath(configFileName)
 		util.LogErrorAndExit(err, "")
-		configFileName = fAbs
 	}
 
 	// Check for valid config

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -47,7 +47,7 @@ func CheckMachineReadableOutputCommand(cmd *cobra.Command) {
 	if hasFlagChanged && outputFlag.Value.String() == "json" && machineOutput == "" {
 
 		// By default we "disable" logging, so undisable it so that the below error can be shown.
-		flag.Set("o", "")
+		_ = flag.Set("o", "")
 
 		// Output the error
 		log.Error("Machine readable output is not yet implemented for this command")
@@ -59,6 +59,6 @@ func CheckMachineReadableOutputCommand(cmd *cobra.Command) {
 	// in order to have NO verbose output when combining both `-o json` and `-v 4` so json output
 	// is not malformed / mixed in with normal logging
 	if log.IsJSON() {
-		flag.Set("v", "0")
+		_ = flag.Set("v", "0")
 	}
 }

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -49,7 +49,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 			if context == "" {
 				log.Error(errors.Cause(err))
 			} else {
-				log.Errorf(fmt.Sprintf("%s", strings.Title(context)), a...)
+				log.Errorf(strings.Title(context), a...)
 			}
 		}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -290,7 +290,7 @@ func GetServiceClassAndPlans(client *occlient.Client, serviceName string) (Servi
 	for _, result := range planResults {
 		plan, err := NewServicePlan(result)
 		if err != nil {
-
+			return ServiceClass{}, nil, err
 		}
 
 		plans = append(plans, plan)

--- a/pkg/testingutil/deploymentconfigs.go
+++ b/pkg/testingutil/deploymentconfigs.go
@@ -10,14 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func getContainerPort(containerPort int32, containerProtocol corev1.Protocol) (container corev1.ContainerPort) {
-	return corev1.ContainerPort{
-		Name:          fmt.Sprintf("%v/%v", containerPort, containerProtocol),
-		ContainerPort: containerPort,
-		Protocol:      containerProtocol,
-	}
-}
-
 func getContainer(componentName string, applicationName string, ports []corev1.ContainerPort,
 	envFromSources []corev1.EnvFromSource) corev1.Container {
 	return corev1.Container{

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -103,6 +103,9 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 
 	newFileMap := make(map[string]FileData)
 	walk := func(fn string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if fi.IsDir() {
 
 			// if folder is the root folder, don't add it

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1080,10 +1080,9 @@ func TestRemoveDuplicate(t *testing.T) {
 
 func TestRemoveRelativePathFromFiles(t *testing.T) {
 	type args struct {
-		path    string
-		input   []string
-		output  []string
-		wantErr bool
+		path   string
+		input  []string
+		output []string
 	}
 	tests := []struct {
 		name    string

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -87,7 +87,7 @@ func ReplaceString(filename string, oldString string, newString string) {
 
 	newContent := strings.Replace(string(f), oldString, newString, 1)
 
-	err = ioutil.WriteFile(filename, []byte(newContent), 644)
+	err = ioutil.WriteFile(filename, []byte(newContent), 0644)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -36,6 +36,8 @@ func RandString(n int) string {
 // expected output  within the timeout period.
 func WaitForCmdOut(program string, args []string, timeout int, errOnFail bool, check func(output string) bool) bool {
 	pingTimeout := time.After(time.Duration(timeout) * time.Minute)
+	// this is a test package so time.Tick() is acceptable
+	// nolint
 	tick := time.Tick(time.Second)
 	for {
 		select {

--- a/tests/helper/reporter/httpMeasurementReporter.go
+++ b/tests/helper/reporter/httpMeasurementReporter.go
@@ -110,7 +110,10 @@ func getPRNumber() (int, error) {
 	}
 
 	var data clonerefsOptions
-	json.Unmarshal([]byte(jsonData), &data)
+	err := json.Unmarshal([]byte(jsonData), &data)
+	if err != nil {
+		return 0, fmt.Errorf("error in unmarshalling json")
+	}
 
 	if len(data.Refs) < 1 {
 		return 0, fmt.Errorf("no refs in the input json")

--- a/tests/helper/reporter/junitReporter.go
+++ b/tests/helper/reporter/junitReporter.go
@@ -14,7 +14,7 @@ import (
 func JunitReport(t *testing.T, filePath string) *reporters.JUnitReporter {
 	time := time.Now()
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		os.Mkdir(filePath, os.ModePerm)
+		_ = os.Mkdir(filePath, os.ModePerm)
 	}
 	xmlFileName := fmt.Sprintf(filepath.Join(filePath, "junit_%d-%d-%d_%02d-%02d-%02d.xml"), time.Year(), time.Month(),
 		time.Day(), time.Hour(), time.Minute(), time.Second())

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -12,8 +12,6 @@ import (
 
 // TODO: A neater way to provide odo path. Currently we assume \
 // odo and oc in $PATH already.
-var testNamespacedImage = "https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json"
-var testPHPGitURL = "https://github.com/appuio/example-php-sti-helloworld"
 var oc helper.OcRunner
 var project string
 var context string

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -15,10 +15,6 @@ import (
 )
 
 func componentTests(args ...string) {
-	const initContainerName = "copy-files-to-volume"
-	const wildflyURI1 = "https://github.com/marekjelen/katacoda-odo-backend"
-	const wildflyURI2 = "https://github.com/mik-dass/katacoda-odo-backend"
-	const appRootVolumeName = "-testing-s2idata"
 	var oc helper.OcRunner
 	var project string
 	var context string
@@ -295,10 +291,7 @@ func componentTests(args ...string) {
 					project,
 					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
-						if err != nil {
-							return false
-						}
-						return true
+						return err == nil
 					},
 				)
 				Expect(remoteCmdExecPass).To(Equal(true))
@@ -320,10 +313,7 @@ func componentTests(args ...string) {
 					project,
 					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
-						if err != nil {
-							return false
-						}
-						return true
+						return err == nil
 					},
 				)
 				Expect(remoteCmdExecPass).To(Equal(true))
@@ -357,10 +347,7 @@ func componentTests(args ...string) {
 					project,
 					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
-						if err != nil {
-							return false
-						}
-						return true
+						return err == nil
 					},
 				)
 				Expect(remoteCmdExecPass).To(Equal(true))
@@ -382,10 +369,7 @@ func componentTests(args ...string) {
 					project,
 					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
-						if err != nil {
-							return false
-						}
-						return true
+						return err == nil
 					},
 				)
 				Expect(remoteCmdExecPass).To(Equal(true))
@@ -434,10 +418,7 @@ func componentTests(args ...string) {
 				project,
 				[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 				func(cmdOp string, err error) bool {
-					if err != nil {
-						return false
-					}
-					return true
+					return err == nil
 				},
 			)
 			Expect(remoteCmdExecPass).To(Equal(true))


### PR DESCRIPTION
**What kind of PR is this?**

/kind cleanup

**What does does this PR do / why we need it:**

It adds golangci-lint as a travis job
It also adds the golangci-lint as make target.
It also fixes the current lint errors in our code base.

**Which issue(s) this PR fixes:**

Fixes #1927

**How to test changes / Special notes to the reviewer:**

run `golangci-lint run` and check that no errors occur
