### PR TITLE
Swapped out StringSliceVarP for StringArrayVarP to parse cli parameter…

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -271,7 +271,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		},
 	}
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
-	serviceCreateCmd.Flags().StringSliceVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
+	serviceCreateCmd.Flags().StringArrayVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")
 	serviceCreateCmd.Flags().BoolVarP(&o.wait, "wait", "w", false, "Wait until the service is ready")
 	genericclioptions.AddContextFlag(serviceCreateCmd, &o.componentContext)
 	completion.RegisterCommandHandler(serviceCreateCmd, completion.ServiceClassCompletionHandler)


### PR DESCRIPTION
…rs where the value contains a comma separated list that is intended to be a single value

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
 
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:

This provides the ability to specify create parameters with a value that contains commas. Effectively letting odo behave like oc process (which accepts commas in parameter values without issue)

**Which issue(s) this PR fixes**:

Fixes #?
[2547](https://github.com/openshift/odo/issues/2547)
**How to test changes / Special notes to the reviewer**:

Issue the command odo service create amq-broker-72-gluster -p AMQ_PROTOCOL=amqp -p AMQ_QUEUES=queue1,queue2,queue3,queue4 -p AMQ_USER=some_user -p AMQ_PASSWORD=some_password