### PR TITLE
Fixing app delete flake in service test file

### DIFF
--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -450,7 +450,7 @@ var _ = Describe("odo service command tests", func() {
 				return strings.Contains(output, "dh-postgresql-apb")
 			})
 
-			helper.CmdShouldPass("odo", "app", "delete", app, "-f")
+			helper.CmdShouldPass("odo", "app", "delete", app, "--project", project, "-f")
 
 			ocArgs = []string{"get", "serviceinstances", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
Due to parallel run race condition arises when spec selects the active project. Such flake is fixed in this pr.
**Which issue(s) this PR fixes**:

Fixes #2765

**How to test changes / Special notes to the reviewer**:
make test-cmd-service