### PR TITLE
Add kclient functions for creating deployments

### DIFF
--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -1,0 +1,37 @@
+package kclient
+
+import (
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateDeployment creates a deployment based on the given pod
+func (c *Client) CreateDeployment(pod *corev1.Pod) (*appsv1.Deployment, error) {
+
+	replicas := int32(1)
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: pod.ObjectMeta,
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: pod.Labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: pod.ObjectMeta,
+				Spec:       pod.Spec,
+			},
+		},
+	}
+
+	deploy, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Create(&deployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to create Deployment for %s", pod.ObjectMeta.Name)
+	}
+	return deploy, nil
+}

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -7,14 +7,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// constants for deployments
+const (
+	DeploymentKind       = "Deployment"
+	DeploymentAPIVersion = "apps/v1"
+)
+
 // CreateDeployment creates a deployment based on the given pod
 func (c *Client) CreateDeployment(pod *corev1.Pod) (*appsv1.Deployment, error) {
 
 	replicas := int32(1)
 	deployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
+			Kind:       DeploymentKind,
+			APIVersion: DeploymentAPIVersion,
 		},
 		ObjectMeta: pod.ObjectMeta,
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/kclient/deployments_test.go
+++ b/pkg/kclient/deployments_test.go
@@ -71,8 +71,8 @@ func TestCreateDeployment(t *testing.T) {
 				}
 				deployment := appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{
-						Kind:       "Deployment",
-						APIVersion: "apps/v1",
+						Kind:       DeploymentKind,
+						APIVersion: DeploymentAPIVersion,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tt.deploymentName,

--- a/pkg/kclient/deployments_test.go
+++ b/pkg/kclient/deployments_test.go
@@ -1,0 +1,106 @@
+package kclient
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestCreateDeployment(t *testing.T) {
+
+	container := &corev1.Container{
+		Name:            "container1",
+		Image:           "image1",
+		ImagePullPolicy: corev1.PullAlways,
+
+		Command: []string{"tail"},
+		Args:    []string{"-f", "/dev/null"},
+		Env:     []corev1.EnvVar{},
+	}
+
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":       "app",
+				"component": "frontend",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			Containers:         []corev1.Container{*container},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		deploymentName string
+		wantErr        bool
+	}{
+		{
+			name:           "Case: Valid deployment name",
+			deploymentName: "pod",
+			wantErr:        false,
+		},
+		{
+			name:           "Case: Invalid deployment name",
+			deploymentName: "",
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// initialising the fakeclient
+			fkclient, fkclientset := FakeNew()
+			fkclient.Namespace = "default"
+
+			fkclientset.Kubernetes.PrependReactor("create", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if tt.deploymentName == "" {
+					return true, nil, errors.Errorf("deployment name is empty")
+				}
+				deployment := appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.deploymentName,
+					},
+				}
+				return true, &deployment, nil
+			})
+
+			pod.ObjectMeta.Name = tt.deploymentName
+			createdDeployment, err := fkclient.CreateDeployment(pod)
+
+			// Checks for unexpected error cases
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("fkclient.CreateDeployment(pod) unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+
+				if len(fkclientset.Kubernetes.Actions()) != 1 {
+					t.Errorf("expected 1 action in StartDeployment got: %v", fkclientset.Kubernetes.Actions())
+				} else {
+					if createdDeployment.Name != tt.deploymentName {
+						t.Errorf("deployment name does not match the expected name, expected: %s, got %s", tt.deploymentName, createdDeployment.Name)
+					}
+				}
+
+			}
+
+		})
+	}
+}

--- a/pkg/kclient/generators.go
+++ b/pkg/kclient/generators.go
@@ -1,0 +1,50 @@
+package kclient
+
+import (
+
+	// api resource types
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GenerateContainerSpec creates a container spec that can be used when creating a pod
+func GenerateContainerSpec(name, image string, isPrivileged bool, command, args []string, envVars []corev1.EnvVar) corev1.Container {
+	container := &corev1.Container{
+		Name:            name,
+		Image:           image,
+		ImagePullPolicy: corev1.PullAlways,
+
+		Command: command,
+		Args:    args,
+		Env:     envVars,
+	}
+
+	if isPrivileged {
+		container.SecurityContext = &corev1.SecurityContext{
+			Privileged: &isPrivileged,
+		}
+	}
+
+	return *container
+}
+
+// GeneratePodSpec creates a pod spec
+func GeneratePodSpec(podName, namespace, serviceAccountName string, labels map[string]string, containers []corev1.Container) *corev1.Pod {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: serviceAccountName,
+			Containers:         containers,
+		},
+	}
+
+	return pod
+}

