### PR TITLE
add app and project in the create service equivalent command template

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -25,6 +25,8 @@ const (
 	createRecommendedCommandName = "create"
 	equivalentTemplate           = "{{.CmdFullName}} {{.ServiceType}}" +
 		"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
+		" --app {{.Application}}" +
+		" --project {{.Project}}" +
 		"{{if .Plan}} --plan {{.Plan}}{{end}}" +
 		"{{range $key, $value := .ParametersMap}} -p {{$key}}={{$value}}{{end}}"
 )

--- a/pkg/odo/cli/service/create_test.go
+++ b/pkg/odo/cli/service/create_test.go
@@ -2,10 +2,15 @@ package service
 
 import (
 	"testing"
+
+	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
 )
 
 func TestOutputNonInteractiveEquivalent(t *testing.T) {
 	t.Parallel()
+
+	client, _ := occlient.FakeNew()
 
 	tests := []struct {
 		name     string
@@ -15,6 +20,8 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "when output is not requested, should return empty string",
 			options: ServiceCreateOptions{
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
+
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   false,
 				ServiceType: "foo",
@@ -24,66 +31,76 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "just service class",
 			options: ServiceCreateOptions{
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
+
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
 				ServiceType: "foo",
 			},
-			expected: RecommendedCommandName + " foo",
+			expected: RecommendedCommandName + " foo --app app --project testproject",
 		},
 		{
 			name: "just service class and name",
 			options: ServiceCreateOptions{
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
+
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
 				ServiceType: "foo",
 				ServiceName: "myservice",
 			},
-			expected: RecommendedCommandName + " foo myservice",
+			expected: RecommendedCommandName + " foo myservice --app app --project testproject",
 		},
 		{
 			name: "service class, name and plan",
 			options: ServiceCreateOptions{
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
+
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
 				ServiceType: "foo",
 				ServiceName: "myservice",
 				Plan:        "dev",
 			},
-			expected: RecommendedCommandName + " foo myservice --plan dev",
+			expected: RecommendedCommandName + " foo myservice --app app --project testproject --plan dev",
 		},
 		{
 			name: "service class and plan",
 			options: ServiceCreateOptions{
+				Context:     genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
 				ServiceType: "foo",
 				Plan:        "dev",
 			},
-			expected: RecommendedCommandName + " foo --plan dev",
+			expected: RecommendedCommandName + " foo --app app --project testproject --plan dev",
 		},
 		{
 			name: "service class and empty params",
 			options: ServiceCreateOptions{
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",
 				ParametersMap: map[string]string{},
 			},
-			expected: RecommendedCommandName + " foo",
+			expected: RecommendedCommandName + " foo --app app --project testproject",
 		},
 		{
 			name: "service class and params",
 			options: ServiceCreateOptions{
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",
 				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
 			},
-			expected: RecommendedCommandName + " foo -p param1=value1 -p param2=value2",
+			expected: RecommendedCommandName + " foo --app app --project testproject -p param1=value1 -p param2=value2",
 		},
 		{
 			name: "all",
 			options: ServiceCreateOptions{
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",
@@ -91,7 +108,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 				Plan:          "plan",
 				ParametersMap: map[string]string{"param1": "value1", "param2": "value2"},
 			},
-			expected: RecommendedCommandName + " foo name --plan plan -p param1=value1 -p param2=value2",
+			expected: RecommendedCommandName + " foo name --app app --project testproject --plan plan -p param1=value1 -p param2=value2",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2696

**How to test changes / Special notes to the reviewer**:
Create a service and check the equivalent command 
```
$ odo service create --app test 
? Which kind of service do you wish to create database
? Which database service class should we use  [Use arrows to move, type to filter]
  dh-mssql-apb
  dh-mysql-apb
  dh-postgresql-apb
> mariadb-persistent
? Which database service class should we use mariadb-persistent
? Enter a value for string property DATABASE_SERVICE_NAME (Database Service Name): mariadb
? Enter a value for string property MARIADB_VERSION (Version of MariaDB Image): 10.2
? Enter a value for string property MEMORY_LIMIT (Memory Limit): 512Mi
? Enter a value for string property MYSQL_DATABASE (MariaDB Database Name): sampledb
? Enter a value for string property VOLUME_CAPACITY (Volume Capacity): 1Gi
? Provide values for non-required properties No
? How should we name your service  mariadb-persistent
? Output the non-interactive version of the selected options Yes
? Wait for the service to be ready No
Deploying service mariadb-persistent of type: mariadb-persistent
 ✓  Deploying service [29ms]
 ✓  Service 'mariadb-persistent' was created

Progress of the provisioning will not be reported and might take a long time
You can see the current status by executing 'odo service list'
Optionally, link mariadb-persistent to your component by running: 'odo link <component-name>'
Equivalent command:
odo service create mariadb-persistent mariadb-persistent --app test --project testproject --plan default -p DATABASE_SERVICE_NAME=mariadb -p MARIADB_VERSION=10.2 -p MEMORY_LIMIT=512Mi -p MYSQL_DATABASE=sampledb -p VOLUME_CAPACITY=1Gi

```
It should have app and project flags