### PR TITLE
removed duplicate LocalConfigInfo and redundent file reads

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -898,7 +898,7 @@ func List(client *occlient.Client, applicationName string, localConfigInfo *conf
 	}
 
 	if localConfigInfo != nil {
-		component, err := GetComponentFromConfig(*localConfigInfo)
+		component, err := GetComponentFromConfig(localConfigInfo)
 		if err != nil {
 			return GetMachineReadableFormatForList(components), err
 		}
@@ -917,7 +917,7 @@ func List(client *occlient.Client, applicationName string, localConfigInfo *conf
 }
 
 // GetComponentFromConfig returns the component on the config if it exists
-func GetComponentFromConfig(localConfig config.LocalConfigInfo) (Component, error) {
+func GetComponentFromConfig(localConfig *config.LocalConfigInfo) (Component, error) {
 	if localConfig.ConfigFileExists() {
 		component := getMachineReadableFormat(localConfig.GetName(), localConfig.GetType())
 

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -246,7 +246,8 @@ func TestGetComponentLinkedSecretNames(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	componentConfig, err := GetComponentFromConfig(GetOneExistingConfigInfo("comp", "app", "test"))
+	mockConfig := GetOneExistingConfigInfo("comp", "app", "test")
+	componentConfig, err := GetComponentFromConfig(&mockConfig)
 	if err != nil {
 		t.Errorf("error occured while calling GetComponentFromConfig, error: %v", err)
 	}
@@ -939,7 +940,7 @@ func TestGetComponentFromConfig(t *testing.T) {
 			}
 			cfg := &tt.existingConfig
 
-			got, _ := GetComponentFromConfig(*cfg)
+			got, _ := GetComponentFromConfig(cfg)
 
 			if !reflect.DeepEqual(got.Spec, tt.wantSpec.Spec) {
 				t.Errorf("the component spec is different, want: %v,\n got: %v", tt.wantSpec.Spec, got.Spec)

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -29,8 +29,8 @@ type CommonPushOptions struct {
 	sourceType       config.SrcType
 	sourcePath       string
 	componentContext string
-	LocalConfigInfo  *config.LocalConfigInfo
-	EnvSpecificInfo  *envinfo.EnvSpecificInfo
+
+	EnvSpecificInfo *envinfo.EnvSpecificInfo
 
 	pushConfig         bool
 	pushSource         bool

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -269,7 +269,9 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.interactive = true
 	}
 
-	co.LocalConfigInfo, err = config.NewLocalConfigInfo(co.componentContext)
+	// this populates the LocalConfigInfo as well
+	co.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -86,7 +86,7 @@ func (do *DeleteOptions) Run() (err error) {
 			// 1. Get list of active components in the cluster
 			// 2. Use this list to find the components to which our component is linked and generate secret names that are linked
 			// 3. Unlink these secrets from the components
-			compoList, err := component.List(do.Client, do.Context.Application, &do.LocalConfigInfo)
+			compoList, err := component.List(do.Client, do.Context.Application, do.LocalConfigInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 
-	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -28,7 +27,6 @@ var describeExample = ktemplates.Examples(`  # Describe nodejs component
 
 // DescribeOptions is a dummy container to attach complete, validate and run pattern
 type DescribeOptions struct {
-	localConfigInfo  *config.LocalConfigInfo
 	componentContext string
 	isPushed         bool
 	*ComponentOptions
@@ -36,7 +34,7 @@ type DescribeOptions struct {
 
 // NewDescribeOptions returns new instance of ListOptions
 func NewDescribeOptions() *DescribeOptions {
-	return &DescribeOptions{nil, "", false, &ComponentOptions{}}
+	return &DescribeOptions{"", false, &ComponentOptions{}}
 }
 
 // Complete completes describe args
@@ -45,8 +43,7 @@ func (do *DescribeOptions) Complete(name string, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
-	do.localConfigInfo, err = config.NewLocalConfigInfo(do.componentContext)
-	return err
+	return nil
 }
 
 // Validate validates the describe parameters
@@ -82,7 +79,7 @@ func (do *DescribeOptions) Run() (err error) {
 	}
 
 	if log.IsJSON() {
-		componentDesc.Spec.Ports = do.localConfigInfo.GetPorts()
+		componentDesc.Spec.Ports = do.LocalConfigInfo.GetPorts()
 		machineoutput.OutputSuccess(componentDesc)
 	} else {
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -91,7 +91,7 @@ func (lo *ListOptions) Run() (err error) {
 		var componentList []component.Component
 
 		if len(apps) == 0 && lo.LocalConfigInfo.ConfigFileExists() {
-			comps, err := component.List(lo.Client, lo.LocalConfigInfo.GetApplication(), &lo.LocalConfigInfo)
+			comps, err := component.List(lo.Client, lo.LocalConfigInfo.GetApplication(), lo.LocalConfigInfo)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func (lo *ListOptions) Run() (err error) {
 
 		// interating over list of application and get list of all components
 		for _, app := range apps {
-			comps, err := component.List(lo.Client, app, &lo.LocalConfigInfo)
+			comps, err := component.List(lo.Client, app, lo.LocalConfigInfo)
 			if err != nil {
 				return err
 			}
@@ -110,7 +110,7 @@ func (lo *ListOptions) Run() (err error) {
 		components = component.GetMachineReadableFormatForList(componentList)
 	} else {
 
-		components, err = component.List(lo.Client, lo.Application, &lo.LocalConfigInfo)
+		components, err = component.List(lo.Client, lo.Application, lo.LocalConfigInfo)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch components list")
 		}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/component"
-	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
@@ -55,13 +54,9 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		return nil
 	}
 
-	conf, err := config.NewLocalConfigInfo(po.componentContext)
-	if err != nil {
-		return errors.Wrap(err, "unable to retrieve configuration information")
-	}
+	// Set the correct context, which also sets the LocalConfigInfo
+	po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 
-	// Set the necessary values within WatchOptions
-	po.LocalConfigInfo = conf
 	err = po.SetSourceInfo()
 	if err != nil {
 		return errors.Wrap(err, "unable to set source information")
@@ -72,8 +67,6 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		return errors.Wrap(err, "unable to apply ignore information")
 	}
 
-	// Set the correct context
-	po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 	prjName := po.LocalConfigInfo.GetProject()
 	po.ResolveSrcAndConfigFlags()
 	err = po.ResolveProject(prjName)

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -61,7 +61,8 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 		o.paramName = args[0]
 		o.paramValue = args[1]
 	}
-	err = o.InitConfigFromContext()
+	// we initialize the context irrespective of --now flag being provided
+	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -62,10 +62,6 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 		o.paramValue = args[1]
 	}
 	// we initialize the context irrespective of --now flag being provided
-	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-	if err != nil {
-		return err
-	}
 	if o.now {
 		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 		prjName := o.LocalConfigInfo.GetProject()
@@ -74,6 +70,8 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 		if err != nil {
 			return err
 		}
+	} else {
+		o.Context = genericclioptions.NewConfigContext(cmd)
 	}
 	return
 }

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -60,12 +60,12 @@ func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	if o.envArray == nil {
 		o.paramName = args[0]
 	}
-	err = o.InitConfigFromContext()
+	// we initialize the context irrespective of --now flag being provided
+	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 	if err != nil {
 		return err
 	}
 	if o.now {
-		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 		prjName := o.LocalConfigInfo.GetProject()
 		o.ResolveSrcAndConfigFlags()
 		err = o.ResolveProject(prjName)

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -60,18 +60,17 @@ func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	if o.envArray == nil {
 		o.paramName = args[0]
 	}
-	// we initialize the context irrespective of --now flag being provided
-	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-	if err != nil {
-		return err
-	}
+
 	if o.now {
+		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 		prjName := o.LocalConfigInfo.GetProject()
 		o.ResolveSrcAndConfigFlags()
 		err = o.ResolveProject(prjName)
 		if err != nil {
 			return err
 		}
+	} else {
+		o.Context = genericclioptions.NewConfigContext(cmd)
 	}
 	return
 }

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -15,8 +15,7 @@ type InfoOptions struct {
 	Namespace     string
 	PortForwarder *debug.DefaultPortForwarder
 	*genericclioptions.Context
-	localConfigInfo *config.LocalConfigInfo
-	contextDir      string
+	contextDir string
 }
 
 var (
@@ -43,7 +42,7 @@ func NewInfoOptions() *InfoOptions {
 func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
 	cfg, err := config.NewLocalConfigInfo(o.contextDir)
-	o.localConfigInfo = cfg
+	o.LocalConfigInfo = cfg
 
 	// Using Discard streams because nothing important is logged
 	o.PortForwarder = debug.NewDefaultPortForwarder(cfg.GetName(), cfg.GetApplication(), o.Client, k8sgenclioptions.NewTestIOStreamsDiscard())
@@ -61,7 +60,7 @@ func (o InfoOptions) Run() error {
 	if debugFileInfo, debugging := debug.GetDebugInfo(o.PortForwarder); debugging {
 		log.Infof("Debug is running for the component on the local port : %v\n", debugFileInfo.LocalPort)
 	} else {
-		log.Infof("Debug is not running for the component %v\n", o.localConfigInfo.GetName())
+		log.Infof("Debug is not running for the component %v\n", o.LocalConfigInfo.GetName())
 	}
 	return nil
 }

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -34,7 +34,6 @@ type PortForwardOptions struct {
 	// ReadChannel is used to receive status of port forwarding ( ready or not ready )
 	ReadyChannel chan struct{}
 	*genericclioptions.Context
-	localConfigInfo *config.LocalConfigInfo
 }
 
 var (
@@ -65,13 +64,11 @@ func NewPortForwardOptions() *PortForwardOptions {
 // Complete completes all the required options for port-forward cmd.
 func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 
+	// this populates the LocalConfigInfo
 	o.Context = genericclioptions.NewContext(cmd)
-	cfg, err := config.NewLocalConfigInfo(o.contextDir)
-	if err != nil {
-		return err
-	}
-	o.localConfigInfo = cfg
 
+	// a small shortcut
+	cfg := o.Context.LocalConfigInfo
 	remotePort := cfg.GetDebugPort()
 
 	// try to listen on the given local port and check if the port is free or not
@@ -126,7 +123,7 @@ func (o PortForwardOptions) Run() error {
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
 	defer signal.Stop(signals)
-	defer os.RemoveAll(debug.GetDebugInfoFilePath(o.Client, o.localConfigInfo.GetName(), o.localConfigInfo.GetApplication()))
+	defer os.RemoveAll(debug.GetDebugInfoFilePath(o.Client, o.LocalConfigInfo.GetName(), o.LocalConfigInfo.GetApplication()))
 
 	go func() {
 		<-signals

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -40,11 +39,6 @@ func NewStorageCreateOptions() *StorageCreateOptions {
 
 // Complete completes StorageCreateOptions after they've been created
 func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
-	o.LocalConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
-	if err != nil {
-		return err
-	}
 	o.Context = genericclioptions.NewContext(cmd)
 	if len(args) != 0 {
 		o.storageName = args[0]

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -30,7 +30,6 @@ type StorageCreateOptions struct {
 	storageSize      string
 	storagePath      string
 	componentContext string
-	localConfig      *config.LocalConfigInfo
 	*genericclioptions.Context
 }
 
@@ -42,7 +41,7 @@ func NewStorageCreateOptions() *StorageCreateOptions {
 // Complete completes StorageCreateOptions after they've been created
 func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
-	o.localConfig, err = config.NewLocalConfigInfo(o.componentContext)
+	o.LocalConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
 	if err != nil {
 		return err
 	}
@@ -58,12 +57,12 @@ func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []
 // Validate validates the StorageCreateOptions based on completed values
 func (o *StorageCreateOptions) Validate() (err error) {
 	// validate storage path
-	return o.localConfig.ValidateStorage(o.storageName, o.storagePath)
+	return o.LocalConfigInfo.ValidateStorage(o.storageName, o.storagePath)
 }
 
 // Run contains the logic for the odo storage create command
 func (o *StorageCreateOptions) Run() (err error) {
-	storageResult, err := o.localConfig.StorageCreate(o.storageName, o.storageSize, o.storagePath)
+	storageResult, err := o.LocalConfigInfo.StorageCreate(o.storageName, o.storageSize, o.storagePath)
 	if err != nil {
 		return err
 	}
@@ -73,7 +72,7 @@ func (o *StorageCreateOptions) Run() (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(storageResultMachineReadable)
 	} else {
-		log.Successf("Added storage %v to %v", o.storageName, o.localConfig.GetName())
+		log.Successf("Added storage %v to %v", o.storageName, o.LocalConfigInfo.GetName())
 		log.Italic("\nPlease use `odo push` command to make the storage accessible to the component")
 	}
 	return

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/util/completion"
@@ -31,7 +30,6 @@ var (
 
 type StorageListOptions struct {
 	componentContext string
-	localConfig      *config.LocalConfigInfo
 	*genericclioptions.Context
 }
 
@@ -42,11 +40,8 @@ func NewStorageListOptions() *StorageListOptions {
 
 // Complete completes StorageListOptions after they've been created
 func (o *StorageListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	// this also initializes the context as well
 	o.Context = genericclioptions.NewContext(cmd)
-	o.localConfig, err = config.NewLocalConfigInfo(o.componentContext)
-	if err != nil {
-		return err
-	}
 	return
 }
 
@@ -57,7 +52,7 @@ func (o *StorageListOptions) Validate() (err error) {
 
 func (o *StorageListOptions) Run() (err error) {
 
-	storageList, err := storage.ListStorageWithState(o.Client, o.localConfig, o.Component(), o.Application)
+	storageList, err := storage.ListStorageWithState(o.Client, o.LocalConfigInfo, o.Component(), o.Application)
 	if err != nil {
 		return err
 	}
@@ -65,7 +60,7 @@ func (o *StorageListOptions) Run() (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(storageList)
 	} else {
-		printStorage(storageList, o.localConfig.GetName())
+		printStorage(storageList, o.LocalConfigInfo.GetName())
 	}
 
 	return

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -44,7 +44,6 @@ func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []stri
 		o.Context = genericclioptions.NewContext(cmd)
 	}
 	o.urlName = args[0]
-	err = o.InitConfigFromContext()
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -29,7 +29,6 @@ var (
 
 // URLListOptions encapsulates the options for the odo url list command
 type URLListOptions struct {
-	localConfigInfo  *config.LocalConfigInfo
 	componentContext string
 	*genericclioptions.Context
 }
@@ -42,7 +41,7 @@ func NewURLListOptions() *URLListOptions {
 // Complete completes URLListOptions after they've been Listed
 func (o *URLListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.Context = genericclioptions.NewContext(cmd)
-	o.localConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
+	o.LocalConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")
 	}
@@ -57,7 +56,7 @@ func (o *URLListOptions) Validate() (err error) {
 // Run contains the logic for the odo url list command
 func (o *URLListOptions) Run() (err error) {
 
-	urls, err := url.List(o.Client, o.localConfigInfo, o.Component(), o.Application)
+	urls, err := url.List(o.Client, o.LocalConfigInfo, o.Component(), o.Application)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -277,7 +277,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 		Application:     app,
 		OutputFlag:      outputFlag,
 		command:         command,
-		LocalConfigInfo: *localConfiguration,
+		LocalConfigInfo: localConfiguration,
 	}
 
 	// create a context from the internal representation
@@ -311,7 +311,7 @@ type internalCxt struct {
 	Application     string
 	cmp             string
 	OutputFlag      string
-	LocalConfigInfo config.LocalConfigInfo
+	LocalConfigInfo *config.LocalConfigInfo
 }
 
 // Component retrieves the optionally specified component or the current one if it is set. If no component is set, exit with

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -30,6 +30,26 @@ func NewContextCreatingAppIfNeeded(command *cobra.Command) *Context {
 	return newContext(command, true, false)
 }
 
+// NewConfigContext is a special kind of context which only contains local configuration, other information is not retrived
+//  from the cluster. This is useful for commands which don't want to connect to cluster.
+func NewConfigContext(command *cobra.Command) *Context {
+
+	// Check for valid config
+	localConfiguration, err := getValidConfig(command, false)
+	if err != nil {
+		util.LogErrorAndExit(err, "")
+	}
+	outputFlag := FlagValueIfSet(command, OutputFlagName)
+
+	ctx := &Context{
+		internalCxt{
+			LocalConfigInfo: localConfiguration,
+			OutputFlag:      outputFlag,
+		},
+	}
+	return ctx
+}
+
 // NewContextCompletion disables checking for a local configuration since when we use autocompletion on the command line, we
 // couldn't care less if there was a configuriation. We only need to check the parameters.
 func NewContextCompletion(command *cobra.Command) *Context {
@@ -253,6 +273,7 @@ func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error)
 
 // newContext creates a new context based on the command flags, creating missing app when requested
 func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingConfiguration bool) *Context {
+
 	client := client(command)
 
 	// Check for valid config


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

 /kind cleanup
/kind code-refactoring

**What does does this PR do / why we need it**:
We have `LocalConfigInfo` as part of `Context` but we still are initialising it multiple times and even at places have duplicate declarations. So removing those.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2602

**How to test changes / Special notes to the reviewer**:
Tests should pass and @cdrage you should probably be unblocked. 
