### PR TITLE
Add debug machine readable output json

### DIFF
--- a/pkg/debug/info_test.go
+++ b/pkg/debug/info_test.go
@@ -14,15 +14,19 @@ import (
 )
 
 // fakeOdoDebugFileString creates a json string of a fake OdoDebugFile
-func fakeOdoDebugFileString(typeMeta v1.TypeMeta, processId int, projectName, appName, componentName string, remotePort, localPort int) (string, error) {
+func fakeOdoDebugFileString(typeMeta v1.TypeMeta, processID int, projectName, appName, componentName string, remotePort, localPort int) (string, error) {
 	odoDebugFile := OdoDebugFile{
-		TypeMeta:       typeMeta,
-		DebugProcessId: processId,
-		ProjectName:    projectName,
-		AppName:        appName,
-		ComponentName:  componentName,
-		RemotePort:     remotePort,
-		LocalPort:      localPort,
+		TypeMeta: typeMeta,
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: projectName,
+			Name:      componentName,
+		},
+		Spec: OdoDebugFileSpec{
+			App:            appName,
+			DebugProcessID: processID,
+			RemotePort:     remotePort,
+			LocalPort:      localPort,
+		},
 	}
 
 	data, err := json.Marshal(odoDebugFile)
@@ -64,12 +68,16 @@ func Test_createDebugInfoFile(t *testing.T) {
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid(),
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     9001,
-				LocalPort:      5858,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid(),
+					App:            "app",
+					RemotePort:     9001,
+					LocalPort:      5858,
+				},
 			},
 			alreadyExistFile: false,
 			wantErr:          false,
@@ -89,12 +97,16 @@ func Test_createDebugInfoFile(t *testing.T) {
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid(),
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     9004,
-				LocalPort:      5758,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid(),
+					App:            "app",
+					RemotePort:     9004,
+					LocalPort:      5758,
+				},
 			},
 			alreadyExistFile: true,
 			wantErr:          false,
@@ -173,22 +185,32 @@ func Test_getDebugInfo(t *testing.T) {
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid(),
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     5858,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid(),
+					App:            "app",
+					RemotePort:     5858,
+					LocalPort:      9001,
+				},
 			},
 			readDebugFile: OdoDebugFile{
 				TypeMeta: v1.TypeMeta{
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid(),
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     5858,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid(),
+					App:            "app",
+					RemotePort:     5858,
+					LocalPort:      9001,
+				},
 			},
 			debugPortListening: true,
 			fileExists:         true,
@@ -225,11 +247,16 @@ func Test_getDebugInfo(t *testing.T) {
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid(),
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     5858,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid(),
+					App:            "app",
+					RemotePort:     5858,
+					LocalPort:      9001,
+				},
 			},
 			fileExists:   true,
 			debugRunning: false,
@@ -250,11 +277,16 @@ func Test_getDebugInfo(t *testing.T) {
 					Kind:       "OdoDebugInfo",
 					APIVersion: "v1",
 				},
-				DebugProcessId: os.Getpid() + 818177979,
-				ProjectName:    "testing-1",
-				AppName:        "app",
-				ComponentName:  "nodejs-ex",
-				RemotePort:     5858,
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nodejs-ex",
+					Namespace: "testing-1",
+				},
+				Spec: OdoDebugFileSpec{
+					DebugProcessID: os.Getpid() + 818177979,
+					App:            "app",
+					RemotePort:     5858,
+					LocalPort:      9001,
+				},
 			},
 			fileExists:   true,
 			debugRunning: false,
@@ -284,12 +316,12 @@ func Test_getDebugInfo(t *testing.T) {
 			odoDebugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)
 			if tt.fileExists {
 				fakeString, err := fakeOdoDebugFileString(tt.readDebugFile.TypeMeta,
-					tt.readDebugFile.DebugProcessId,
-					tt.readDebugFile.ProjectName,
-					tt.readDebugFile.AppName,
-					tt.readDebugFile.ComponentName,
-					tt.readDebugFile.RemotePort,
-					tt.readDebugFile.LocalPort)
+					tt.readDebugFile.Spec.DebugProcessID,
+					tt.readDebugFile.ObjectMeta.Namespace,
+					tt.readDebugFile.Spec.App,
+					tt.readDebugFile.ObjectMeta.Name,
+					tt.readDebugFile.Spec.RemotePort,
+					tt.readDebugFile.Spec.LocalPort)
 
 				if err != nil {
 					t.Errorf("error occured while getting odo debug file string, cause: %v", err)
@@ -306,7 +338,7 @@ func Test_getDebugInfo(t *testing.T) {
 			if tt.debugPortListening {
 				startListenerChan := make(chan bool)
 				go func() {
-					err := testingutil.FakePortListener(startListenerChan, stopListenerChan, tt.readDebugFile.LocalPort)
+					err := testingutil.FakePortListener(startListenerChan, stopListenerChan, tt.readDebugFile.Spec.LocalPort)
 					if err != nil {
 						// the fake listener failed, show error and close the channel
 						t.Errorf("error while starting fake port listerner, cause: %v", err)

--- a/pkg/debug/info_test.go
+++ b/pkg/debug/info_test.go
@@ -305,12 +305,12 @@ func Test_getDebugInfo(t *testing.T) {
 				t.Errorf("error occured while getting a free port, cause: %v", err)
 			}
 
-			if (OdoDebugFile{}) != tt.readDebugFile {
-				tt.readDebugFile.LocalPort = freePort
+			if tt.readDebugFile.Spec.LocalPort != 0 {
+				tt.readDebugFile.Spec.LocalPort = freePort
 			}
 
-			if (OdoDebugFile{}) != tt.wantDebugFile {
-				tt.wantDebugFile.LocalPort = freePort
+			if tt.wantDebugFile.Spec.LocalPort != 0 {
+				tt.wantDebugFile.Spec.LocalPort = freePort
 			}
 
 			odoDebugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -1,9 +1,12 @@
 package debug
 
 import (
+	"fmt"
+
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/spf13/cobra"
 	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -58,9 +61,13 @@ func (o InfoOptions) Validate() error {
 // Run implements all the necessary functionality for port-forward cmd.
 func (o InfoOptions) Run() error {
 	if debugFileInfo, debugging := debug.GetDebugInfo(o.PortForwarder); debugging {
-		log.Infof("Debug is running for the component on the local port : %v\n", debugFileInfo.LocalPort)
+		if log.IsJSON() {
+			machineoutput.OutputSuccess(debugFileInfo)
+		} else {
+			log.Infof("Debug is running for the component on the local port : %v", debugFileInfo.Spec.LocalPort)
+		}
 	} else {
-		log.Infof("Debug is not running for the component %v\n", o.LocalConfigInfo.GetName())
+		return fmt.Errorf("debug is not running for the component %v", o.LocalConfigInfo.GetName())
 	}
 	return nil
 }
@@ -70,10 +77,11 @@ func NewCmdInfo(name, fullName string) *cobra.Command {
 
 	opts := NewInfoOptions()
 	cmd := &cobra.Command{
-		Use:     name,
-		Short:   "Displays debug info of a component",
-		Long:    infoLong,
-		Example: infoExample,
+		Use:         name,
+		Short:       "Displays debug info of a component",
+		Long:        infoLong,
+		Example:     infoExample,
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(opts, cmd, args)
 		},

--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -38,6 +38,31 @@ var _ = Describe("odo debug command tests", func() {
 	})
 
 	Context("odo debug on a nodejs:latest component", func() {
+		It("check that machine output debug information works", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+
+			httpPort, err := util.HttpGetFreePort()
+			Expect(err).NotTo(HaveOccurred())
+			freePort := strconv.Itoa(httpPort)
+
+			stopChannel := make(chan bool)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort, "--context", context)
+			}()
+
+			// Make sure that the debug information output, outputs correctly.
+			// We do *not* check the json output since the debugProcessID will be different each time.
+			helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context, "-o", "json"}, 1, true, func(output string) bool {
+				Expect(output).To(ContainSubstring(`"kind": "OdoDebugInfo"`))
+				Expect(output).To(ContainSubstring(`"localPort": ` + freePort))
+				return true
+			})
+
+			stopChannel <- true
+		})
+
 		It("should expect a ws connection when tried to connect on different debug port locally and remotely", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
@@ -119,7 +144,7 @@ var _ = Describe("odo debug command tests", func() {
 			runningString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
 			Expect(runningString).To(ContainSubstring(freePort))
 			stopChannel <- true
-			failString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
+			failString := helper.CmdShouldFail("odo", "debug", "info", "--context", context)
 			Expect(failString).To(ContainSubstring("not running"))
 
 			// according to https://golang.org/pkg/os/#Signal On Windows, sending os.Interrupt to a process with os.Process.Signal is not implemented

--- a/tests/integration/debug/cmd_debug_test.go
+++ b/tests/integration/debug/cmd_debug_test.go
@@ -65,9 +65,6 @@ var _ = Describe("odo debug command serial tests", func() {
 			listenerStarted = true
 		}
 
-		debugInfoString := helper.CmdShouldPass("odo", "debug", "info", "--context", context)
-		Expect(debugInfoString).To(ContainSubstring(""))
-
 		freePort := ""
 		helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context}, 1, true, func(output string) bool {
 			if strings.Contains(output, "Debug is running") {


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change

**What does does this PR do / why we need it**:

- Adds machine readable output for `odo debug info -o json`
- Updates the current spec to add ObjectMeta as well as move information
into `Spec`, `ObjectMeta` and `TypeMeta`.

Example:

```json
{
    "kind": "OdoDebugInfo",
    "apiVersion": "v1",
    "metadata": {
        "name": "nodejs-nodejs-ex-oguc",
        "namespace": "testing",
        "creationTimestamp": null
    },
    "spec": {
        "app": "app",
        "debugProcessID": 5902,
        "remotePort": 5858,
        "localPort": 5858
    }
}
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2555

**How to test changes / Special notes to the reviewer**:

Run:

```sh
odo debug port-forward
odo debug info -o json
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>