### PR TITLE
resolve odo list --help having different output then odo component list --help

### DIFF
--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -152,6 +152,8 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path of the directory to scan for odo component directories")
 	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")
+	componentListCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
+
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(componentListCmd)
 	//Adding `--application` flag


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind bug

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2415

**How to test changes / Special notes to the reviewer**:
Compare
```
odo list --help 
odo component list --help
```
the flags and additional flags should be same for both
