### PR TITLE
Fix odo catalog describe service command to not require odo config file

### DIFF
--- a/pkg/odo/cli/catalog/describe/service.go
+++ b/pkg/odo/cli/catalog/describe/service.go
@@ -41,7 +41,7 @@ func NewDescribeServiceOptions() *DescribeServiceOptions {
 
 // Complete completes DescribeServiceOptions after they've been created
 func (o *DescribeServiceOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
+	o.Context = genericclioptions.NewContext(cmd, true)
 	o.serviceName = args[0]
 
 	return

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -20,8 +20,12 @@ import (
 const DefaultAppName = "app"
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
-func NewContext(command *cobra.Command) *Context {
-	return newContext(command, false, false)
+func NewContext(command *cobra.Command, ignoreMissingConfiguration ...bool) *Context {
+	ignoreMissingConfig := false
+	if len(ignoreMissingConfiguration) == 1 {
+		ignoreMissingConfig = ignoreMissingConfiguration[0]
+	}
+	return newContext(command, false, ignoreMissingConfig)
 }
 
 // NewContextCreatingAppIfNeeded creates a new Context struct populated with the current state based on flags specified for the


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does does this PR do / why we need it**:
Currently, the odo configuration file is required for describing catalog services. This is not the desired behavior. odo configuration file should not be necessary for describing catalog services. This PR fixes that issue.

**Which issue(s) this PR fixes**:

Fixes #2605 

**How to test changes / Special notes to the reviewer**:
Execution of `odo catalog describe service <serivce-name>` command should work without requiring the `.odo/config.yml` file.