### PR TITLE
resolve wrong argument in errorf - use component name instead of all args

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -410,7 +410,7 @@ func CreateComponent(client *occlient.Client, componentConfig config.LocalConfig
 	case config.LOCAL:
 		fileInfo, err := os.Stat(createArgs.SourcePath)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get info of path %+v of component %+v", createArgs.SourcePath, createArgs)
+			return errors.Wrapf(err, "failed to get info of path %+v of component %+v", createArgs.SourcePath, createArgs.Name)
 		}
 		if !fileInfo.IsDir() {
 			return fmt.Errorf("component creation with args %+v as path needs to be a directory", createArgs)


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:
No issue

**How to test changes / Special notes to the reviewer**:
error log should now show correct information
