### PR TITLE
Cleanup service creation output

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -224,7 +224,9 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
-	s := log.Spinner("Creating service")
+	log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
+
+	s := log.Spinner("Deploying service")
 	defer s.End(false)
 	err = svc.CreateService(o.Client, o.ServiceName, o.ServiceType, o.Plan, o.ParametersMap, o.Application)
 	if err != nil {
@@ -243,6 +245,10 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		log.Successf(`Service '%s' was created`, o.ServiceName)
 		log.Italic("\nProgress of the provisioning will not be reported and might take a long time\nYou can see the current status by executing 'odo service list'")
 	}
+
+	// Information on what to do next
+	log.Infof("Optionally, link %s to your component by running: 'odo link <component-name>'", o.ServiceType)
+
 	equivalent := o.outputNonInteractiveEquivalent()
 	if len(equivalent) > 0 {
 		log.Info("Equivalent command:\n" + ui.StyledOutput(equivalent, "cyan"))


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind cleanup
/kind enhancement

**What does does this PR do / why we need it**:

Cleans up the output for service creation and adds an output of what to
do next:

```sh
Deploying service mongodb of type: dh-mongodb-apb
 ✓  Deploying service [78ms]
 ✓  Service 'mongodb' was created and is currently provisioning
View the status of the provision by executing 'odo service list'
Optionally, link dh-mongodb-apb to your component by running: 'odo link <component-name>'
```

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

```sh
make bin && ./odo service create dh-mongodb-apb mongodb --plan persistent -p DATABASE_SERVICE_NAME=mongodb -p MEMORY_LIMIT=512Mi -p MONGODB_DATABASE=sampledb -p VOLUME_CAPACITY=1Gi
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>