### PR TITLE
Add "odo component create" back to shortcuts.

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -576,7 +576,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		Long:        createLongDesc,
 		Example:     fmt.Sprintf(createExample, fullName),
 		Args:        cobra.RangeArgs(0, 2),
-		Annotations: map[string]string{"machineoutput": "json", "component": "component"},
+		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(co, cmd, args)
 		},


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind enhancement

**What does does this PR do / why we need it**:

`odo create` was removed when the annotations were unfortunately set
incorrectly.

```
Component Shortcuts:
  delete      Delete component
  describe    Describe component
  link        Link component to a service or component
  list        List all components in the current application
  log         Retrieve the log for the given component
  push        Push source code to a component
  unlink      Unlink component to a service or component
  update      Update the source code path of a component
  watch       Watch for changes, update component on change
```

**Which issue(s) this PR fixes**:

No issue

**How to test changes / Special notes to the reviewer**:

```sh
odo --help
```

Should now show `create` under "Component Shortcuts"

Signed-off-by: Charlie Drage <charlie@charliedrage.com>