### PR TITLE
Odo Push Show Error to User from Openshift

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -82,7 +82,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 	// Apply config
 	err := component.ApplyConfig(cpo.Context.Client, *cpo.localConfigInfo, stdout, cpo.doesComponentExist)
 	if err != nil {
-		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
+		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}
 
 	return nil

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -49,7 +49,8 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 			if context == "" {
 				log.Error(errors.Cause(err))
 			} else {
-				log.Errorf(strings.Title(context), a...)
+				printstring := fmt.Sprintf("%s%s", strings.Title(context), "\nError: %v")
+				log.Errorf(printstring, err)
 			}
 		}
 


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
 /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
This commit updates, odo push output to show exact error to user from openshift, so that user can know the cause of error and updates local config accordingly. e.g. When a user creates a storage 
with some **invalid name** ,  it does not out show user the cause of error.
```
[adisky@localhost odo]$ odo storage create storageFive --context ~/my_components/nodejs-ex/ --path /data5 --size 1Gi
 ✓  Added storage storageFive to nodejs-nodejs-ex-cqli

Please use `odo push` command to make the storage accessible to the component
[adisky@localhost odo]$ odo push
 ✗  Blank source location, does the .odo directory exist?
[adisky@localhost odo]$ odo push --context ~/my_components/nodejs-ex/
Validation
 ✓  Checking component [12ms]

Configuration changes
 ✗  Retrieving component data [9ms]
 ✗  Failed To Update Config To Component Deployed
```
**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
create storage with some invalid specs, In the output you will get the exact cause of the error.
