### PR TITLE
Add documentation to skip CI when pushing docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,11 +7,14 @@
 > /kind cleanup
 > /kind deprecation
 > /kind design
-> /kind documentation
 > /kind failing-test
 > /kind feature
 > /kind flake
 > /kind code-refactoring
+>
+> Documentation changes: Please include [skip ci] in your commit message as well
+> /kind documentation
+> [skip ci]
 
 **What does does this PR do / why we need it**:
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

This improves pushing documentation changes by including `[skip ci]`
somewhere in the commit message in order to skip any Travis CI build
from running.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2704

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>