### PR TITLE
Update bootstrap image to 1.1.1

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -106,7 +106,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use getBoostrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.0.2"
+	defaultBootstrapperImage = "registry.access.redhat.com/openshiftdo/odo-init-image-rhel7:1.1.1"
 
 	// ENV variable to overwrite image used to bootstrap SupervisorD in S2I builder Image
 	bootstrapperImageEnvName = "ODO_BOOTSTRAPPER_IMAGE"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

Updates the bootstrap image to 1.1.1 as 0.16.0 of odo-init-image has
been released: https://github.com/openshift/odo-init-image/releases/tag/0.16.0

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>