### PR TITLE
Update doc since Codewind project already used odo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,6 +77,7 @@ These are some of the IDE plugins which use odo:
 
 * link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector[VS Code Openshift Connector]
 * link:http://plugins.jetbrains.com/plugin/12030-openshift-connector-by-red-hat[Openshift Connector for Intellij]
+* link:https://www.eclipse.org/codewind[Codewind for Eclipse Che]
 
 
 [[glossary]]


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind docs

**What does does this PR do / why we need it**:
Currently Codewind already supported OpenShift projects and can use odo as build engine to build projects, so we can add Codewind as `projects using odo` on official odo website.

**Which issue(s) this PR fixes**:
Issue in Codewind repository: https://github.com/eclipse/codewind/issues/754
