### PR TITLE
get imageStreamRef back to catalog component out list

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -17,7 +17,7 @@ type ComponentSpec struct {
 	AllTags        []string            `json:"allTags"`
 	NonHiddenTags  []string            `json:"nonHiddenTags"`
 	SupportedTags  []string            `json:"supportedTags"`
-	ImageStreamRef imagev1.ImageStream `json:"-"`
+	ImageStreamRef imagev1.ImageStream `json:"imageStreamRef"`
 }
 
 // ComponentTypeList lists all the ComponentType's


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2707 

**How to test changes **:
`odo catalog list components -o json` will have `imageStreamRef` included in its output