### PR TITLE
Add italic font when describing what to do next

### DIFF
--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -89,7 +89,7 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 	// If a new file has been created, we output what to do next (obviously odo help). This is taken from:
 	// https://github.com/openshift/origin/blob/4c293b86b111d9aaeba7bb1e72ee57410652ae9d/pkg/oc/cli/login/login.go#L184
 	if newFileCreated {
-		odolog.Infof("Welcome! See '%s help' to get started.", a.CommandName)
+		odolog.Italicf("\nWelcome! See '%s help' to get started.", a.CommandName)
 	}
 
 	return nil

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -231,6 +231,15 @@ func Italic(a ...interface{}) {
 	}
 }
 
+// Italicf will simply print out information on a new italic line
+// this is **normally** used as a way to describe what's next within odo.
+func Italicf(format string, a ...interface{}) {
+	italic := color.New(color.Italic).SprintFunc()
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s\n", italic(fmt.Sprintf(format, a...)))
+	}
+}
+
 // Info will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Info(a ...interface{}) {

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -90,7 +90,7 @@ func (o *ListOptions) Run() (err error) {
 			apps := application.GetMachineReadableFormatForList([]application.App{})
 			machineoutput.OutputSuccess(apps)
 		} else {
-			log.Infof("There are no applications deployed in the project '%v'.", o.Project)
+			log.Infof("There are no applications deployed in the project '%v'", o.Project)
 		}
 	}
 	return

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -153,7 +153,7 @@ func (o *commonLinkOptions) run() (err error) {
 
 		// Output what to do next if first linking...
 		if o.operationName == "link" {
-			log.Infof(`
+			log.Italicf(`
 You can now access the environment variables from within the component pod, for example:
 $%s is now available as a variable within component %s`, exampleEnv, o.Component())
 		}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -464,7 +464,7 @@ func (co *CreateOptions) Validate() (err error) {
 	}
 
 	if !supported {
-		log.Infof("Warning: %s is not fully supported by odo, and it is not guaranteed to work.", *co.componentSettings.Type)
+		log.Infof("Warning: %s is not fully supported by odo, and it is not guaranteed to work", *co.componentSettings.Type)
 	}
 
 	s := log.Spinner("Validating component")
@@ -498,7 +498,7 @@ func (co *CreateOptions) Run() (err error) {
 			return errors.Wrapf(err, "failed to push the changes")
 		}
 	} else {
-		log.Infof("Please use `odo push` command to create the component with source deployed")
+		log.Italic("\nPlease use `odo push` command to create the component with source deployed")
 	}
 	return
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -88,7 +88,7 @@ func (po *PushOptions) Validate() (err error) {
 
 	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
 		s.End(false)
-		log.Info("Run 'odo catalog list components' for a list of supported component types")
+		log.Italic("\nRun 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *po.localConfigInfo.GetComponentSettings().Type, errors.Cause(err))
 	}
 

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -93,9 +93,8 @@ func (o *SetOptions) Run() (err error) {
 		if err := o.lci.SetEnvVars(newEnvVarList); err != nil {
 			return err
 		}
-
-		log.Info("Environment variables were successfully updated.")
-		log.Info("Run `odo push --config` command to apply changes to the cluster.")
+		log.Success("Environment variables were successfully updated")
+		log.Italic("\nRun `odo push --config` command to apply changes to the cluster.")
 
 		return nil
 	}
@@ -114,8 +113,8 @@ func (o *SetOptions) Run() (err error) {
 		return err
 	}
 
-	log.Info("Local config was successfully updated.")
-	log.Info("Run `odo push --config` command to apply changes to the cluster.")
+	log.Success("Local config successfully updated")
+	log.Italic("\nRun `odo push --config` command to apply changes to the cluster")
 
 	return nil
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -93,8 +93,8 @@ func (o *UnsetOptions) Run() (err error) {
 			return err
 		}
 
-		log.Info("Environment variables were successfully updated.")
-		log.Info("Run `odo push --config` command to apply changes to the cluster.")
+		log.Success("Environment variables were successfully updated")
+		log.Italic("\nRun `odo push --config` command to apply changes to the cluster")
 		return nil
 	}
 

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -65,7 +65,7 @@ func (o *SetOptions) Run() (err error) {
 	if !o.configForceFlag {
 		if isSet := cfg.IsSet(o.paramName); isSet {
 			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the config", o.paramName)) {
-				log.Info("Aborted by the user.")
+				log.Info("Aborted by the user")
 				return nil
 			}
 		}
@@ -76,7 +76,7 @@ func (o *SetOptions) Run() (err error) {
 		return err
 	}
 
-	log.Info("Global preference was successfully updated.")
+	log.Info("Global preference was successfully updated")
 	return nil
 }
 

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -65,7 +65,7 @@ func (o *UnsetOptions) Run() (err error) {
 
 		if isSet := cfg.IsSet(o.paramName); isSet {
 			if !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the preference", o.paramName)) {
-				log.Infof("Aborted by the user.")
+				log.Infof("Aborted by the user")
 				return nil
 			}
 		} else {
@@ -78,7 +78,7 @@ func (o *UnsetOptions) Run() (err error) {
 		return err
 	}
 
-	log.Info("Global preference was successfully updated.")
+	log.Info("Global preference was successfully updated")
 	return nil
 
 }

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -241,8 +241,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		}
 	} else {
 		log.Successf(`Service '%s' was created`, o.ServiceName)
-		log.Info(`Progress of the provisioning will not be reported and might take a long time.
-You can see the current status by executing 'odo service list'`)
+		log.Italic("\nProgress of the provisioning will not be reported and might take a long time\nYou can see the current status by executing 'odo service list'")
 	}
 	equivalent := o.outputNonInteractiveEquivalent()
 	if len(equivalent) > 0 {

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -73,7 +73,7 @@ func (o *StorageCreateOptions) Run() (err error) {
 		machineoutput.OutputSuccess(storageResultMachineReadable)
 	} else {
 		log.Successf("Added storage %v to %v", o.storageName, o.localConfig.GetName())
-		log.Infof("Please use `odo push` command to make the storage accessible to the component")
+		log.Italic("\nPlease use `odo push` command to make the storage accessible to the component")
 	}
 	return
 }

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -72,7 +72,7 @@ func (o *StorageDeleteOptions) Run() (err error) {
 		}
 
 		log.Infof("Deleted storage %v from %v", o.storageName, o.localConfig.GetName())
-		log.Infof("Please use `odo push` command to delete the storage from the cluster")
+		log.Italic("\nPlease use `odo push` command to delete the storage from the cluster")
 	} else {
 		return fmt.Errorf("aborting deletion of storage: %v", o.storageName)
 	}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -98,8 +98,8 @@ func (o *URLCreateOptions) Run() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "failed to persist the component settings to config file")
 	}
-	log.Successf("URL %s created for component: %v\n", o.urlName, o.Component())
-	log.Info("To create URL on the OpenShift Cluster, please use `odo push`")
+	log.Successf("URL %s created for component: %v", o.urlName, o.Component())
+	log.Italic("\nTo create URL on the OpenShift Cluster, please use `odo push`")
 	return
 }
 

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -74,7 +74,7 @@ func (o *URLDeleteOptions) Run() (err error) {
 			return err
 		}
 		log.Successf("URL %s removed from the config file", o.urlName)
-		log.Info("To delete URL on the OpenShift Cluster, please use `odo push`")
+		log.Italic("\nTo delete URL on the OpenShift Cluster, please use `odo push`")
 	} else {
 		return fmt.Errorf("aborting deletion of URL: %v", o.urlName)
 	}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -474,7 +474,7 @@ func componentTests(args ...string) {
 		It("creates a local python component and check for unsupported warning", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
 			output := helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
-			Expect(output).To(ContainSubstring("Warning: python is not fully supported by odo, and it is not guaranteed to work."))
+			Expect(output).To(ContainSubstring("Warning: python is not fully supported by odo, and it is not guaranteed to work"))
 		})
 
 		It("creates a local nodejs component and check unsupported warning hasn't occured", func() {


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind code refactorting
/kind docs
/kind enhancement

**What does does this PR do / why we need it**:

This PR:
 - Adds italic font when outputting what to "do next". Essentially, when
 using log.Info it's for a "bold" or "title" log. When using log.Italic
 it's mainly used for when we want to say to the user what to do next,
 such as using `odo push` to propagate changes
 - Removes random periods which aren't suppose to be there (all output
 should not be sentences with periods)

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Run: `odo create nodejs` or any other similar commands, such as `odo
url create` which have "next steps" in them.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>