### PR TITLE
Add --wait to project delete

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -4,7 +4,6 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/pkg/errors"
 
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,18 +44,16 @@ func Create(client *occlient.Client, projectName string, wait bool) error {
 }
 
 // Delete deletes the project with name projectName and returns errors if any
-func Delete(client *occlient.Client, projectName string) error {
-	// Loading spinner
-	s := log.Spinnerf("Deleting project %s", projectName)
-	defer s.End(false)
+func Delete(client *occlient.Client, projectName string, wait bool) error {
+	if projectName == "" {
+		return errors.Errorf("no project name given")
+	}
 
 	// Delete the requested project
-	err := client.DeleteProject(projectName)
+	err := client.DeleteProject(projectName, wait)
 	if err != nil {
 		return errors.Wrap(err, "unable to delete project")
 	}
-
-	s.End(true)
 	return nil
 }
 

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,6 +46,41 @@ var _ = Describe("odo project command tests", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "project", "-h")
 			Expect(appHelp).To(ContainSubstring("Perform project operations"))
+		})
+	})
+
+	Context("Should be able to delete a project with --wait", func() {
+		var projectName string
+		JustBeforeEach(func() {
+			projectName = helper.RandString(6)
+		})
+
+		It("--wait should work with deleting a project", func() {
+
+			// Create the project
+			helper.CmdShouldPass("odo", "project", "create", projectName)
+
+			// Delete with --wait
+			output := helper.CmdShouldPass("odo", "project", "delete", projectName, "-f", "--wait")
+			Expect(output).To(ContainSubstring("Waiting for project to be deleted"))
+
+		})
+
+	})
+
+	Context("Delete the project with flag -o json", func() {
+		var projectName string
+		JustBeforeEach(func() {
+			projectName = helper.RandString(6)
+		})
+
+		// odo project delete foobar -o json
+		It("should be able to delete project and show output in json format", func() {
+			helper.CmdShouldPass("odo", "project", "create", projectName, "-o", "json")
+
+			actual := helper.CmdShouldPass("odo", "project", "delete", projectName, "-o", "json")
+			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.dev/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Deleted project : %s"}`, projectName, projectName, projectName)
+			Expect(desired).Should(MatchJSON(actual))
 		})
 	})
 


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind feature
/kind enhancement

**What does does this PR do / why we need it**:

Adds `--wait` parameter. Ex. `odo project delete myproject --wait`

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/1884

**How to test changes / Special notes to the reviewer**:

```sh
odo project create foobar
odo project delete foobar --wait
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>