### PR TITLE
Build and package for all RHEL architectures

### DIFF
--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -19,8 +19,6 @@ Summary:        %{product_name} client odo CLI binary
 License:        ASL 2.0
 URL:            https://github.com/openshift/odo/tree/%{odo_cli_version}
 
-ExclusiveArch:  x86_64
-
 Source0:        %{source_tar}
 BuildRequires:  gcc
 BuildRequires:  golang >= %{golang_version}
@@ -39,17 +37,23 @@ mkdir -p %{gopath}/src/github.com/openshift
 ln -s "$(pwd)" %{gopath}/src/github.com/openshift/odo
 export GOPATH=%{gopath}
 cd %{gopath}/src/github.com/openshift/odo
+%ifarch x86_64
+# go test -race is not supported on all arches
 make test
+%endif
 make prepare-release
 unlink %{gopath}/src/github.com/openshift/odo
 rm -rf %{gopath}
 
 %install
 mkdir -p %{buildroot}/%{_bindir}
-install -m 0755 dist/bin/linux-amd64/odo %{buildroot}%{_bindir}/odo
+install -m 0755 dist/bin/linux-`go env GOARCH`/odo %{buildroot}%{_bindir}/odo
 mkdir -p %{buildroot}%{_datadir}
 install -d %{buildroot}%{_datadir}/%{name}-redistributable
 install -p -m 755 dist/release/odo-linux-amd64 %{buildroot}%{_datadir}/%{name}-redistributable/odo-linux-amd64
+install -p -m 755 dist/release/odo-linux-arm64 %{buildroot}%{_datadir}/%{name}-redistributable/odo-linux-arm64
+install -p -m 755 dist/release/odo-linux-ppc64le %{buildroot}%{_datadir}/%{name}-redistributable/odo-linux-ppc64le
+install -p -m 755 dist/release/odo-linux-s390x %{buildroot}%{_datadir}/%{name}-redistributable/odo-linux-s390x
 install -p -m 755 dist/release/odo-darwin-amd64 %{buildroot}%{_datadir}/%{name}-redistributable/odo-darwin-amd64
 install -p -m 755 dist/release/odo-windows-amd64.exe %{buildroot}%{_datadir}/%{name}-redistributable/odo-windows-amd64.exe
 cp -avrf dist/release/odo*.tar.gz %{buildroot}%{_datadir}/%{name}-redistributable
@@ -75,6 +79,12 @@ Obsoletes:      %{package_name}-redistributable
 %dir %{_datadir}/%{name}-redistributable
 %{_datadir}/%{name}-redistributable/odo-linux-amd64
 %{_datadir}/%{name}-redistributable/odo-linux-amd64.tar.gz
+%{_datadir}/%{name}-redistributable/odo-linux-arm64
+%{_datadir}/%{name}-redistributable/odo-linux-arm64.tar.gz
+%{_datadir}/%{name}-redistributable/odo-linux-ppc64le
+%{_datadir}/%{name}-redistributable/odo-linux-ppc64le.tar.gz
+%{_datadir}/%{name}-redistributable/odo-linux-s390x
+%{_datadir}/%{name}-redistributable/odo-linux-s390x.tar.gz
 %{_datadir}/%{name}-redistributable/odo-darwin-amd64
 %{_datadir}/%{name}-redistributable/odo-darwin-amd64.tar.gz
 %{_datadir}/%{name}-redistributable/odo-windows-amd64.exe

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -11,11 +11,11 @@ if [[ -z "${COMMON_FLAGS}" ]]; then
     exit 1
 fi
 
-for platform in linux darwin windows ; do
-  echo "Cross compiling $platform-amd64 and placing binary at dist/bin/$platform-amd64/"
-  if [ $platform == "windows" ]; then
-    GOARCH=amd64 GOOS=$platform go build -o dist/bin/$platform-amd64/odo.exe -ldflags="$COMMON_FLAGS" ./cmd/odo/
+for platform in linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64 windows-amd64 ; do
+  echo "Cross compiling $platform and placing binary at dist/bin/$platform/"
+  if [ $platform == "windows-amd64" ]; then
+    GOARCH=amd64 GOOS=windows go build -o dist/bin/$platform/odo.exe -ldflags="$COMMON_FLAGS" ./cmd/odo/
   else
-    GOARCH=amd64 GOOS=$platform go build -o dist/bin/$platform-amd64/odo -ldflags="$COMMON_FLAGS" ./cmd/odo/
+    GOARCH=${platform#*-} GOOS=${platform%-*} go build -o dist/bin/$platform/odo -ldflags="$COMMON_FLAGS" ./cmd/odo/
   fi
 done


### PR DESCRIPTION
**What kind of PR is this?**
/kind enhancement

**What does does this PR do / why we need it**:
OpenShift is currently available for X86-64 and IBM Power LE, and IBM Z is coming.  IBM customers will expect to be able to download and run odo on their systems (particularly on Z where admins generally prefer homogeneous environments).  oc is also available on all RHEL architectures:

https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/

The same should apply to odo, particularly as download links thereto are provided from the console.

**How to test changes / Special notes to the reviewer**:
A successful scratch build has been done internally.