### PR TITLE
Add support for url describe command

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -2482,6 +2482,12 @@ func (c *Client) ListRoutes(labelSelector string) ([]routev1.Route, error) {
 	return routeList.Items, nil
 }
 
+func (c *Client) GetRoute(name string) (*routev1.Route, error) {
+	route, err := c.routeClient.Routes(c.Namespace).Get(name, metav1.GetOptions{})
+	return route, err
+
+}
+
 // ListRouteNames lists all the names of the routes based on the given label
 // selector
 func (c *Client) ListRouteNames(labelSelector string) ([]string, error) {

--- a/pkg/odo/cli/url/describe.go
+++ b/pkg/odo/cli/url/describe.go
@@ -1,0 +1,107 @@
+package url
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	"github.com/openshift/odo/pkg/odo/util"
+	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/url"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	ktemplates "k8s.io/kubernetes/pkg/kubectl/util/templates"
+)
+
+// DescribeRecommendedCommandName is the recommended describe command name
+const describeRecommendedCommandName = "describe"
+
+var describeExample = ktemplates.Examples(`  # Describe a URL
+%[1]s myurl
+`)
+
+// URLListOptions encapsulates the options for the odo url list command
+type URLDescribeOptions struct {
+	localConfigInfo  *config.LocalConfigInfo
+	componentContext string
+	url              string
+	*genericclioptions.Context
+}
+
+// NewURLDescribeOptions creates a new URLCreateOptions instance
+func NewURLDescribeOptions() *URLDescribeOptions {
+	return &URLDescribeOptions{&config.LocalConfigInfo{}, "", "", &genericclioptions.Context{}}
+}
+
+// Complete completes URLDescribeOptions after they've been Listed
+func (o *URLDescribeOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.Context = genericclioptions.NewContext(cmd)
+	o.localConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
+	if err != nil {
+		return errors.Wrap(err, "failed initialize local config")
+	}
+	o.url = args[0]
+	return
+}
+
+// Validate validates the URLDescribeOptions based on completed values
+func (o *URLDescribeOptions) Validate() (err error) {
+	return util.CheckOutputFlag(o.OutputFlag)
+}
+
+// Run contains the logic for the odo url list command
+func (o *URLDescribeOptions) Run() (err error) {
+
+	u, err := url.Get(o.Client, o.localConfigInfo, o.url, o.Application)
+	if err != nil {
+		return err
+	}
+
+	if log.IsJSON() {
+		machineoutput.OutputSuccess(u)
+	} else {
+
+		tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(tabWriterURL, "NAME", "\t", "STATE", "\t", "URL", "\t", "PORT")
+
+		// are there changes between local and cluster states?
+		outOfSync := false
+		fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host), "\t", u.Spec.Port)
+		if u.Status.State != url.StateTypePushed {
+			outOfSync = true
+		}
+		tabWriterURL.Flush()
+		if outOfSync {
+			fmt.Fprintf(os.Stdout, "\n")
+			fmt.Fprintf(os.Stdout, "There are local changes. Please run 'odo push'.\n")
+		}
+	}
+
+	return
+}
+
+// NewCmdURLDescribe implements the odo url describe command.
+func NewCmdURLDescribe(name, fullName string) *cobra.Command {
+	o := NewURLDescribeOptions()
+	urlDescribeCmd := &cobra.Command{
+		Use:         name + " [url name]",
+		Short:       "Describe a URL",
+		Long:        `Describe a URL`,
+		Example:     fmt.Sprintf(describeExample, fullName),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"machineoutput": "json", "command": "url"},
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(o, cmd, args)
+		},
+	}
+	urlDescribeCmd.SetUsageTemplate(util.CmdUsageTemplate)
+	genericclioptions.AddContextFlag(urlDescribeCmd, &o.componentContext)
+	completion.RegisterCommandHandler(urlDescribeCmd, completion.URLCompletionHandler)
+	completion.RegisterCommandFlagHandler(urlDescribeCmd, "context", completion.FileCompletionHandler)
+
+	return urlDescribeCmd
+}

