### PR TITLE
Adds the debug info command

### DIFF
--- a/pkg/debug/info.go
+++ b/pkg/debug/info.go
@@ -1,0 +1,144 @@
+package debug
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/testingutil/filesystem"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type OdoDebugFile struct {
+	metav1.TypeMeta
+	DebugProcessId int
+	ProjectName    string
+	AppName        string
+	ComponentName  string
+	RemotePort     int
+	LocalPort      int
+}
+
+// GetDebugInfoFilePath gets the file path of the debug info file
+func GetDebugInfoFilePath(client *occlient.Client, componentName, appName string) string {
+	tempDir := os.TempDir()
+	debugFileSuffix := "odo-debug.json"
+	s := []string{client.Namespace, appName, componentName, debugFileSuffix}
+	debugFileName := strings.Join(s, "-")
+	return filepath.Join(tempDir, debugFileName)
+}
+
+func CreateDebugInfoFile(f *DefaultPortForwarder, portPair string) error {
+	return createDebugInfoFile(f, portPair, filesystem.DefaultFs{})
+}
+
+// createDebugInfoFile creates a file in the temp directory with information regarding the debugging session of a component
+func createDebugInfoFile(f *DefaultPortForwarder, portPair string, fs filesystem.Filesystem) error {
+	portPairs := strings.Split(portPair, ":")
+	if len(portPairs) != 2 {
+		return errors.New("port pair should be of the format localPort:RemotePort")
+	}
+
+	localPort, err := strconv.Atoi(portPairs[0])
+	if err != nil {
+		return errors.New("local port should be a int")
+	}
+	remotePort, err := strconv.Atoi(portPairs[1])
+	if err != nil {
+		return errors.New("remote port should be a int")
+	}
+
+	odoDebugFile := OdoDebugFile{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OdoDebugInfo",
+			APIVersion: "v1",
+		},
+		DebugProcessId: os.Getpid(),
+		ProjectName:    f.client.Namespace,
+		AppName:        f.appName,
+		ComponentName:  f.componentName,
+		RemotePort:     remotePort,
+		LocalPort:      localPort,
+	}
+	odoDebugPathData, err := json.Marshal(odoDebugFile)
+	if err != nil {
+		return errors.New("error marshalling json data")
+	}
+
+	// writes the data to the debug info file
+	file, err := fs.OpenFile(GetDebugInfoFilePath(f.client, f.componentName, f.appName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(odoDebugPathData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetDebugInfo(f *DefaultPortForwarder) (OdoDebugFile, bool) {
+	return getDebugInfo(f, filesystem.DefaultFs{})
+}
+
+// getDebugInfo gets information regarding the debugging session of the component
+// returns the OdoDebugFile from the debug info file
+// returns true if debugging is running else false
+func getDebugInfo(f *DefaultPortForwarder, fs filesystem.Filesystem) (OdoDebugFile, bool) {
+	// gets the debug info file path and reads/unmarshals it
+	debugInfoFilePath := GetDebugInfoFilePath(f.client, f.componentName, f.appName)
+	readFile, err := fs.ReadFile(debugInfoFilePath)
+	if err != nil {
+		glog.V(4).Infof("the debug %v is not present", debugInfoFilePath)
+		return OdoDebugFile{}, false
+	}
+
+	var odoDebugFileData OdoDebugFile
+	err = json.Unmarshal(readFile, &odoDebugFileData)
+	if err != nil {
+		glog.V(4).Infof("couldn't unmarshal the debug file %v", debugInfoFilePath)
+		return OdoDebugFile{}, false
+	}
+
+	// get the debug process id and send a signal 0 to check if it's alive or not
+	// according to https://golang.org/pkg/os/#FindProcess
+	// On Unix systems, FindProcess always succeeds and returns a Process for the given pid, regardless of whether the process exists.
+	// thus this step will pass on Unix systems and so for those systems and some others supporting signals
+	// we check if the process is alive or not by sending a signal 0 to the process
+	processInfo, err := os.FindProcess(odoDebugFileData.DebugProcessId)
+	if err != nil || processInfo == nil {
+		glog.V(4).Infof("error getting the process info for pid %v", odoDebugFileData.DebugProcessId)
+		return OdoDebugFile{}, false
+	}
+
+	// signal is not available on windows so we skip this step for windows
+	if runtime.GOOS != "windows" {
+		err = processInfo.Signal(syscall.Signal(0))
+		if err != nil {
+			glog.V(4).Infof("error sending signal 0 to pid %v, cause: %v", odoDebugFileData.DebugProcessId, err)
+			return OdoDebugFile{}, false
+		}
+	}
+
+	// gets the debug local port and tries to listen on it
+	// if error doesn't occur the debug port was free and thus no debug process was using the port
+	addressLook := "localhost:" + strconv.Itoa(odoDebugFileData.LocalPort)
+	listener, err := net.Listen("tcp", addressLook)
+	if err == nil {
+		glog.V(4).Infof("the debug port %v is free, thus debug is not running", odoDebugFileData.LocalPort)
+		err = listener.Close()
+		if err != nil {
+			glog.V(4).Infof("error occurred while closing the listener, cause :%v", err)
+		}
+		return OdoDebugFile{}, false
+	}
+	// returns the unmarshalled data
+	return odoDebugFileData, true
+}

--- a/pkg/debug/info_test.go
+++ b/pkg/debug/info_test.go
@@ -1,0 +1,348 @@
+package debug
+
+import (
+	"encoding/json"
+	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/testingutil/filesystem"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakeOdoDebugFileString creates a json string of a fake OdoDebugFile
+func fakeOdoDebugFileString(typeMeta v1.TypeMeta, processId int, projectName, appName, componentName string, remotePort, localPort int) (string, error) {
+	odoDebugFile := OdoDebugFile{
+		TypeMeta:       typeMeta,
+		DebugProcessId: processId,
+		ProjectName:    projectName,
+		AppName:        appName,
+		ComponentName:  componentName,
+		RemotePort:     remotePort,
+		LocalPort:      localPort,
+	}
+
+	data, err := json.Marshal(odoDebugFile)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// fakeDebugPortListener starts a fake test server and listens on the given localPort
+func fakeDebugPortListener(t *testing.T, started chan<- int, stopChan <-chan int, localPort int) {
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log(w, "running")
+	}))
+
+	listener, err := net.Listen("tcp", "localhost:"+strconv.Itoa(localPort))
+	if err != nil {
+		t.Errorf("error occured while starting fake listener, cause :%v", err)
+	}
+	testServer.Listener = listener
+	testServer.Start()
+	started <- 0
+	timeout := time.After(10 * time.Second)
+
+	select {
+	case <-stopChan:
+		testServer.Close()
+	case <-timeout:
+		testServer.Close()
+		t.Errorf("timeout waiting for stop signal for fake server")
+	}
+}
+
+func Test_createDebugInfoFile(t *testing.T) {
+
+	// create a fake fs in memory
+	fs := filesystem.NewFakeFs()
+
+	type args struct {
+		defaultPortForwarder *DefaultPortForwarder
+		portPair             string
+		fs                   filesystem.Filesystem
+	}
+	tests := []struct {
+		name             string
+		args             args
+		alreadyExistFile bool
+		wantDebugInfo    OdoDebugFile
+		wantErr          bool
+	}{
+		{
+			name: "case 1: normal json write to the debug file",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					componentName: "nodejs-ex",
+					appName:       "app",
+				},
+				portPair: "5858:9001",
+				fs:       fs,
+			},
+			wantDebugInfo: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid(),
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     9001,
+				LocalPort:      5858,
+			},
+			alreadyExistFile: false,
+			wantErr:          false,
+		},
+		{
+			name: "case 2: overwrite the debug file",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					componentName: "nodejs-ex",
+					appName:       "app",
+				},
+				portPair: "5758:9004",
+				fs:       fs,
+			},
+			wantDebugInfo: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid(),
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     9004,
+				LocalPort:      5758,
+			},
+			alreadyExistFile: true,
+			wantErr:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Fake the client with the appropriate arguments
+			client, _ := occlient.FakeNew()
+			client.Namespace = "testing-1"
+			tt.args.defaultPortForwarder.client = client
+
+			debugFilePath := GetDebugInfoFilePath(client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)
+			// create a already existing file
+			if tt.alreadyExistFile {
+				_, err := testingutil.MkFileWithContent(debugFilePath, "blah", fs)
+				if err != nil {
+					t.Errorf("error happened while writing, cause: %v", err)
+				}
+			}
+
+			if err := createDebugInfoFile(tt.args.defaultPortForwarder, tt.args.portPair, tt.args.fs); (err != nil) != tt.wantErr {
+				t.Errorf("createDebugInfoFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			readBytes, err := fs.ReadFile(debugFilePath)
+			if err != nil {
+				t.Errorf("error while reading file, cause: %v", err)
+			}
+			var odoDebugFileData OdoDebugFile
+			err = json.Unmarshal(readBytes, &odoDebugFileData)
+			if err != nil {
+				t.Errorf("error occured while unmarshalling json, cause: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.wantDebugInfo, odoDebugFileData) {
+				t.Errorf("odo debug info on file doesn't match, got: %v, want: %v", odoDebugFileData, tt.wantDebugInfo)
+			}
+
+			// clear the odo debug info file
+			_ = fs.RemoveAll(debugFilePath)
+		})
+	}
+}
+
+func Test_getDebugInfo(t *testing.T) {
+
+	// create a fake fs in memory
+	fs := filesystem.NewFakeFs()
+
+	type args struct {
+		defaultPortForwarder *DefaultPortForwarder
+		fs                   filesystem.Filesystem
+	}
+	tests := []struct {
+		name               string
+		args               args
+		fileExists         bool
+		debugPortListening bool
+		readDebugFile      OdoDebugFile
+		wantDebugFile      OdoDebugFile
+		debugRunning       bool
+	}{
+		{
+			name: "case 1: the debug file exists",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					appName:       "app",
+					componentName: "nodejs-ex",
+				},
+				fs: fs,
+			},
+			wantDebugFile: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid(),
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     5858,
+				LocalPort:      9001,
+			},
+			readDebugFile: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid(),
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     5858,
+				LocalPort:      9001,
+			},
+			debugPortListening: true,
+			fileExists:         true,
+			debugRunning:       true,
+		},
+		{
+			name: "case 2: the debug file doesn't exists",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					appName:       "app",
+					componentName: "nodejs-ex",
+				},
+				fs: fs,
+			},
+			debugPortListening: true,
+			wantDebugFile:      OdoDebugFile{},
+			readDebugFile:      OdoDebugFile{},
+			fileExists:         false,
+			debugRunning:       false,
+		},
+		{
+			name: "case 3: debug port not listening",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					appName:       "app",
+					componentName: "nodejs-ex",
+				},
+				fs: fs,
+			},
+			debugPortListening: false,
+			wantDebugFile:      OdoDebugFile{},
+			readDebugFile: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid(),
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     5858,
+				LocalPort:      9001,
+			},
+			fileExists:   true,
+			debugRunning: false,
+		},
+		{
+			name: "case 4: the process is not running",
+			args: args{
+				defaultPortForwarder: &DefaultPortForwarder{
+					appName:       "app",
+					componentName: "nodejs-ex",
+				},
+				fs: fs,
+			},
+			debugPortListening: true,
+			wantDebugFile:      OdoDebugFile{},
+			readDebugFile: OdoDebugFile{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "OdoDebugInfo",
+					APIVersion: "v1",
+				},
+				DebugProcessId: os.Getpid() + 818177979,
+				ProjectName:    "testing-1",
+				AppName:        "app",
+				ComponentName:  "nodejs-ex",
+				RemotePort:     5858,
+				LocalPort:      9001,
+			},
+			fileExists:   true,
+			debugRunning: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Fake the client with the appropriate arguments
+			client, _ := occlient.FakeNew()
+			client.Namespace = "testing-1"
+			tt.args.defaultPortForwarder.client = client
+
+			odoDebugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)
+			if tt.fileExists {
+				fakeString, err := fakeOdoDebugFileString(tt.readDebugFile.TypeMeta,
+					tt.readDebugFile.DebugProcessId,
+					tt.readDebugFile.ProjectName,
+					tt.readDebugFile.AppName,
+					tt.readDebugFile.ComponentName,
+					tt.readDebugFile.RemotePort,
+					tt.readDebugFile.LocalPort)
+
+				if err != nil {
+					t.Errorf("error occured while getting odo debug file string, cause: %v", err)
+				}
+
+				_, err = testingutil.MkFileWithContent(odoDebugFilePath, fakeString, fs)
+				if err != nil {
+					t.Errorf("error occured while writing to file, cause: %v", err)
+				}
+			}
+
+			stopChan := make(chan int)
+			if tt.debugPortListening {
+				started := make(chan int)
+				go fakeDebugPortListener(t, started, stopChan, tt.readDebugFile.LocalPort)
+				// wait for the test server to start listening
+				<-started
+			}
+
+			got, resultRunning := getDebugInfo(tt.args.defaultPortForwarder, tt.args.fs)
+
+			if !reflect.DeepEqual(got, tt.wantDebugFile) {
+				t.Errorf("getDebugInfo() got = %v, want %v", got, tt.wantDebugFile)
+			}
+			if resultRunning != tt.debugRunning {
+				t.Errorf("getDebugInfo() got1 = %v, want %v", resultRunning, tt.debugRunning)
+			}
+
+			// clear the odo debug info file
+			_ = fs.RemoveAll(odoDebugFilePath)
+
+			// close the listener
+			if tt.debugPortListening {
+				stopChan <- 0
+			}
+		})
+	}
+}

