### PR TITLE
Adds auto selection of port if the default port is occupied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ test-cmd-watch:
 # Run odo debug command tests
 test-cmd-debug:
 	ginkgo $(GINKGO_FLAGS) -focus="odo debug command tests" tests/integration/
+	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo debug command serial tests" tests/integration/debug/
 
 # Run command's integration tests irrespective of service catalog status in the cluster.
 # Service, link and login/logout command tests are not the part of this test run

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/debug"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/openshift/odo/pkg/util"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -63,9 +67,36 @@ func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []st
 
 	o.Context = genericclioptions.NewContext(cmd)
 	cfg, err := config.NewLocalConfigInfo(o.contextDir)
+	if err != nil {
+		return err
+	}
 	o.localConfigInfo = cfg
 
 	remotePort := cfg.GetDebugPort()
+
+	// try to listen on the given local port and check if the port is free or not
+	addressLook := "localhost:" + strconv.Itoa(o.localPort)
+	listener, err := net.Listen("tcp", addressLook)
+	if err != nil {
+		// if the local-port flag is set by the user, return the error and stop execution
+		flag := cmd.Flags().Lookup("local-port")
+		if flag != nil && flag.Changed {
+			return err
+		}
+		// else display a error message and auto select a new free port
+		log.Errorf("the local debug port %v is not free, cause: %v", o.localPort, err)
+		o.localPort, err = util.HttpGetFreePort()
+		if err != nil {
+			return err
+		}
+		log.Infof("The local port %v is auto selected", o.localPort)
+	} else {
+		err = listener.Close()
+		if err != nil {
+			return err
+		}
+	}
+
 	o.PortPair = fmt.Sprintf("%d:%d", o.localPort, remotePort)
 
 	// Using Discard streams because nothing important is logged

--- a/pkg/testingutil/httputils.go
+++ b/pkg/testingutil/httputils.go
@@ -1,0 +1,36 @@
+package testingutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"time"
+)
+
+// fakeDebugPortListener starts a fake test server and listens on the given localPort
+func FakePortListener(startedChan chan<- bool, stopChan <-chan bool, localPort int) error {
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("running")
+	}))
+
+	listener, err := net.Listen("tcp", "localhost:"+strconv.Itoa(localPort))
+	if err != nil {
+		return err
+	}
+	testServer.Listener = listener
+	testServer.Start()
+	startedChan <- true
+	timeout := time.After(10 * time.Second)
+
+	select {
+	case <-stopChan:
+		testServer.Close()
+	case <-timeout:
+		testServer.Close()
+		return errors.New("timeout waiting for listerner to start")
+	}
+	return nil
+}

--- a/pkg/testingutil/httputils.go
+++ b/pkg/testingutil/httputils.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// fakeDebugPortListener starts a fake test server and listens on the given localPort
+// FakePortListener starts a fake test server and listens on the given localPort
 func FakePortListener(startedChan chan<- bool, stopChan <-chan bool, localPort int) error {
 	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("running")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -626,3 +626,17 @@ func DeletePath(path string) error {
 	}
 	return nil
 }
+
+// HttpGetFreePort gets a free port from the system
+func HttpGetFreePort() (int, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return -1, err
+	}
+	freePort := listener.Addr().(*net.TCPAddr).Port
+	err = listener.Close()
+	if err != nil {
+		return -1, err
+	}
+	return freePort, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/url"
 	"os"
 	"os/user"
@@ -10,6 +11,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -1124,6 +1126,34 @@ func TestRemoveRelativePathFromFiles(t *testing.T) {
 				t.Errorf("expected %v, got %v", tt.args.output, output)
 			}
 
+		})
+	}
+}
+
+func TestHttpGetFreePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "case 1: get a valid free port",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HttpGetFreePort()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HttpGetFreePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			addressLook := "localhost:" + strconv.Itoa(got)
+			listener, err := net.Listen("tcp", addressLook)
+			if err != nil {
+				t.Errorf("expected a free port, but listening failed cause: %v", err)
+			} else {
+				_ = listener.Close()
+			}
 		})
 	}
 }

