### PR TITLE
Remove machineoutput annotation from odo create

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -539,7 +539,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		Long:        createLongDesc,
 		Example:     fmt.Sprintf(createExample, fullName),
 		Args:        cobra.RangeArgs(0, 2),
-		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
+		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(co, cmd, args)
 		},

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -47,11 +47,6 @@ func componentTests(args ...string) {
 			Expect(output).NotTo(ContainSubstring("Specify output format, supported format: json"))
 		})
 
-		It("Help for odo create should contain machine output", func() {
-			output := helper.CmdShouldPass("odo", "create", "--help")
-			Expect(output).To(ContainSubstring("Specify output format, supported format: json"))
-		})
-
 	})
 
 	Context("Creating component", func() {

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -31,6 +31,15 @@ var _ = Describe("odo project command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
+	Context("Machine readable output tests", func() {
+
+		It("Help for odo project list should contain machine output", func() {
+			output := helper.CmdShouldPass("odo", "project", "list", "--help")
+			Expect(output).To(ContainSubstring("Specify output format, supported format: json"))
+		})
+
+	})
+
 	Context("when running help for project command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "project", "-h")


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind cleanup

**What does does this PR do / why we need it**:

We don't actually have json / machine readable output implemented yet
for `odo create`

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>