### PR TITLE
Update CheckForExistence to get right resource

### DIFF
--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -432,7 +432,7 @@ func (oc *OcRunner) WaitForDCRollout(dcName string, project string, timeout time
 
 // CheckForExistence checks if the given resource exists on the cluster
 func (oc *OcRunner) CheckForExistence(resourceName, namespace string) {
-	session := CmdRunner(oc.path, "get", "routes", "--namespace", namespace)
+	session := CmdRunner(oc.path, "get", resourceName, "--namespace", namespace)
 	Eventually(session).Should(gexec.Exit(0))
 	output := string(session.Wait().Out.Contents())
 	Expect(output).To(ContainSubstring(""))

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -430,9 +430,9 @@ func (oc *OcRunner) WaitForDCRollout(dcName string, project string, timeout time
 	session.Wait(timeout)
 }
 
-// CheckForExistence checks if the given resource exists on the cluster
-func (oc *OcRunner) CheckForExistence(resourceName, namespace string) {
-	session := CmdRunner(oc.path, "get", resourceName, "--namespace", namespace)
+// CheckForExistence checks if the given resource type exists on the cluster
+func (oc *OcRunner) CheckForExistence(resourceType, namespace string) {
+	session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
 	Eventually(session).Should(gexec.Exit(0))
 	output := string(session.Wait().Out.Contents())
 	Expect(output).To(ContainSubstring(""))


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind cleanup


**What does does this PR do / why we need it**:
I was poking through the integration test code and saw that `CheckForExistence` in `test/helper/helper_oc.go` doesn't actually work as intended:
https://github.com/openshift/odo/blob/9b3c652fdf9b155273c06909165fa5dc48d9e858/tests/helper/helper_oc.go#L434-L439

This PR updates `CheckForExistence` so that it uses the passed in resource type, rather than just routes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openshift/odo/issues/2697

