### PR TITLE
Delete services belonging to an application during 'odo app delete'

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -76,16 +76,16 @@ func Delete(client *occlient.Client, name string) error {
 	// belonging to the app
 	svcList, err := service.List(client, name)
 	if err != nil {
-		return errors.Wrapf(err, "unable to delete the application %s due to failure in listing service(s) in the application", name)
-	}
-
-	for _, svc := range svcList.Items {
-		err = service.DeleteServiceAndUnlinkComponents(client, svc.Name, name)
-		if err != nil {
-			return errors.Wrapf(err, "unable to delete the application %s due to failure in deleting service(s) in the application", name)
+		// error is returned when there's no Service Catalog enabled in the service
+		glog.V(4).Infof("Service catalog is not enabled in the cluster, skipping service deletion")
+	} else {
+		for _, svc := range svcList.Items {
+			err = service.DeleteServiceAndUnlinkComponents(client, svc.Name, name)
+			if err != nil {
+				return errors.Wrapf(err, "unable to delete the application %s due to failure in deleting service(s) in the application", name)
+			}
 		}
 	}
-
 	// delete application from cluster
 	err = client.Delete(labels)
 	if err != nil {

--- a/pkg/application/labels/labels.go
+++ b/pkg/application/labels/labels.go
@@ -22,7 +22,7 @@ const OdoVersion = "app.kubernetes.io/managed-by-version"
 // GetLabels return labels that identifies given application
 // additional labels are used only when creating object
 // if you are creating something use additional=true
-// if you need labels to filter component than use additional=false
+// if you need labels to filter component then use additional=false
 func GetLabels(application string, additional bool) map[string]string {
 	labels := map[string]string{
 		ApplicationLabel: application,

--- a/pkg/component/labels/labels.go
+++ b/pkg/component/labels/labels.go
@@ -16,7 +16,7 @@ const ComponentTypeVersion = "app.openshift.io/runtime-version"
 // GetLabels return labels that should be applied to every object for given component in active application
 // additional labels are used only for creating object
 // if you are creating something use additional=true
-// if you need labels to filter component that use additional=false
+// if you need labels to filter component then use additional=false
 func GetLabels(componentName string, applicationName string, additional bool) map[string]string {
 	labels := applabels.GetLabels(applicationName, additional)
 	labels[ComponentLabel] = componentName

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2398,8 +2398,6 @@ func (c *Client) CreateServiceBinding(bindingName string, namespace string, labe
 				Labels:    labels,
 			},
 			Spec: scv1beta1.ServiceBindingSpec{
-				//ExternalID: UUID,
-
 				InstanceRef: scv1beta1.LocalObjectReference{
 					Name: bindingName,
 				},

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2379,7 +2379,7 @@ func (c *Client) CreateServiceInstance(serviceName string, serviceType string, s
 	}
 
 	// Create the secret containing the parameters of the plan selected.
-	err = c.CreateServiceBinding(serviceName, c.Namespace)
+	err = c.CreateServiceBinding(serviceName, c.Namespace, labels)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create the secret %s for the service instance", serviceName)
 	}
@@ -2389,12 +2389,13 @@ func (c *Client) CreateServiceInstance(serviceName string, serviceType string, s
 
 // CreateServiceBinding creates a ServiceBinding (essentially a secret) within the namespace of the
 // service instance created using the service's parameters.
-func (c *Client) CreateServiceBinding(bindingName string, namespace string) error {
+func (c *Client) CreateServiceBinding(bindingName string, namespace string, labels map[string]string) error {
 	_, err := c.serviceCatalogClient.ServiceBindings(namespace).Create(
 		&scv1beta1.ServiceBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      bindingName,
 				Namespace: namespace,
+				Labels:    labels,
 			},
 			Spec: scv1beta1.ServiceBindingSpec{
 				//ExternalID: UUID,

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -1487,12 +1487,14 @@ func TestCreateServiceBinding(t *testing.T) {
 		name        string
 		bindingNS   string
 		bindingName string
+		labels      map[string]string
 		wantErr     bool
 	}{
 		{
 			name:        "Case: Valid request for creating a secret",
 			bindingNS:   "",
 			bindingName: "foo",
+			labels:      map[string]string{"app": "app"},
 			wantErr:     false,
 		},
 	}
@@ -1500,7 +1502,7 @@ func TestCreateServiceBinding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient, fakeClientSet := FakeNew()
 
-			err := fakeClient.CreateServiceBinding(tt.bindingName, tt.bindingNS)
+			err := fakeClient.CreateServiceBinding(tt.bindingName, tt.bindingNS, tt.labels)
 
 			if err == nil && !tt.wantErr {
 				if len(fakeClientSet.ServiceCatalogClientSet.Actions()) != 1 {

--- a/pkg/odo/cli/application/application.go
+++ b/pkg/odo/cli/application/application.go
@@ -92,19 +92,19 @@ func printDeleteAppInfo(client *occlient.Client, appName string, projectName str
 				}
 			}
 		}
-		// List services that will be removed
-		serviceList, err := service.List(client, appName)
-		if err != nil {
-			log.Info("No services / could not get services")
-			glog.V(4).Info(err.Error())
-		}
-		if len(serviceList.Items) != 0 {
-			log.Info("This application has following service that will be deleted")
-			for _, ser := range serviceList.Items {
-				log.Info("service named", ser.ObjectMeta.Name, "of type", ser.Spec.Type)
-			}
-		}
-
 	}
+	// List services that will be removed
+	serviceList, err := service.List(client, appName)
+	if err != nil {
+		log.Info("No services / could not get services")
+		glog.V(4).Info(err.Error())
+	}
+	if len(serviceList.Items) != 0 {
+		log.Info("This application has following service(s) that will be deleted")
+		for _, ser := range serviceList.Items {
+			log.Info("service named", ser.ObjectMeta.Name, "of type", ser.Spec.Type)
+		}
+	}
+
 	return nil
 }

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -454,8 +454,8 @@ var _ = Describe("odo service command tests", func() {
 
 			ocArgs = []string{"get", "serviceinstances"}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Deprovisioning")
-			})
+				return strings.Contains(output, "No resources found")
+			}, true)
 		})
 	})
 })

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -452,10 +451,10 @@ var _ = Describe("odo service command tests", func() {
 			})
 
 			helper.CmdShouldPass("odo", "app", "delete", app, "-f")
-			odoArgs := []string{"service", "list", "--app", app}
-			helper.WaitForCmdOut("odo", odoArgs, 1, false, func(output string) bool {
-				fmt.Println(output)
-				return strings.Contains(output, "There are no services deployed for this application")
+
+			ocArgs = []string{"get", "serviceinstances"}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Deprovisioning")
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
This PR deletes the service (ServiceInstance) created from Service Catalog when user tries to delete an application (`odo app delete <app-name>`).

When there are no components in the application but only service(s), it also prints the list of services that would be deleted when doing `odo app delete <app-name>`. This list of services was not getting printed unless there was a component in `<app-name>` marked for deletion.

**Which issue(s) this PR fixes**:

Fixes #2113 

**How to test changes / Special notes to the reviewer**:
1. Create a service from Service Catalog `odo service create`
2. Make sure the service shows up in `odo service list --app app`
3. Now delete the app `odo app delete app -f`
4. Make sure that no services exist. (Check on OpenShift web console)