### PR TITLE
Refactoring output of machine output

### DIFF
--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -65,12 +65,7 @@ func (o *DescribeOptions) Validate() (err error) {
 func (o *DescribeOptions) Run() (err error) {
 	if log.IsJSON() {
 		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.Project)
-		out, err := machineoutput.MarshalJSONIndented(appDef)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
-
+		machineoutput.OutputSuccess(appDef)
 	} else {
 		// List of Component
 		componentList, err := component.List(o.Client, o.appName, nil)

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -68,11 +68,7 @@ func (o *ListOptions) Run() (err error) {
 			}
 
 			appListDef := application.GetMachineReadableFormatForList(appList)
-			out, err := machineoutput.MarshalJSONIndented(appListDef)
-			if err != nil {
-				return err
-			}
-			fmt.Println(string(out))
+			machineoutput.OutputSuccess(appListDef)
 
 		} else {
 			log.Infof("The project '%v' has the following applications:", o.Project)
@@ -91,13 +87,9 @@ func (o *ListOptions) Run() (err error) {
 		}
 	} else {
 		if log.IsJSON() {
-			out, err := machineoutput.MarshalJSONIndented(application.GetMachineReadableFormatForList([]application.App{}))
-			if err != nil {
-				return err
-			}
-			fmt.Println(string(out))
+			apps := application.GetMachineReadableFormatForList([]application.App{})
+			machineoutput.OutputSuccess(apps)
 		} else {
-
 			log.Infof("There are no applications deployed in the project '%v'.", o.Project)
 		}
 	}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -70,11 +70,7 @@ func (do *DescribeOptions) Run() (err error) {
 	}
 	if log.IsJSON() {
 		componentDesc.Spec.Ports = do.localConfigInfo.GetPorts()
-		out, err := machineoutput.MarshalJSONIndented(componentDesc)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
+		machineoutput.OutputSuccess(componentDesc)
 	} else {
 
 		odoutil.PrintComponentInfo(do.Context.Client, do.componentName, componentDesc, do.Context.Application, do.Context.Project)

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -67,11 +67,7 @@ func (lo *ListOptions) Run() (err error) {
 			return err
 		}
 		if log.IsJSON() {
-			out, err := machineoutput.MarshalJSONIndented(components)
-			if err != nil {
-				return err
-			}
-			fmt.Println(string(out))
+			machineoutput.OutputSuccess(components)
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
@@ -122,13 +118,7 @@ func (lo *ListOptions) Run() (err error) {
 	glog.V(4).Infof("the components are %+v", components)
 
 	if log.IsJSON() {
-
-		out, err := machineoutput.MarshalJSONIndented(components)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
-
+		machineoutput.OutputSuccess(components)
 	} else {
 		if len(components.Items) == 0 {
 			log.Errorf("There are no components deployed.")

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -53,11 +53,7 @@ func (plo *ProjectListOptions) Run() (err error) {
 		return err
 	}
 	if log.IsJSON() {
-		out, err := machineoutput.MarshalJSONIndented(projects)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
+		machineoutput.OutputSuccess(projects)
 	} else {
 
 		if len(projects.Items) == 0 {

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -70,11 +70,7 @@ func (o *StorageCreateOptions) Run() (err error) {
 	storageResultMachineReadable := storage.GetMachineReadableFormat(storageResult.Name, storageResult.Size, storageResult.Path)
 
 	if log.IsJSON() {
-		out, err := machineoutput.MarshalJSONIndented(storageResultMachineReadable)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
+		machineoutput.OutputSuccess(storageResultMachineReadable)
 	} else {
 		log.Successf("Added storage %v to %v", o.storageName, o.localConfig.GetName())
 		log.Infof("Please use `odo push` command to make the storage accessible to the component")

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -70,11 +70,7 @@ func (o *StorageListOptions) Run() (err error) {
 	storageListResultMachineReadable := storage.GetMachineReadableFormatForList(storageListMachineReadable)
 
 	if log.IsJSON() {
-		out, err := machineoutput.MarshalJSONIndented(storageListResultMachineReadable)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
+		machineoutput.OutputSuccess(storageListResultMachineReadable)
 	} else {
 		// defining the column structure of the table
 		tabWriterMounted := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -63,11 +63,7 @@ func (o *URLListOptions) Run() (err error) {
 	}
 
 	if log.IsJSON() {
-		out, err := machineoutput.MarshalJSONIndented(urls)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(out))
+		machineoutput.OutputSuccess(urls)
 	} else {
 		if len(urls.Items) == 0 {
 			return fmt.Errorf("no URLs found for component %v in application %v", o.Component(), o.Application)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/golang/glog"
-	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -580,20 +579,6 @@ func CheckOutputFlag(outputFlag string) bool {
 		return true
 	}
 	return false
-}
-
-// MachineOutput provides string output and error if any
-// In future if we support any new format, we just need to add case in following switch case
-func MachineOutput(outputFlag string, resource interface{}) (string, error) {
-	var out []byte
-	var err error
-	switch outputFlag {
-	case "json":
-		// If `-o json` is provided
-		out, err = machineoutput.MarshalJSONIndented(resource)
-	}
-
-	return string(out), err
 }
 
 // RemoveDuplicates goes through a string slice and removes all duplicates.


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind code refactorting

**What does does this PR do / why we need it**:

Refactors the machine readable output to use the
`machineoutput.OutputSuccess(structFormattedOutputHere)` function instead.

This removes using `fmt.Println(output)`.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Use odo component list -o json or any other json-output-formatted
command.

No tests have been added as they are already covered via integration /
unit tests and this is simply a code refactor.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>