### PR TITLE
Error checking was removed for WaitAndGetPod

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1953,6 +1953,8 @@ func (c *Client) WaitAndGetPod(selector string, desiredPhase corev1.PodPhase, wa
 	case val := <-podChannel:
 		spinner.End(true)
 		return val, nil
+	case err := <-watchErrorChannel:
+		return nil, err
 	case <-time.After(pushTimeout):
 
 		// Create a useful error if there are any failed events


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:

Error checking was erronously removed when implementing event
information. Instead of tests failing, they timed out instead..

See this line of code:

https://github.com/openshift/odo/pull/2627/files#diff-6025e9b620e9321c03c11bf29e5c4dbdL1848

**Which issue(s) this PR fixes**:

Fixes N/A, no issue was created.

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>