### PR TITLE
Deleting a component also unlinks it from components it might be linked to

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1513,7 +1513,7 @@ func addDebugPortToEnv(envVarList *config.EnvVarList, componentConfig config.Loc
 // It returns a map with keys indicating the components that are linked to the parent component
 // and values indicating the corresponding secret names
 func UnlinkComponents(parentComponent Component, compoList ComponentList) map[string][]string {
-	components := make(map[string][]string)
+	componentSecrets := make(map[string][]string)
 	for _, comp := range compoList.Items {
 		// .Items contains the list of components in the cluster
 		for component, ports := range comp.Status.LinkedComponents {
@@ -1523,12 +1523,12 @@ func UnlinkComponents(parentComponent Component, compoList ComponentList) map[st
 				// Component is linked with our parent component
 				// We need to create secret name for this and unlink the secret from component before deleting parent component
 				for _, port := range ports {
-					components[comp.Name] = append(components[comp.Name], generateSecretName(parentComponent.Name, comp.Spec.App, port))
+					componentSecrets[comp.Name] = append(componentSecrets[comp.Name], generateSecretName(parentComponent.Name, comp.Spec.App, port))
 				}
 			}
 		}
 	}
-	return components
+	return componentSecrets
 }
 
 func generateSecretName(compName, app, port string) string {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1508,3 +1508,29 @@ func addDebugPortToEnv(envVarList *config.EnvVarList, componentConfig config.Loc
 		Value: fmt.Sprint(componentConfig.GetDebugPort()),
 	})
 }
+
+// UnlinkComponents takes the component to be deleted and list of active components in the cluster as arguments.
+// It returns a map with keys indicating the components that are linked to the parent component
+// and values indicating the corresponding secret names
+func UnlinkComponents(parentComponent Component, compoList ComponentList) map[string][]string {
+	components := make(map[string][]string)
+	for _, comp := range compoList.Items {
+		// .Items contains the list of components in the cluster
+		for component, ports := range comp.Status.LinkedComponents {
+			// Status.LinkedComponents is a map where key is the name of the component and value is a slice of ports.
+			// We can use this info to create a secret name
+			if component == parentComponent.Name {
+				// Component is linked with our parent component
+				// We need to create secret name for this and unlink the secret from component before deleting parent component
+				for _, port := range ports {
+					components[comp.Name] = append(components[comp.Name], generateSecretName(parentComponent.Name, comp.Spec.App, port))
+				}
+			}
+		}
+	}
+	return components
+}
+
+func generateSecretName(compName, app, port string) string {
+	return strings.Join([]string{compName, app, port}, "-")
+}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -960,7 +960,6 @@ func TestUnlinkComponents(t *testing.T) {
 		parentComponent Component
 		childComponents []Component
 		ports           []string
-		wantErr         bool
 	}{
 		{
 			name:            "Case 1: Single child component linked to only one port of parent component",
@@ -975,7 +974,7 @@ func TestUnlinkComponents(t *testing.T) {
 			ports:           []string{"8080", "8443"},
 		},
 		{
-			name:            "Case 3: Multiple child components linke to multiple ports of parent component",
+			name:            "Case 3: Multiple child components linked to multiple ports of parent component",
 			parentComponent: fakeComponent("java"),
 			childComponents: []Component{fakeComponent("nodejs"), fakeComponent("python")},
 			ports:           []string{"8080", "8443"},
@@ -1017,6 +1016,7 @@ func TestUnlinkComponents(t *testing.T) {
 
 }
 
+// fakeComponent returns a Component of name & type specified by cmpType
 func fakeComponent(cmpType string) Component {
 	return Component{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"github.com/openshift/odo/pkg/util"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"sort"
 	"testing"
+
+	"github.com/openshift/odo/pkg/util"
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
@@ -950,4 +952,96 @@ func TestGetComponentFromConfig(t *testing.T) {
 		})
 	}
 
+}
+
+func TestUnlinkComponents(t *testing.T) {
+	tests := []struct {
+		name            string
+		parentComponent Component
+		childComponents []Component
+		ports           []string
+		wantErr         bool
+	}{
+		{
+			name:            "Case 1: Single child component linked to only one port of parent component",
+			parentComponent: fakeComponent("java"),
+			childComponents: []Component{fakeComponent("nodejs")},
+			ports:           []string{"8080"},
+		},
+		{
+			name:            "Case 2: Single child component linked to multiple ports of parent component",
+			parentComponent: fakeComponent("java"),
+			childComponents: []Component{fakeComponent("nodejs")},
+			ports:           []string{"8080", "8443"},
+		},
+		{
+			name:            "Case 3: Multiple child components linke to multiple ports of parent component",
+			parentComponent: fakeComponent("java"),
+			childComponents: []Component{fakeComponent("nodejs"), fakeComponent("python")},
+			ports:           []string{"8080", "8443"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := make(map[string][]string)
+
+			componentList := ComponentList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "odo.openshift.io/v1alpha1",
+				},
+				ListMeta: metav1.ListMeta{},
+				Items:    tt.childComponents,
+			}
+
+			// link the components and create map of what we want (to avoid running the two loops second time)
+			for _, childComponent := range tt.childComponents {
+				for _, port := range tt.ports {
+					linkFakeComponents(&tt.parentComponent, &childComponent, port)
+					want[childComponent.Name] = append(
+						want[childComponent.Name],
+						fmt.Sprintf("%s-%s-%s", tt.parentComponent.Name, tt.parentComponent.Spec.App, port),
+					)
+				}
+			}
+
+			// run the tests
+			got := UnlinkComponents(tt.parentComponent, componentList)
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got %q, wanted %q", got, want)
+			}
+		})
+	}
+
+}
+
+func fakeComponent(cmpType string) Component {
+	return Component{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Component",
+			APIVersion: "odo.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmpType,
+			Namespace: "test",
+		},
+		Spec: ComponentSpec{
+			Type: cmpType,
+			App:  "app",
+		},
+		Status: ComponentStatus{
+			State:            "Pushed",
+			LinkedServices:   []string{},
+			LinkedComponents: map[string][]string{},
+		},
+	}
+}
+
+// linkFakeComponents adds link to "port" of "componentA" in "componentB". It
+// is equivalent to doing `odo link componentA --port <port>` from component
+// directory of componentB
+func linkFakeComponents(componentA, componentB *Component, port string) {
+	componentB.Status.LinkedComponents[componentA.Name] = append(componentB.Status.LinkedComponents[componentA.Name], port)
 }

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -81,7 +81,33 @@ func (do *DeleteOptions) Run() (err error) {
 		}
 
 		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v from %v?", do.componentName, do.Application)) {
