### PR TITLE
Remove devfile push cmd

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/version"
 	"github.com/openshift/odo/pkg/odo/util"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -174,13 +173,6 @@ func NewCmdOdo(name, fullName string) *cobra.Command {
 		preference.NewCmdPreference(preference.RecommendedCommandName, util.GetFullName(fullName, preference.RecommendedCommandName)),
 		debug.NewCmdDebug(debug.RecommendedCommandName, util.GetFullName(fullName, debug.RecommendedCommandName)),
 	)
-
-	// Expose commands in experimental mode, if experimental mode is enabled.
-	if experimental.IsExperimentalModeEnabled() {
-		rootCmd.AddCommand(
-			component.NewCmdPushDevfile(component.PushDevfileRecommendedCommandName, util.GetFullName(fullName, component.PushDevfileRecommendedCommandName)),
-		)
-	}
 
 	odoutil.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
 

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -1,55 +1,28 @@
 package component
 
 import (
-	"fmt"
-
 	"github.com/openshift/odo/pkg/devfile"
-	"github.com/openshift/odo/pkg/odo/cli/project"
-	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/spf13/cobra"
-	ktemplates "k8s.io/kubernetes/pkg/kubectl/util/templates"
 )
 
-// examples
-var pushDevFileExample = ktemplates.Examples(`
-Devfile support is an experimental feature which extends the support for the use of Che devfiles in odo
-for performing various odo operations.
+/*
+Devfile support is an experimental feature which extends the support for the
+use of Che devfiles in odo for performing various odo operations.
 
 The devfile support progress can be tracked by:
 https://github.com/openshift/odo/issues/2467
 
-Please note that this feature is currently under development and the "push-devfile" command has been
-temporarily exposed only for experimental purposes, and may/will be removed in future releases.
-  `)
+Please note that this feature is currently under development and the "--devfile"
+flag is exposed only if the experimental mode in odo is enabled.
 
-const PushDevfileRecommendedCommandName = "push-devfile"
-
-// PushDevfileOptions encapsulates odo component push-devfile  options
-type PushDevfileOptions struct {
-	devfilePath string
-	*genericclioptions.Context
-}
-
-// NewPushDevfileOptions returns new instance of PushDevfileOptions
-func NewPushDevfileOptions() *PushDevfileOptions {
-	return &PushDevfileOptions{}
-}
-
-// Complete completes  args
-func (pdo *PushDevfileOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	return nil
-}
-
-// Validate validates the  parameters
-func (pdo *PushDevfileOptions) Validate() (err error) {
-	return nil
-}
+The behaviour of this feature is subject to change as development for this
+feature progresses.
+*/
 
 // Run has the logic to perform the required actions as part of command
-func (pdo *PushDevfileOptions) Run() (err error) {
+func (po *PushOptions) DevfilePush() (err error) {
 
 	// Parse devfile
-	devObj, err := devfile.Parse(pdo.devfilePath)
+	devObj, err := devfile.Parse(po.devfilePath)
 	if err != nil {
 		return err
 	}
@@ -61,25 +34,4 @@ func (pdo *PushDevfileOptions) Run() (err error) {
 	}
 
 	return nil
-}
-
-// NewCmdPushDevfile implements odo push-devfile  command
-func NewCmdPushDevfile(name, fullName string) *cobra.Command {
-	o := NewPushDevfileOptions()
-
-	var pushDevfileCmd = &cobra.Command{
-		Use:     name,
-		Short:   "Push component using devfile.",
-		Long:    "Push component using devfile.",
-		Example: fmt.Sprintf(pushDevFileExample, fullName),
-		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			genericclioptions.GenericRun(o, cmd, args)
-		},
-	}
-
-	pushDevfileCmd.Flags().StringVar(&o.devfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
-	project.AddProjectFlag(pushDevfileCmd)
-
-	return pushDevfileCmd
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -28,10 +28,8 @@ var pushCmdExample = ktemplates.Examples(`  # Push source code to the current co
 %[1]s my-component --context ~/mycode
   `)
 
-const (
-	// PushRecommendedCommandName is the recommended push command name
-	PushRecommendedCommandName = "push"
-)
+// PushRecommendedCommandName is the recommended push command name
+const PushRecommendedCommandName = "push"
 
 // PushOptions encapsulates options that push command uses
 type PushOptions struct {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,9 @@ const PushRecommendedCommandName = "push"
 // PushOptions encapsulates options that push command uses
 type PushOptions struct {
 	*CommonPushOptions
+
+	// devfile path
+	devfilePath string
 }
 
 // NewPushOptions returns new instance of PushOptions
@@ -44,6 +48,11 @@ func NewPushOptions() *PushOptions {
 
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+
+	if experimental.IsExperimentalModeEnabled() {
+		return nil
+	}
+
 	conf, err := config.NewLocalConfigInfo(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve configuration information")
@@ -75,6 +84,10 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 // Validate validates the push parameters
 func (po *PushOptions) Validate() (err error) {
 
+	if experimental.IsExperimentalModeEnabled() {
+		return nil
+	}
+
 	log.Info("Validation")
 
 	// First off, we check to see if the component exists. This is ran each time we do `odo push`
@@ -102,7 +115,14 @@ func (po *PushOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run() (err error) {
-	return po.Push()
+	// if experimental mode is enabled, use devfile push
+	if experimental.IsExperimentalModeEnabled() {
+		// devfile push
+		return po.DevfilePush()
+	} else {
+		// Legacy odo push
+		return po.Push()
+	}
 }
 
 // NewCmdPush implements the push odo command
@@ -126,6 +146,11 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Flags().BoolVar(&po.pushConfig, "config", false, "Use config flag to only apply config on to cluster")
 	pushCmd.Flags().BoolVar(&po.pushSource, "source", false, "Use source flag to only push latest source on to cluster")
 	pushCmd.Flags().BoolVarP(&po.forceBuild, "force-build", "f", false, "Use force-build flag to force building the component")
+
+	// enable devfile flag if experimental mode is enabled
+	if experimental.IsExperimentalModeEnabled() {
+		pushCmd.Flags().StringVar(&po.devfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
+	}
 
 	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What does does this PR do / why we need it**:
This PR removes the `push-devfile` command and replaces it's behavior by adding the `--devfile` flag to the `odo push` command itself. 

**Which issue(s) this PR fixes**:

Fixes #2538 

**How to test changes / Special notes to the reviewer**:
The experimental mode needs to be enabled and the `--devfile` flag needs to be explicitly set for the devfile feature to work.