### PR TITLE
Add `odo preference set PushTimeout` / pod timeout configuration

### DIFF
--- a/pkg/odo/cli/preference/preference.go
+++ b/pkg/odo/cli/preference/preference.go
@@ -15,8 +15,7 @@ const RecommendedCommandName = "preference"
 
 var preferenceLongDesc = ktemplates.LongDesc(`Modifies odo specific configuration settings within the global preference file.
 
-%[1]s
-`)
+%[1]s`)
 
 // NewCmdPreference implements the utils config odo command
 func NewCmdPreference(name, fullName string) *cobra.Command {

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -26,6 +26,7 @@ var (
    %[1]s %[2]s false
    %[1]s %[3]s "app"
    %[1]s %[4]s 20
+   %[1]s %[5]s 30
 	`)
 )
 
@@ -88,7 +89,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Short: "Set a value in odo config file",
 		Long:  fmt.Sprintf(setLongDesc, preference.FormatSupportedParameters()),
 		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName,
-			preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting),
+			preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting, preference.PushTimeoutSetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return fmt.Errorf("please provide a parameter name and value")

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -24,9 +24,10 @@ var (
 `)
 	unsetExample = ktemplates.Examples(`
    # Unset a preference value in the global preference
-   %[1]s  %[2]s
-   %[1]s  %[3]s
-   %[1]s  %[4]s
+   %[1]s %[2]s
+   %[1]s %[3]s
+   %[1]s %[4]s
+   %[1]s %[5]s
 	`)
 )
 
@@ -90,7 +91,7 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		Use:     name,
 		Short:   "Unset a value in odo preference file",
 		Long:    fmt.Sprintf(unsetLongDesc, preference.FormatSupportedParameters()),
-		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName, preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting),
+		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName, preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting, preference.PushTimeoutSetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("please provide a parameter name")

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -54,6 +54,7 @@ func (o *ViewOptions) Run() (err error) {
 	fmt.Fprintln(w, "UpdateNotification", "\t", showBlankIfNil(cfg.OdoSettings.UpdateNotification))
 	fmt.Fprintln(w, "NamePrefix", "\t", showBlankIfNil(cfg.OdoSettings.NamePrefix))
 	fmt.Fprintln(w, "Timeout", "\t", showBlankIfNil(cfg.OdoSettings.Timeout))
+	fmt.Fprintln(w, "PushTimeout", "\t", showBlankIfNil(cfg.OdoSettings.PushTimeout))
 	w.Flush()
 	return
 }

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -21,10 +21,10 @@ const (
 	preferenceKind       = "Preference"
 	preferenceAPIVersion = "odo.openshift.io/v1alpha1"
 
-	//DefaultTimeout for openshift server connection check
+	//DefaultTimeout for openshift server connection check (in seconds)
 	DefaultTimeout = 1
 
-	// DefaultPushTimeout is the default timeout for pods
+	// DefaultPushTimeout is the default timeout for pods (in seconds)
 	DefaultPushTimeout = 240
 
 	// UpdateNotificationSetting is the name of the setting controlling update notification
@@ -49,7 +49,7 @@ const (
 // TimeoutSettingDescription is human-readable description for the timeout setting
 var TimeoutSettingDescription = fmt.Sprintf("Timeout (in seconds) for OpenShift server connection check (Default: %d)", DefaultTimeout)
 
-//
+// PushTimeoutSettingDescription adds a description for PushTimeout
 var PushTimeoutSettingDescription = fmt.Sprintf("PushTimeout (in seconds) for waiting for a Pod to come up (Default: %d)", DefaultPushTimeout)
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -287,6 +287,14 @@ func TestSetConfiguration(t *testing.T) {
 			existingConfig: Preference{},
 			wantErr:        true,
 		},
+		{
+			name:           fmt.Sprintf("Case 12: %s set to 300 with mixed case in parameter name", TimeoutSetting),
+			parameter:      "PushTimeout",
+			value:          "99",
+			existingConfig: Preference{},
+			want:           99,
+			wantErr:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -41,10 +41,11 @@ var _ = Describe("odo push command tests", func() {
 	Context("Check pod timeout", func() {
 
 		It("Check that pod timeout works and we time out immediately..", func() {
-			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "preference", "set", "PushTimeout", "1")
-			helper.CmdShouldFail("odo", "push", "--context", context+"/nodejs-ex")
+			output := helper.CmdShouldFail("odo", "push", "--context", context+"/nodejs-ex")
+			Expect(output).To(ContainSubstring("waited 1s but couldn't find running pod matching selector"))
 		})
 
 	})

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -38,6 +38,17 @@ var _ = Describe("odo push command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
+	Context("Check pod timeout", func() {
+
+		It("Check that pod timeout works and we time out immediately..", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "preference", "set", "PushTimeout", "1")
+			helper.CmdShouldFail("odo", "push", "--context", context+"/nodejs-ex")
+		})
+
+	})
+
 	Context("Check for label propagation after pushing", func() {
 
 		It("Check for labels", func() {


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind feature
/kind enhancement

**What does does this PR do / why we need it**:

Adds the ability to set your own pushtimeout, being able to configure
how long to wait for the push to time out.

For example:

```sh
odo preference set PushTimeout 30
```

Will set the default pod timeout to 30 seconds.

**Which issue(s) this PR fixes**:

Fixes #943

**How to test changes / Special notes to the reviewer**:

```sh
odo create nodejs
odo preference set PushTimeout 1
odo push
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>