### PR TITLE
Add check for "FIt" script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install:
 
 # run all validation tests
 .PHONY: validate
-validate: gofmt check-vendor vet validate-vendor-licenses sec #lint
+validate: gofmt check-fit check-vendor vet validate-vendor-licenses sec #lint
 
 .PHONY: gofmt
 gofmt:
@@ -59,6 +59,10 @@ gofmt:
 .PHONY: check-vendor
 check-vendor:
 	./scripts/check-vendor.sh
+
+.PHONY: check-fit
+check-fit:
+	./scripts/check-fit.sh
 
 .PHONY: validate-vendor-licenses
 validate-vendor-licenses:

--- a/scripts/check-fit.sh
+++ b/scripts/check-fit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if grep -nr "FIt(" tests/; then
+  echo "Not OK. FIt exists somewhere in the testing code. Please remove it."
+  exit 1
+else
+  echo "OK"
+fi


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->

/kind enhancement

**What does does this PR do / why we need it**:

Adds a small script to check for instances of `FIt(` being in the code.
This helps with regards to not merging in tests with FIt in integration.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>