### PR TITLE
If clonePath is set, sync to it

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -343,7 +343,8 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, e
 }
 
 // getSyncFolder returns the folder that we need to sync the source files to
-// If there's exactly one project defined in the devfile, return `/projects/<projectName>`
+// If there's exactly one project defined in the devfile, and clonePath isn't set return `/projects/<projectName>`
+// If there's exactly one project, and clonePath is set, return `/projects/<clonePath>`
 // Otherwise (zero projects or many), return `/projects`
 func getSyncFolder(projects []versionsCommon.DevfileProject) string {
 	if len(projects) == 1 {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -343,10 +343,16 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, e
 }
 
 // getSyncFolder returns the folder that we need to sync the source files to
-// If there's exactly one project defined in the devfile, return `/projects/<projectName`
+// If there's exactly one project defined in the devfile, return `/projects/<projectName>`
 // Otherwise (zero projects or many), return `/projects`
 func getSyncFolder(projects []versionsCommon.DevfileProject) string {
 	if len(projects) == 1 {
+		project := projects[0]
+		// If the clonepath is set to a value, set it to be the sync folder
+		// As some devfiles rely on the code being synced to the folder in the clonepath
+		if project.ClonePath != nil {
+			return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, *project.ClonePath))
+		}
 		return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projects[0].Name))
 	}
 	return kclient.OdoSourceVolumeMount

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -282,7 +282,11 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	defer s.End(false)
 
 	// If there's only one project defined in the devfile, sync to `/projects/project-name`, otherwise sync to /projects
-	syncFolder := getSyncFolder(a.Devfile.Data.GetProjects())
+	syncFolder, err := getSyncFolder(a.Devfile.Data.GetProjects())
+	if err != nil {
+		return errors.Wrapf(err, "unable to sync the files to the component")
+	}
+
 	if syncFolder != kclient.OdoSourceVolumeMount {
 		// Need to make sure the folder already exists on the component or else sync will fail
 		glog.V(4).Infof("Creating %s on the remote container if it doesn't already exist", syncFolder)
@@ -345,18 +349,25 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, e
 // getSyncFolder returns the folder that we need to sync the source files to
 // If there's exactly one project defined in the devfile, and clonePath isn't set return `/projects/<projectName>`
 // If there's exactly one project, and clonePath is set, return `/projects/<clonePath>`
+// If the clonePath is an absolute path or contains '..', return an error
 // Otherwise (zero projects or many), return `/projects`
-func getSyncFolder(projects []versionsCommon.DevfileProject) string {
+func getSyncFolder(projects []versionsCommon.DevfileProject) (string, error) {
 	if len(projects) == 1 {
 		project := projects[0]
 		// If the clonepath is set to a value, set it to be the sync folder
 		// As some devfiles rely on the code being synced to the folder in the clonepath
 		if project.ClonePath != nil {
-			return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, *project.ClonePath))
+			if strings.HasPrefix(*project.ClonePath, "/") {
+				return "", fmt.Errorf("the clonePath in the devfile must be a relative path")
+			}
+			if strings.Contains(*project.ClonePath, "..") {
+				return "", fmt.Errorf("the clonePath in the devfile cannot escape the projects root. Don't use .. to try and do that")
+			}
+			return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, *project.ClonePath)), nil
 		}
-		return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projects[0].Name))
+		return filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projects[0].Name)), nil
 	}
-	return kclient.OdoSourceVolumeMount
+	return kclient.OdoSourceVolumeMount, nil
 
 }
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -208,16 +208,19 @@ func TestGetSyncFolder(t *testing.T) {
 	projectNames := []string{"some-name", "another-name"}
 	projectRepos := []string{"https://github.com/some/repo.git", "https://github.com/another/repo.git"}
 	projectClonePath := "src/github.com/golang/example/"
+	invalidClonePaths := []string{"/var", "../var", "pkg/../../var"}
 
 	tests := []struct {
 		name     string
 		projects []versionsCommon.DevfileProject
 		want     string
+		wantErr  bool
 	}{
 		{
 			name:     "Case 1: No projects",
 			projects: []versionsCommon.DevfileProject{},
 			want:     kclient.OdoSourceVolumeMount,
+			wantErr:  false,
 		},
 		{
 			name: "Case 2: One project",
@@ -230,7 +233,8 @@ func TestGetSyncFolder(t *testing.T) {
 					},
 				},
 			},
-			want: filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projectNames[0])),
+			want:    filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projectNames[0])),
+			wantErr: false,
 		},
 		{
 			name: "Case 3: Multiple projects",
@@ -250,7 +254,8 @@ func TestGetSyncFolder(t *testing.T) {
 					},
 				},
 			},
