### PR TITLE
Adding machine output to component create

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -667,13 +667,13 @@ func (co *CreateOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-
 		if existsInCluster {
 			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.Project)
 			if err != nil {
 				return err
 			}
 		} else {
+			co.Context, co.LocalConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
 			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
 			if err != nil {
 				return err

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	catalogutil "github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/cli/component/ui"
@@ -660,6 +661,26 @@ func (co *CreateOptions) Run() (err error) {
 	} else {
 		log.Italic("\nPlease use `odo push` command to create the component with source deployed")
 	}
+	if log.IsJSON() {
+		var componentDesc component.Component
+		existsInCluster, err := component.Exists(co.Context.Client, *co.componentSettings.Name, co.Context.Application)
+		if err != nil {
+			return err
+		}
+
+		if existsInCluster {
+			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.Project)
+			if err != nil {
+				return err
+			}
+		} else {
+			componentDesc, err = component.GetComponentFromConfig(*co.LocalConfigInfo)
+			if err != nil {
+				return err
+			}
+		}
+		machineoutput.OutputSuccess(componentDesc)
+	}
 	return
 }
 
@@ -699,7 +720,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		Long:        createLongDesc,
 		Example:     fmt.Sprintf(createExample, fullName),
 		Args:        cobra.RangeArgs(0, 2),
-		Annotations: map[string]string{"command": "component"},
+		Annotations: map[string]string{"machineoutput": "json", "command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(co, cmd, args)
 		},

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -663,6 +663,10 @@ func (co *CreateOptions) Run() (err error) {
 	}
 	if log.IsJSON() {
 		var componentDesc component.Component
+		co.Context, co.LocalConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
+		if err != nil {
+			return err
+		}
 		existsInCluster, err := component.Exists(co.Context.Client, *co.componentSettings.Name, co.Context.Application)
 		if err != nil {
 			return err
@@ -673,12 +677,12 @@ func (co *CreateOptions) Run() (err error) {
 				return err
 			}
 		} else {
-			co.Context, co.LocalConfigInfo, err = genericclioptions.UpdatedContext(co.Context)
 			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
 			if err != nil {
 				return err
 			}
 		}
+		componentDesc.Spec.Ports = co.LocalConfigInfo.GetPorts()
 		machineoutput.OutputSuccess(componentDesc)
 	}
 	return

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -674,7 +674,7 @@ func (co *CreateOptions) Run() (err error) {
 				return err
 			}
 		} else {
-			componentDesc, err = component.GetComponentFromConfig(*co.LocalConfigInfo)
+			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
 			if err != nil {
 				return err
 			}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -239,7 +239,7 @@ func componentTests(args ...string) {
 		It("should describe not pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Not Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -248,7 +248,7 @@ func componentTests(args ...string) {
 		It("should describe pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -239,7 +239,7 @@ func componentTests(args ...string) {
 		It("should describe not pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Not Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"], "status": {"state": "Not Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -248,7 +248,7 @@ func componentTests(args ...string) {
 		It("should describe pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex", "ports": ["8080/TCP"],"status": {"state": "Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -237,18 +237,20 @@ func componentTests(args ...string) {
 		})
 
 		It("should describe not pushed component when it is created with json output", func() {
-			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 
 		It("should describe pushed component when it is created with json output", func() {
-			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -236,6 +236,24 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 
+		It("should describe not pushed component when it is created with json output", func() {
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
+			Expect(err).Should(BeNil())
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Not Pushed"}}`)
+			Expect(err).Should(BeNil())
+			Expect(cmpDescribeJSON).To(Equal(expected))
+			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
+		})
+
+		It("should describe pushed component when it is created with json output", func() {
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
+			Expect(err).Should(BeNil())
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","status": {"state": "Pushed"}}`)
+			Expect(err).Should(BeNil())
+			Expect(cmpDescribeJSON).To(Equal(expected))
+			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
+		})
+
 		It("should list the component in the same app when one is pushed and the other one is not pushed", func() {
 			helper.Chdir(originalDir)
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -239,7 +239,7 @@ func componentTests(args ...string) {
 		It("should describe not pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"], "status": {"state": "Not Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -248,7 +248,7 @@ func componentTests(args ...string) {
 		It("should describe pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex", "ports": ["8080/TCP"],"status": {"state": "Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing", "source": "https://github.com/openshift/nodejs-ex","type":"nodejs","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]},"status": {"state": "Pushed"}}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -239,7 +239,7 @@ func componentTests(args ...string) {
 		It("should describe not pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -248,7 +248,7 @@ func componentTests(args ...string) {
 		It("should describe pushed component when it is created with json output", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing", "source": "https://github.com/openshift/nodejs-ex","type":"nodejs","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]},"status": {"state": "Pushed"}}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -250,7 +250,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)


### PR DESCRIPTION
 - Cleaning machine output
 - Changing as needed to affected packages
 - Adding machine output to component create

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #2309 

**How to test changes / Special notes to the reviewer**:
```
❯ odo create -o json nodejs
{
    "kind": "Component",
    "apiVersion": "odo.openshift.io/v1alpha1",
    "metadata": {
        "name": "nodejs-nodejs-ex-2-quxc",
        "namespace": "myproject",
        "creationTimestamp": null
    },
    "spec": {
        "app": "app",
        "type": "nodejs",
        "source": "file://./",
        "ports": [
            "8080/TCP"
        ]
    },
    "status": {
        "state": "Not Pushed"
    }
}

❯ odo create python --now -o json
{
    "kind": "Component",
    "apiVersion": "odo.openshift.io/v1alpha1",
    "metadata": {
        "name": "python-python-bveb",
        "namespace": "myproject",
        "creationTimestamp": null
    },
    "spec": {
        "app": "app",
        "type": "python",
        "source": "file://./",
        "env": [
            {
                "name": "DEBUG_PORT",
                "value": "5858"
            }
        ]
    },
    "status": {
        "state": "Pushed"
    }
}


```