-			err := component.Delete(do.Client, do.componentName, do.Application)
+			// Before actually deleting the component, first unlink it from any component(s) in the cluster it might be linked to
+			// We do this in three steps:
+			// 1. Get list of active components in the cluster
+			// 2. Use this list to find the components to which our component is linked and generate secret names that are linked
+			// 3. Unlink these secrets from the components
+			compoList, err := component.List(do.Client, do.Context.Application, &do.LocalConfigInfo)
+			if err != nil {
+				return err
+			}
+
+			parentComponent, err := component.GetComponent(do.Client, do.componentName, do.Context.Application, do.Context.Project)
+			if err != nil {
+				return err
+			}
+
+			componentSecrets := component.UnlinkComponents(parentComponent, compoList)
+
+			for component, secret := range componentSecrets {
+				for _, secretName := range secret {
+					err = do.Client.UnlinkSecret(secretName, component, do.Context.Application)
+					if err != nil {
+						return err
+					}
+					log.Successf("Unlinked component %q from component %q for secret %q", parentComponent.Name, component, secretName)
+				}
+			}
+			err = component.Delete(do.Client, do.componentName, do.Application)
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -99,12 +99,19 @@ func (do *DeleteOptions) Run() (err error) {
 			componentSecrets := component.UnlinkComponents(parentComponent, compoList)
 
 			for component, secret := range componentSecrets {
+				spinner := log.Spinner("Unlinking components")
 				for _, secretName := range secret {
+
+					defer spinner.End(false)
+
 					err = do.Client.UnlinkSecret(secretName, component, do.Context.Application)
 					if err != nil {
+						log.Errorf("Unlinking failed")
 						return err
 					}
-					log.Successf("Unlinked component %q from component %q for secret %q", parentComponent.Name, component, secretName)
+
+					spinner.End(true)
+					log.Successf(fmt.Sprintf("Unlinked component %q from component %q for secret %q", parentComponent.Name, component, secretName))
 				}
 			}
 			err = component.Delete(do.Client, do.componentName, do.Application)

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -133,5 +133,23 @@ var _ = Describe("odo link and unlink command tests", func() {
 
 			helper.CmdShouldPass("odo", "unlink", "backend", "--app", appName, "--port", "8080", "--context", frontendContext)
 		})
+
+		It("should successfully delete component after linked component is deleted", func() {
+			// first create the two components
+			helper.CopyExample(filepath.Join("source", "nodejs"), frontendContext)
+			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", frontendContext, "--project", project)
+			helper.CmdShouldPass("odo", "push", "--context", frontendContext)
+			helper.CopyExample(filepath.Join("source", "nodejs"), backendContext)
+			helper.CmdShouldPass("odo", "create", "nodejs", "backend", "--context", backendContext, "--project", project)
+			helper.CmdShouldPass("odo", "push", "--context", backendContext)
+
+			// now link frontend to the backend component
+			helper.CmdShouldPass("odo", "link", "backend", "--port", "8080", "--context", frontendContext)
+
+			// now delete the backend component and then the frontend component
+			// this didn't work earlier: https://github.com/openshift/odo/issues/2355
+			helper.CmdShouldPass("odo", "delete", "-f", "--context", backendContext)
+			helper.CmdShouldPass("odo", "delete", "-f", "--context", frontendContext)
+		})
 	})
 })


### PR DESCRIPTION


**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->
/kind bug

**What does does this PR do / why we need it**:
This PR unlinks a component requested for deletion from all the components it might be linked to in the OpenShift cluster

**Which issue(s) this PR fixes**:

Fixes #2355 

**How to test changes / Special notes to the reviewer**:
1. `odo create nodejs node`
2. `odo create java java`
3. From component `node`'s context directory do `odo link java --port 8080`
4. From component `java`'s context directory do `odo delete -f`
5. From component `node`'s context directory do `odo delete -f`