### PR TITLE
Improve error messaging

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
@@ -204,6 +205,14 @@ func Warning(a ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	if !IsJSON() {
 		fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, yellow(getWarningString()), suffixSpacing, fmt.Sprintln(a...))
+	}
+}
+
+// OutputError will output an error message meant to notify the user of what's happening.
+func OutputError(a ...interface{}) {
+	red := color.New(color.FgRed).SprintFunc()
+	if !IsJSON() {
+		fmt.Fprintf(GetStderr(), "%s%s", red("\nERROR:\n"), red(fmt.Sprintln(a...)))
 	}
 }
 
@@ -384,4 +393,14 @@ func getSpacingString() string {
 		return "-"
 	}
 	return "•"
+}
+
+// capitalize a sentence / string
+func capitalize(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+	tmp := []rune(str)
+	tmp[0] = unicode.ToUpper(tmp[0])
+	return string(tmp)
 }

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -47,10 +47,10 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 		} else {
 			glog.V(4).Infof("Error:\n%v", err)
 			if context == "" {
-				log.Error(errors.Cause(err))
+				log.OutputError(errors.Cause(err))
 			} else {
 				printstring := fmt.Sprintf("%s%s", strings.Title(context), "\nError: %v")
-				log.Errorf(printstring, err)
+				log.OutputError(printstring, err)
 			}
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does does this PR do / why we need it**:

Improves the way that we output error messaging. Ex:

```sh
~/openshift
▶ odo push -f

ERROR:
Blank source location, does the .odo directory exist?

```

The PR:
 - Capitalize the error message
 - Makes it distinctive by making it red
 - Seperates it from the other output in order to make it easier to read

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Please run it and let me know

Signed-off-by: Charlie Drage <charlie@charliedrage.com>