### PR TITLE
Updating nodejs:8 to nodejs:latest for source example run on openshift 4.*

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -146,33 +146,33 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the nodejs-8-rhel7 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs", "nodejs:latest", project, appName)
 		})
 
 		It("Should be able to verify the nodejs-8 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs", "nodejs:latest", project, appName)
 		})
 
 		It("Should be able to verify the nodejs-10 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs", "nodejs:latest", project, appName)
 		})
 
 		It("Should be able to verify the centos7-s2i-nodejs image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs", "nodejs:latest", project, appName)
 		})
 
 		It("Should be able to verify the centos7-s2i-nodejs:10.x image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:latest", project, appName)
 		})
 
 		It("Should be able to verify the nodejs-8-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs:8", project)
-			verifySupportedImage(filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs", "nodejs:8", project, appName)
+			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs", "nodejs:latest", project, appName)
 		})
 	})
 })

--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -36,10 +36,10 @@ var _ = Describe("odo debug command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	Context("odo debug on a nodejs:8 component", func() {
+	Context("odo debug on a nodejs:latest component", func() {
 		It("should expect a ws connection when tried to connect on different debug port locally and remotely", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--force", "DebugPort", "9292", "--context", context)
 			dbgPort := helper.GetConfigValueWithContext("DebugPort", context)
 			Expect(dbgPort).To(Equal("9292"))
@@ -55,7 +55,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should expect a ws connection when tried to connect on default debug port locally", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			go func() {
 				helper.CmdShouldRunWithTimeout(60*time.Second, "odo", "debug", "port-forward", "--context", context)
@@ -71,7 +71,7 @@ var _ = Describe("odo debug command tests", func() {
 	Context("odo debug info should work on a odo component", func() {
 		It("should start a debug session and run debug info on a running debug session", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			freePort := strconv.Itoa(helper.HttpGetFreePort())
@@ -92,7 +92,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should start a debug session and run debug info on a closed debug session", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			freePort := strconv.Itoa(helper.HttpGetFreePort())

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -271,7 +271,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should push only the modified files", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:8", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -539,7 +539,7 @@ func componentTests(args ...string) {
 
 		It("creates a local nodejs component and check unsupported warning hasn't occured", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs:8", componentName, "--app", appName, "--project", project, "--context", context)...)
+			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs:latest", componentName, "--app", appName, "--project", project, "--context", context)...)
 			Expect(output).NotTo(ContainSubstring("Warning"))
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

nodejs:latest tag is supported on openshift 4.* so updating nodejs:8 to the latest tag.

**Which issue(s) this PR fixes**:

Fixes #2542 

**How to test changes / Special notes to the reviewer**:
It should run successfully on prow 4.*