### PR TITLE
Fix odo describe for not pushed components

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -469,7 +469,7 @@ func ListStorageWithState(client *occlient.Client, localConfig *config.LocalConf
 		return StorageList{}, err
 	}
 
-	storageListConfig := convertListLocalToMachine(storageConfig)
+	storageListConfig := ConvertListLocalToMachine(storageConfig)
 
 	storageCluster, err := List(client, componentName, applicationName)
 	if err != nil {
@@ -519,7 +519,7 @@ func isPushed(storageName string, storageCluster StorageList) bool {
 }
 
 // It converts storage config list to StorageList type
-func convertListLocalToMachine(storageListConfig []config.ComponentStorageSettings) StorageList {
+func ConvertListLocalToMachine(storageListConfig []config.ComponentStorageSettings) StorageList {
 
 	var storageListLocal []Storage
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -218,6 +218,7 @@ func componentTests(args ...string) {
 		It("should describe the component when it is not pushed", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "url", "create", "url-1", "--context", context)
+			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "URL,0,Name,url-1")
 			cmpDescribe := helper.CmdShouldPass("odo", append(args, "describe", "--context", context)...)
 
@@ -225,10 +226,11 @@ func componentTests(args ...string) {
 			Expect(cmpDescribe).To(ContainSubstring("nodejs"))
 			Expect(cmpDescribe).To(ContainSubstring("url-1"))
 			Expect(cmpDescribe).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
+			Expect(cmpDescribe).To(ContainSubstring("storage-1"))
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","url": ["url-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","url": ["url-1"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
Fixes odo describe for not pushed components

**Which issue(s) this PR fixes**:

Fixes  #2594

**How to test changes / Special notes to the reviewer**: `odo describe` command should not fail
```
$ odo create nodejs
$ odo storage create --size 1Gi --path  /data1
$ odo describe
```
