### PR TITLE
changed DEBUG_MODE to DEV_MODE in odo-debug design doc

### DIFF
--- a/docs/proposals/odo-debug.md
+++ b/docs/proposals/odo-debug.md
@@ -20,8 +20,8 @@ Table of Contents:
 
 ## Design overview
 
-The debug mode inside the container is controlled by `DEBUG_MODE` and `DEBUG_PORT` environment variables.
-- by default supported component (Java and NodeJS) are started with debug enabled. This can be optionaly disabled by setting `DEBUG_MODE=false`
+The debug mode inside the container is controlled by `DEV_MODE` and `DEBUG_PORT` environment variables.
+- by default supported component (Java and NodeJS) are started with debug enabled. This can be optionaly disabled by setting `DEV_MODE=false`
 - `DEBUG_PORT` is optional and controls the port of the remote debugger.
 
 Odo sets up port-forwarding to allow a debugger to connect to the running process. 


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->
/kind code-refactoring
/kind enhancement

**What does does this PR do / why we need it**:
After https://github.com/openshift/odo-init-image/pull/45 is merged. we will be using `DEV_MODE` to control debug mode so we need to change the docs to reflect that information
**Which issue(s) this PR fixes**:

Partly https://github.com/openshift/odo/issues/2409

**How to test changes / Special notes to the reviewer**:
Doc change