### PR TITLE
add supportedTags list in the odo catalog list component json output

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -225,6 +225,7 @@ func getDefaultBuilderImages(client *occlient.Client) ([]ComponentType, error) {
 // SliceSupportedTags splits the tags in to fully supported and unsupported tags
 func SliceSupportedTags(component ComponentType) ([]string, []string) {
 
+	// this makes sure that json marshal shows these lists as [] instead of null
 	supTag, unSupTag := []string{}, []string{}
 	tagMap := createImageTagMap(component.Spec.ImageStreamRef.Spec.Tags)
 	for _, tag := range component.Spec.NonHiddenTags {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -225,7 +225,7 @@ func getDefaultBuilderImages(client *occlient.Client) ([]ComponentType, error) {
 // SliceSupportedTags splits the tags in to fully supported and unsupported tags
 func SliceSupportedTags(component ComponentType) ([]string, []string) {
 
-	var supTag, unSupTag []string
+	supTag, unSupTag := []string{}, []string{}
 	tagMap := createImageTagMap(component.Spec.ImageStreamRef.Spec.Tags)
 	for _, tag := range component.Spec.NonHiddenTags {
 		imageName := tagMap[tag]

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -16,6 +16,7 @@ type ComponentType struct {
 type ComponentSpec struct {
 	AllTags        []string            `json:"allTags"`
 	NonHiddenTags  []string            `json:"nonHiddenTags"`
+	SupportedTags  []string            `json:"supportedTags"`
 	ImageStreamRef imagev1.ImageStream `json:"-"`
 }
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -59,6 +59,7 @@ func (o *ListComponentsOptions) Validate() (err error) {
 func (o *ListComponentsOptions) Run() (err error) {
 	if log.IsJSON() {
 		for i, image := range o.catalogList.Items {
+			// here we don't care about the unsupported tags (second return value)
 			supported, _ := catalog.SliceSupportedTags(image)
 			o.catalogList.Items[i].Spec.SupportedTags = supported
 		}

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -58,6 +58,10 @@ func (o *ListComponentsOptions) Validate() (err error) {
 // Run contains the logic for the command associated with ListComponentsOptions
 func (o *ListComponentsOptions) Run() (err error) {
 	if log.IsJSON() {
+		for i, image := range o.catalogList.Items {
+			supported, _ := catalog.SliceSupportedTags(image)
+			o.catalogList.Items[i].Spec.SupportedTags = supported
+		}
 		machineoutput.OutputSuccess(o.catalogList)
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -235,6 +235,7 @@ func componentTests(args ...string) {
 			// Since components catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
 			Expect(output).To(ContainSubstring("List"))
+			Expect(output).To(ContainSubstring("supportedTags"))
 		})
 
 		It("binary component should not fail when --context is not set", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What does does this PR do / why we need it**:
adds `supportedTags` list in the `odo catalog list components`'s machine readable output.
The `supportedTags` is not removed from the out if it's empty, this is done to make the output consistent for all `ComponentType`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2208

**How to test changes / Special notes to the reviewer**:
```
odo catalog list components -o json
```
should have the `supportedTags` and it should be consistent with `odo catalog list components`