### PR TITLE
Adds delete function for devfiles support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "watch, storage, app, project, push, devfile catalog, devfile create, devfile push command integration tests"
+      name: "watch, storage, app, project, push, devfile catalog, devfile create, devfile push, devfile delete command integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
@@ -121,6 +121,7 @@ jobs:
         - travis_wait make test-cmd-devfile-create
         - travis_wait make test-cmd-devfile-push
         - travis_wait make test-cmd-devfile-watch
+        - travis_wait make test-cmd-devfile-delete
         - odo logout
 
     - <<: *base-test

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,11 @@ test-cmd-devfile-push:
 .PHONY: test-cmd-devfile-watch
 test-cmd-devfile-watch:
 	ginkgo $(GINKGO_FLAGS) -focus="odo devfile watch command tests" tests/integration/devfile/
+
+# Run odo devfile delete command tests
+.PHONY: test-cmd-devfile-delete
+test-cmd-devfile-delete:
+	ginkgo $(GINKGO_FLAGS) -focus="odo devfile delete command tests" tests/integration/devfile/
 	
 # Run odo storage command tests
 .PHONY: test-cmd-storage

--- a/pkg/devfile/adapters/common/interface.go
+++ b/pkg/devfile/adapters/common/interface.go
@@ -4,6 +4,7 @@ package common
 type ComponentAdapter interface {
 	Push(parameters PushParameters) error
 	DoesComponentExist(cmpName string) bool
+	Delete(labels map[string]string) error
 }
 
 // StorageAdapter defines the storage functions that platform-specific adapters must implement

