### PR TITLE
Detect component has not been build yet

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -283,6 +283,7 @@ func isSupportedImage(imgName string) bool {
 		"openjdk/openjdk-11-rhel8:latest",
 		"openjdk/openjdk-11-rhel7:latest",
 		"rhscl/nodejs-8-rhel7:latest",
+		"rhscl/nodejs-10-rhel7:latest",
 		"rhoar-nodejs/nodejs-8:latest",
 		"rhoar-nodejs/nodejs-10:latest",
 		"bucharestgold/centos7-s2i-nodejs:8.x",

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -96,7 +96,8 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.0.0"
+	// defaultBootstrapperImage = "registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.0.0"
+	defaultBootstrapperImage = "yusufk53/odo-init-image:1066"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"

--- a/pkg/occlient/templates.go
+++ b/pkg/occlient/templates.go
@@ -88,8 +88,10 @@ func generateSupervisordDeploymentConfig(commonObjectMeta metav1.ObjectMeta, com
 							// Using the appropriate configuration file that contains the "run" script for the component.
 							// either from: /usr/libexec/s2i/assemble or /opt/app-root/src/.s2i/bin/assemble
 							Args: []string{
+								"-pre",
+								"/opt/odo/bin/s2i-setup",
 								"-main",
-								"/opt/odo/bin/supervisord -c /opt/odo/conf/supervisor.conf",
+								"/opt/odo/bin/supervisord -c /opt/app-root/conf/supervisor.conf",
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
1. Execute "s2i-setup" script as a pre-start hook in go-init.
2. Use the "supervisor.conf" on persistent volume, mounted on "/opt/app-src", as supervisord config file.

Fixes #1066

**What kind of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Detects that component has been built or not and accordingly sets "autostart=true" in supervisor.conf. As a result of this, supervisord does not attempt to start the application and does not flood the logs with failure messages.

**Which issue(s) this PR fixes**:

Fixes #1066

**How to test changes / Special notes to the reviewer**:
- Create an empty directory
- Create an odo component for any supported language
- Do `odo push` for the empty source directory
- Expected Result: Supervisord should not start