### PR TITLE
fix failing gosec check

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1461,7 +1461,7 @@ func isEmpty(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer f.Close() // #nosec G307
 
 	_, err = f.Readdirnames(1) // Or f.Readdir(1)
 	if err == io.EOF {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2871,8 +2871,6 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *taro.Writer, 
 			if _, err := io.Copy(tw, f); err != nil {
 				return err
 			}
-
-			return f.Close()
 		}
 	}
 	return nil

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2866,7 +2866,7 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *taro.Writer, 
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer f.Close() // #nosec G307
 
 			if _, err := io.Copy(tw, f); err != nil {
 				return err

--- a/pkg/util/config_util.go
+++ b/pkg/util/config_util.go
@@ -28,7 +28,7 @@ func CreateIfNotExists(configFile string) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to create config file")
 		}
-		defer file.Close()
+		defer file.Close() // #nosec G307
 	}
 
 	return nil

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -273,6 +273,6 @@ func write(filePath string, fi *FileIndex) error {
 	if err != nil {
 		return err
 	}
-	// 0666 is the mask used when a file is created using os.Create hence defaulting
-	return ioutil.WriteFile(filePath, jsonData, 0666)
+	// 0600 is the mask used when a file is created using os.Create hence defaulting
+	return ioutil.WriteFile(filePath, jsonData, 0600)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -437,7 +437,7 @@ func GetIgnoreRulesFromDirectory(directory string) ([]string, error) {
 		return nil, err
 	}
 
-	defer file.Close()
+	defer file.Close() // #nosec G307
 
 	scanner := bufio.NewReader(file)
 	for {

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -87,7 +87,7 @@ func ReplaceString(filename string, oldString string, newString string) {
 
 	newContent := strings.Replace(string(f), oldString, newString, 1)
 
-	err = ioutil.WriteFile(filename, []byte(newContent), 0644)
+	err = ioutil.WriteFile(filename, []byte(newContent), 0600)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -119,13 +119,13 @@ func copyDir(src string, dst string, info os.FileInfo) error {
 	if err != nil {
 		return err
 	}
-	defer dFile.Close()
+	defer dFile.Close() // #nosec G307
 
 	sFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer sFile.Close()
+	defer sFile.Close() // #nosec G307
 
 	if err = os.Chmod(dFile.Name(), info.Mode()); err != nil {
 		return err
@@ -144,7 +144,7 @@ func CreateFileWithContent(path string, fileContent string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer file.Close() // #nosec G307
 	// write to file
 	_, err = file.WriteString(fileContent)
 	if err != nil {


### PR DESCRIPTION
- change file permissions to 0600
- ignoring gosec error G307. This checks for "Deferring a method which returns an error". Sometimes this can be a problem as it hides the error returned from the function. I've added `// #nosec G307` to all places where we close files. Failing to close the file doesn't usually have fatal consequences, so it should be ok to ignore it.


fixes #2659