--- a/pkg/devfile/adapters/interface.go
+++ b/pkg/devfile/adapters/interface.go
@@ -5,4 +5,5 @@ import "github.com/openshift/odo/pkg/devfile/adapters/common"
 type PlatformAdapter interface {
 	Push(parameters common.PushParameters) error
 	DoesComponentExist(cmpName string) bool
+	Delete(labels map[string]string) error
 }

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -41,3 +41,14 @@ func (k Adapter) Push(parameters common.PushParameters) error {
 func (k Adapter) DoesComponentExist(cmpName string) bool {
 	return k.componentAdapter.DoesComponentExist(cmpName)
 }
+
+// Delete deletes the Kubernetes resources that correspond to the devfile
+func (k Adapter) Delete(labels map[string]string) error {
+
+	err := k.componentAdapter.Delete(labels)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -577,3 +577,12 @@ func getCmdToDeleteFiles(delFiles []string, syncFolder string) []string {
 	cmdArr := []string{"rm", "-rf"}
 	return append(cmdArr, rmPaths...)
 }
+
+// Delete deletes the component
+func (a Adapter) Delete(labels map[string]string) error {
+	if !utils.ComponentExists(a.Client, a.ComponentName) {
+		return errors.Errorf("the component %s doesn't exist on the cluster", a.ComponentName)
+	}
+
+	return a.Client.DeleteDeployment(labels)
+}

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"github.com/openshift/odo/pkg/util"
+	"github.com/pkg/errors"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -11,7 +13,9 @@ import (
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/testingutil"
 
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	ktesting "k8s.io/client-go/testing"
 )
@@ -520,4 +524,90 @@ func TestWaitAndGetComponentPod(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAdapterDelete(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	tests := []struct {
+		name               string
+		args               args
+		existingDeployment *v1.Deployment
+		componentName      string
+		componentExists    bool
+		wantErr            bool
+	}{
+		{
+			name: "case 1: component exists and given labels are valid",
+			args: args{labels: map[string]string{
+				"component": "component",
+			}},
+			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
+			componentName:      "component",
+			componentExists:    true,
+			wantErr:            false,
+		},
+		{
+			name:               "case 2: component exists and given labels are not valid",
+			args:               args{labels: nil},
+			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
+			componentName:      "component",
+			componentExists:    true,
+			wantErr:            true,
+		},
+		{
+			name: "case 3: component doesn't exists",
+			args: args{labels: map[string]string{
+				"component": "component",
+			}},
+			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
+			componentName:      "component",
+			componentExists:    false,
+			wantErr:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfile.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					ComponentType: "nodejs",
+				},
+			}
+
+			adapterCtx := adaptersCommon.AdapterContext{
+				ComponentName: tt.componentName,
+				Devfile:       devObj,
+			}
+
+			if !tt.componentExists {
+				adapterCtx.ComponentName = "doesNotExists"
+			}
+
+			fkclient, fkclientset := kclient.FakeNew()
+
+			a := Adapter{
+				Client:         *fkclient,
+				AdapterContext: adapterCtx,
+			}
+
+			fkclientset.Kubernetes.PrependReactor("delete-collection", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if util.ConvertLabelsToSelector(tt.args.labels) != action.(ktesting.DeleteCollectionAction).GetListRestrictions().Labels.String() {
+					return true, nil, errors.Errorf("collection labels are not matching, wanted: %v, got: %v", util.ConvertLabelsToSelector(tt.args.labels), action.(ktesting.DeleteCollectionAction).GetListRestrictions().Labels.String())
+				}
+				return true, nil, nil
+			})
+
+			fkclientset.Kubernetes.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if action.(ktesting.GetAction).GetName() != tt.componentName {
+					return true, nil, errors.Errorf("get action called with different component name, want: %s, got: %s", action.(ktesting.GetAction).GetName(), tt.componentName)
+				}
+				return true, tt.existingDeployment, nil
+			})
+
+			if err := a.Delete(tt.args.labels); (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,4 +137,19 @@ func (c *Client) UpdateDeployment(deploymentSpec appsv1.DeploymentSpec) (*appsv1
 		return nil, errors.Wrapf(err, "unable to update Deployment %s", objectMeta.Name)
 	}
 	return deploy, nil
+}
+
+// DeleteDeployment deletes the deployments with the given selector
+func (c *Client) DeleteDeployment(labels map[string]string) error {
+	if labels == nil {
+		return errors.New("labels for deletion are empty")
+	}
+	// convert labels to selector
+	selector := util.ConvertLabelsToSelector(labels)
+	glog.V(4).Infof("Selectors used for deletion: %s", selector)
+
+	// Delete Deployment
+	glog.V(4).Info("Deleting Deployment")
+
+	return c.KubeClient.AppsV1().Deployments(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 }

--- a/pkg/testingutil/deployments.go
+++ b/pkg/testingutil/deployments.go
@@ -1,0 +1,20 @@
+package testingutil
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// createFakeDeployment creates a fake deployment with the given pod name and labels
+func CreateFakeDeployment(podName string) *appsv1.Deployment {
+	fakeUID := types.UID("12345")
+
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+			UID:  fakeUID,
+		},
+	}
+	return &deployment
+}

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -1,0 +1,86 @@
+package devfile
+
+import (
+	"github.com/openshift/odo/tests/helper"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo devfile delete command tests", func() {
+	var namespace string
+	var context string
+	var currentWorkingDirectory string
+
+	// TODO: all oc commands in all devfile related test should get replaced by kubectl
+	// TODO: to goal is not to use "oc"
+	oc := helper.NewOcRunner("oc")
+
+	// This is run after every Spec (It)
+	var _ = BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		namespace = helper.CreateRandProject()
+		context = helper.CreateNewContext()
+		currentWorkingDirectory = helper.Getwd()
+		helper.Chdir(context)
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+
+		// Devfile commands require experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.DeleteProject(namespace)
+		helper.Chdir(currentWorkingDirectory)
+		helper.DeleteDir(context)
+		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	Context("when devfile delete command is executed", func() {
+
+		It("should delete the component created from the devfile and also the owned resources", func() {
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", namespace, componentName)
+
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
+
+			helper.CmdShouldPass("odo", "delete", "--devfile", "devfile.yaml", "--namespace", namespace, "-f")
+
+			oc.WaitAndCheckForExistence("deployments", namespace, 1)
+			oc.WaitAndCheckForExistence("pods", namespace, 1)
+			oc.WaitAndCheckForExistence("services", namespace, 1)
+
+			// once https://github.com/openshift/odo/issues/2808 is resolved
+			// create a url also in this scenario
+			//oc.WaitAndCheckForExistence("ingress", namespace, 1)
+		})
+	})
+
+	Context("when devfile delete command is executed with all flag", func() {
+
+		It("should delete the component created from the devfile and also the env folder", func() {
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", namespace, componentName)
+
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
+
+			helper.CmdShouldPass("odo", "url", "create", "example", "--host", "1.2.3.4.nip.io", "--context", context)
+
+			helper.CmdShouldPass("odo", "delete", "--devfile", "devfile.yaml", "--namespace", namespace, "-f", "--all")
+
+			oc.WaitAndCheckForExistence("deployments", namespace, 1)
+
+			files := helper.ListFilesInDir(filepath.Join(context, ".odo"))
+			Expect(files).To(Not(ContainElement("env")))
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: mik-dass <mrinald7@gmail.com>

**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

This PR also adds support for all flag. The all flag deletes the env folder present in the .odo folder.

**Which issue(s) this PR fixes**:

Fixes #2591 

**How to test changes / Special notes to the reviewer**:

- execute `odo push` on a devfile component
- execute `odo delete -f` and check if the devfile component is deleted from the cluster

`Test the --all flag`

- execute `odo push` on a devfile component
- create a url
- execute `odo delete -f --all` and check if the devfile component is deleted from the cluster. Also check if the env folder is deleted from the `.odo` folder