--- a/pkg/odo/cli/url/url.go
+++ b/pkg/odo/cli/url/url.go
@@ -24,20 +24,22 @@ func NewCmdURL(name, fullName string) *cobra.Command {
 	urlCreateCmd := NewCmdURLCreate(createRecommendedCommandName, odoutil.GetFullName(fullName, createRecommendedCommandName))
 	urlDeleteCmd := NewCmdURLDelete(deleteRecommendedCommandName, odoutil.GetFullName(fullName, deleteRecommendedCommandName))
 	urlListCmd := NewCmdURLList(listRecommendedCommandName, odoutil.GetFullName(fullName, listRecommendedCommandName))
+	urlDescribeCmd := NewCmdURLDescribe(describeRecommendedCommandName, odoutil.GetFullName(fullName, describeRecommendedCommandName))
 	urlCmd := &cobra.Command{
 		Use:   name,
 		Short: urlShortDesc,
 		Long:  urlLongDesc,
-		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s",
 			urlCreateCmd.Example,
 			urlDeleteCmd.Example,
-			urlListCmd.Example),
+			urlListCmd.Example,
+			urlDescribeCmd.Example),
 	}
 
 	// Add a defined annotation in order to appear in the help menu
 	urlCmd.Annotations = map[string]string{"command": "main"}
 	urlCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
-	urlCmd.AddCommand(urlCreateCmd, urlDeleteCmd, urlListCmd)
+	urlCmd.AddCommand(urlCreateCmd, urlDeleteCmd, urlListCmd, urlDescribeCmd)
 
 	return urlCmd
 }

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// Get returns URL defination for given URL name
+// Get returns URL definition for given URL name
 func (urls URLList) Get(urlName string) URL {
 	for _, url := range urls.Items {
 		if url.Name == urlName {
@@ -28,6 +28,45 @@ func (urls URLList) Get(urlName string) URL {
 	}
 	return URL{}
 
+}
+
+// Get returns URL definition for given URL name
+func Get(client *occlient.Client, localConfig *config.LocalConfigInfo, urlName string, applicationName string) (URL, error) {
+	remoteUrlName, err := util.NamespaceOpenShiftObject(urlName, applicationName)
+	if err != nil {
+		return URL{}, errors.Wrapf(err, "unable to create namespaced name")
+	}
+
+	// Check whether remote already created the route
+	remoteExist := true
+	route, err := client.GetRoute(remoteUrlName)
+	if err != nil {
+		remoteExist = false
+	}
+
+	localConfigURLs := localConfig.GetURL()
+	for _, configURL := range localConfigURLs {
+		localURL := ConvertConfigURL(configURL)
+		// search local URL, if it exist in local, update state with remote status
+		if localURL.Name == urlName {
+			if remoteExist {
+				localURL.Status.State = StateTypePushed
+			} else {
+				localURL.Status.State = StateTypeNotPushed
+			}
+			return localURL, nil
+		}
+	}
+
+	if err == nil && remoteExist {
+		// Remote exist, but not in local, so it's deleted status
+		clusterURL := getMachineReadableFormat(*route)
+		clusterURL.Status.State = StateTypeLocallyDeleted
+		return clusterURL, nil
+	}
+
+	// can't find the URL in local and remote
+	return URL{}, errors.New(fmt.Sprintf("the url %v does not exist", urlName))
 }
 
 // Delete deletes a URL

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -88,6 +88,28 @@ var _ = Describe("odo url command tests", func() {
 		})
 	})
 
+	Context("Describing urls", func() {
+		It("should describe appropriate URLs and push message", func() {
+			var stdout string
+			url1 := helper.RandString(5)
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
+
+			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
+			stdout = helper.CmdShouldPass("odo", "url", "describe", url1, "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
+
+			helper.CmdShouldPass("odo", "push", "--context", context)
+			stdout = helper.CmdShouldPass("odo", "url", "describe", url1, "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url1, "Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{"Not Pushed", "odo push"})
+
+			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", context)
+			stdout = helper.CmdShouldPass("odo", "url", "describe", url1, "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", url1, "odo push"})
+		})
+	})
+
 	Context("when listing urls using -o json flag", func() {
 		JustBeforeEach(func() {
 			originalDir = helper.Getwd()


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:

implemented this: I certainly can do further change on the output format, just submit 
this for some comments

```
[root@xyimgr77 frontend]# ../odo url list
Found the following URLs for component ubi-frontend-gmhz in application app:
NAME                       STATE          URL     PORT
ubi-frontend-gmhz-8080     Not Pushed     ://     8080

There are local changes. Please run 'odo push'.
[root@xyimgr77 frontend]# ../odo url describe
 ✗  url  not found
[root@xyimgr77 frontend]# ../odo url describe abc
 ✗  url abc not found
[root@xyimgr77 frontend]# ../odo url describe ubi-frontend-gmhz-8080
NAME                       STATE          URL     PORT
ubi-frontend-gmhz-8080     Not Pushed     ://     8080

There are local changes. Please run 'odo push'.
[root@xyimgr77 frontend]#

```
**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
