### PR TITLE
Including testingutil package in test coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef GITCOMMIT
 else
         GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 endif
-PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor | grep -v $(PROJECT)/tests )
+PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor | grep -v $(PROJECT)/tests)
 COMMON_FLAGS := -X $(PROJECT)/pkg/version.GITCOMMIT=$(GITCOMMIT)
 BUILD_FLAGS := -ldflags="-w $(COMMON_FLAGS)"
 DEBUG_BUILD_FLAGS := -ldflags="$(COMMON_FLAGS)"

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -6,7 +6,7 @@
 set -e
 echo "" > coverage.txt
 go test -i -race ./cmd/odo
-for d in $(go list ./... | grep -v vendor | grep -v tests | grep -v testingutil); do
+for d in $(go list ./... | grep -v vendor | grep -v tests); do
     # For watch related tests, race check causes issue so disabling them here as race is already tested in other tests when used with `-coverprofile=profile.out`
     if [ "$d" = "github.com/openshift/odo/pkg/component" ]; then
         go test -coverprofile=profile.out -covermode=atomic $d


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
missing testingutil test coverage report 
**Which issue(s) this PR fixes**:

Fixes #? NA

**How to test changes / Special notes to the reviewer**:
make test-coverage should include ```testingutil``` pkg and it should be reflected in travis job that generates the test coverage report