--- a/pkg/kclient/generators.go
+++ b/pkg/kclient/generators.go
@@ -48,10 +48,8 @@ func GeneratePodTemplateSpec(podName, namespace, serviceAccountName string, labe
 
 // GenerateDeploymentSpec creates a deployment spec
 func GenerateDeploymentSpec(podTemplateSpec corev1.PodTemplateSpec) *appsv1.DeploymentSpec {
-	replicas := int32(1)
 	labels := podTemplateSpec.ObjectMeta.Labels
 	deploymentSpec := &appsv1.DeploymentSpec{
-		Replicas: &replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: labels,
 		},

--- a/pkg/kclient/generators_test.go
+++ b/pkg/kclient/generators_test.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestGenerateContainerSpec(t *testing.T) {
+func TestGenerateContainer(t *testing.T) {
 
 	tests := []struct {
 		name         string
@@ -42,53 +42,53 @@ func TestGenerateContainerSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			containerSpec := GenerateContainerSpec(tt.name, tt.image, tt.isPrivileged, tt.command, tt.args, tt.envVars)
+			container := GenerateContainer(tt.name, tt.image, tt.isPrivileged, tt.command, tt.args, tt.envVars)
 
-			if containerSpec.Name != tt.name {
-				t.Errorf("expected %s, actual %s", tt.name, containerSpec.Name)
+			if container.Name != tt.name {
+				t.Errorf("expected %s, actual %s", tt.name, container.Name)
 			}
 
-			if containerSpec.Image != tt.image {
-				t.Errorf("expected %s, actual %s", tt.image, containerSpec.Image)
+			if container.Image != tt.image {
+				t.Errorf("expected %s, actual %s", tt.image, container.Image)
 			}
 
 			if tt.isPrivileged {
-				if *containerSpec.SecurityContext.Privileged != tt.isPrivileged {
-					t.Errorf("expected %t, actual %t", tt.isPrivileged, *containerSpec.SecurityContext.Privileged)
+				if *container.SecurityContext.Privileged != tt.isPrivileged {
+					t.Errorf("expected %t, actual %t", tt.isPrivileged, *container.SecurityContext.Privileged)
 				}
-			} else if tt.isPrivileged == false && containerSpec.SecurityContext != nil {
+			} else if tt.isPrivileged == false && container.SecurityContext != nil {
 				t.Errorf("expected security context to be nil but it was defined")
 			}
 
-			if len(containerSpec.Command) != len(tt.command) {
-				t.Errorf("expected %d, actual %d", len(tt.command), len(containerSpec.Command))
+			if len(container.Command) != len(tt.command) {
+				t.Errorf("expected %d, actual %d", len(tt.command), len(container.Command))
 			} else {
-				for i := range containerSpec.Command {
-					if containerSpec.Command[i] != tt.command[i] {
-						t.Errorf("expected %s, actual %s", tt.command[i], containerSpec.Command[i])
+				for i := range container.Command {
+					if container.Command[i] != tt.command[i] {
+						t.Errorf("expected %s, actual %s", tt.command[i], container.Command[i])
 					}
 				}
 			}
 
-			if len(containerSpec.Args) != len(tt.args) {
-				t.Errorf("expected %d, actual %d", len(tt.args), len(containerSpec.Args))
+			if len(container.Args) != len(tt.args) {
+				t.Errorf("expected %d, actual %d", len(tt.args), len(container.Args))
 			} else {
-				for i := range containerSpec.Args {
-					if containerSpec.Args[i] != tt.args[i] {
-						t.Errorf("expected %s, actual %s", tt.args[i], containerSpec.Args[i])
+				for i := range container.Args {
+					if container.Args[i] != tt.args[i] {
+						t.Errorf("expected %s, actual %s", tt.args[i], container.Args[i])
 					}
 				}
 			}
 
-			if len(containerSpec.Env) != len(tt.envVars) {
-				t.Errorf("expected %d, actual %d", len(tt.envVars), len(containerSpec.Env))
+			if len(container.Env) != len(tt.envVars) {
+				t.Errorf("expected %d, actual %d", len(tt.envVars), len(container.Env))
 			} else {
-				for i := range containerSpec.Env {
-					if containerSpec.Env[i].Name != tt.envVars[i].Name {
-						t.Errorf("expected name %s, actual name %s", tt.envVars[i].Name, containerSpec.Env[i].Name)
+				for i := range container.Env {
+					if container.Env[i].Name != tt.envVars[i].Name {
+						t.Errorf("expected name %s, actual name %s", tt.envVars[i].Name, container.Env[i].Name)
 					}
-					if containerSpec.Env[i].Value != tt.envVars[i].Value {
-						t.Errorf("expected value %s, actual value %s", tt.envVars[i].Value, containerSpec.Env[i].Value)
+					if container.Env[i].Value != tt.envVars[i].Value {
+						t.Errorf("expected value %s, actual value %s", tt.envVars[i].Value, container.Env[i].Value)
 					}
 				}
 			}
@@ -129,7 +129,7 @@ func TestGeneratePodSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.podName, func(t *testing.T) {
 
-			podSpec := GeneratePodSpec(tt.podName, tt.namespace, tt.serviceAccount, tt.labels, []corev1.Container{*container})
+			podSpec := GeneratePodTemplateSpec(tt.podName, tt.namespace, tt.serviceAccount, tt.labels, []corev1.Container{*container})
 
 			if podSpec.Name != tt.podName {
 				t.Errorf("expected %s, actual %s", tt.podName, podSpec.Name)

--- a/pkg/kclient/generators_test.go
+++ b/pkg/kclient/generators_test.go
@@ -1,0 +1,154 @@
+package kclient
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGenerateContainerSpec(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		image        string
+		isPrivileged bool
+		command      []string
+		args         []string
+		envVars      []corev1.EnvVar
+	}{
+		{
+			name:         "",
+			image:        "",
+			isPrivileged: false,
+			command:      []string{},
+			args:         []string{},
+			envVars:      []corev1.EnvVar{},
+		},
+		{
+			name:         "container1",
+			image:        "quay.io/eclipse/che-java8-maven:nightly",
+			isPrivileged: true,
+			command:      []string{"tail"},
+			args:         []string{"-f", "/dev/null"},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "test",
+					Value: "123",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			containerSpec := GenerateContainerSpec(tt.name, tt.image, tt.isPrivileged, tt.command, tt.args, tt.envVars)
+
+			if containerSpec.Name != tt.name {
+				t.Errorf("expected %s, actual %s", tt.name, containerSpec.Name)
+			}
+
+			if containerSpec.Image != tt.image {
+				t.Errorf("expected %s, actual %s", tt.image, containerSpec.Image)
+			}
+
+			if tt.isPrivileged {
+				if *containerSpec.SecurityContext.Privileged != tt.isPrivileged {
+					t.Errorf("expected %t, actual %t", tt.isPrivileged, *containerSpec.SecurityContext.Privileged)
+				}
+			} else if tt.isPrivileged == false && containerSpec.SecurityContext != nil {
+				t.Errorf("expected security context to be nil but it was defined")
+			}
+
+			if len(containerSpec.Command) != len(tt.command) {
+				t.Errorf("expected %d, actual %d", len(tt.command), len(containerSpec.Command))
+			} else {
+				for i := range containerSpec.Command {
+					if containerSpec.Command[i] != tt.command[i] {
+						t.Errorf("expected %s, actual %s", tt.command[i], containerSpec.Command[i])
+					}
+				}
+			}
+
+			if len(containerSpec.Args) != len(tt.args) {
+				t.Errorf("expected %d, actual %d", len(tt.args), len(containerSpec.Args))
+			} else {
+				for i := range containerSpec.Args {
+					if containerSpec.Args[i] != tt.args[i] {
+						t.Errorf("expected %s, actual %s", tt.args[i], containerSpec.Args[i])
+					}
+				}
+			}
+
+			if len(containerSpec.Env) != len(tt.envVars) {
+				t.Errorf("expected %d, actual %d", len(tt.envVars), len(containerSpec.Env))
+			} else {
+				for i := range containerSpec.Env {
+					if containerSpec.Env[i].Name != tt.envVars[i].Name {
+						t.Errorf("expected name %s, actual name %s", tt.envVars[i].Name, containerSpec.Env[i].Name)
+					}
+					if containerSpec.Env[i].Value != tt.envVars[i].Value {
+						t.Errorf("expected value %s, actual value %s", tt.envVars[i].Value, containerSpec.Env[i].Value)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func TestGeneratePodSpec(t *testing.T) {
+
+	container := &corev1.Container{
+		Name:            "container1",
+		Image:           "image1",
+		ImagePullPolicy: corev1.PullAlways,
+
+		Command: []string{"tail"},
+		Args:    []string{"-f", "/dev/null"},
+		Env:     []corev1.EnvVar{},
+	}
+
+	tests := []struct {
+		podName        string
+		namespace      string
+		serviceAccount string
+		labels         map[string]string
+	}{
+		{
+			podName:        "podSpecTest",
+			namespace:      "default",
+			serviceAccount: "default",
+			labels: map[string]string{
+				"app":       "app",
+				"component": "frontend",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.podName, func(t *testing.T) {
+
+			podSpec := GeneratePodSpec(tt.podName, tt.namespace, tt.serviceAccount, tt.labels, []corev1.Container{*container})
+
+			if podSpec.Name != tt.podName {
+				t.Errorf("expected %s, actual %s", tt.podName, podSpec.Name)
+			}
+
+			if podSpec.Namespace != tt.namespace {
+				t.Errorf("expected %s, actual %s", tt.namespace, podSpec.Namespace)
+			}
+
+			if len(podSpec.Labels) != len(tt.labels) {
+				t.Errorf("expected %d, actual %d", len(tt.labels), len(podSpec.Labels))
+			} else {
+				for i := range podSpec.Labels {
+					if podSpec.Labels[i] != tt.labels[i] {
+						t.Errorf("expected %s, actual %s", tt.labels[i], podSpec.Labels[i])
+					}
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>

**What type of PR is this?**
/kind feature


**What does does this PR do / why we need it**:
Adds the base kclient functions required for creating a Deployment that consists of a Pod with containers that map to each of the components in a Devfile. Once the devfile parsing is complete I can add the rest of the required code in a separate PR.

**Which issue(s) this PR fixes**:

Partially implements https://github.com/openshift/odo/issues/2471

**How to test changes / Special notes to the reviewer**:

1. `cd pkg/kclient`
1. `go test -v`

Results:
```
=== RUN   TestCreateDeployment
=== RUN   TestCreateDeployment/Case:_Valid_deployment_name
=== RUN   TestCreateDeployment/Case:_Invalid_deployment_name
--- PASS: TestCreateDeployment (0.00s)
    --- PASS: TestCreateDeployment/Case:_Valid_deployment_name (0.00s)
    --- PASS: TestCreateDeployment/Case:_Invalid_deployment_name (0.00s)
=== RUN   TestGenerateContainerSpec
=== RUN   TestGenerateContainerSpec/#00
=== RUN   TestGenerateContainerSpec/container1
--- PASS: TestGenerateContainerSpec (0.00s)
    --- PASS: TestGenerateContainerSpec/#00 (0.00s)
    --- PASS: TestGenerateContainerSpec/container1 (0.00s)
=== RUN   TestGeneratePodSpec
=== RUN   TestGeneratePodSpec/podSpecTest
--- PASS: TestGeneratePodSpec (0.00s)
    --- PASS: TestGeneratePodSpec/podSpecTest (0.00s)
=== RUN   TestWaitAndGetPod
=== RUN   TestWaitAndGetPod/phase:_running
 ✓  Waiting for component to start [196543ns]
=== RUN   TestWaitAndGetPod/phase:_failed
 ✗  Waiting for component to start [100852ns]
=== RUN   TestWaitAndGetPod/phase:_unknown
 ✗  Waiting for component to start [103256ns]
--- PASS: TestWaitAndGetPod (0.00s)
    --- PASS: TestWaitAndGetPod/phase:_running (0.00s)
    --- PASS: TestWaitAndGetPod/phase:_failed (0.00s)
    --- PASS: TestWaitAndGetPod/phase:_unknown (0.00s)
PASS
ok  	github.com/openshift/odo/pkg/kclient	1.220s
```
