### PR TITLE
Removes the annotation 'app.openshift.io/vcs-uri' for local and binary components

### DIFF
--- a/docs/dev/machine-output.adoc
+++ b/docs/dev/machine-output.adoc
@@ -226,7 +226,6 @@ See the below table for a list of all possible machine readable output commands:
   },
   "spec": {
     "type": "nodejs",
-    "source": "file://./",
     "url": [
       "example",
       "json",
@@ -260,7 +259,6 @@ See the below table for a list of all possible machine readable output commands:
       },
       "spec": {
         "type": "nodejs",
-        "source": "file://./",
         "url": [
           "example",
           "json",

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1020,7 +1020,7 @@ func GetComponentSource(client *occlient.Client, componentName string, applicati
 	}
 
 	var sourcePath string
-	if sourceType == "git" {
+	if sourceType == string(config.GIT) {
 		sourcePath = deploymentConfig.ObjectMeta.Annotations[componentSourceURLAnnotation]
 	}
 
@@ -1073,7 +1073,7 @@ func Update(client *occlient.Client, componentConfig config.LocalConfigInfo, new
 
 	// Create annotations
 	annotations := make(map[string]string)
-	if newSourceType == "git" {
+	if newSourceType == config.GIT {
 		annotations[componentSourceURLAnnotation] = newSource
 	}
 	annotations[ComponentSourceTypeAnnotation] = string(newSourceType)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -979,7 +979,6 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 				a := getMachineReadableFormat(data.GetName(), data.GetType())
 				a.Namespace = data.GetProject()
 				a.Spec.App = data.GetApplication()
-				a.Spec.Source = data.GetSourceLocation()
 				a.Spec.Ports = data.GetPorts()
 				a.Status.Context = con
 				state := "Not Pushed"

--- a/pkg/devfile/versions/1.0.0/devfileJsonSchema100.go
+++ b/pkg/devfile/versions/1.0.0/devfileJsonSchema100.go
@@ -113,7 +113,7 @@ const JsonSchema100 = `{
                             },
                             "location": {
                                 "type": "string",
-                                "description": "Project's source location address. Should be URL for git and github located projects, or file:// for zip.",
+                                "description": "Project's source location address. Should be URL for git and github located projects",
                                 "examples": [
                                     "git@github.com:spring-projects/spring-petclinic.git"
                                 ]

--- a/pkg/devfile/versions/common/types.go
+++ b/pkg/devfile/versions/common/types.go
@@ -63,7 +63,7 @@ type DevfileProject struct {
 type DevfileProjectSource struct {
 	Type DevfileProjectType `yaml:"type" json:"type"`
 
-	// Project's source location address. Should be URL for git and github located projects, or file:// for zip."
+	// Project's source location address. Should be URL for git and github located projects"
 	Location string `yaml:"location" json:"location"`
 
 	// The name of the of the branch to check out after obtaining the source from the location.

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -44,7 +44,7 @@ func fakeDeploymentConfig(name string, image string, envVars []corev1.EnvVar, en
 	labels[applabels.ApplicationLabel] = name
 
 	// save source path as annotation
-	annotations := map[string]string{"app.openshift.io/vcs-uri": "./",
+	annotations := map[string]string{
 		"app.kubernetes.io/component-source-type": "local",
 	}
 
@@ -811,7 +811,6 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{
@@ -828,7 +827,6 @@ func TestUpdateDCAnnotations(t *testing.T) {
 			name:   "non existing dc",
 			dcName: "nodejs",
 			annotations: map[string]string{
-				"app.openshift.io/vcs-uri":                "file:///temp/nodejs-ex",
 				"app.kubernetes.io/component-source-type": "local",
 			},
 			existingDc: appsv1.DeploymentConfig{

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -70,9 +70,9 @@ func (lo *ListOptions) Run() (err error) {
 			machineoutput.OutputSuccess(components)
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE", "\t", "CONTEXT")
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "CONTEXT")
 			for _, file := range components.Items {
-				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Namespace, "\t", file.Spec.Type, "\t", file.Spec.Source, "\t", file.Status.State, "\t", file.Status.Context)
+				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Namespace, "\t", file.Spec.Type, "\t", file.Status.State, "\t", file.Status.Context)
 
 			}
 			w.Flush()
@@ -125,9 +125,9 @@ func (lo *ListOptions) Run() (err error) {
 			return
 		}
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCE", "\t", "STATE")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE")
 		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.Source, "\t", comp.Status.State)
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State)
 		}
 		w.Flush()
 	}

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -78,13 +77,8 @@ var _ = Describe("odo app command tests", func() {
 			appListOutput := helper.CmdShouldPass("odo", "app", "list")
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
-			var sourcePath string
-			if runtime.GOOS == "windows" {
-				sourcePath = "file:///./"
-			} else {
-				sourcePath = "file://./"
-			}
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","source":"%s","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project, sourcePath)
+
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe")

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -135,7 +135,7 @@ func componentTests(args ...string) {
 				contextPath = strings.TrimSpace(context)
 			}
 			// this orders the json
-			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","source":"./","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
+			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 
 			actual, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "list", "-o", "json", "--path", filepath.Dir(context))...))
@@ -175,11 +175,11 @@ func componentTests(args ...string) {
 			helper.DeleteDir(context2)
 			helper.DeleteProject(project2)
 			// this orders the json
-			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","source":"./","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
+			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 			// this orders the json
-			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","source":"./","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
+			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -592,13 +592,7 @@ func componentTests(args ...string) {
 
 			// check the source location and type in the deployment config
 			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
-			var sourcePath string
-			if runtime.GOOS == "windows" {
-				sourcePath = "file:///./"
-			} else {
-				sourcePath = "file://./"
-			}
-			Expect(getSourceLocation).To(ContainSubstring(sourcePath))
+			Expect(getSourceLocation).To(ContainSubstring(""))
 			getSourceType := oc.SourceTypeDC("cmp-git", "testing", project)
 			Expect(getSourceType).To(ContainSubstring("local"))
 		})
@@ -633,11 +627,7 @@ func componentTests(args ...string) {
 
 			Expect(cmpDescribe).To(ContainSubstring(cmpName))
 			Expect(cmpDescribe).To(ContainSubstring("nodejs"))
-			if runtime.GOOS == "windows" {
-				Expect(cmpDescribe).To(ContainSubstring("file:///./"))
-			} else {
-				Expect(cmpDescribe).To(ContainSubstring("file://./"))
-			}
+
 			url := helper.DetermineRouteURL(context)
 			Expect(cmpDescribe).To(ContainSubstring(url))
 
@@ -667,13 +657,8 @@ func componentTests(args ...string) {
 			Expect(cmpListOutput).To(ContainSubstring(cmpName))
 
 			actualDesCompJSON := helper.CmdShouldPass("odo", append(args, "describe", cmpName, "--app", appName, "--project", project, "-o", "json")...)
-			var sourcePath string
-			if runtime.GOOS == "windows" {
-				sourcePath = "file:///./"
-			} else {
-				sourcePath = "file://./"
-			}
-			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","source":"%s","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project, sourcePath)
+
+			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project)
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			helper.CmdShouldPass("odo", append(args, "delete", cmpName, "--app", appName, "--project", project, "-f")...)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:

Removes the annotation 'app.openshift.io/vcs-uri' for local and binary components. It also removes the 'SOURCE' column from the 'odo list' command.

**Which issue(s) this PR fixes**:

Fixes #2175 

**How to test changes / Special notes to the reviewer**:

- create a local component and check that the above mentioned annotation is not present in the DC.
- create a git component and check that the above mentioned annotation is present in the DC.
- check the source code and check if the annotation is used for only git components.
- run `odo list` with combination of all the flags (not with json flag) and check that the `SOURCE` column is not present.
- run the above steps with the json flag and check if the source is displayed only for the git components.