### PR TITLE
Add State to Odo Storage List

### DIFF
--- a/pkg/config/fakeConfig.go
+++ b/pkg/config/fakeConfig.go
@@ -50,6 +50,36 @@ func GetOneExistingConfigInfo(componentName, applicationName, projectName string
 	}
 }
 
+func GetOneExistingConfigInfoStorage(componentName, applicationName, projectName, storeName, storeSize, storePath string) LocalConfigInfo {
+	componentType := "nodejs"
+	sourceLocation := "./"
+
+	storageValue := []ComponentStorageSettings{
+		{
+			Name: storeName,
+			Size: storeSize,
+			Path: storePath,
+		},
+	}
+
+	localVar := LOCAL
+
+	return LocalConfigInfo{
+		configFileExists: true,
+		LocalConfig: LocalConfig{
+			componentSettings: ComponentSettings{
+				Name:           &componentName,
+				Application:    &applicationName,
+				Type:           &componentType,
+				SourceLocation: &sourceLocation,
+				Storage:        &storageValue,
+				Project:        &projectName,
+				SourceType:     &localVar,
+			},
+		},
+	}
+}
+
 func GetOneGitExistingConfigInfo(componentName, applicationName, projectName string) LocalConfigInfo {
 	localConfigInfo := GetOneExistingConfigInfo(componentName, applicationName, projectName)
 	git := GIT

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -69,7 +69,6 @@ func (o *StorageListOptions) Run() (err error) {
 	}
 
 	return
-
 }
 
 func printStorage(storageList storage.StorageList, compName string) {
@@ -93,7 +92,6 @@ func printStorage(storageList storage.StorageList, compName string) {
 	}
 
 	fmt.Println("")
-
 }
 
 // NewCmdStorageList implements the odo storage list command.

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -3,15 +3,14 @@ package storage
 import (
 	"fmt"
 	"os"
+	"text/tabwriter"
 
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
 
-	"text/tabwriter"
-
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	ktemplates "k8s.io/kubernetes/pkg/kubectl/util/templates"
 
@@ -56,43 +55,45 @@ func (o *StorageListOptions) Validate() (err error) {
 	return nil
 }
 
-// Run contains the logic for the odo storage list command
 func (o *StorageListOptions) Run() (err error) {
-	storageListConfig, err := o.localConfig.StorageList()
+
+	storageList, err := storage.ListStorageWithState(o.Client, o.localConfig, o.Component(), o.Application)
 	if err != nil {
 		return err
 	}
 
-	storageListMachineReadable := []storage.Storage{}
-
-	for _, storageConfig := range storageListConfig {
-		storageListMachineReadable = append(storageListMachineReadable, storage.GetMachineReadableFormat(storageConfig.Name, storageConfig.Size, storageConfig.Path))
-	}
-	storageListResultMachineReadable := storage.GetMachineReadableFormatForList(storageListMachineReadable)
-
 	if log.IsJSON() {
-		machineoutput.OutputSuccess(storageListResultMachineReadable)
+		machineoutput.OutputSuccess(storageList)
 	} else {
-		// defining the column structure of the table
+		printStorage(storageList, o.localConfig.GetName())
+	}
+
+	return
+
+}
+
+func printStorage(storageList storage.StorageList, compName string) {
+
+	if len(storageList.Items) > 0 {
+
 		tabWriterMounted := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 
 		// create headers of mounted storage table
-		fmt.Fprintln(tabWriterMounted, "NAME", "\t", "SIZE", "\t", "PATH")
+		fmt.Fprintln(tabWriterMounted, "NAME", "\t", "SIZE", "\t", "PATH", "\t", "STATE")
 		// iterating over all mounted storage and put in the mount storage table
-		if len(storageListConfig) > 0 {
-			for _, mStorage := range storageListConfig {
-				fmt.Fprintln(tabWriterMounted, mStorage.Name, "\t", mStorage.Size, "\t", mStorage.Path)
-			}
-
-			// print all mounted storage of the given component
-			log.Infof("The component '%v' has the following storage attached:", o.localConfig.GetName())
-			tabWriterMounted.Flush()
-		} else {
-			log.Infof("The component '%v' has no storage attached", o.localConfig.GetName())
+		for _, mStorage := range storageList.Items {
+			fmt.Fprintln(tabWriterMounted, mStorage.Name, "\t", mStorage.Spec.Size, "\t", mStorage.Status.Path, "\t", mStorage.State)
 		}
-		fmt.Println("")
+
+		// print all mounted storage of the given component
+		log.Infof("The component '%v' has the following storage attached:", compName)
+		tabWriterMounted.Flush()
+	} else {
+		log.Infof("The component '%v' has no storage attached", compName)
 	}
-	return
+
+	fmt.Println("")
+
 }
 
 // NewCmdStorageList implements the odo storage list command.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"fmt"
+
+	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 
 	applabels "github.com/openshift/odo/pkg/application/labels"
@@ -458,4 +460,79 @@ func GetMachineReadableFormat(storageName, storageSize, storagePath string) Stor
 			Path: storagePath,
 		},
 	}
