### PR TITLE
Add env variable "ODO_LOG_LEVEL" to control odo verbosity (#2351)

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -43,6 +43,13 @@ func main() {
 		}
 	}
 
+	// Override the logging level by the value (if set) by the ODO_LOG_LEVEL env
+	// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
+	v := flag.CommandLine.Lookup("v").Value.String()
+	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" {
+		_ = flag.CommandLine.Set("v", level)
+	}
+
 	// run the completion, in case that the completion was invoked
 	// and ran as a completion script or handled a flag that passed
 	// as argument, the Run method will return true,

--- a/docs/dev/logging.adoc
+++ b/docs/dev/logging.adoc
@@ -6,7 +6,9 @@ https://godoc.org/github.com/golang/glog[Glog] is used for V style logging in `o
 
 Every `odo` command takes an optional flag `-v` that must be used with an integer log level in the range from 0-9. Any INFO severity log statement that is logged at a level lesser than or equal to the one passed with the command alongside `-v` flag will be logged to STDOUT.
 
-All ERROR severity level log messages will always be logged regardless of the passed `v` level.
+Alternatively, enviroment variable `ODO_LOG_LEVEL` can be used to set the verbosity of the log level in the integer range 0-9. The value set by `ODO_LOG_LEVEL` can be overridden by explicitly passing the `-v` command line flag to the `odo` command, in such an event `-v` flag takes precedence over the enviroment variable `ODO_LOG_LEVEL`.
+
+All ERROR severity level log messages will always be logged regardless of the values of `v` or `ODO_LOG_LEVEL`.
 
 == Usage
 


### PR DESCRIPTION
* Add enviroment variable "ODO_LOG_LEVEL" to control odo verbosity. Command line flag "-v", if set, will take precedence over "ODO_LOG_LEVEL"

**What kind of PR is this?**
/kind enhancement

**What does does this PR do / why we need it**:
This PR enable a user to set odo log level by setting the environment variable "ODO_LOG_LEVEL"

**Which issue(s) this PR fixes**:
Fixes #2351 