### PR TITLE
Exports ODO_LOG_LEVEL env variable in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - &osx-test
       stage: Test
       name: "Unit test on OSX"
-      os: 
+      os:
         - osx
       go_import_path: github.com/openshift/odo
       go: "1.13.1"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ SLOW_SPEC_THRESHOLD := 120
 # To enable verbosity export or set env GINKGO_TEST_ARGS like "GINKGO_TEST_ARGS=-v"
 GINKGO_TEST_ARGS ?=
 
+# ODO_LOG_LEVEL sets the verbose log level for the make tests
+export ODO_LOG_LEVEL ?= 4
+
 # Env variable UNIT_TEST_ARGS is used to get control over enabling test flags along with go test.
 # For example:
 # To enable verbosity export or set env GINKGO_TEST_ARGS like "GINKGO_TEST_ARGS=-v"

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/log"
@@ -46,7 +47,9 @@ func main() {
 	// Override the logging level by the value (if set) by the ODO_LOG_LEVEL env
 	// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
 	v := flag.CommandLine.Lookup("v").Value.String()
-	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" {
+	// if the json flag is passed and is valid, we don't turn on ODO_LOG_LEVEL
+	jsonFlagValue := flag.CommandLine.Lookup("o").Value.String()
+	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" && strings.ToLower(jsonFlagValue) != "json" {
 		_ = flag.CommandLine.Set("v", level)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does does this PR do / why we need it**:

Expose ODO_LOG_LEVEL env to the integration tests for getting verbose logs for failing tests

**How to test changes / Special notes to the reviewer**:
 
Check that a failing test has verbose logs.