### PR TITLE
Wait for component deletion, Add `--wait` flag to `odo delete`

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -87,7 +87,7 @@ func Delete(client *occlient.Client, name string) error {
 		}
 	}
 	// delete application from cluster
-	err = client.Delete(labels)
+	err := client.Delete(labels, false)
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -87,7 +87,7 @@ func Delete(client *occlient.Client, name string) error {
 		}
 	}
 	// delete application from cluster
-	err := client.Delete(labels, false)
+	err = client.Delete(labels, false)
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete application %s", name)
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -270,14 +270,14 @@ func CreateFromPath(client *occlient.Client, params occlient.CreateArgs) error {
 }
 
 // Delete whole component
-func Delete(client *occlient.Client, componentName string, applicationName string) error {
+func Delete(client *occlient.Client, wait bool, componentName, applicationName string) error {
 
 	// Loading spinner
 	s := log.Spinnerf("Deleting component %s", componentName)
 	defer s.End(false)
 
 	labels := componentlabels.GetLabels(componentName, applicationName, false)
-	err := client.Delete(labels)
+	err := client.Delete(labels, wait)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting component %s", componentName)
 	}

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"fmt"
+
 	odoUtil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/application"

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -2,9 +2,10 @@ package component
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
-	"path/filepath"
 
 	"github.com/openshift/odo/pkg/util"
 
@@ -36,6 +37,7 @@ var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'.
 type DeleteOptions struct {
 	componentForceDeleteFlag bool
 	componentDeleteAllFlag   bool
+	componentDeleteWaitFlag  bool
 	componentContext         string
 	isCmpExists              bool
 	*ComponentOptions
@@ -48,7 +50,7 @@ type DeleteOptions struct {
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, "", false, &ComponentOptions{}, "", "", nil}
+	return &DeleteOptions{false, false, false, "", false, &ComponentOptions{}, "", "", nil}
 }
 
 // Complete completes log args
@@ -171,7 +173,7 @@ func (do *DeleteOptions) Run() (err error) {
 					log.Successf(fmt.Sprintf("Unlinked component %q from component %q for secret %q", parentComponent.Name, component, secretName))
 				}
 			}
-			err = component.Delete(do.Client, do.componentName, do.Application)
+			err = component.Delete(do.Client, do.componentDeleteWaitFlag, do.componentName, do.Application)
 			if err != nil {
 				return err
 			}
@@ -235,6 +237,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 
 	componentDeleteCmd.Flags().BoolVarP(&do.componentForceDeleteFlag, "force", "f", false, "Delete component without prompting")
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteAllFlag, "all", "a", false, "Delete component and local config")
+	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteWaitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
 
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -481,3 +481,11 @@ func (oc *OcRunner) GetServices(namespace string) string {
 	output := string(session.Wait().Out.Contents())
 	return output
 }
+
+// VerifyResourceDeleted verifies if the given resource is deleted from cluster
+func (oc *OcRunner) VerifyResourceDeleted(resourceType, resourceName, namespace string) {
+	session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
+	Eventually(session).Should(gexec.Exit(0))
+	output := string(session.Wait().Out.Contents())
+	Expect(output).NotTo(ContainSubstring(resourceName))
+}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -835,13 +835,14 @@ func componentTests(args ...string) {
 		It("should delete the component and the owned resources", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
-			helper.CmdShouldPass("odo", "url", "create", "example", "--context", context)
-			helper.CmdShouldPass("odo", "storage", "create", "storage-name", "--size", "1Gi", "--path", "/data", "--context", context)
-			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName, "URL,0,Name,example")
+			helper.CmdShouldPass("odo", "url", "create", "example-1", "--context", context)
+
+			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName, "URL,0,Name,example-1")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
-			helper.CmdShouldPass("odo", "url", "create", "example-1", "--context", context)
-			helper.CmdShouldPass("odo", "storage", "create", "storage-name-1", "--size", "1Gi", "--path", "/data-1", "--context", context)
+			helper.CmdShouldPass("odo", "url", "create", "example-2", "--context", context)
+			helper.CmdShouldPass("odo", "storage", "create", "storage-2", "--size", "1Gi", "--path", "/data2", "--context", context)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--context", context)...)
@@ -852,6 +853,31 @@ func componentTests(args ...string) {
 			oc.WaitAndCheckForExistence("bc", project, 1)
 			oc.WaitAndCheckForExistence("is", project, 1)
 			oc.WaitAndCheckForExistence("service", project, 1)
+		})
+
+		It("should delete the component and the owned resources with wait flag", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", "url", "create", "example-1", "--context", context)
+
+			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName, "URL,0,Name,example-1")
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+
+			helper.CmdShouldPass("odo", "url", "create", "example-2", "--context", context)
+			helper.CmdShouldPass("odo", "storage", "create", "storage-2", "--size", "1Gi", "--path", "/data2", "--context", context)
+			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
+
+			// delete with --wait flag
+			helper.CmdShouldPass("odo", append(args, "delete", "-f", "-w", "--context", context)...)
+
+			oc.VerifyResourceDeleted("routes", "example", project)
+			oc.VerifyResourceDeleted("service", cmpName, project)
+			// verify s2i pvc is delete
+			oc.VerifyResourceDeleted("pvc", "s2idata", project)
+			oc.VerifyResourceDeleted("pvc", "storage-1", project)
+			oc.VerifyResourceDeleted("pvc", "storage-2", project)
+			oc.VerifyResourceDeleted("dc", cmpName, project)
 		})
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
It adds `--wait` flag in `odo component delete`, which waits for component and its dependents to get deleted. with `foregroundDeletionPolicy` kubernetes deletes the dependent first which are referring `dc` with `ownerReference`. Then it deletes the `dc` itself. we have added `watch` to `dc` so that it waits for deletion of `dc`

**Which issue(s) this PR fixes**:

Fixes #2682  

**How to test changes / Special notes to the reviewer**:
Run `odo delete -f -w` on a deployed component, 
Run `oc get pvc`, check th s2i pvc gets deleted
Run `oc get route`, check the route created via url gets deleted