### PR TITLE
Fixes storage owner references.

### DIFF
--- a/pkg/occlient/volumes.go
+++ b/pkg/occlient/volumes.go
@@ -194,7 +194,7 @@ func updateStorageOwnerReference(client *Client, pvc *corev1.PersistentVolumeCla
 		return err
 	}
 	for _, owRf := range ownerReference {
-		pvc.SetOwnerReferences(append(pvc.GetOwnerReferences(), owRf))
+		latestPVC.SetOwnerReferences(append(pvc.GetOwnerReferences(), owRf))
 	}
 	_, err = client.kubeClient.CoreV1().PersistentVolumeClaims(client.Namespace).Update(latestPVC)
 	if err != nil {

--- a/pkg/occlient/volumes_test.go
+++ b/pkg/occlient/volumes_test.go
@@ -289,12 +289,13 @@ func Test_updateStorageOwnerReference(t *testing.T) {
 			fakeClient, fakeClientSet := FakeNew()
 
 			fakeClientSet.Kubernetes.PrependReactor("get", "persistentvolumeclaims", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, tt.args.pvc, nil
+				returnedPVC := *tt.args.pvc
+				return true, &returnedPVC, nil
 			})
 
 			fakeClientSet.Kubernetes.PrependReactor("update", "persistentvolumeclaims", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 				pvc := action.(ktesting.UpdateAction).GetObject().(*corev1.PersistentVolumeClaim)
-				if pvc.OwnerReferences[0].Name != fakeDC.Name {
+				if pvc.OwnerReferences == nil || pvc.OwnerReferences[0].Name != fakeDC.Name {
 					t.Errorf("owner reference not set for dc %s", tt.args.pvc.Name)
 				}
 				return true, pvc, nil

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -450,10 +450,25 @@ func (oc *OcRunner) WaitForDCRollout(dcName string, project string, timeout time
 	session.Wait(timeout)
 }
 
-// CheckForExistence checks if the given resource type exists on the cluster
-func (oc *OcRunner) CheckForExistence(resourceType, namespace string) {
-	session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
-	Eventually(session).Should(gexec.Exit(0))
-	output := string(session.Wait().Out.Contents())
-	Expect(strings.ToLower(output)).To(ContainSubstring(""))
+// WaitAndCheckForExistence wait for the given and checks if the given resource type gets deleted on the cluster
+func (oc *OcRunner) WaitAndCheckForExistence(resourceType, namespace string, timeoutMinutes int) bool {
+	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)
+	// this is a test package so time.Tick() is acceptable
+	// nolint
+	tick := time.Tick(time.Second)
+	for {
+		select {
+		case <-pingTimeout:
+			Fail(fmt.Sprintf("Timeout out after %v minutes", timeoutMinutes))
+
+		case <-tick:
+			session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
+			Eventually(session).Should(gexec.Exit(0))
+			output := string(session.Wait().Err.Contents())
+
+			if strings.Contains(strings.ToLower(output), "no resources found") {
+				return true
+			}
+		}
+	}
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -464,6 +464,7 @@ func (oc *OcRunner) WaitAndCheckForExistence(resourceType, namespace string, tim
 		case <-tick:
 			session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
 			Eventually(session).Should(gexec.Exit(0))
+			// https://github.com/kubernetes/kubectl/issues/847
 			output := string(session.Wait().Err.Contents())
 
 			if strings.Contains(strings.ToLower(output), "no resources found") {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -826,12 +826,12 @@ func componentTests(args ...string) {
 
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--context", context)...)
 
-			oc.CheckForExistence("routes", project)
-			oc.CheckForExistence("dc", project)
-			oc.CheckForExistence("pvc", project)
-			oc.CheckForExistence("bc", project)
-			oc.CheckForExistence("is", project)
-			oc.CheckForExistence("service", project)
+			oc.WaitAndCheckForExistence("routes", project, 1)
+			oc.WaitAndCheckForExistence("dc", project, 1)
+			oc.WaitAndCheckForExistence("pvc", project, 1)
+			oc.WaitAndCheckForExistence("bc", project, 1)
+			oc.WaitAndCheckForExistence("is", project, 1)
+			oc.WaitAndCheckForExistence("service", project, 1)
 		})
 	})
 }


### PR DESCRIPTION
This PR also fixes CheckForExistence() function and the unit test for updateStorageOwnerReference()

Signed-off-by: mik-dass <mrinald7@gmail.com>

**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Fixes storage owner references. This PR also fixes CheckForExistence() function and the unit test for updateStorageOwnerReference()

**Which issue(s) this PR fixes**:

Fixes #2710 

**How to test changes / Special notes to the reviewer**:

- create a component, attach a storage to it and push
- execute `odo delete -f`
- execute `oc get pvc` and check if all PVCs belonging to the component are deleted or not.
