### PR TITLE
Use env variable for unit test verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ SLOW_SPEC_THRESHOLD := 120
 # To enable verbosity export or set env GINKGO_VERBOSE_MODE like "GINKGO_VERBOSE_MODE=-v"
 GINKGO_VERBOSE_MODE ?=
 
-# Env variable UNIT_TEST_VERBOSE_MODE is used to get control over enabling go test
-# verbose mode for unit test run. By default go test verbosity is not enabled.
-# To enable verbosity export or set env UNIT_TEST_VERBOSE_MODE like "UNIT_TEST_VERBOSE_MODE=-v"
-UNIT_TEST_VERBOSE_MODE ?=
+# Env variable UNIT_TEST_ARGS is used to get control over enabling test flags
+# along with go test. To enable verbosity export or set env UNIT_TEST_ARGS like "UNIT_TEST_ARGS=-v"
+
+UNIT_TEST_ARGS ?=
 
 GINKGO_FLAGS_ALL = $(GINKGO_VERBOSE_MODE) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ SLOW_SPEC_THRESHOLD := 120
 # To enable verbosity export or set env GINKGO_VERBOSE_MODE like "GINKGO_VERBOSE_MODE=-v"
 GINKGO_VERBOSE_MODE ?=
 
+# Env variable UNIT_TEST_VERBOSE_MODE is used to get control over enabling go test
+# verbose mode for unit test run. By default go test verbosity is not enabled.
+# To enable verbosity export or set env UNIT_TEST_VERBOSE_MODE like "UNIT_TEST_VERBOSE_MODE=-v"
+UNIT_TEST_VERBOSE_MODE ?=
+
 GINKGO_FLAGS_ALL = $(GINKGO_VERBOSE_MODE) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
 
 # Flags for tests that must not be run in parallel.
@@ -130,7 +135,7 @@ configure-installer-tests-cluster:
 
 .PHONY: test
 test:
-	go test -race $(PKGS)
+	go test $(UNIT_TEST_VERBOSE_MODE) -race $(PKGS)
 
 # Run generic integration tests
 .PHONY: test-generic

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,17 @@ TEST_EXEC_NODES ?= 2
 # Slow spec threshold for ginkgo tests. After this time (in second), ginkgo marks test as slow
 SLOW_SPEC_THRESHOLD := 120
 
-# Env variable GINKGO_VERBOSE_MODE is used to get control over enabling ginkgo
-# verbose mode against each test target run. By default ginkgo verbosity is not enabled.
-# To enable verbosity export or set env GINKGO_VERBOSE_MODE like "GINKGO_VERBOSE_MODE=-v"
-GINKGO_VERBOSE_MODE ?=
+# Env variable GINKGO_TEST_ARGS is used to get control over enabling ginkgo test flags against each test target run.
+# For example:
+# To enable verbosity export or set env GINKGO_TEST_ARGS like "GINKGO_TEST_ARGS=-v"
+GINKGO_TEST_ARGS ?=
 
-# Env variable UNIT_TEST_ARGS is used to get control over enabling test flags
-# along with go test. To enable verbosity export or set env UNIT_TEST_ARGS like "UNIT_TEST_ARGS=-v"
-
+# Env variable UNIT_TEST_ARGS is used to get control over enabling test flags along with go test.
+# For example:
+# To enable verbosity export or set env GINKGO_TEST_ARGS like "GINKGO_TEST_ARGS=-v"
 UNIT_TEST_ARGS ?=
 
-GINKGO_FLAGS_ALL = $(GINKGO_VERBOSE_MODE) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
+GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) -randomizeAllSpecs -slowSpecThreshold=$(SLOW_SPEC_THRESHOLD) -timeout $(TIMEOUT)
 
 # Flags for tests that must not be run in parallel.
 GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1
@@ -135,7 +135,7 @@ configure-installer-tests-cluster:
 
 .PHONY: test
 test:
