### PR TITLE
Disabling ginkgo JUNIT report generator

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -27,6 +27,3 @@ make test-e2e-all
 make test-benchmark
 
 odo logout
-
-# upload the junit test reports
-cp -r reports $ARTIFACTS_DIR

--- a/scripts/openshiftci-presubmit-e2etests.sh
+++ b/scripts/openshiftci-presubmit-e2etests.sh
@@ -19,6 +19,3 @@ make test-e2e-beta
 make test-e2e-java
 make test-e2e-source
 odo logout
-
-# upload the junit test reports
-cp -r reports $ARTIFACTS_DIR

--- a/scripts/openshiftci-presubmit-integrationtests.sh
+++ b/scripts/openshiftci-presubmit-integrationtests.sh
@@ -29,6 +29,3 @@ make test-cmd-url
 make test-cmd-push
 make test-cmd-link-unlink
 odo logout
-
-# upload the junit test reports
-cp -r reports $ARTIFACTS_DIR

--- a/tests/e2escenarios/e2escenarios_suite_test.go
+++ b/tests/e2escenarios/e2escenarios_suite_test.go
@@ -5,10 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
 )
 
 func TestE2eScenarios(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "odo e2e scenarios", []Reporter{reporter.JunitReport(t, "../../reports")})
+	RunSpecs(t, "odo e2e scenarios")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	//RunSpecsWithDefaultAndCustomReporters(t, "odo e2e scenarios", []Reporter{reporter.JunitReport(t, "../../reports")})
 }

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -7,10 +7,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
 )
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Integration Suite", []Reporter{reporter.JunitReport(t, "../../reports")})
+	RunSpecs(t, "Integration Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Integration Suite", []Reporter{reporter.JunitReport(t, "../../reports")})
 }

--- a/tests/integration/loginlogout/loginlogout_suite_test.go
+++ b/tests/integration/loginlogout/loginlogout_suite_test.go
@@ -5,10 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
 )
 
 func TestLoginlogout(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Loginlogout Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	RunSpecs(t, "Loginlogout Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Loginlogout Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
 }

--- a/tests/integration/project/project_suite_test.go
+++ b/tests/integration/project/project_suite_test.go
@@ -5,10 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
 )
 
 func TestProject(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	RunSpecs(t, "Project Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
 }

--- a/tests/integration/servicecatalog/servicecatalog_suite_test.go
+++ b/tests/integration/servicecatalog/servicecatalog_suite_test.go
@@ -5,10 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
 )
 
 func TestServicecatalog(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Servicecatalog Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	RunSpecs(t, "Servicecatalog Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Servicecatalog Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
 }


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind test

**What does does this PR do / why we need it**:
Ginkgo customReporters does not record properly the status of specs in JUNIT report. So disabling the JUNIT reports generator
**Which issue(s) this PR fixes**:

Fixes - No, However due to the ginkgo upstream issue https://github.com/onsi/ginkgo/issues/628, it good to disable the reporting part till the issue is fixed.

**How to test changes / Special notes to the reviewer**:
make <any_test_target> should not create JUNIT reports.
