### PR TITLE
Add ability to create new service backed by an operator

### DIFF
--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // constants for deployments
@@ -152,4 +154,21 @@ func (c *Client) DeleteDeployment(labels map[string]string) error {
 	glog.V(4).Info("Deleting Deployment")
 
 	return c.KubeClient.AppsV1().Deployments(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
+}
+
+// CreateDynamicDeployment creates a dynamic deployment for Operator backed service
+func (c *Client) CreateDynamicDeployment(exampleCR map[string]interface{}, group, version, resource string) error {
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	deployment := &unstructured.Unstructured{
+		Object: exampleCR,
+	}
+
+	result, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Create(deployment, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(result.GetName())
+	return nil
 }

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -164,11 +164,11 @@ func (c *Client) CreateDynamicResource(exampleCustomResource map[string]interfac
 		Object: exampleCustomResource,
 	}
 
-	result, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Create(deployment, metav1.CreateOptions{})
+	// Create the dynamic resource based on the alm-example for the CRD
+	_, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Create(deployment, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(result.GetName())
 	return nil
 }

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -157,11 +157,11 @@ func (c *Client) DeleteDeployment(labels map[string]string) error {
 }
 
 // CreateDynamicDeployment creates a dynamic deployment for Operator backed service
-func (c *Client) CreateDynamicDeployment(exampleCR map[string]interface{}, group, version, resource string) error {
+func (c *Client) CreateDynamicResource(exampleCustomResource map[string]interface{}, group, version, resource string) error {
 	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
 
 	deployment := &unstructured.Unstructured{
-		Object: exampleCR,
+		Object: exampleCustomResource,
 	}
 
 	result, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Create(deployment, metav1.CreateOptions{})

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -29,7 +29,10 @@ type Client struct {
 	KubeClientConfig *rest.Config
 	Namespace        string
 	OperatorClient   *operatorsclientset.OperatorsV1alpha1Client
-	DynamicClient    dynamic.Interface // DynamicClient interacts with client-go's `dynamic` package
+	// DynamicClient interacts with client-go's `dynamic` package. It is used
+	// to dynamically create service from an operator. It can take an arbitrary
+	// yaml and create k8s/OpenShift resource from it.
+	DynamicClient dynamic.Interface
 }
 
 // New creates a new client

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Required for Kube clusters which use auth plugins
 	"k8s.io/client-go/rest"
@@ -28,6 +29,7 @@ type Client struct {
 	KubeClientConfig *rest.Config
 	Namespace        string
 	OperatorClient   *operatorsclientset.OperatorsV1alpha1Client
+	DynamicClient    dynamic.Interface // DynamicClient interacts with client-go's `dynamic` package
 }
 
 // New creates a new client
@@ -56,6 +58,11 @@ func New() (*Client, error) {
 	}
 
 	client.OperatorClient, err = operatorsclientset.NewForConfig(client.KubeClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client.DynamicClient, err = dynamic.NewForConfig(client.KubeClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -6,6 +6,16 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ErrNoSuchOperator = odoError("Could not find specified operator")
+)
+
+type odoError string
+
+func (e odoError) Error() string {
+	return string(e)
+}
+
 // GetClusterServiceVersionList returns a list of CSVs in the cluster
 // It is equivalent to doing `oc get csvs` using oc cli
 func (c *Client) GetClusterServiceVersionList() (*olm.ClusterServiceVersionList, error) {
@@ -15,4 +25,18 @@ func (c *Client) GetClusterServiceVersionList() (*olm.ClusterServiceVersionList,
 		return &olm.ClusterServiceVersionList{}, err
 	}
 	return csvs, nil
+}
+
+// GetClusterServiceVersion returns a particular CSV from a list of CSVs
+func (c *Client) GetClusterServiceVersion(name string) (olm.ClusterServiceVersion, error) {
+	csvs, err := c.GetClusterServiceVersionList()
+	if err != nil {
+		return olm.ClusterServiceVersion{}, err
+	}
+	for _, item := range csvs.Items {
+		if item.Name == name {
+			return item, nil
+		}
+	}
+	return olm.ClusterServiceVersion{}, ErrNoSuchOperator
 }

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -3,18 +3,13 @@ package kclient
 import (
 	"github.com/golang/glog"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	ErrNoSuchOperator = odoError("Could not find specified operator")
+var (
+	ErrNoSuchOperator = errors.New("Could not find specified operator")
 )
-
-type odoError string
-
-func (e odoError) Error() string {
-	return string(e)
-}
 
 // GetClusterServiceVersionList returns a list of CSVs in the cluster
 // It is equivalent to doing `oc get csvs` using oc cli

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -57,6 +58,15 @@ func CreateService(client *occlient.Client, serviceName string, serviceType stri
 	if err != nil {
 		return errors.Wrap(err, "unable to create service instance")
 
+	}
+	return nil
+}
+
+// CreateOperatorService creates new service (actually a Deployment) from OperatorHub
+func CreateOperatorService(client *kclient.Client, serviceName string, serviceType string, crd string, parameters map[string]string, applicationName, group, version, resource string, exampleCR map[string]interface{}) error {
+	err := client.CreateDynamicDeployment(exampleCR, group, version, resource)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create operator backed service")
 	}
 	return nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -63,8 +63,8 @@ func CreateService(client *occlient.Client, serviceName string, serviceType stri
 }
 
 // CreateOperatorService creates new service (actually a Deployment) from OperatorHub
-func CreateOperatorService(client *kclient.Client, group, version, resource string, exampleCR map[string]interface{}) error {
-	err := client.CreateDynamicResource(exampleCR, group, version, resource)
+func CreateOperatorService(client *kclient.Client, group, version, resource string, CustomResourceDefinition map[string]interface{}) error {
+	err := client.CreateDynamicResource(CustomResourceDefinition, group, version, resource)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create operator backed service")
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -63,8 +63,8 @@ func CreateService(client *occlient.Client, serviceName string, serviceType stri
 }
 
 // CreateOperatorService creates new service (actually a Deployment) from OperatorHub
-func CreateOperatorService(client *kclient.Client, serviceName string, serviceType string, crd string, parameters map[string]string, applicationName, group, version, resource string, exampleCR map[string]interface{}) error {
-	err := client.CreateDynamicDeployment(exampleCR, group, version, resource)
+func CreateOperatorService(client *kclient.Client, group, version, resource string, exampleCR map[string]interface{}) error {
+	err := client.CreateDynamicResource(exampleCR, group, version, resource)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create operator backed service")
 	}

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"os"
+	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,6 +21,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		// TODO: remove this when OperatorHub integration is fully baked into odo
 		os.Setenv("ODO_EXPERIMENTAL", "true")
 	})
+
 	Context("When experimental mode is enabled", func() {
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
@@ -27,4 +30,29 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			Expect(stdOut).To(ContainSubstring("etcdoperator"))
 		})
 	})
+
+	Context("When creating an operator backed service", func() {
+		It("should be able to create EtcdCluster from its alm example", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+
+			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
+
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", CI_OPERATOR_HUB_PROJECT}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// Delete the pods created. This should idealy be done by `odo
+			// service delete` but that's implemented for operator backed
+			// services yet.
+			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+		})
+	})
+
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
This PR creates operator backed services. 

**Which issue(s) this PR fixes**:
Fixes a part of #2613 

**How to test changes / Special notes to the reviewer**:
* On a CRC or OCP 4.x cluster, create a project using `developer` user: `odo project create myproject`
* Log into the OpenShift Web Console as `kubeadmin` user and install etcd operator in the `myproject` namespace.
* Go to the cli and confirm that the operator is installed in `myproject` namespace
   ```sh
   $ export ODO_EXPERIMENTAL=true
   $ odo login https://api.crc.testing:6443 -u developer -p developer
   $ odo catalog list services
   Operators available through Operator Hub
   NAME                       CRDs
   etcdoperator.v0.9.4        EtcdCluster, EtcdBackup, EtcdRestore
   ```
* Create the operator backed service:
  ```sh
  odo service create etcdoperator.v0.9.4 --crd EtcdCluster
  Deploying service etcdoperator.v0.9.4 of type: etcdoperator.v0.9.4
  example
   ✓  Deploying service [6ms]
   ✓  Service 'etcdoperator.v0.9.4' was created

  Progress of the provisioning will not be reported and might take a long time
  You can see the current status by executing 'odo service list'
  Optionally, link etcdoperator.v0.9.4 to your component by running: 'odo link <component-name>'
  ```
* Verify that pods have come up (`odo` doesn't support listing operator backed services yet so use `oc` CLI for this):
  ```sh
  $ oc get pods
  NAME                               READY   STATUS    RESTARTS   AGE
  etcd-operator-59c7bf9dfd-sdtl2     3/3     Running   0          20m
  example-8jgjmhq4m2                 1/1     Running   0          31s
  example-d6p2l2s7f8                 1/1     Running   0          103s
  example-rrnm4sz7rs                 1/1     Running   0          55s
  ```