-	go test $(UNIT_TEST_VERBOSE_MODE) -race $(PKGS)
+	go test $(UNIT_TEST_ARGS) -race $(PKGS)
 
 # Run generic integration tests
 .PHONY: test-generic

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -321,7 +321,7 @@ There are some test environment variable that helps to get more control over the
 
 * GINKGO_VERBOSE_MODE: Env variable GINKGO_VERBOSE_MODE is used to get control over enabling ginkgo verbose mode against each test target run. By default ginkgo verbosity is not enabled. To enable verbosity export or set env GINKGO_VERBOSE_MODE like `GINKGO_VERBOSE_MODE=-v`.
 
-* UNIT_TEST_VERBOSE_MODE: Env variable UNIT_TEST_VERBOSE_MODE is used to get control over enabling go test verbose mode for unit test run. By default go test verbosity is not enabled. To enable verbosity export or set env UNIT_TEST_VERBOSE_MODE like `UNIT_TEST_VERBOSE_MODE=-v`.
+* UNIT_TEST_ARGS: Env variable UNIT_TEST_ARGS is used to get control over enabling test flags along with go test. To enable verbosity export or set env UNIT_TEST_ARGS like `UNIT_TEST_ARGS=-v`.
 
 *Running integration tests:*
 

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -319,9 +319,9 @@ There are some test environment variable that helps to get more control over the
 
 * SLOW_SPEC_THRESHOLD: Env variable SLOW_SPEC_THRESHOLD is used for ginkgo tests. After this time (in second), ginkgo marks test as slow. The default value is set to 120s.
 
-* GINKGO_VERBOSE_MODE: Env variable GINKGO_VERBOSE_MODE is used to get control over enabling ginkgo verbose mode against each test target run. By default ginkgo verbosity is not enabled. To enable verbosity export or set env GINKGO_VERBOSE_MODE like `GINKGO_VERBOSE_MODE=-v`.
+* GINKGO_TEST_ARGS: Env variable GINKGO_TEST_ARGS is used to get control over enabling test flags against each test target run. For example, To enable verbosity export or set env GINKGO_TEST_ARGS like `GINKGO_TEST_ARGS=-v`.
 
-* UNIT_TEST_ARGS: Env variable UNIT_TEST_ARGS is used to get control over enabling test flags along with go test. To enable verbosity export or set env UNIT_TEST_ARGS like `UNIT_TEST_ARGS=-v`.
+* UNIT_TEST_ARGS: Env variable UNIT_TEST_ARGS is used to get control over enabling test flags along with go test. For example, To enable verbosity export or set env UNIT_TEST_ARGS like `UNIT_TEST_ARGS=-v`.
 
 *Running integration tests:*
 

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -321,6 +321,8 @@ There are some test environment variable that helps to get more control over the
 
 * GINKGO_VERBOSE_MODE: Env variable GINKGO_VERBOSE_MODE is used to get control over enabling ginkgo verbose mode against each test target run. By default ginkgo verbosity is not enabled. To enable verbosity export or set env GINKGO_VERBOSE_MODE like `GINKGO_VERBOSE_MODE=-v`.
 
+* UNIT_TEST_VERBOSE_MODE: Env variable UNIT_TEST_VERBOSE_MODE is used to get control over enabling go test verbose mode for unit test run. By default go test verbosity is not enabled. To enable verbosity export or set env UNIT_TEST_VERBOSE_MODE like `UNIT_TEST_VERBOSE_MODE=-v`.
+
 *Running integration tests:*
 
 By default, tests are run against the `odo` binary placed in the PATH which is created by command `make`. Integration tests can be run in two (parallel and sequential) ways. To control the parallel run use environment variable `TEST_EXEC_NODES`. For example component test can be run


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind feature

**What does does this PR do / why we need it**:
Enabling verbose mode for unit test run. Helps to debugging the unit test failure 
**Which issue(s) this PR fixes**:

Fixes #? NA

**How to test changes / Special notes to the reviewer**:

UNIT_TEST_VERBOSE_MODE=-v make test 
