### PR TITLE
remove ImageStreamRef from machine readable output

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -16,7 +16,7 @@ type ComponentType struct {
 type ComponentSpec struct {
 	AllTags        []string            `json:"allTags"`
 	NonHiddenTags  []string            `json:"nonHiddenTags"`
-	ImageStreamRef imagev1.ImageStream `json:"imageStreamRef"`
+	ImageStreamRef imagev1.ImageStream `json:"-"`
 }
 
 // ComponentTypeList lists all the ComponentType's


### PR DESCRIPTION
**What kind of PR is this?**
<!--
DELETE the kind(s) which are not applicable before opening the PR.
-->
/kind api-change
/kind cleanup

**What does does this PR do / why we need it**:
Cleaning up the machine readable output for `odo catalog list components`. 
**Which issue(s) this PR fixes**:

No issue

**How to test changes / Special notes to the reviewer**:
```
odo catalog list components -o json
```
shouldn't have `ImageStreamRef`' information.