### PR TITLE
Fix help output for url and storage

### DIFF
--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -17,9 +17,10 @@ import (
 const createRecommendedCommandName = "create"
 
 var (
-	urlCreateShortDesc = `Create storage and mount to a component`
-	urlCreateLongDesc  = ktemplates.LongDesc(`Create storage and mount to a component`)
-	urlCreateExample   = ktemplates.Examples(`  # Create storage of size 1Gb to a component
+	storageCreateShortDesc = `Create storage and mount to a component`
+	storageCreateLongDesc  = ktemplates.LongDesc(`Create storage and mount to a component`)
+	storageCreateExample   = ktemplates.Examples(`
+	# Create storage of size 1Gb to a component
   %[1]s mystorage --path=/opt/app-root/src/storage/ --size=1Gi
 	`)
 )
@@ -83,9 +84,9 @@ func NewCmdStorageCreate(name, fullName string) *cobra.Command {
 	o := NewStorageCreateOptions()
 	storageCreateCmd := &cobra.Command{
 		Use:         name,
-		Short:       urlCreateShortDesc,
-		Long:        urlCreateLongDesc,
-		Example:     fmt.Sprintf(urlCreateExample, fullName),
+		Short:       storageCreateShortDesc,
+		Long:        storageCreateLongDesc,
+		Example:     fmt.Sprintf(storageCreateExample, fullName),
 		Args:        cobra.MaximumNArgs(1),
 		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -17,7 +17,8 @@ const deleteRecommendedCommandName = "delete"
 var (
 	storageDeleteShortDesc = `Delete storage from component`
 	storageDeleteLongDesc  = ktemplates.LongDesc(`Delete storage from component`)
-	storageDeleteExample   = ktemplates.Examples(`  # Delete storage mystorage from the currently active component
+	storageDeleteExample   = ktemplates.Examples(`
+	# Delete storage mystorage from the currently active component
   %[1]s mystorage
 `)
 )

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -23,7 +23,8 @@ const listRecommendedCommandName = "list"
 var (
 	storageListShortDesc = `List storage attached to a component`
 	storageListLongDesc  = ktemplates.LongDesc(`List storage attached to a component`)
-	storageListExample   = ktemplates.Examples(`  # List all storage attached or mounted to the current component and 
+	storageListExample   = ktemplates.Examples(`
+	# List all storage attached or mounted to the current component and 
   # all unattached or unmounted storage in the current application
   %[1]s
 	`)

--- a/pkg/odo/cli/storage/storage.go
+++ b/pkg/odo/cli/storage/storage.go
@@ -23,25 +23,20 @@ func NewCmdStorage(name, fullName string) *cobra.Command {
 	storageCreateCmd := NewCmdStorageCreate(createRecommendedCommandName, odoutil.GetFullName(fullName, createRecommendedCommandName))
 	storageDeleteCmd := NewCmdStorageDelete(deleteRecommendedCommandName, odoutil.GetFullName(fullName, deleteRecommendedCommandName))
 	storageListCmd := NewCmdStorageList(listRecommendedCommandName, odoutil.GetFullName(fullName, listRecommendedCommandName))
-	//storageMountCmd := NewCmdStorageMount(mountRecommendedCommandName, odoutil.GetFullName(fullName, mountRecommendedCommandName))
-	//storageUnMountCmd := NewCmdStorageUnMount(unMountRecommendedCommandName, odoutil.GetFullName(fullName, unMountRecommendedCommandName))
 
 	var storageCmd = &cobra.Command{
 		Use:   name,
 		Short: storageShortDesc,
 		Long:  storageLongDesc,
-		Example: fmt.Sprintf("%s\n%s\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
 			storageCreateCmd.Example,
 			storageDeleteCmd.Example,
-			//storageUnMountCmd.Example,
 			storageListCmd.Example),
 	}
 
 	storageCmd.AddCommand(storageCreateCmd)
 	storageCmd.AddCommand(storageDeleteCmd)
-	//storageCmd.AddCommand(storageUnMountCmd)
 	storageCmd.AddCommand(storageListCmd)
-	//storageCmd.AddCommand(storageMountCmd)
 
 	// Add a defined annotation in order to appear in the help menu
 	storageCmd.Annotations = map[string]string{"command": "main"}

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -28,7 +28,7 @@ func NewCmdURL(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: urlShortDesc,
 		Long:  urlLongDesc,
-		Example: fmt.Sprintf("%s\n%s\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
 			urlCreateCmd.Example,
 			urlDeleteCmd.Example,
 			urlListCmd.Example),


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind cleanup

**What does does this PR do / why we need it**:

Fixes the output in `odo storage --help` and `odo url --help` with the
missing newlines.

The new output:
```sh
Examples:
  # Create a URL with a specific name by automatically detecting the port used by the component
  odo url create example

  # Create a URL for the current component with a specific port
  odo url create --port 8080

  # Create a URL with a specific name and port
  odo url create example --port 8080

  # Delete a URL to a component
  odo url delete myurl

  # List the available URLs
  odo url list
```

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

```sh
odo storage --help
odo url --help
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>