### PR TITLE
Update the README with corresponding languages and package managers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,16 +35,40 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 === Officially supported languages and corresponding container images
 
 .Supported container images
-[options="header"]
-|====
-|Node.js|Java
-|`centos/nodejs-8-centos7`|`redhat-openjdk-18/openjdk18-openshift`
-|`rhoar-nodejs/nodejs-8`|`openjdk/openjdk-11-rhel8`
-|`rhoar-nodejs/nodejs-10`|`openjdk/openjdk-11-rhel7`
-|`bucharestgold/centos7-s2i-nodejs`|
-|`rhscl/nodejs-8-rhel7`|
-|`rhscl/nodejs-10-rhel7`|
-|====
+[cols=",,",options="header",]
+|===
+|Language |Container Image |Supported Package Manager
+|*Node.js*
+|https://github.com/sclorg/s2i-nodejs-container[centos/nodejs-8-centos7]
+|NPM
+
+| |https://access.redhat.com/articles/3376841[rhoar-nodejs/nodejs-8]
+|NPM
+
+|
+|https://www.github.com/bucharest-gold/centos7-s2i-nodejs[bucharestgold/centos7-s2i-nodejs]
+|NPM
+
+|
+|https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-8-rhel7[rhscl/nodejs-8-rhel7]
+|NPM
+
+|
+|https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-10-rhel7[rhscl/nodejs-10-rhel7]
+|NPM
+
+|*Java*
+|https://access.redhat.com/containers/#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift[redhat-openjdk-18/openjdk18-openshift]
+|Maven, Gradle
+
+|
+|https://access.redhat.com/containers/#/registry.access.redhat.com/openjdk/openjdk-11-rhel8[openjdk/openjdk-11-rhel8]
+|Maven, Gradle
+
+|
+|https://access.redhat.com/containers/#/registry.access.redhat.com/openjdk/openjdk-11-rhel7[openjdk/openjdk-11-rhel7]
+|Maven, Gradle
+|===
 
 [id="odo-listing-available-images"]
 ==== Listing available container images


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What does does this PR do / why we need it**:

I found that I had *no idea* what package manager I could use. I would
use Yarn for Node.js and found that it wasn't enabled... Same goes with
Java as well as Ruby (although that's unsupported) with their
corresponding package managers.

This adds more details to the GitHub README with regards to what package
managers are actually supported

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2683

**How to test changes / Special notes to the reviewer**:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>