### PR TITLE
update supported image list and use the updated bootstrap image for CI

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -364,6 +364,7 @@ func SliceSupportedTags(component ComponentType) ([]string, []string) {
 	// this makes sure that json marshal shows these lists as [] instead of null
 	supTag, unSupTag := []string{}, []string{}
 	tagMap := createImageTagMap(component.Spec.ImageStreamRef.Spec.Tags)
+
 	for _, tag := range component.Spec.NonHiddenTags {
 		imageName := tagMap[tag]
 		if isSupportedImage(imageName) {
@@ -378,7 +379,6 @@ func SliceSupportedTags(component ComponentType) ([]string, []string) {
 // IsComponentTypeSupported takes the componentType e.g. java:8 and return true if
 // it is fully supported i.e. debug mode and more.
 func IsComponentTypeSupported(client *occlient.Client, componentType string) (bool, error) {
-
 	_, componentType, _, componentVersion := util.ParseComponentImageName(componentType)
 
 	imageStream, err := client.GetImageStream("", componentType, componentVersion)
@@ -386,6 +386,7 @@ func IsComponentTypeSupported(client *occlient.Client, componentType string) (bo
 		return false, err
 	}
 	tagMap := createImageTagMap(imageStream.Spec.Tags)
+
 	return isSupportedImage(tagMap[componentVersion]), nil
 }
 
@@ -429,12 +430,12 @@ func isSupportedImage(imgName string) bool {
 		"redhat-openjdk-18/openjdk18-openshift:latest",
 		"openjdk/openjdk-11-rhel8:latest",
 		"openjdk/openjdk-11-rhel7:latest",
-		"centos/nodejs-10-centos7",
-		"centos/nodejs-12-centos7",
-		"rhscl/nodejs-10-rhel7",
-		"rhscl/nodejs-12-rhel7",
-		"bucharestgold/centos7-s2i-nodejs",
-		"nodeshift/centos7-s2i-nodejs",
+		"centos/nodejs-10-centos7:latest",
+		"centos/nodejs-12-centos7:latest",
+		"rhscl/nodejs-10-rhel7:latest",
+		"rhscl/nodejs-12-rhel7:latest",
+		"bucharestgold/centos7-s2i-nodejs:latest",
+		"nodeshift/centos7-s2i-nodejs:latest",
 	}
 	for _, supImage := range supportedImages {
 		if supImage == imgName {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -429,13 +429,12 @@ func isSupportedImage(imgName string) bool {
 		"redhat-openjdk-18/openjdk18-openshift:latest",
 		"openjdk/openjdk-11-rhel8:latest",
 		"openjdk/openjdk-11-rhel7:latest",
-		"rhscl/nodejs-8-rhel7:latest",
-		"rhscl/nodejs-10-rhel7:latest",
-		"rhoar-nodejs/nodejs-8:latest",
-		"rhoar-nodejs/nodejs-10:latest",
-		"bucharestgold/centos7-s2i-nodejs:8.x",
-		"bucharestgold/centos7-s2i-nodejs:10.x",
-		"centos/nodejs-8-centos7:latest",
+		"centos/nodejs-10-centos7",
+		"centos/nodejs-12-centos7",
+		"rhscl/nodejs-10-rhel7",
+		"rhscl/nodejs-12-rhel7",
+		"bucharestgold/centos7-s2i-nodejs",
+		"nodeshift/centos7-s2i-nodejs",
 	}
 	for _, supImage := range supportedImages {
 		if supImage == imgName {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -436,6 +436,14 @@ func isSupportedImage(imgName string) bool {
 		"rhscl/nodejs-12-rhel7:latest",
 		"bucharestgold/centos7-s2i-nodejs:latest",
 		"nodeshift/centos7-s2i-nodejs:latest",
+
+		// older images which we should remove soon
+		"rhoar-nodejs/nodejs-8:latest",
+		"rhoar-nodejs/nodejs-10:latest",
+		"bucharestgold/centos7-s2i-nodejs:8.x",
+		"bucharestgold/centos7-s2i-nodejs:10.x",
+		"centos/nodejs-8-centos7:latest",
+		"rhscl/nodejs-8-rhel7:latest",
 	}
 	for _, supImage := range supportedImages {
 		if supImage == imgName {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -154,7 +154,7 @@ func TestSliceSupportedTags(t *testing.T) {
 		},
 		Spec: ComponentSpec{
 			NonHiddenTags: []string{
-				"10", "8", "6", "latest",
+				"12", "10", "8", "latest",
 			},
 			ImageStreamRef: *imageStream,
 		},
@@ -162,8 +162,8 @@ func TestSliceSupportedTags(t *testing.T) {
 
 	supTags, unSupTags := SliceSupportedTags(img)
 
-	if !reflect.DeepEqual(supTags, []string{"10", "8", "latest"}) ||
-		!reflect.DeepEqual(unSupTags, []string{"6"}) {
+	if !reflect.DeepEqual(supTags, []string{"12", "10", "latest"}) ||
+		!reflect.DeepEqual(unSupTags, []string{"8"}) {
 		t.Fatal("supported or unsupported tags are not as expected")
 	}
 }
@@ -460,9 +460,9 @@ func TestIsDevfileComponentSupported(t *testing.T) {
 func MockImageStream() *imagev1.ImageStream {
 
 	tags := map[string]string{
-		"10": "docker.io/rhoar-nodejs/nodejs-10",
-		"8":  "docker.io/rhoar-nodejs/nodejs-8",
-		"6":  "docker.io/centos/nodejs-6-centos7:latest",
+		"12": "docker.io/rhscl/nodejs-12-rhel7:latest",
+		"10": "docker.io/rhscl/nodejs-10-rhel7:latest",
+		"8":  "docker.io/rhoar-nodejs/nodejs-8:latest",
 	}
 
 	imageStream := &imagev1.ImageStream{
@@ -490,7 +490,7 @@ func MockImageStream() *imagev1.ImageStream {
 			Annotations: map[string]string{"tags": "builder"},
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamTag",
-				Name: "10",
+				Name: "12",
 			},
 		})
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -154,7 +154,7 @@ func TestSliceSupportedTags(t *testing.T) {
 		},
 		Spec: ComponentSpec{
 			NonHiddenTags: []string{
-				"12", "10", "8", "latest",
+				"12", "10", "8", "6", "latest",
 			},
 			ImageStreamRef: *imageStream,
 		},
@@ -162,8 +162,8 @@ func TestSliceSupportedTags(t *testing.T) {
 
 	supTags, unSupTags := SliceSupportedTags(img)
 
-	if !reflect.DeepEqual(supTags, []string{"12", "10", "latest"}) ||
-		!reflect.DeepEqual(unSupTags, []string{"8"}) {
+	if !reflect.DeepEqual(supTags, []string{"12", "10", "8", "latest"}) ||
+		!reflect.DeepEqual(unSupTags, []string{"6"}) {
 		t.Fatal("supported or unsupported tags are not as expected")
 	}
 }
@@ -463,6 +463,8 @@ func MockImageStream() *imagev1.ImageStream {
 		"12": "docker.io/rhscl/nodejs-12-rhel7:latest",
 		"10": "docker.io/rhscl/nodejs-10-rhel7:latest",
 		"8":  "docker.io/rhoar-nodejs/nodejs-8:latest",
+		// an unspported one
+		"6": "docker.io/rhoar-nodejs/nodejs-6:latest",
 	}
 
 	imageStream := &imagev1.ImageStream{

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -170,9 +170,12 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 
+<<<<<<< HEAD
 		It("Should be able to verify the nodejs-8-centos7 image", func() {
 			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
+=======
+>>>>>>> removed unsupported nodejs-8 and 10 images
 	})
 })

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -170,12 +170,9 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 
-<<<<<<< HEAD
 		It("Should be able to verify the nodejs-8-centos7 image", func() {
 			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
-=======
->>>>>>> removed unsupported nodejs-8 and 10 images
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature

> /kind flake
> /kind code-refactoring

**What does does this PR do / why we need it**:
init-image PR related to this https://github.com/openshift/odo-init-image/pull/50
update supported image list and use the updated bootstrap image for CI ( this needs to be reversed ) and also removed unsupported nodejs tests

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2603
Fixes https://github.com/openshift/odo/issues/2640
Fixes https://github.com/openshift/odo/issues/2647
Fixes https://github.com/openshift/odo/issues/2664
Fixes https://github.com/openshift/odo/issues/2639 (as per @mik-dass confirmation in the comments )
Fixes https://github.com/openshift/odo/issues/2663 ( as per @mik-dass confirmation in the comments )

**How to test changes / Special notes to the reviewer**:
Try smart push and debug scenarios on 4.4 cluster