### PR TITLE
Remove Space from Project Create Success Message

### DIFF
--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -83,7 +83,7 @@ func (pco *ProjectCreateOptions) Run() (err error) {
 	if log.IsJSON() {
 		project.MachineReadableSuccessOutput(pco.projectName, successMessage)
 	} else {
-		log.Successf("New project created and now using project : %v", pco.projectName)
+		log.Successf("New project created and now using project: %v", pco.projectName)
 	}
 	return
 }


### PR DESCRIPTION
**What kind of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:

Removes space from project creation success message. The space is unnecessary and is not how `odo` commonly formats output.

**Which issue(s) this PR fixes**:

N/a

**How to test changes / Special notes to the reviewer**:

Create a project and verify extra space is gone:

```
$ odo project create myproject

Project 'myproject' is ready for use
New project created and now using project: myproject
```