### PR TITLE
Upgrade apiVersion to v1 from v1alpha1

### DIFF
--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -512,7 +512,7 @@ Below is working example of how we would implement a "HelloWorld" struct.
     machineOutput := GenericSuccess{
       TypeMeta: metav1.TypeMeta{
         Kind:       "HelloWorldExample",
-        APIVersion: "odo.openshift.io/v1alpha1",
+        APIVersion: "odo.openshift.io/v1",
       }, 
       ObjectMeta: metav1.ObjectMeta{
         Name: "MyProject",

--- a/docs/dev/machine-output.adoc
+++ b/docs/dev/machine-output.adoc
@@ -170,7 +170,7 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "Application",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {
     "name": "app",
     "namespace": "myproject",
@@ -189,12 +189,12 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "List",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {},
   "items": [
     {
       "kind": "Application",
-      "apiVersion": "odo.openshift.io/v1alpha1",
+      "apiVersion": "odo.openshift.io/v1",
       "metadata": {
         "name": "app",
         "namespace": "myproject",
@@ -219,7 +219,7 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "Component",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {
     "name": "nodejs-nvnh",
     "creationTimestamp": null
@@ -247,12 +247,12 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "List",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {},
   "items": [
     {
       "kind": "Component",
-      "apiVersion": "odo.openshift.io/v1alpha1",
+      "apiVersion": "odo.openshift.io/v1",
       "metadata": {
         "name": "nodejs-nvnh",
         "creationTimestamp": null
@@ -282,12 +282,12 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "List",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {},
   "items": [
     {
       "kind": "Project",
-      "apiVersion": "odo.openshift.io/v1alpha1",
+      "apiVersion": "odo.openshift.io/v1",
       "metadata": {
         "name": "myproject",
         "creationTimestamp": null
@@ -311,7 +311,7 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "storage",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {
     "name": "mystorage",
     "creationTimestamp": null
@@ -334,7 +334,7 @@ See the below table for a list of all possible machine readable output commands:
   "items": [
     {
       "kind": "Storage",
-      "apiVersion": "odo.openshift.io/v1alpha1",
+      "apiVersion": "odo.openshift.io/v1",
       "metadata": {
         "name": "mystorage",
         "creationTimestamp": null
@@ -354,7 +354,7 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "url",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {
     "name": "foobar-8080",
     "creationTimestamp": null
@@ -373,12 +373,12 @@ See the below table for a list of all possible machine readable output commands:
 ----
 {
   "kind": "List",
-  "apiVersion": "odo.openshift.io/v1alpha1",
+  "apiVersion": "odo.openshift.io/v1",
   "metadata": {},
   "items": [
     {
       "kind": "url",
-      "apiVersion": "odo.openshift.io/v1alpha1",
+      "apiVersion": "odo.openshift.io/v1",
       "metadata": {
         "name": "foobar-8080",
         "creationTimestamp": null

--- a/docs/proposals/odo-debug.md
+++ b/docs/proposals/odo-debug.md
@@ -32,7 +32,7 @@ Odo sets up port-forwarding to allow a debugger to connect to the running proces
 
 ```yaml
 kind: LocalConfig
-apiversion: odo.openshift.io/v1alpha1
+apiversion: odo.openshift.io/v1
 ComponentSettings:
   Type: nodejs
   SourceLocation: ./
@@ -72,7 +72,7 @@ Optional flag, that controls the number of the local port. The value is not stor
 ##### The `DebugPort` is set in the LocalConfig:
 ```yaml
 kind: LocalConfig
-apiversion: odo.openshift.io/v1alpha1
+apiversion: odo.openshift.io/v1
 ComponentSettings:
   Type: nodejs
   SourceLocation: ./
@@ -89,7 +89,7 @@ ComponentSettings:
 ##### If the `DebugPort` is NOT set in the LocalConfig:
 ```yaml
 kind: LocalConfig
-apiversion: odo.openshift.io/v1alpha1
+apiversion: odo.openshift.io/v1
 ComponentSettings:
   Type: nodejs
   SourceLocation: ./

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	appAPIVersion = "odo.openshift.io/v1alpha1"
+	appAPIVersion = "odo.openshift.io/v1"
 	appKind       = "Application"
 	appList       = "List"
 )

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -164,7 +164,7 @@ func ListComponents(client *occlient.Client) (ComponentTypeList, error) {
 	return ComponentTypeList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		Items: catalogList,
 	}, nil
@@ -219,7 +219,7 @@ func ListServices(client *occlient.Client) (ServiceTypeList, error) {
 	return ServiceTypeList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		Items: clusterServiceClasses,
 	}, nil
@@ -243,7 +243,7 @@ func SearchService(client *occlient.Client, name string) (ServiceTypeList, error
 	return ServiceTypeList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		Items: result,
 	}, nil
@@ -274,7 +274,7 @@ func getClusterCatalogServices(client *occlient.Client) ([]ServiceType, error) {
 		classNames = append(classNames, ServiceType{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ServiceType",
-				APIVersion: "odo.openshift.io/v1alpha1",
+				APIVersion: "odo.openshift.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: class.Spec.ExternalName,
@@ -499,7 +499,7 @@ func getBuildersFromImageStreams(imageStreams []imagev1.ImageStream, imageStream
 			catalogImage := ComponentType{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ComponentType",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      imageStream.Name,

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1426,7 +1426,7 @@ func getMachineReadableFormat(componentName, componentType string) Component {
 	return Component{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Component",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: componentName,
@@ -1447,7 +1447,7 @@ func GetMachineReadableFormatForList(components []Component) ComponentList {
 	return ComponentList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ListMeta: metav1.ListMeta{},
 		Items:    components,

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -284,7 +284,7 @@ func TestList(t *testing.T) {
 			output: ComponentList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items: []Component{
@@ -314,7 +314,7 @@ func TestList(t *testing.T) {
 			output: ComponentList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items: []Component{
@@ -545,7 +545,7 @@ func Test_getMachineReadableFormat(t *testing.T) {
 			want: Component{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Component",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "frontend",
@@ -583,7 +583,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 					{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Component",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "frontend",
@@ -596,7 +596,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 					{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Component",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "backend",
@@ -611,14 +611,14 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 			want: ComponentList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items: []Component{
 					{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Component",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "frontend",
@@ -631,7 +631,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 					{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "Component",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "backend",
@@ -798,7 +798,7 @@ func TestUnlinkComponents(t *testing.T) {
 			componentList := ComponentList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items:    tt.childComponents,
@@ -866,7 +866,7 @@ func getFakeComponent(compName, namespace, appName, compType string, state State
 	return Component{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Component",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      compName,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ const (
 	localConfigEnvName    = "LOCALODOCONFIG"
 	configFileName        = "config.yaml"
 	localConfigKind       = "LocalConfig"
-	localConfigAPIVersion = "odo.openshift.io/v1alpha1"
+	localConfigAPIVersion = "odo.openshift.io/v1"
 	// DefaultDebugPort is the default port used for debugging on remote pod
 	DefaultDebugPort = 5858
 )

--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -13,7 +13,7 @@ import (
 const Kind = "Error"
 
 // APIVersion is the current API version we are using
-const APIVersion = "odo.openshift.io/v1alpha1"
+const APIVersion = "odo.openshift.io/v1"
 
 // GenericError for machine readable output error messages
 type GenericError struct {

--- a/pkg/odo/cli/catalog/util/util_test.go
+++ b/pkg/odo/cli/catalog/util/util_test.go
@@ -29,7 +29,7 @@ func TestFilterHiddenServices(t *testing.T) {
 			input: catalog.ServiceTypeList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foobar",
@@ -72,7 +72,7 @@ func TestFilterHiddenServices(t *testing.T) {
 			expected: catalog.ServiceTypeList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foobar",

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -19,7 +19,7 @@ const (
 	GlobalConfigEnvName  = "GLOBALODOCONFIG"
 	configFileName       = "preference.yaml"
 	preferenceKind       = "Preference"
-	preferenceAPIVersion = "odo.openshift.io/v1alpha1"
+	preferenceAPIVersion = "odo.openshift.io/v1"
 
 	//DefaultTimeout for openshift server connection check (in seconds)
 	DefaultTimeout = 1

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -98,7 +98,7 @@ func GetMachineReadableFormat(projectName string, isActive bool) Project {
 	return Project{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Project",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      projectName,
@@ -117,7 +117,7 @@ func MachineReadableSuccessOutput(projectName string, message string) {
 	machineOutput := machineoutput.GenericSuccess{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Project",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      projectName,
@@ -134,7 +134,7 @@ func getMachineReadableFormatForList(projects []Project) ProjectList {
 	return ProjectList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ListMeta: metav1.ListMeta{},
 		Items:    projects,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -144,7 +144,7 @@ func List(client *occlient.Client, applicationName string) (ServiceList, error) 
 			Service{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Service",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: elem.Labels[componentlabels.ComponentLabel],
@@ -157,7 +157,7 @@ func List(client *occlient.Client, applicationName string) (ServiceList, error) 
 	return ServiceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceList",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		Items: services,
 	}, nil
@@ -213,7 +213,7 @@ func ListWithDetailedStatus(client *occlient.Client, applicationName string) (Se
 	return ServiceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceList",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		Items: services.Items,
 	}, nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -393,7 +393,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 				Service{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Service",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mysql-persistent",
@@ -409,7 +409,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 				Service{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Service",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "postgresql-ephemeral",
@@ -425,7 +425,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 				Service{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Service",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mongodb",
@@ -441,7 +441,7 @@ func TestListWithDetailedStatus(t *testing.T) {
 				Service{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Service",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "jenkins-persistent",

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -442,7 +442,7 @@ func GetMachineReadableFormatForList(storage []Storage) StorageList {
 	return StorageList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ListMeta: metav1.ListMeta{},
 		Items:    storage,
@@ -453,7 +453,7 @@ func GetMachineReadableFormatForList(storage []Storage) StorageList {
 // storagePath indicates the path to which the storage is mounted to, "" if not mounted
 func GetMachineReadableFormat(storageName, storageSize, storagePath string) Storage {
 	return Storage{
-		TypeMeta:   metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1alpha1"},
+		TypeMeta:   metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: storageName},
 		Spec: StorageSpec{
 			Size: storageSize,

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -89,7 +89,7 @@ func TestGetMachineReadableFormat(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pvc-example",
 				},
-				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1alpha1"},
+				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1"},
 				Spec: StorageSpec{
 					Size: "100Mi",
 					Path: "data",
@@ -106,7 +106,7 @@ func TestGetMachineReadableFormat(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pvc-example",
 				},
-				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1alpha1"},
+				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.openshift.io/v1"},
 				Spec: StorageSpec{
 					Size: "500Mi",
 					Path: "",
@@ -140,7 +140,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "List",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					Spec: StorageSpec{
 						Size: "100Mi",
@@ -151,7 +151,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 			want: StorageList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items: []Storage{
@@ -161,7 +161,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "List",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						Spec: StorageSpec{
 							Size: "100Mi",
@@ -180,7 +180,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "List",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					Spec: StorageSpec{
 						Size: "100Mi",
@@ -193,7 +193,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "List",
-						APIVersion: "odo.openshift.io/v1alpha1",
+						APIVersion: "odo.openshift.io/v1",
 					},
 					Spec: StorageSpec{
 						Size: "500Mi",
@@ -204,7 +204,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 			want: StorageList{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
-					APIVersion: "odo.openshift.io/v1alpha1",
+					APIVersion: "odo.openshift.io/v1",
 				},
 				ListMeta: metav1.ListMeta{},
 				Items: []Storage{
@@ -214,7 +214,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "List",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						Spec: StorageSpec{
 							Size: "100Mi",
@@ -227,7 +227,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "List",
-							APIVersion: "odo.openshift.io/v1alpha1",
+							APIVersion: "odo.openshift.io/v1",
 						},
 						Spec: StorageSpec{
 							Size: "500Mi",

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -383,7 +383,7 @@ func ConvertConfigURL(configURL config.ConfigURL) URL {
 	return URL{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "url",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configURL.Name,
@@ -485,7 +485,7 @@ func GetValidExposedPortNumber(exposedPort int) (int, error) {
 // getMachineReadableFormat gives machine readable URL definition
 func getMachineReadableFormat(r routev1.Route) URL {
 	return URL{
-		TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.openshift.io/v1alpha1"},
+		TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.openshift.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: r.Labels[urlLabels.URLLabel]},
 		Spec:       URLSpec{Host: r.Spec.Host, Port: r.Spec.Port.TargetPort.IntValue(), Protocol: GetProtocol(r, iextensionsv1.Ingress{}, experimental.IsExperimentalModeEnabled()), Secure: r.Spec.TLS != nil},
 	}
@@ -496,7 +496,7 @@ func getMachineReadableFormatForList(urls []URL) URLList {
 	return URLList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "List",
-			APIVersion: "odo.openshift.io/v1alpha1",
+			APIVersion: "odo.openshift.io/v1",
 		},
 		ListMeta: metav1.ListMeta{},
 		Items:    urls,

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -51,7 +51,7 @@ var _ = Describe("odo app command tests", func() {
 			appList := helper.CmdShouldPass("odo", "app", "list", "--project", project)
 			Expect(appList).To(ContainSubstring("There are no applications deployed"))
 			actual := helper.CmdShouldPass("odo", "app", "list", "-o", "json", "--project", project)
-			desired := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
+			desired := `{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[]}`
 			Expect(desired).Should(MatchJSON(actual))
 
 			appDelete := helper.CmdShouldFail("odo", "app", "delete", "test", "--project", project, "-f")
@@ -78,11 +78,11 @@ var _ = Describe("odo app command tests", func() {
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
 
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe")
-			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{}}`, project)
+			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1","metadata":{"name":"myapp","namespace":"%s","creationTimestamp":null},"spec":{}}`, project)
 			actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", "myapp", "-o", "json")
 			Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 
@@ -113,12 +113,12 @@ var _ = Describe("odo app command tests", func() {
 			appListOutput := helper.CmdShouldPass("odo", "app", "list", "--project", project)
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "app", "list", "-o", "json", "--project", project)
-			//desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[]}`
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}]}`, project, cmpName)
+			//desiredCompListJSON := `{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[]}`
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"Application","apiVersion":"odo.openshift.io/v1","metadata":{"name":"app","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}]}`, project, cmpName)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project)
-			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}`, appName, project, cmpName)
+			desiredDesAppJSON := fmt.Sprintf(`{"kind":"Application","apiVersion":"odo.openshift.io/v1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"spec":{"components":["%s"]}}`, appName, project, cmpName)
 			actualDesAppJSON := helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project, "-o", "json")
 			Expect(desiredDesAppJSON).Should(MatchJSON(actualDesAppJSON))
 

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -130,11 +130,11 @@ var _ = Describe("odo storage command tests", func() {
 			helper.CopyExample(filepath.Join("source", "wildfly"), context)
 			helper.CmdShouldPass("odo", "component", "create", "wildfly", "wildfly", "--app", "wildflyapp", "--project", project, "--context", context)
 			actualJSONStorage := helper.CmdShouldPass("odo", "storage", "create", "mystorage", "--path=/opt/app-root/src/storage/", "--size=1Gi", "--context", context, "-o", "json")
-			desiredJSONStorage := `{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi","path":"/opt/app-root/src/storage/"}}`
+			desiredJSONStorage := `{"kind":"storage","apiVersion":"odo.openshift.io/v1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi","path":"/opt/app-root/src/storage/"}}`
 			Expect(desiredJSONStorage).Should(MatchJSON(actualJSONStorage))
 
 			actualStorageList := helper.CmdShouldPass("odo", "storage", "list", "--context", context, "-o", "json")
-			desiredStorageList := `{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"storage","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi","path":"/opt/app-root/src/storage/"},"status":"Not Pushed"}]}`
+			desiredStorageList := `{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"storage","apiVersion":"odo.openshift.io/v1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi","path":"/opt/app-root/src/storage/"},"status":"Not Pushed"}]}`
 			Expect(desiredStorageList).Should(MatchJSON(actualStorageList))
 
 			helper.CmdShouldPass("odo", "storage", "delete", "mystorage", "--context", context, "-f")

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -131,7 +131,7 @@ var _ = Describe("odo url command tests", func() {
 			actualURLListJSON := helper.CmdShouldPass("odo", "url", "list", "-o", "json")
 			fullURLPath := helper.DetermineRouteURL("")
 			pathNoHTTP := strings.Split(fullURLPath, "//")[1]
-			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"http","port":8080,"secure":false},"status":{"state": "Pushed"}}]}`, pathNoHTTP)
+			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"http","port":8080,"secure":false},"status":{"state": "Pushed"}}]}`, pathNoHTTP)
 			Expect(desiredURLListJSON).Should(MatchJSON(actualURLListJSON))
 		})
 
@@ -144,7 +144,7 @@ var _ = Describe("odo url command tests", func() {
 			actualURLListJSON := helper.CmdShouldPass("odo", "url", "list", "-o", "json")
 			fullURLPath := helper.DetermineRouteURL("")
 			pathNoHTTP := strings.Split(fullURLPath, "//")[1]
-			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"https","port":8080,"secure":true},"status":{"state": "Pushed"}}]}`, pathNoHTTP)
+			desiredURLListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.openshift.io/v1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"host":"%s","protocol":"https","port":8080,"secure":true},"status":{"state": "Pushed"}}]}`, pathNoHTTP)
 			Expect(desiredURLListJSON).Should(MatchJSON(actualURLListJSON))
 		})
 	})

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -135,7 +135,7 @@ func componentTests(args ...string) {
 				contextPath = strings.TrimSpace(context)
 			}
 			// this orders the json
-			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
+			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 
 			actual, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "list", "-o", "json", "--path", filepath.Dir(context))...))
@@ -175,11 +175,11 @@ func componentTests(args ...string) {
 			helper.DeleteDir(context2)
 			helper.DeleteProject(project2)
 			// this orders the json
-			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
+			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 			// this orders the json
-			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
+			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 
@@ -199,7 +199,7 @@ func componentTests(args ...string) {
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--project", project)...)
 			Expect(cmpList).To(ContainSubstring("cmp-git"))
 			actualCompListJSON := helper.CmdShouldPass("odo", append(args, "list", "--project", project, "-o", "json")...)
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"cmp-git","namespace":"%s","creationTimestamp":null},"spec":{"app":"testing","type":"nodejs","source":"https://github.com/openshift/nodejs-ex","sourceType": "git","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"cmp-git","namespace":"%s","creationTimestamp":null},"spec":{"app":"testing","type":"nodejs","source":"https://github.com/openshift/nodejs-ex","sourceType": "git","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 			cmpAllList := helper.CmdShouldPass("odo", append(args, "list", "--all-apps")...)
 			Expect(cmpAllList).To(ContainSubstring("cmp-git"))
@@ -249,7 +249,7 @@ func componentTests(args ...string) {
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1", "url-2"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1", "url-2"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 
@@ -264,7 +264,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","sourceType": "local","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","sourceType": "local","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -274,7 +274,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","sourceType": "local","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","sourceType": "local","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -702,7 +702,7 @@ func componentTests(args ...string) {
 
 			actualDesCompJSON := helper.CmdShouldPass("odo", append(args, "describe", cmpName, "--app", appName, "--project", project, "-o", "json")...)
 
-			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project)
+			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project)
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			helper.CmdShouldPass("odo", append(args, "delete", cmpName, "--app", appName, "--project", project, "-f")...)

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -80,7 +80,7 @@ var _ = Describe("odo generic", func() {
 		// odo project create foobar -o json
 		It("should be able to create project and show output in json format", func() {
 			actual := helper.CmdShouldPass("odo", "project", "create", projectName, "-o", "json")
-			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Project '%s' is ready for use"}`, projectName, projectName, projectName)
+			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Project '%s' is ready for use"}`, projectName, projectName, projectName)
 			Expect(desired).Should(MatchJSON(actual))
 		})
 	})
@@ -97,7 +97,7 @@ var _ = Describe("odo generic", func() {
 		It("should fail along with proper machine readable output", func() {
 			helper.CmdShouldPass("odo", "project", "create", projectName)
 			actual := helper.CmdShouldFail("odo", "project", "create", projectName, "-o", "json")
-			desired := fmt.Sprintf(`{"kind":"Error","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"creationTimestamp":null},"message":"unable to create new project: unable to create new project %s: project.project.openshift.io \"%s\" already exists"}`, projectName, projectName)
+			desired := fmt.Sprintf(`{"kind":"Error","apiVersion":"odo.openshift.io/v1","metadata":{"creationTimestamp":null},"message":"unable to create new project: unable to create new project %s: project.project.openshift.io \"%s\" already exists"}`, projectName, projectName)
 			Expect(desired).Should(MatchJSON(actual))
 		})
 	})
@@ -113,7 +113,7 @@ var _ = Describe("odo generic", func() {
 			helper.CmdShouldPass("odo", "project", "create", projectName, "-o", "json")
 
 			actual := helper.CmdShouldPass("odo", "project", "delete", projectName, "-o", "json")
-			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Deleted project : %s"}`, projectName, projectName, projectName)
+			desired := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1","metadata":{"name":"%s","namespace":"%s","creationTimestamp":null},"message":"Deleted project : %s"}`, projectName, projectName, projectName)
 			Expect(desired).Should(MatchJSON(actual))
 		})
 	})
@@ -132,7 +132,7 @@ var _ = Describe("odo generic", func() {
 		})
 		It("should be able to return project list", func() {
 			actualProjectListJSON := helper.CmdShouldPass("odo", "project", "list", "-o", "json")
-			partOfProjectListJSON := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"%s","creationTimestamp":null},`, project)
+			partOfProjectListJSON := fmt.Sprintf(`{"kind":"Project","apiVersion":"odo.openshift.io/v1","metadata":{"name":"%s","creationTimestamp":null},`, project)
 			Expect(actualProjectListJSON).To(ContainSubstring(partOfProjectListJSON))
 		})
 	})*/

--- a/tests/integration/project/cmd_project_test.go
+++ b/tests/integration/project/cmd_project_test.go
@@ -57,7 +57,7 @@ var _ = Describe("odo project command tests", func() {
 
 			// project deletion doesn't happen immediately and older projects still might exist
 			// so we test subset of the string
-			expected, err := helper.Unindented(`{"kind":"Project","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"` + project + `","namespace":"` + project + `","creationTimestamp":null},"spec":{},"status":{"active":true}}`)
+			expected, err := helper.Unindented(`{"kind":"Project","apiVersion":"odo.openshift.io/v1","metadata":{"name":"` + project + `","namespace":"` + project + `","creationTimestamp":null},"spec":{},"status":{"active":true}}`)
 			Expect(err).Should(BeNil())
 
 			helper.WaitForCmdOut("odo", []string{"project", "list", "-o", "json"}, 1, true, func(output string) bool {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind api-change

**What does does this PR do / why we need it**:

We reached 1.0.0 a while ago! We can consider this apiVersion to be v1
now and obviously new features / changes to be alpha.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2490

**How to test changes / Special notes to the reviewer**:

N/A, just run tests or deploy a component

Signed-off-by: Charlie Drage <charlie@charliedrage.com>