-			want: kclient.OdoSourceVolumeMount,
+			want:    kclient.OdoSourceVolumeMount,
+			wantErr: false,
 		},
 		{
 			name: "Case 4: Clone path set",
@@ -264,11 +269,62 @@ func TestGetSyncFolder(t *testing.T) {
 					},
 				},
 			},
-			want: filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projectClonePath)),
+			want:    filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projectClonePath)),
+			wantErr: false,
+		},
+		{
+			name: "Case 5: Invalid clone path, set with absolute path",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: &invalidClonePaths[0],
+					Name:      projectNames[0],
+					Source: versionsCommon.DevfileProjectSource{
+						Type:     versionsCommon.DevfileProjectTypeGit,
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Case 6: Invalid clone path, starts with ..",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: &invalidClonePaths[1],
+					Name:      projectNames[0],
+					Source: versionsCommon.DevfileProjectSource{
+						Type:     versionsCommon.DevfileProjectTypeGit,
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Case 7: Invalid clone path, contains ..",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: &invalidClonePaths[2],
+					Name:      projectNames[0],
+					Source: versionsCommon.DevfileProjectSource{
+						Type:     versionsCommon.DevfileProjectTypeGit,
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
-		syncFolder := getSyncFolder(tt.projects)
+		syncFolder, err := getSyncFolder(tt.projects)
+
+		if !tt.wantErr == (err != nil) {
+			t.Errorf("expected %v, actual %v", tt.wantErr, err)
+		}
+
 		if syncFolder != tt.want {
 			t.Errorf("expected %s, actual %s", tt.want, syncFolder)
 		}

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -205,9 +205,9 @@ func TestGetFirstContainerWithSourceVolume(t *testing.T) {
 }
 
 func TestGetSyncFolder(t *testing.T) {
-	projectPaths := []string{"/some/path", "/another/path"}
 	projectNames := []string{"some-name", "another-name"}
 	projectRepos := []string{"https://github.com/some/repo.git", "https://github.com/another/repo.git"}
+	projectClonePath := "src/github.com/golang/example/"
 
 	tests := []struct {
 		name     string
@@ -223,8 +223,7 @@ func TestGetSyncFolder(t *testing.T) {
 			name: "Case 2: One project",
 			projects: []versionsCommon.DevfileProject{
 				{
-					ClonePath: &projectPaths[0],
-					Name:      projectNames[0],
+					Name: projectNames[0],
 					Source: versionsCommon.DevfileProjectSource{
 						Type:     versionsCommon.DevfileProjectTypeGit,
 						Location: projectRepos[0],
@@ -237,16 +236,14 @@ func TestGetSyncFolder(t *testing.T) {
 			name: "Case 3: Multiple projects",
 			projects: []versionsCommon.DevfileProject{
 				{
-					ClonePath: &projectPaths[0],
-					Name:      projectNames[0],
+					Name: projectNames[0],
 					Source: versionsCommon.DevfileProjectSource{
 						Type:     versionsCommon.DevfileProjectTypeGit,
 						Location: projectRepos[0],
 					},
 				},
 				{
-					ClonePath: &projectPaths[1],
-					Name:      projectNames[1],
+					Name: projectNames[1],
 					Source: versionsCommon.DevfileProjectSource{
 						Type:     versionsCommon.DevfileProjectTypeGit,
 						Location: projectRepos[1],
@@ -254,6 +251,20 @@ func TestGetSyncFolder(t *testing.T) {
 				},
 			},
 			want: kclient.OdoSourceVolumeMount,
+		},
+		{
+			name: "Case 4: Clone path set",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: &projectClonePath,
+					Name:      projectNames[0],
+					Source: versionsCommon.DevfileProjectSource{
+						Type:     versionsCommon.DevfileProjectTypeGit,
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want: filepath.ToSlash(filepath.Join(kclient.OdoSourceVolumeMount, projectClonePath)),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
This PR updates the sync code to sync to the devfile's clonePath folder if it's set. Certain devfiles, such as the official Go devfile, rely on this field being set properly (see https://github.com/eclipse/che-devfile-registry/blob/5a41b4b0c85893a6ee99059fcceab35b8a71780c/devfiles/go/devfile.yaml#L46 for example)

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2741