### PR TITLE
fix wwhrd licence detection

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -10,6 +10,9 @@ whitelist:
   - FreeBSD
   - ISC
   - MPL-2.0
+  - BSD-3-Clause
+  - BSD-2-Clause
+  - MPL-2.0-no-copyleft-exception
 
 exceptions:
   # wwhrd currently does not detect ISC which is compatible with Odo so, add it under exceptions to avoid errors due to it being not recognised
@@ -23,3 +26,13 @@ exceptions:
   # go-digest contains common digest package used across the container ecosystem
   # This is OpenShift dependency, ODO do not use this directly
   - github.com/opencontainers/go-digest
+  # MIT licence - wwhrd is not detecting it correctly
+  - github.com/ghodss/yaml
+  # Apache License 2.0 - wwhrd is not detecting it correctly
+  - github.com/prometheus/common/...
+  # Apache License 2.0 - wwhrd is not detecting it correctly
+  - github.com/docker/spdystream/...
+  # BSD licence - wwhrd is not detecting it correctly
+  - github.com/gogo/protobuf/...
+  # BSD licence - wwhrd is not detecting it correctly
+  - github.com/golang/protobuf/...


### PR DESCRIPTION
new wwhrd version broke some of the detections
- BSD license is split to BSD-3-Clause and BSD-2-Clause
- MPL-2.0 is now MPL-2.0-no-copyleft-exception
- some of the previously detected packages are no detected by new version
