### PR TITLE
Adds disclaimer that experimental mode is enabled

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -197,6 +197,14 @@ func Swarningf(format string, a ...interface{}) string {
 	return fmt.Sprintf(" %s%s%s", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
 }
 
+// Experimental will output in an appropriate "progress" manner
+func Experimental(a ...interface{}) {
+	yellow := color.New(color.FgYellow).SprintFunc()
+	if !IsJSON() {
+		fmt.Fprintf(GetStdout(), "%s\n", yellow(fmt.Sprintln(a...)))
+	}
+}
+
 // Warning will output in an appropriate "progress" manner
 func Warning(a ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintFunc()

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -285,7 +285,12 @@ func (co *CreateOptions) setResourceLimits() error {
 
 // Complete completes create args
 func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+
 	if experimental.IsExperimentalModeEnabled() {
+
+		// Add a disclaimer that we are in *experimental mode*
+		log.Experimental("Experimental mode is enabled, use at your own risk")
+
 		if len(args) == 0 {
 			co.interactive = true
 		}
@@ -361,10 +366,13 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.devfileMetadata.componentName = strings.ToLower(componentName)
 		co.devfileMetadata.componentNamespace = componentNamespace
 
+		// Categorize the sections
+		log.Info("Validation")
+
 		// Since we need to support both devfile and s2i, so we have to check if the component type is
 		// supported by devfile, if it is supported we return, but if it is not supported we still need to
 		// run all codes related with s2i
-		spinner := log.Spinner("Checking if the specified component type is supported devfile component type")
+		spinner := log.Spinner("Checking Devfile compatibility")
 
 		for _, devfileComponent := range catalogDevfileList.Items {
 			if co.devfileMetadata.componentType == devfileComponent.Name && devfileComponent.Support {
@@ -579,10 +587,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 // Validate validates the create parameters
 func (co *CreateOptions) Validate() (err error) {
+
 	if experimental.IsExperimentalModeEnabled() {
 		if co.devfileMetadata.devfileSupport {
 			// Validate if the devfile component that user wants to create already exists
-			spinner := log.Spinner("Validating component")
+			spinner := log.Spinner("Validating Devfile")
 			defer spinner.End(false)
 
 			if util.CheckPathExists(EnvFilePath) {
@@ -599,6 +608,8 @@ func (co *CreateOptions) Validate() (err error) {
 			return nil
 		}
 	}
+
+	log.Info("Validation")
 
 	supported, err := catalog.IsComponentTypeSupported(co.Context.Client, *co.componentSettings.Type)
 	if err != nil {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -93,7 +93,9 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 // Validate validates the push parameters
 func (po *PushOptions) Validate() (err error) {
 
-	// if experimental flag is set and devfile is present
+	// If the experimental flag is set and devfile is present, then we do *not* validate
+	// TODO: We need to clean this section up a bit.. We should also validate Devfile here
+	// too.
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		return nil
 	}
@@ -125,9 +127,9 @@ func (po *PushOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run() (err error) {
-	// if experimental mode is enabled, use devfile push
+	// If experimental mode is enabled, use devfile push
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
-		// devfile push
+		// Return Devfile push
 		return po.DevfilePush()
 	} else {
 		// Legacy odo push

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -65,6 +65,25 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(output).To(ContainSubstring(cmpName))
 		})
 
+		It("Check that the experimental warning appears for create and push", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			// Check that it will contain the experimental mode output
+			experimentalOutputMsg := "Experimental mode is enabled, use at your own risk"
+			Expect(helper.CmdShouldPass("odo", "create", "nodejs")).To(ContainSubstring(experimentalOutputMsg))
+
+		})
+
+		It("Check that the experimental warning does *not* appear when Experimental is set to false", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "false")
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			// Check that it will contain the experimental mode output
+			experimentalOutputMsg := "Experimental mode is enabled, use at your own risk"
+			Expect(helper.CmdShouldPass("odo", "create", "nodejs")).To(Not(ContainSubstring(experimentalOutputMsg)))
+		})
+
 		It("Check that odo push works with a devfile", func() {
 			// Devfile push requires experimental mode to be set
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What does does this PR do / why we need it**:

Adds a disclaimer that experimental mode is enabled when using `odo
create` or `odo push`.

See asciinema:

[![asciicast](https://asciinema.org/a/A6ITI1wNQL9hahhLsCz4DT6wQ.svg)](https://asciinema.org/a/A6ITI1wNQL9hahhLsCz4DT6wQ)

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

```sh
odo preference set experimental true
git clone https://github.com/openshift/nodejs-ex
odo create nodejs
odo push
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>