+}
+
+func ListStorageWithState(client *occlient.Client, localConfig *config.LocalConfigInfo, componentName string, applicationName string) (StorageList, error) {
+
+	storageConfig, err := localConfig.StorageList()
+	if err != nil {
+		return StorageList{}, err
+	}
+
+	storageListConfig := convertListLocalToMachine(storageConfig)
+
+	storageCluster, err := List(client, componentName, applicationName)
+	if err != nil {
+		glog.V(4).Infof("Storage List from Cluster Error: %v", err)
+	}
+
+	var storageList []Storage
+
+	// Iterate over local storage list, to add State PUSHED/NOT PUSHED
+	for _, storeLocal := range storageListConfig.Items {
+		storeLocal.State = StateTypeNotPushed
+		if isPushed(storeLocal.Name, storageCluster) {
+			storeLocal.State = StateTypePushed
+		}
+
+		storageList = append(storageList, storeLocal)
+	}
+
+	// Iterate over cluster storage list, to add State Locally Deleted
+	for _, storeCluster := range storageCluster.Items {
+		if isLocallyDeleted(storeCluster.Name, storageListConfig) {
+			storeCluster.State = StateTypeLocallyDeleted
+			storageList = append(storageList, storeCluster)
+
+		}
+
+	}
+
+	return GetMachineReadableFormatForList(storageList), nil
+
+}
+
+func isLocallyDeleted(storageName string, storageLocal StorageList) bool {
+	for _, storage := range storageLocal.Items {
+		if storageName == storage.Name {
+			return false
+		}
+
+	}
+	return true
+
+}
+
+func isPushed(storageName string, storageCluster StorageList) bool {
+
+	for _, storage := range storageCluster.Items {
+		if storageName == storage.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// It converts storage config list to StorageList type
+func convertListLocalToMachine(storageListConfig []config.ComponentStorageSettings) StorageList {
+
+	var storageListLocal []Storage
+
+	for _, storeLocal := range storageListConfig {
+		s := GetMachineReadableFormat(storeLocal.Name, storeLocal.Size, storeLocal.Path)
+		storageListLocal = append(storageListLocal, s)
+	}
+
+	return GetMachineReadableFormatForList(storageListLocal)
+
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -473,7 +473,7 @@ func ListStorageWithState(client *occlient.Client, localConfig *config.LocalConf
 
 	storageCluster, err := List(client, componentName, applicationName)
 	if err != nil {
-		glog.V(4).Infof("Storage List from Cluster Error: %v", err)
+		glog.V(4).Infof("Storage list from cluster error: %v", err)
 	}
 
 	var storageList []Storage
@@ -484,7 +484,6 @@ func ListStorageWithState(client *occlient.Client, localConfig *config.LocalConf
 		if isPushed(storeLocal.Name, storageCluster) {
 			storeLocal.State = StateTypePushed
 		}
-
 		storageList = append(storageList, storeLocal)
 	}
 
@@ -493,13 +492,10 @@ func ListStorageWithState(client *occlient.Client, localConfig *config.LocalConf
 		if isLocallyDeleted(storeCluster.Name, storageListConfig) {
 			storeCluster.State = StateTypeLocallyDeleted
 			storageList = append(storageList, storeCluster)
-
 		}
-
 	}
 
 	return GetMachineReadableFormatForList(storageList), nil
-
 }
 
 func isLocallyDeleted(storageName string, storageLocal StorageList) bool {
@@ -507,19 +503,18 @@ func isLocallyDeleted(storageName string, storageLocal StorageList) bool {
 		if storageName == storage.Name {
 			return false
 		}
-
 	}
-	return true
 
+	return true
 }
 
 func isPushed(storageName string, storageCluster StorageList) bool {
-
 	for _, storage := range storageCluster.Items {
 		if storageName == storage.Name {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -534,5 +529,4 @@ func convertListLocalToMachine(storageListConfig []config.ComponentStorageSettin
 	}
 
 	return GetMachineReadableFormatForList(storageListLocal)
-
 }

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -10,7 +10,20 @@ type Storage struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              StorageSpec   `json:"spec,omitempty"`
 	Status            StorageStatus `json:"status,omitempty"`
+	State             StorageState  `json:"state,omitempty"`
 }
+
+// StorageState
+type StorageState string
+
+const (
+	// StateTypePushed means that Storage is present both locally and on cluster
+	StateTypePushed StorageState = "Pushed"
+	// StateTypeNotPushed means that Storage is only in local config, but not on the cluster
+	StateTypeNotPushed = "Not Pushed"
+	// StateTypeLocallyDeleted means that Storage was deleted from the local config, but it is still present on the cluster
+	StateTypeLocallyDeleted = "Locally Deleted"
+)
 
 // StorageSpec indicates size and path of storage
 type StorageSpec struct {

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -140,4 +140,29 @@ var _ = Describe("odo storage command tests", func() {
 		})
 	})
 
+	Context("when running storage list command to check state", func() {
+		It("should list storage with correct state", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+
+			// create storage, list storage should have state "Not Pushed"
+			helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path=/tmp1", "--size=1Gi", "--context", context)
+			StorageList := helper.CmdShouldPass("odo", "storage", "list", "--context", context)
+			Expect(StorageList).To(ContainSubstring("Not Pushed"))
+
+			// Push storage, list storage should have state "Pushed"
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			StorageList = helper.CmdShouldPass("odo", "storage", "list", "--context", context)
+			Expect(StorageList).To(ContainSubstring("Pushed"))
+
+			// Delete storage, list storage should have state "Locally Deleted"
+			helper.CmdShouldPass("odo", "storage", "delete", "pv1", "-f", "--context", context)
+			StorageList = helper.CmdShouldPass("odo", "storage", "list", "--context", context)
+			Expect(StorageList).To(ContainSubstring("Locally Deleted"))
+
+		})
+	})
+
 })

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -58,7 +58,7 @@ var _ = Describe("odo storage command tests", func() {
 			// --app string         Application, defaults to active application
 			// --component string   Component, defaults to active component.
 			// --project string     Project, defaults to active project
-			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "5Gi", "--context", context)
+			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "1Gi", "--context", context)
 			Expect(storAdd).To(ContainSubstring("nodejs"))
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
@@ -77,6 +77,7 @@ var _ = Describe("odo storage command tests", func() {
 
 			// delete the storage
 			helper.CmdShouldPass("odo", "storage", "delete", "pv1", "--context", context, "-f")
+			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			storeList = helper.CmdShouldPass("odo", "storage", "list", "--context", context)
 			Expect(storeList).NotTo(ContainSubstring("pv1"))
@@ -92,7 +93,7 @@ var _ = Describe("odo storage command tests", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
 			helper.CmdShouldPass("odo", "component", "create", "python", "python", "--app", "pyapp", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
-			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "5Gi", "--context", context)
+			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "1Gi", "--context", context)
 			Expect(storAdd).To(ContainSubstring("python"))
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
@@ -111,8 +112,10 @@ var _ = Describe("odo storage command tests", func() {
 
 			// delete the storage
 			helper.CmdShouldPass("odo", "storage", "delete", "pv1", "--context", context, "-f")
+			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			storeList = helper.CmdShouldPass("odo", "storage", "list", "--context", context)
+
 			Expect(storeList).NotTo(ContainSubstring("pv1"))
 
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -129,9 +132,9 @@ var _ = Describe("odo storage command tests", func() {
 			desiredJSONStorage := `{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi"},"status":{"path":"/opt/app-root/src/storage/"}}`
 			Expect(desiredJSONStorage).Should(MatchJSON(actualJSONStorage))
 
-			actualSrorageList := helper.CmdShouldPass("odo", "storage", "list", "--context", context, "-o", "json")
-			desiredSrorageList := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi"},"status":{"path":"/opt/app-root/src/storage/"}}]}`
-			Expect(desiredSrorageList).Should(MatchJSON(actualSrorageList))
+			actualStorageList := helper.CmdShouldPass("odo", "storage", "list", "--context", context, "-o", "json")
+			desiredStorageList := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi"},"status":{"path":"/opt/app-root/src/storage/"}, "state":"Not Pushed"}]}`
+			Expect(desiredStorageList).Should(MatchJSON(actualStorageList))
 
 			helper.CmdShouldPass("odo", "storage", "delete", "mystorage", "--context", context, "-f")
 		})


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
 /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
This PR adds feature to list storage state, Pushed, NotPushed
or Locally Deleted

**Which issue(s) this PR fixes**:

Fixes  #2559

**How to test changes / Special notes to the reviewer**:
Run `odo storage list`, It will show state in the output

```
[adisky@localhost nodejs-ex]$ odo storage list
The component 'nodejs-nodejs-ex-cqli' has the following storage attached:
NAME             SIZE     PATH       STATE
newstorage       1Gi      /data      Pushed
storage-five     1Gi      /data5     Pushed
storageSeven     1Gi      /data7     Not Pushed
mystorage2       1Gi                 Locally Deleted
```

