### PR TITLE
Add Unknown State to Component.

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -29,6 +29,10 @@ func ListInProject(client *occlient.Client) ([]string, error) {
 
 	var appNames []string
 
+	if client == nil {
+		return appNames, nil
+	}
+
 	// Get all DeploymentConfigs with the "app" label
 	deploymentConfigAppNames, err := client.GetDeploymentConfigLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -992,8 +992,9 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 				a.Status.Context = con
 				if client != nil {
 					a.Status.State = GetComponentState(client, data.GetName(), data.GetApplication())
+				} else {
+					a.Status.State = StateTypeUnknown
 				}
-				a.Status.State = StateTypeUnknown
 				components = append(components, a)
 			}
 			return nil

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -34,7 +34,19 @@ type ComponentList struct {
 // ComponentStatus is Status of components
 type ComponentStatus struct {
 	Context          string              `json:"context,omitempty"`
-	State            string              `json:"state"`
+	State            State               `json:"state"`
 	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
 	LinkedServices   []string            `json:"linkedServices,omitempty"`
 }
+
+// State reperesents component state
+type State string
+
+const (
+	// StateTypePushed means that Storage is present both locally and on cluster
+	StateTypePushed State = "Pushed"
+	// StateTypeNotPushed means that Storage is only in local config, but not on the cluster
+	StateTypeNotPushed = "Not Pushed"
+	// StateTypeUnknown means that odo cannot tell its state
+	StateTypeUnknown = "Unknown"
+)

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2731,11 +2731,7 @@ func (c *Client) GetDeploymentConfigFromName(name string) (*appsv1.DeploymentCon
 	glog.V(4).Infof("Getting DeploymentConfig: %s", name)
 	deploymentConfig, err := c.appsClient.DeploymentConfigs(c.Namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		if !strings.Contains(err.Error(), fmt.Sprintf(DEPLOYMENT_CONFIG_NOT_FOUND_ERROR_STR, name)) {
-			return nil, errors.Wrapf(err, "unable to get DeploymentConfig %s", name)
-		} else {
-			return nil, DEPLOYMENT_CONFIG_NOT_FOUND
-		}
+		return nil, err
 	}
 	return deploymentConfig, nil
 }

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -681,21 +681,21 @@ func (co *CreateOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		existsInCluster, err := component.Exists(co.Context.Client, *co.componentSettings.Name, co.Context.Application)
-		if err != nil {
-			return err
-		}
-		if existsInCluster {
-			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.Project)
+		state := component.GetComponentState(co.Client, *co.componentSettings.Name, co.Context.Application)
+
+		if state == component.StateTypeNotPushed || state == component.StateTypeUnknown {
+			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
+			componentDesc.Status.State = state
 			if err != nil {
 				return err
 			}
 		} else {
-			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
+			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.Project)
 			if err != nil {
 				return err
 			}
 		}
+
 		componentDesc.Spec.Ports = co.LocalConfigInfo.GetPorts()
 		machineoutput.OutputSuccess(componentDesc)
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -45,16 +46,26 @@ func NewListOptions() *ListOptions {
 
 // Complete completes log args
 func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	lo.Context = genericclioptions.NewContext(cmd)
+
+	if util.CheckKubeConfigExist() {
+		glog.V(4).Infof("New Context")
+		lo.Context = genericclioptions.NewContext(cmd)
+	} else {
+		glog.V(4).Infof("New Config Context")
+		lo.Context = genericclioptions.NewConfigContext(cmd)
+
+	}
 	return
+
 }
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	if !lo.allAppsFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
-		return odoutil.ThrowContextError()
+	if util.CheckKubeConfigExist() {
+		if !lo.allAppsFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
+			return odoutil.ThrowContextError()
+		}
 	}
-
 	return nil
 }
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -61,10 +61,20 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
-	if util.CheckKubeConfigExist() {
-		if !lo.allAppsFlag && lo.pathFlag == "" && (lo.Context.Project == "" || lo.Application == "") {
-			return odoutil.ThrowContextError()
-		}
+
+	var project, app string
+
+	if !util.CheckKubeConfigExist() {
+		project = lo.LocalConfigInfo.GetProject()
+		app = lo.LocalConfigInfo.GetApplication()
+
+	} else {
+		project = lo.Context.Project
+		app = lo.Application
+	}
+
+	if !lo.allAppsFlag && lo.pathFlag == "" && (project == "" || app == "") {
+		return odoutil.ThrowContextError()
 	}
 	return nil
 }

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -136,9 +136,10 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 	// URL
 	if componentDesc.Spec.URL != nil {
 		var output string
+
 		if !experimental.IsExperimentalModeEnabled() {
 			// if the component is not pushed
-			if componentDesc.Status.State == "Not Pushed" {
+			if componentDesc.Status.State == component.StateTypeNotPushed {
 				// Gather the output
 				for i, componentURL := range componentDesc.Spec.URL {
 					output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL, componentDesc.Spec.Ports[i])
@@ -153,6 +154,7 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 					url := urls.Get(componentURL)
 					output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, ""), url.Spec.Port)
 				}
+
 			}
 		}
 		// Cut off the last newline and output

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -766,3 +766,21 @@ func ValidateK8sResourceName(key string, value string) error {
 
 	return nil
 }
+
+// CheckKubeConfigExist checks for existence of kubeconfig
+func CheckKubeConfigExist() bool {
+
+	var kubeconfig string
+
+	if os.Getenv("KUBECONFIG") != "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	} else {
+		kubeconfig = "~/.kube/config"
+	}
+
+	if CheckPathExists(kubeconfig) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -775,7 +775,8 @@ func CheckKubeConfigExist() bool {
 	if os.Getenv("KUBECONFIG") != "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	} else {
-		kubeconfig = "~/.kube/config"
+		home, _ := os.UserHomeDir()
+		kubeconfig = fmt.Sprintf("%s/.kube/config", home)
 	}
 
 	if CheckPathExists(kubeconfig) {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -214,6 +214,17 @@ func componentTests(args ...string) {
 			Expect(cmpList).To(ContainSubstring("Not Pushed"))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
+		It("should list the state as unknown for disconnected cluster", func() {
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "MinCPU,100m")
+			kubeconfigOld := os.Getenv("KUBECONFIG")
+			os.Setenv("KUBECONFIG", "/no/such/path")
+			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context, "--v", "9")...)
+			Expect(cmpList).To(ContainSubstring("cmp-git"))
+			Expect(cmpList).To(ContainSubstring("Unknown"))
+			os.Setenv("KUBECONFIG", kubeconfigOld)
+			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
+		})
 
 		It("should describe the component when it is not pushed", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
When odo is not connected to cluster, is should list out component from local config with state `unknown`.

**Which issue(s) this PR fixes**:
Fixes #2444

**How to test changes / Special notes to the reviewer**:
Run `odo list --path <path>` on a not logged in cluster, is should return `state` of all the component to `unknown`.
```
[adisky@localhost odo]$ odo list --path ~/
APP     NAME                    PROJECT         TYPE       STATE       CONTEXT
app     frontend                new-project     nodejs     Unknown     /home/adisky/multicompapp/frontend
app     nodejs-mycmp6-fijc      default         nodejs     Unknown     /home/adisky/mycmp6
app     nodejs-myname1-gewe     ezsnxrczvt      nodejs     Unknown     /home/adisky/myname1
```