--- a/pkg/odo/cli/debug/debug.go
+++ b/pkg/odo/cli/debug/debug.go
@@ -15,6 +15,7 @@ Debug allows you to remotely debug your application`
 func NewCmdDebug(name, fullName string) *cobra.Command {
 
 	portforwardCmd := NewCmdPortForward(portforwardCommandName, util.GetFullName(fullName, portforwardCommandName))
+	infoCmd := NewCmdInfo(infoCommandName, util.GetFullName(fullName, infoCommandName))
 
 	debugCmd := &cobra.Command{
 		Use:     name,
@@ -25,6 +26,7 @@ func NewCmdDebug(name, fullName string) *cobra.Command {
 
 	debugCmd.SetUsageTemplate(util.CmdUsageTemplate)
 	debugCmd.AddCommand(portforwardCmd)
+	debugCmd.AddCommand(infoCmd)
 	debugCmd.Annotations = map[string]string{"command": "main"}
 
 	return debugCmd

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -1,0 +1,85 @@
+package debug
+
+import (
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/debug"
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/spf13/cobra"
+	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubernetes/pkg/kubectl/util/templates"
+)
+
+// PortForwardOptions contains all the options for running the port-forward cli command.
+type InfoOptions struct {
+	Namespace     string
+	PortForwarder *debug.DefaultPortForwarder
+	*genericclioptions.Context
+	localConfigInfo *config.LocalConfigInfo
+	contextDir      string
+}
+
+var (
+	infoLong = templates.LongDesc(`
+			Gets information regarding any debug session of the component.
+	`)
+
+	infoExample = templates.Examples(`
+		# Get information regarding any debug session of the component
+		odo debug info
+		
+		`)
+)
+
+const (
+	infoCommandName = "info"
+)
+
+func NewInfoOptions() *InfoOptions {
+	return &InfoOptions{}
+}
+
+// Complete completes all the required options for port-forward cmd.
+func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.Context = genericclioptions.NewContext(cmd)
+	cfg, err := config.NewLocalConfigInfo(o.contextDir)
+	o.localConfigInfo = cfg
+
+	// Using Discard streams because nothing important is logged
+	o.PortForwarder = debug.NewDefaultPortForwarder(cfg.GetName(), cfg.GetApplication(), o.Client, k8sgenclioptions.NewTestIOStreamsDiscard())
+
+	return err
+}
+
+// Validate validates all the required options for port-forward cmd.
+func (o InfoOptions) Validate() error {
+	return nil
+}
+
+// Run implements all the necessary functionality for port-forward cmd.
+func (o InfoOptions) Run() error {
+	if debugFileInfo, debugging := debug.GetDebugInfo(o.PortForwarder); debugging {
+		log.Infof("Debug is running for the component on the local port : %v\n", debugFileInfo.LocalPort)
+	} else {
+		log.Infof("Debug is not running for the component %v\n", o.localConfigInfo.GetName())
+	}
+	return nil
+}
+
+// NewCmdInfo implements the debug info odo command
+func NewCmdInfo(name, fullName string) *cobra.Command {
+
+	opts := NewInfoOptions()
+	cmd := &cobra.Command{
+		Use:     name,
+		Short:   "Displays debug info of a component",
+		Long:    infoLong,
+		Example: infoExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(opts, cmd, args)
+		},
+	}
+	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
+
+	return cmd
+}

--- a/pkg/testingutil/fileutils.go
+++ b/pkg/testingutil/fileutils.go
@@ -2,6 +2,7 @@ package testingutil
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/testingutil/filesystem"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -129,4 +130,20 @@ func SimulateFileModifications(basePath string, fileModification FileProperties)
 		return "", fmt.Errorf("Unsupported file operation %s", fileModification.ModificationType)
 	}
 	return "", nil
+}
+
+func MkFileWithContent(path, content string, fs filesystem.Filesystem) (string, error) {
+	path = filepath.FromSlash(path)
+	f, err := fs.Create(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create file in path %s", path)
+	}
+	_, err = f.WriteString(content)
+	if err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
 }

--- a/tests/helper/helper_http.go
+++ b/tests/helper/helper_http.go
@@ -3,11 +3,13 @@ package helper
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 // HttpWaitForWithStatus periodically (every interval) calls GET to given url
@@ -47,4 +49,14 @@ func HttpWaitForWithStatus(url string, match string, maxRetry int, interval int,
 // ends when a 200 HTTP result response contains match string, or after the maxRetry
 func HttpWaitFor(url string, match string, maxRetry int, interval int) {
 	HttpWaitForWithStatus(url, match, maxRetry, interval, 200)
+}
+
+// HttpGetFreePort gets a free port from the system
+func HttpGetFreePort() int {
+	listener, err := net.Listen("tcp", "localhost:0")
+	Expect(err).NotTo(HaveOccurred())
+	freePort := listener.Addr().(*net.TCPAddr).Port
+	err = listener.Close()
+	Expect(err).NotTo(HaveOccurred())
+	return freePort
 }

--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -3,6 +3,8 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -64,5 +66,65 @@ var _ = Describe("odo debug command tests", func() {
 			helper.HttpWaitForWithStatus("http://localhost:5858", "WebSockets request was expected", 12, 5, 400)
 		})
 
+	})
+
+	Context("odo debug info should work on a odo component", func() {
+		It("should start a debug session and run debug info on a running debug session", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+
+			freePort := strconv.Itoa(helper.HttpGetFreePort())
+
+			stopChannel := make(chan int)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort, "--context", context)
+			}()
+
+			// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+			// We are just using this to validate if nodejs agent is listening on the other side
+			helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
+			runningString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
+			Expect(runningString).To(ContainSubstring(freePort))
+			Expect(helper.ListFilesInDir(os.TempDir())).To(ContainElement(project + "-app" + "-nodejs-cmp-" + project + "-odo-debug.json"))
+			stopChannel <- 0
+		})
+
+		It("should start a debug session and run debug info on a closed debug session", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+
+			freePort := strconv.Itoa(helper.HttpGetFreePort())
+
+			stopChannel := make(chan int)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort, "--context", context)
+			}()
+
+			// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+			// We are just using this to validate if nodejs agent is listening on the other side
+			helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
+			runningString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
+			Expect(runningString).To(ContainSubstring(freePort))
+			stopChannel <- 0
+			failString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
+			Expect(failString).To(ContainSubstring("not running"))
+
+			// according to https://golang.org/pkg/os/#Signal On Windows, sending os.Interrupt to a process with os.Process.Signal is not implemented
+			// discussion on the go repo https://github.com/golang/go/issues/6720
+			// session.Interrupt() will not work as it internally uses syscall.SIGINT
+			// thus debug port-forward won't stop running
+			// the solution is to use syscall.SIGKILL for windows but this will kill the process immediately
+			// and the cleaning and closing tasks for debug port-forward won't run and the debug info file won't be cleared
+			// thus we skip this last check
+			// CTRL_C_EVENTS from the terminal works fine https://github.com/golang/go/issues/6720#issuecomment-66087737
+			// here's a hack to generate the event https://golang.org/cl/29290044
+			// but the solution is unacceptable https://github.com/golang/go/issues/6720#issuecomment-66087749
+			if runtime.GOOS != "windows" {
+				Expect(helper.ListFilesInDir(os.TempDir())).To(Not(ContainElement(project + "-app" + "-nodejs-cmp-" + project + "-odo-debug.json")))
+			}
+
+		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
Adds the debug info command

/kind feature

**What does does this PR do / why we need it**:
This PR adds the debug info command. It detects if a debug session is running on the component or not.

**Which issue(s) this PR fixes**:

Fixes #2015 

**How to test changes / Special notes to the reviewer**:
- Start a debug port-forward session on a component
- run debug info on the component from a different terminal window