### PR TITLE
change checks of ODO_SRC_PATH/src in tests and a temporary fix for project list flake

### DIFF
--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -34,10 +34,10 @@ var _ = Describe("odo debug command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	Context("odo debug on a nodejs component", func() {
+	Context("odo debug on a nodejs:8 component", func() {
 		It("should expect a ws connection when tried to connect on different debug port locally and remotely", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--force", "DebugPort", "9292", "--context", context)
 			dbgPort := helper.GetConfigValueWithContext("DebugPort", context)
 			Expect(dbgPort).To(Equal("9292"))
@@ -53,7 +53,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should expect a ws connection when tried to connect on default debug port locally", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			go func() {
 				helper.CmdShouldRunWithTimeout(60*time.Second, "odo", "debug", "port-forward", "--context", context)

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -197,7 +197,7 @@ var _ = Describe("odo push command tests", func() {
 			Expect(output).To(Not(ContainSubstring("No file changes detected, skipping build")))
 		})
 
-		FIt("should push only the modified files", func() {
+		It("should push only the modified files", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -75,7 +75,7 @@ var _ = Describe("odo push command tests", func() {
 			podName := oc.GetRunningPodNameOfComp(cmpName, project)
 
 			envs := oc.GetEnvs(cmpName, appName, project)
-			dir := fmt.Sprintf("%s/%s", envs["ODO_S2I_SRC_BIN_PATH"], "/src")
+			dir := envs["ODO_S2I_DEPLOYMENT_DIR"]
 
 			stdOut := oc.ExecListDir(podName, project, dir)
 			Expect(stdOut).To(ContainSubstring(("foobar.txt")))
@@ -113,7 +113,7 @@ var _ = Describe("odo push command tests", func() {
 
 			// verify that the new file was pushed
 			envs := oc.GetEnvs(cmpName, appName, project)
-			dir := fmt.Sprintf("%s/%s", envs["ODO_S2I_SRC_BIN_PATH"], "/src")
+			dir := envs["ODO_S2I_DEPLOYMENT_DIR"]
 			stdOut := oc.ExecListDir(podName, project, dir)
 			Expect(stdOut).To(ContainSubstring(("README.md")))
 
@@ -143,7 +143,7 @@ var _ = Describe("odo push command tests", func() {
 			podName := oc.GetRunningPodNameOfComp(cmpName, project)
 
 			envs := oc.GetEnvs(cmpName, appName, project)
-			dir := fmt.Sprintf("%s/%s", envs["ODO_S2I_SRC_BIN_PATH"], "/src")
+			dir := envs["ODO_S2I_DEPLOYMENT_DIR"]
 
 			// verify that the new file was pushed
 			stdOut := oc.ExecListDir(podName, project, dir)
@@ -213,7 +213,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", "/tmp/src/server.js"},
+				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
 				func(cmdOp string, err error) bool {
 					earlierCatServerFile = cmdOp
 					return true
@@ -225,7 +225,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", "/tmp/src/views/index.html"},
+				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
 				func(cmdOp string, err error) bool {
 					earlierCatViewFile = cmdOp
 					return true
@@ -241,7 +241,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", "/tmp/src/views/index.html"},
+				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
 				func(cmdOp string, err error) bool {
 					modifiedCatViewFile = cmdOp
 					return true
@@ -253,7 +253,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", "/tmp/src/server.js"},
+				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
 				func(cmdOp string, err error) bool {
 					modifiedCatServerFile = cmdOp
 					return true
@@ -281,7 +281,7 @@ var _ = Describe("odo push command tests", func() {
 			podName := oc.GetRunningPodNameOfComp("nodejs", project)
 
 			envs := oc.GetEnvs(cmpName, appName, project)
-			dir := fmt.Sprintf("%s/%s", envs["ODO_S2I_SRC_BIN_PATH"], "/src")
+			dir := envs["ODO_S2I_DEPLOYMENT_DIR"]
 
 			// verify that the views folder got pushed
 			stdOut1 := oc.ExecListDir(podName, project, dir)

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -197,72 +197,78 @@ var _ = Describe("odo push command tests", func() {
 			Expect(output).To(Not(ContainSubstring("No file changes detected, skipping build")))
 		})
 
-		It("should push only the modified files", func() {
-			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
-			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
+		// these tests are failing with stat output being different
+		// 	Expected
+		// 	<string>: "...2:01:51.857..."
+		// to equal               |
+		// 	<string>: "...2:01:16.790..."
 
-			url := oc.GetFirstURL(cmpName, appName, project)
-			// Wait for running app before getting info about files.
-			// During the startup sequence there is something that will modify the access time of a source file.
-			helper.HttpWaitFor("http://"+url, "Welcome to your Node.js", 30, 1)
+		// It("should push only the modified files", func() {
+		// 	helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
+		// 	helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+		// 	helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
+		// 	helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
-			earlierCatServerFile := ""
-			oc.CheckCmdOpInRemoteCmpPod(
-				cmpName,
-				appName,
-				project,
-				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
-				func(cmdOp string, err error) bool {
-					earlierCatServerFile = cmdOp
-					return true
-				},
-			)
+		// 	url := oc.GetFirstURL(cmpName, appName, project)
+		// 	// Wait for running app before getting info about files.
+		// 	// During the startup sequence there is something that will modify the access time of a source file.
+		// 	helper.HttpWaitFor("http://"+url, "Welcome to your Node.js", 30, 1)
 
-			earlierCatViewFile := ""
-			oc.CheckCmdOpInRemoteCmpPod(
-				cmpName,
-				appName,
-				project,
-				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
-				func(cmdOp string, err error) bool {
-					earlierCatViewFile = cmdOp
-					return true
-				},
-			)
+		// 	earlierCatServerFile := ""
+		// 	oc.CheckCmdOpInRemoteCmpPod(
+		// 		cmpName,
+		// 		appName,
+		// 		project,
+		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
+		// 		func(cmdOp string, err error) bool {
+		// 			earlierCatServerFile = cmdOp
+		// 			return true
+		// 		},
+		// 	)
 
-			helper.ReplaceString(filepath.Join(context+"/nodejs-ex"+"/views/index.html"), "Welcome to your Node.js application on OpenShift", "UPDATED!")
-			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
-			helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
+		// 	earlierCatViewFile := ""
+		// 	oc.CheckCmdOpInRemoteCmpPod(
+		// 		cmpName,
+		// 		appName,
+		// 		project,
+		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
+		// 		func(cmdOp string, err error) bool {
+		// 			earlierCatViewFile = cmdOp
+		// 			return true
+		// 		},
+		// 	)
 
-			modifiedCatViewFile := ""
-			oc.CheckCmdOpInRemoteCmpPod(
-				cmpName,
-				appName,
-				project,
-				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
-				func(cmdOp string, err error) bool {
-					modifiedCatViewFile = cmdOp
-					return true
-				},
-			)
+		// 	helper.ReplaceString(filepath.Join(context+"/nodejs-ex"+"/views/index.html"), "Welcome to your Node.js application on OpenShift", "UPDATED!")
+		// 	helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
+		// 	helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
 
-			modifiedCatServerFile := ""
-			oc.CheckCmdOpInRemoteCmpPod(
-				cmpName,
-				appName,
-				project,
-				[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
-				func(cmdOp string, err error) bool {
-					modifiedCatServerFile = cmdOp
-					return true
-				},
-			)
+		// 	modifiedCatViewFile := ""
+		// 	oc.CheckCmdOpInRemoteCmpPod(
+		// 		cmpName,
+		// 		appName,
+		// 		project,
+		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
+		// 		func(cmdOp string, err error) bool {
+		// 			modifiedCatViewFile = cmdOp
+		// 			return true
+		// 		},
+		// 	)
 
-			Expect(modifiedCatViewFile).NotTo(Equal(earlierCatViewFile))
-			Expect(modifiedCatServerFile).To(Equal(earlierCatServerFile))
-		})
+		// 	modifiedCatServerFile := ""
+		// 	oc.CheckCmdOpInRemoteCmpPod(
+		// 		cmpName,
+		// 		appName,
+		// 		project,
+		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
+		// 		func(cmdOp string, err error) bool {
+		// 			modifiedCatServerFile = cmdOp
+		// 			return true
+		// 		},
+		// 	)
+
+		// 	Expect(modifiedCatViewFile).NotTo(Equal(earlierCatViewFile))
+		// 	Expect(modifiedCatServerFile).To(Equal(earlierCatServerFile))
+		// })
 	})
 
 	Context("when .odoignore file exists", func() {

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -197,78 +197,74 @@ var _ = Describe("odo push command tests", func() {
 			Expect(output).To(Not(ContainSubstring("No file changes detected, skipping build")))
 		})
 
-		// these tests are failing with stat output being different
-		// 	Expected
-		// 	<string>: "...2:01:51.857..."
-		// to equal               |
-		// 	<string>: "...2:01:16.790..."
+		FIt("should push only the modified files", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
-		// It("should push only the modified files", func() {
-		// 	helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-		// 	helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
-		// 	helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
-		// 	helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
+			url := oc.GetFirstURL(cmpName, appName, project)
+			// Wait for running app before getting info about files.
+			// During the startup sequence there is something that will modify the access time of a source file.
+			helper.HttpWaitFor("http://"+url, "Welcome to your Node.js", 30, 1)
 
-		// 	url := oc.GetFirstURL(cmpName, appName, project)
-		// 	// Wait for running app before getting info about files.
-		// 	// During the startup sequence there is something that will modify the access time of a source file.
-		// 	helper.HttpWaitFor("http://"+url, "Welcome to your Node.js", 30, 1)
+			earlierCatServerFile := ""
+			oc.CheckCmdOpInRemoteCmpPod(
+				cmpName,
+				appName,
+				project,
+				[]string{"stat", "/tmp/src/server.js"},
 
-		// 	earlierCatServerFile := ""
-		// 	oc.CheckCmdOpInRemoteCmpPod(
-		// 		cmpName,
-		// 		appName,
-		// 		project,
-		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
-		// 		func(cmdOp string, err error) bool {
-		// 			earlierCatServerFile = cmdOp
-		// 			return true
-		// 		},
-		// 	)
+				func(cmdOp string, err error) bool {
+					earlierCatServerFile = cmdOp
+					return true
+				},
+			)
 
-		// 	earlierCatViewFile := ""
-		// 	oc.CheckCmdOpInRemoteCmpPod(
-		// 		cmpName,
-		// 		appName,
-		// 		project,
-		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
-		// 		func(cmdOp string, err error) bool {
-		// 			earlierCatViewFile = cmdOp
-		// 			return true
-		// 		},
-		// 	)
+			earlierCatViewFile := ""
+			oc.CheckCmdOpInRemoteCmpPod(
+				cmpName,
+				appName,
+				project,
+				[]string{"stat", "/tmp/src/views/index.html"},
+				func(cmdOp string, err error) bool {
+					earlierCatViewFile = cmdOp
+					return true
+				},
+			)
 
-		// 	helper.ReplaceString(filepath.Join(context+"/nodejs-ex"+"/views/index.html"), "Welcome to your Node.js application on OpenShift", "UPDATED!")
-		// 	helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
-		// 	helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
+			helper.ReplaceString(filepath.Join(context+"/nodejs-ex"+"/views/index.html"), "Welcome to your Node.js application on OpenShift", "UPDATED!")
+			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
+			helper.HttpWaitFor("http://"+url, "UPDATED!", 30, 1)
 
-		// 	modifiedCatViewFile := ""
-		// 	oc.CheckCmdOpInRemoteCmpPod(
-		// 		cmpName,
-		// 		appName,
-		// 		project,
-		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/views/index.html"},
-		// 		func(cmdOp string, err error) bool {
-		// 			modifiedCatViewFile = cmdOp
-		// 			return true
-		// 		},
-		// 	)
+			modifiedCatViewFile := ""
+			oc.CheckCmdOpInRemoteCmpPod(
+				cmpName,
+				appName,
+				project,
+				[]string{"stat", "/tmp/src/views/index.html"},
+				func(cmdOp string, err error) bool {
+					modifiedCatViewFile = cmdOp
+					return true
+				},
+			)
 
-		// 	modifiedCatServerFile := ""
-		// 	oc.CheckCmdOpInRemoteCmpPod(
-		// 		cmpName,
-		// 		appName,
-		// 		project,
-		// 		[]string{"sh", "-c", "stat $ODO_S2I_DEPLOYMENT_DIR/server.js"},
-		// 		func(cmdOp string, err error) bool {
-		// 			modifiedCatServerFile = cmdOp
-		// 			return true
-		// 		},
-		// 	)
+			modifiedCatServerFile := ""
+			oc.CheckCmdOpInRemoteCmpPod(
+				cmpName,
+				appName,
+				project,
+				[]string{"stat", "/tmp/src/server.js"},
 
-		// 	Expect(modifiedCatViewFile).NotTo(Equal(earlierCatViewFile))
-		// 	Expect(modifiedCatServerFile).To(Equal(earlierCatServerFile))
-		// })
+				func(cmdOp string, err error) bool {
+					modifiedCatServerFile = cmdOp
+					return true
+				},
+			)
+
+			Expect(modifiedCatViewFile).NotTo(Equal(earlierCatViewFile))
+			Expect(modifiedCatServerFile).To(Equal(earlierCatServerFile))
+		})
 	})
 
 	Context("when .odoignore file exists", func() {

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -56,7 +56,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should be able to create a file, push, delete, then push again propagating the deletions", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "ruby", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 
 			// Create a new file that we plan on deleting later...
 			newFilePath := filepath.Join(context, "nodejs-ex", "foobar.txt")
@@ -197,9 +197,9 @@ var _ = Describe("odo push command tests", func() {
 			Expect(output).To(Not(ContainSubstring("No file changes detected, skipping build")))
 		})
 
-		It("should push only the modified files", func() {
+		FIt("should push only the modified files", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -55,21 +55,21 @@ var _ = Describe("odo push command tests", func() {
 		})
 
 		It("should be able to create a file, push, delete, then push again propagating the deletions", func() {
-			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/ruby-ex", context+"/ruby-ex")
-			helper.CmdShouldPass("odo", "component", "create", "ruby", cmpName, "--project", project, "--context", context+"/ruby-ex", "--app", appName)
+			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "component", "create", "ruby", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 
 			// Create a new file that we plan on deleting later...
-			newFilePath := filepath.Join(context, "ruby-ex", "foobar.txt")
+			newFilePath := filepath.Join(context, "nodejs-ex", "foobar.txt")
 			if err := helper.CreateFileWithContent(newFilePath, "hello world"); err != nil {
 				fmt.Printf("the foobar.txt file was not created, reason %v", err.Error())
 			}
 
 			// Create a new directory
-			newDirPath := filepath.Join(context, "ruby-ex", "testdir")
+			newDirPath := filepath.Join(context, "nodejs-ex", "testdir")
 			helper.MakeDir(newDirPath)
 
 			// Push
-			helper.CmdShouldPass("odo", "push", "--context", context+"/ruby-ex")
+			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			podName := oc.GetRunningPodNameOfComp(cmpName, project)
@@ -84,7 +84,7 @@ var _ = Describe("odo push command tests", func() {
 			// Now we delete the file and dir and push
 			helper.DeleteDir(newFilePath)
 			helper.DeleteDir(newDirPath)
-			helper.CmdShouldPass("odo", "push", "--context", context+"/ruby-ex", "-v4")
+			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex", "-v4")
 
 			// Then check to see if it's truly been deleted
 			stdOut = oc.ExecListDir(podName, project, dir)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -498,7 +498,7 @@ func componentTests(args ...string) {
 
 		It("creates a local nodejs component and check unsupported warning hasn't occured", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs", componentName, "--app", appName, "--project", project, "--context", context)...)
+			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs:8", componentName, "--app", appName, "--project", project, "--context", context)...)
 			Expect(output).NotTo(ContainSubstring("Warning"))
 		})
 	})

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -293,7 +293,7 @@ func componentTests(args ...string) {
 					cmpName,
 					appName,
 					project,
-					[]string{"ls", "-la", "/tmp/src/package.json"},
+					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
 						if err != nil {
 							return false
@@ -318,7 +318,7 @@ func componentTests(args ...string) {
 					cmpName,
 					appName,
 					project,
-					[]string{"ls", "-la", "/tmp/src/package.json"},
+					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
 						if err != nil {
 							return false
@@ -355,7 +355,7 @@ func componentTests(args ...string) {
 					cmpName,
 					appName,
 					project,
-					[]string{"ls", "-la", "/tmp/src/package.json"},
+					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
 						if err != nil {
 							return false
@@ -380,7 +380,7 @@ func componentTests(args ...string) {
 					cmpName,
 					appName,
 					project,
-					[]string{"ls", "-la", "/tmp/src/package.json"},
+					[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 					func(cmdOp string, err error) bool {
 						if err != nil {
 							return false
@@ -432,7 +432,7 @@ func componentTests(args ...string) {
 				cmpName,
 				appName,
 				project,
-				[]string{"ls", "-la", "/tmp/src/package.json"},
+				[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 				func(cmdOp string, err error) bool {
 					if err != nil {
 						return false


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->
/kind bug
**What does does this PR do / why we need it**:
Due to recent change in the s2i image for nodejs in openshift 4.3. The `/tmp/src` directory doesn't hold the code anymore because it gets moved. 
We know this happens for some images and we have a workaround in the odo-init-image. But our test for nodejs assumes that source is present in `/tmp/src`, due to which they are failing on openshift 4.3.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2357

**How to test changes / Special notes to the reviewer**:
tests should pass on 4.3 cluster