### PR TITLE
Rename -all flag for odo list and Update description

### DIFF
--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -33,7 +33,7 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
 	pathFlag         string
-	allFlag          bool
+	allAppsFlag      bool
 	componentContext string
 	*genericclioptions.Context
 }
@@ -51,7 +51,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	if !lo.allFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
+	if !lo.allAppsFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
 		return odoutil.ThrowContextError()
 	}
 
@@ -81,7 +81,7 @@ func (lo *ListOptions) Run() (err error) {
 	}
 	var components component.ComponentList
 
-	if lo.allFlag {
+	if lo.allAppsFlag {
 		// retrieve list of application
 		apps, err := application.List(lo.Client)
 		if err != nil {
@@ -151,7 +151,7 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	}
 	genericclioptions.AddContextFlag(componentListCmd, &o.componentContext)
 	componentListCmd.Flags().StringVar(&o.pathFlag, "path", "", "path of the directory to scan for odo component directories")
-	componentListCmd.Flags().BoolVar(&o.allFlag, "all", false, "lists all components")
+	componentListCmd.Flags().BoolVar(&o.allAppsFlag, "all-apps", false, "list all components from all applications for the current set project")
 	componentListCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--project` flag

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -201,7 +201,7 @@ func componentTests(args ...string) {
 			actualCompListJSON := helper.CmdShouldPass("odo", append(args, "list", "--project", project, "-o", "json")...)
 			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"cmp-git","namespace":"%s","creationTimestamp":null},"spec":{"app":"testing","type":"nodejs","source":"https://github.com/openshift/nodejs-ex","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
-			cmpAllList := helper.CmdShouldPass("odo", append(args, "list", "--all")...)
+			cmpAllList := helper.CmdShouldPass("odo", append(args, "list", "--all-apps")...)
 			Expect(cmpAllList).To(ContainSubstring("cmp-git"))
 			helper.CmdShouldPass("odo", append(args, "delete", "cmp-git", "-f")...)
 		})


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
the description and name for `--all` flag in `odo list` command was misleading. This PR updates it to `--all-apps`

**Which issue(s) this PR fixes**: 

Fixes #2452 

**How to test changes / Special notes to the reviewer**:
Run `odo list --help` and check for renamed flag and description
```
[adisky@localhost odo]$ odo list --help
List all components in the current application.

Usage:
  odo list [flags]

Examples:
  # List all components in the application
  odo list

Flags:
      --all-apps         List all components from all applications for the current set project
      --app string       Application, defaults to active application
      --context string   Use given context directory as a source for component settings
  -h, --help             Help for list
      --path string      Path of the directory to scan for odo component directories
      --project string   Project, defaults to active project

Additional Flags:
  -o, --o string             Specify output format, supported format: json (default "json")
  -v, --v Level              Log level for V logs. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging
```