--- a/tests/helper/helper_http.go
+++ b/tests/helper/helper_http.go
@@ -4,13 +4,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 // HttpWaitForWithStatus periodically (every interval) calls GET to given url
@@ -54,14 +52,4 @@ func HttpWaitForWithStatus(url string, match string, maxRetry int, interval int,
 // ends when a 200 HTTP result response contains match string, or after the maxRetry
 func HttpWaitFor(url string, match string, maxRetry int, interval int) {
 	HttpWaitForWithStatus(url, match, maxRetry, interval, 200)
-}
-
-// HttpGetFreePort gets a free port from the system
-func HttpGetFreePort() int {
-	listener, err := net.Listen("tcp", "localhost:0")
-	Expect(err).NotTo(HaveOccurred())
-	freePort := listener.Addr().(*net.TCPAddr).Port
-	err = listener.Close()
-	Expect(err).NotTo(HaveOccurred())
-	return freePort
 }

--- a/tests/helper/helper_run.go
+++ b/tests/helper/helper_run.go
@@ -44,7 +44,7 @@ func CmdShouldRunWithTimeout(timeout time.Duration, program string, args ...stri
 }
 
 // CmdShouldRunAndTerminate waits and returns stdout after a closed signal is passed on the closed channel
-func CmdShouldRunAndTerminate(timeoutAfter time.Duration, stopChan chan int, program string, args ...string) string {
+func CmdShouldRunAndTerminate(timeoutAfter time.Duration, stopChan <-chan bool, program string, args ...string) string {
 	session := CmdRunner(program, args...)
 	timeout := time.After(timeoutAfter)
 	select {

--- a/tests/integration/debug/cmd_debug_test.go
+++ b/tests/integration/debug/cmd_debug_test.go
@@ -1,0 +1,94 @@
+package debug
+
+import (
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/tests/helper"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// since during parallel runs of cmd debug, the port might be occupied by the other tests
+// we execute these tests serially
+var _ = Describe("odo debug command serial tests", func() {
+
+	var project string
+	var context string
+
+	// Setup up state for each test spec
+	// create new project (not set as active) and new context directory for each test spec
+	// This is before every spec (It)
+	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		SetDefaultConsistentlyDuration(30 * time.Second)
+		context = helper.CreateNewContext()
+		project = helper.CreateRandProject()
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	AfterEach(func() {
+		helper.DeleteProject(project)
+		helper.DeleteDir(context)
+		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	It("should auto-select a local debug port when the given local port is occupied", func() {
+		helper.CopyExample(filepath.Join("source", "nodejs"), context)
+		helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
+		helper.CmdShouldPass("odo", "push", "--context", context)
+
+		stopChannel := make(chan bool)
+		go func() {
+			helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--context", context)
+		}()
+
+		stopListenerChan := make(chan bool)
+		startListenerChan := make(chan bool)
+		listenerStarted := false
+		go func() {
+			err := testingutil.FakePortListener(startListenerChan, stopListenerChan, config.DefaultDebugPort)
+			if err != nil {
+				close(startListenerChan)
+				Expect(err).Should(BeNil())
+			}
+		}()
+		// wait for the test server to start listening
+		if <-startListenerChan {
+			listenerStarted = true
+		}
+
+		debugInfoString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
+		Expect(debugInfoString).To(ContainSubstring(""))
+
+		freePort := ""
+		helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context}, 1, true, func(output string) bool {
+			if strings.Contains(output, "Debug is running") {
+				splits := strings.SplitN(output, ":", 2)
+				Expect(len(splits)).To(Equal(2))
+				freePort = strings.TrimSpace(splits[1])
+				_, err := strconv.Atoi(freePort)
+				Expect(err).NotTo(HaveOccurred())
+				return true
+			}
+			return false
+		})
+
+		// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+		// We are just using this to validate if nodejs agent is listening on the other side
+		helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
+		stopChannel <- true
+		if listenerStarted == true {
+			stopListenerChan <- true
+		} else {
+			close(stopListenerChan)
+		}
+	})
+})

--- a/tests/integration/debug/debug_suite_test.go
+++ b/tests/integration/debug/debug_suite_test.go
@@ -1,0 +1,15 @@
+package debug
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDebug(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Debug Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

This PR adds auto selection of port if the default port is occupied. This only works when the local-port is not selected by the user using the flag.

**Which issue(s) this PR fixes**:

Fixes #2606 

**How to test changes / Special notes to the reviewer**:
- run some command/program and occupy the port 5858
- run `odo debug port-forward` on the component
- it should throw an error that the port is busy and a different port is auto selected and is used by the program.
- run `debug info` on the component to verify the debug session.
