### PR TITLE
Adds PROJECT field to 'odo list' output

### DIFF
--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -70,9 +70,9 @@ func (lo *ListOptions) Run() (err error) {
 			machineoutput.OutputSuccess(components)
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
 			for _, file := range components.Items {
-				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
+				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Namespace, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
 
 			}
 			w.Flush()
@@ -125,9 +125,9 @@ func (lo *ListOptions) Run() (err error) {
 			return
 		}
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
 		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
 		}
 		w.Flush()
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

(Honestly not sure what the kind is here. Should it be enhancement?)

**What does does this PR do / why we need it**:
$Title

**Which issue(s) this PR fixes**:

Fixes #2219 

**How to test changes / Special notes to the reviewer**:
Before:
```sh
$ odo list --path ~/src
APP     NAME         TYPE       SOURCE                      STATE          CONTEXT
app     backend      java       target/wildwest-1.0.jar     Pushed         /home/dshah/src/Wild-West-Backend
app     frontend     nodejs     ./                          Pushed         /home/dshah/src/Wild-West-Frontend
app     node         nodejs     ./                          Not Pushed     /home/dshah/src/nodejs-ex
```

Now:
```sh
$ odo list --path ~/src
APP     NAME         PROJECT        TYPE       SOURCE                      STATE          CONTEXT
app     backend      myproject      java       target/wildwest-1.0.jar     Pushed         /home/dshah/src/Wild-West-Backend
app     frontend     myproject      nodejs     ./                          Pushed         /home/dshah/src/Wild-West-Frontend
app     node         newproject     nodejs     ./                          Not Pushed     /home/dshah/src/nodejs-ex
```