### PR TITLE
possible fix: index out of bound error on `odo catalog list compoments` when registry url and namespace are not present

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -260,7 +260,17 @@ func createImageTagMap(tagRefs []imagev1.TagReference) map[string]string {
 		imageName := tagRef.From.Name
 		if tagRef.From.Kind == "DockerImage" {
 			// we get the image name from the repo url e.g. registry.redhat.com/openshift/nodejs:10 will give openshift/nodejs:10
-			urlImageName := strings.SplitN(imageName, "/", 2)[1]
+			imageNameParts := strings.SplitN(imageName, "/", 2)
+
+			var urlImageName string
+			// this means the docker image url might just be something like nodejs:10, no namespace or registry info
+			if len(imageNameParts) == 1 {
+				urlImageName = imageNameParts[0]
+				// else block executes when there is a registry information attached in the docker image url
+			} else {
+				// we dont want the registry url portion
+				urlImageName = imageNameParts[1]
+			}
 			// here we remove the tag and digest
 			ns, img, tag, _, _ := occlient.ParseImageName(urlImageName)
 			imageName = ns + "/" + img + ":" + tag


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
Resolved a panic on `odo catalog list component` when the docker image url doesn't have registry url and namespace information

**Which issue(s) this PR fixes**:

Could possibly fix #2628 but we need to wait for the imageStream information to confirm it doesn't panic

**How to test changes / Special notes to the reviewer**:
