### PR TITLE
Validation for empty values in pkg/occlient/occlient.go

### DIFF
--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -5148,6 +5148,20 @@ func TestGetPortsFromBuilderImage(t *testing.T) {
 			want:           []string{"8080/TCP", "8443/TCP"},
 			wantErr:        false,
 		},
+		{
+			name:           "component type: is empty",
+			imageNamespace: "openshift",
+			args:           args{componentType: ""},
+			want:           []string{},
+			wantErr:        true,
+		},
+		{
+			name:           "component type: is invalid",
+			imageNamespace: "openshift",
+			args:           args{componentType: "abc"},
+			want:           []string{},
+			wantErr:        true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
**What does does this PR do / why we need it**:

validates empty values in pkg/occlient/occlient.go

**Which issue(s) this PR fixes**:

Fixes #598 

**How to test changes / Special notes to the reviewer**:
//TODO