### PR TITLE
change "from" to "to" for odo link

### DIFF
--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -115,7 +115,14 @@ func (o *commonLinkOptions) run() (err error) {
 		return err
 	}
 
-	log.Successf("%s %s has been successfully %sed from the component %s\n", linkType, o.suppliedName, o.operationName, o.Component())
+	switch o.operationName {
+	case "link":
+		log.Successf("%s %s has been successfully linked to the component %s\n", linkType, o.suppliedName, o.Component())
+	case "unlink":
+		log.Successf("%s %s has been successfully unlinked from the component %s\n", linkType, o.suppliedName, o.Component())
+	default:
+		return fmt.Errorf("unknown operation %s", o.operationName)
+	}
 
 	secret, err := o.Client.GetSecret(o.secretName, o.Project)
 	if err != nil {


### PR DESCRIPTION
**What kind of PR is this?**
/kind cleanup

**What does does this PR do / why we need it**:

Changes successful `odo link` message from 

`Component backend has been successfully linked from the component frontend`

to

`Component backend has been successfully linked to the component frontend`

This reads a lot more clearly since information is being shared from the first component as part of `odo link`. The current implementation makes it sound as if information is coming from the component specified via the `--component` flag or via the context being worked in.

Looking for advice on whatever `operationName` options are available that could potentially not work with this message. Link was the only option considered here.

**Which issue(s) this PR fixes**:

None