### PR TITLE
Describe services with multiple plans correctly 

### DIFF
--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -56,4 +59,27 @@ type ServicePlan struct {
 	DisplayName string
 	Description string
 	Parameters  servicePlanParameters
+}
+
+func (sp *ServicePlanParameter) UnmarshalJSON(data []byte) error {
+	tempServicePlanParameter := struct {
+		Name                   string      `json:"name"`
+		Title                  string      `json:"title,omitempty"`
+		Description            string      `json:"description,omitempty"`
+		Default                interface{} `json:"default,omitempty"`
+		validation.Validatable `json:",inline,omitempty"`
+	}{}
+
+	err := json.Unmarshal(data, &tempServicePlanParameter)
+	if err != nil {
+		panic(err)
+	}
+	sp.Default = fmt.Sprint(tempServicePlanParameter.Default)
+
+	sp.Name = tempServicePlanParameter.Name
+	sp.Title = tempServicePlanParameter.Title
+	sp.Description = tempServicePlanParameter.Description
+	sp.Validatable = tempServicePlanParameter.Validatable
+
+	return nil
 }

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -61,7 +61,11 @@ type ServicePlan struct {
 	Parameters  servicePlanParameters
 }
 
+// UnmarshalJSON unmarshals the JSON for ServicePlanParameter instead of using
+// the built in json.Unmarshal
 func (sp *ServicePlanParameter) UnmarshalJSON(data []byte) error {
+	// create a temporary struct similar to ServicePlanParameter but with
+	// Default's type set to interface{} so that we can store any value in it
 	tempServicePlanParameter := struct {
 		Name                   string      `json:"name"`
 		Title                  string      `json:"title,omitempty"`
@@ -70,10 +74,13 @@ func (sp *ServicePlanParameter) UnmarshalJSON(data []byte) error {
 		validation.Validatable `json:",inline,omitempty"`
 	}{}
 
+	// unmarshal the json obtained from server into the temporary struct
 	err := json.Unmarshal(data, &tempServicePlanParameter)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	// convert the value into a string so that it can be stored in ServicePlanParameter
 	sp.Default = fmt.Sprint(tempServicePlanParameter.Default)
 
 	sp.Name = tempServicePlanParameter.Name

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -81,7 +81,9 @@ func (sp *ServicePlanParameter) UnmarshalJSON(data []byte) error {
 	}
 
 	// convert the value into a string so that it can be stored in ServicePlanParameter
-	sp.Default = fmt.Sprint(tempServicePlanParameter.Default)
+	if tempServicePlanParameter.Default != nil {
+		sp.Default = fmt.Sprint(tempServicePlanParameter.Default)
+	}
 
 	sp.Name = tempServicePlanParameter.Name
 	sp.Title = tempServicePlanParameter.Title

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -416,4 +416,23 @@ var _ = Describe("odo service command tests", func() {
 			Expect(stdOut).To(ContainSubstring("DB_HOST"))
 		})
 	})
+
+	Context("When describing services", func() {
+		JustBeforeEach(func() {
+			preSetup()
+		})
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should succeed when we're describing service that could have integer value for default field", func() {
+			// https://github.com/openshift/odo/issues/2488
+			helper.CopyExample(filepath.Join("source", "python"), context)
+			helper.CmdShouldPass("odo", "create", "python", "component1", "--context", context, "--project", project)
+			helper.Chdir(context)
+
+			helper.CmdShouldPass("odo", "catalog", "describe", "service", "dh-es-apb")
+			helper.CmdShouldPass("odo", "catalog", "describe", "service", "dh-import-vm-apb")
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
`odo catalog describe service <service-name>` failed for plans where
value of `default` field was an integer. For example below would cause
the command to fail:

```

"instanceCreateParameterSchema": {
    "$schema": "http://json-schema.org/draft-04/schema",
    "additionalProperties": false,
    "properties": {
        "cluster_size": {
            "default": 1,
            "description": "Number of Elasticsearch instances that the cluster will consist of",
            "title": "Cluster size",
            "type": "integer"
        },
```
This PR fixes that issue.
**Which issue(s) this PR fixes**:

Fixes #2488 

**How to test changes / Special notes to the reviewer**:
Check that `odo catalog describe service <service-name>` works well for the services. 