### PR TITLE
List devfile component without connecting cluster if experimental flag is enabled

### DIFF
--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -43,7 +43,11 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	o.Context = genericclioptions.NewContext(cmd)
 	o.catalogList, err = catalog.ListComponents(o.Client)
 	if err != nil {
-		return err
+		if experimental.IsExperimentalModeEnabled() {
+			log.Warning("Please log in to an OpenShift cluster to list OpenShift/s2i components")
+		} else {
+			return err
+		}
 	}
 
 	if experimental.IsExperimentalModeEnabled() {

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/golang/glog"
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
@@ -44,7 +45,7 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	o.catalogList, err = catalog.ListComponents(o.Client)
 	if err != nil {
 		if experimental.IsExperimentalModeEnabled() {
-			log.Warning("Please log in to an OpenShift cluster to list OpenShift/s2i components")
+			glog.V(4).Info("Please log in to an OpenShift cluster to list OpenShift/s2i components")
 		} else {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
If the experimental flag is enabled, user should be able to list devfile components even if user doesn't connect to OpenShift cluster. Instead of failing the `odo catalog list components`, we output the following warning to user:
```
odo catalog list components                                                                                  ✔  17:00:33 
 ⚠  Please log in to an OpenShift cluster to list OpenShift/s2i components

Odo Supported Devfile Components:
NAME                 DESCRIPTION
java-spring-boot     Spring Boot® using IBM Java
openLiberty          Open Liberty microservice in Java
```

**Which issue(s) this PR fixes**:
Fixes #2740 
Fixes #2706 

**How to test changes / Special notes to the reviewer**: