### PR TITLE
Add all test target to a single OpenShift CI presubmit file

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -6,7 +6,6 @@ set -e
 set -x
 
 export CI="openshift"
-export TIMEOUT="30m"
 export GINKGO_VERBOSE_MODE="-v"
 make configure-installer-tests-cluster
 make bin
@@ -17,24 +16,12 @@ export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
 # Integration tests
-make test-generic
+make test-integration
 make test-cmd-login-logout
-make test-cmd-cmp
-make test-cmd-cmp-sub
-make test-cmd-pref-config
-make test-cmd-watch
-make test-cmd-debug
-make test-cmd-storage
-make test-cmd-app
 make test-cmd-project
-make test-cmd-url
-make test-cmd-push
-make test-cmd-link-unlink
 
 # E2e tests
-make test-e2e-beta
-make test-e2e-java
-make test-e2e-source
+make test-e2e-all
 
 # Benchmark tests
 make test-benchmark

--- a/scripts/openshiftci-presubmit-integratione2ebenchmark.sh
+++ b/scripts/openshiftci-presubmit-integratione2ebenchmark.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+export CI="openshift"
+export TIMEOUT="30m"
+export GINKGO_VERBOSE_MODE="-v"
+make configure-installer-tests-cluster
+make bin
+mkdir -p $GOPATH/bin
+go get -u github.com/onsi/ginkgo/ginkgo
+export PATH="$PATH:$(pwd):$GOPATH/bin"
+export ARTIFACTS_DIR="/tmp/artifacts"
+export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
+
+# Integration tests
+make test-generic
+make test-cmd-login-logout
+make test-cmd-cmp
+make test-cmd-cmp-sub
+make test-cmd-pref-config
+make test-cmd-watch
+make test-cmd-debug
+make test-cmd-storage
+make test-cmd-app
+make test-cmd-project
+make test-cmd-url
+make test-cmd-push
+make test-cmd-link-unlink
+
+# E2e tests
+make test-e2e-beta
+make test-e2e-java
+make test-e2e-source
+
+# Benchmark tests
+make test-benchmark
+
+odo logout
+
+# upload the junit test reports
+cp -r reports $ARTIFACTS_DIR


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind test

**What does does this PR do / why we need it**:
Putting all test target to a single OpenShift CI presubmit file to optimize the no of test cluster run for each pr.
**Which issue(s) this PR fixes**:

Fixes - part of #2360 

**How to test changes / Special notes to the reviewer**:
pr https://github.com/openshift/release/pull/5909 should work properly after this goes in.