### PR TITLE
Fix Panic: When odo app describe run out of component folder

### DIFF
--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -85,7 +85,7 @@ func (o *DescribeOptions) Run() (err error) {
 				for _, currentComponent := range componentList.Items {
 					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, o.Project)
 					util.LogErrorAndExit(err, "")
-					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.Application, o.Project)
+					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.appName, o.Project)
 					fmt.Println("--------------------------------------")
 				}
 			}

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -19,6 +19,8 @@ var _ = Describe("odo app command tests", func() {
 
 	appName := "app"
 	cmpName := "nodejs"
+	mountPath := "/data"
+	size := "1Gi"
 
 	// This is run after every Spec (It)
 	var _ = BeforeEach(func() {
@@ -128,5 +130,18 @@ var _ = Describe("odo app command tests", func() {
 
 			helper.CmdShouldPass("odo", "app", "delete", appName, "--project", project, "-f")
 		})
+
+	})
+
+	Context("When running app describe with storage added in component in directory that doesn't contain .odo config directory", func() {
+		It("should successfully execute describe", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "storage", "create", "storage-one", "--context", context, "--path", mountPath, "--size", size)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project)
+
+		})
+
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
 odo app describe command does not work, When run out of component folder, it lists storage from local config. This PR updates it to list storage from oc client, It also adds bounds check at other places to avoid panic in case of no output.

**Which issue(s) this PR fixes**: 

Fixes #2528

**How to test changes / Special notes to the reviewer**:
Run `odo application describe <app> --project <myproject>` after adding storage to a component, from out of component folder, it should work now.
