### PR TITLE
Fix --namespace flag bug for odo create

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -323,13 +323,17 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			componentName = ui.EnterDevfileComponentName(componentType)
 
-			if cmd.Flags().Changed("project") {
-				componentNamespace, err = cmd.Flags().GetString("project")
-				if err != nil {
-					return err
+			if len(co.devfileMetadata.componentNamespace) == 0 {
+				if cmd.Flags().Changed("project") {
+					componentNamespace, err = cmd.Flags().GetString("project")
+					if err != nil {
+						return err
+					}
+				} else {
+					componentNamespace = ui.EnterDevfileComponentNamespace(defaultComponentNamespace)
 				}
 			} else {
-				componentNamespace = ui.EnterDevfileComponentNamespace(defaultComponentNamespace)
+				componentNamespace = co.devfileMetadata.componentNamespace
 			}
 		} else {
 			// Direct mode (User enters the full command)
@@ -346,13 +350,17 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 				componentName = args[0]
 			}
 
-			if cmd.Flags().Changed("project") {
-				componentNamespace, err = cmd.Flags().GetString("project")
-				if err != nil {
-					return err
+			if len(co.devfileMetadata.componentNamespace) == 0 {
+				if cmd.Flags().Changed("project") {
+					componentNamespace, err = cmd.Flags().GetString("project")
+					if err != nil {
+						return err
+					}
+				} else {
+					componentNamespace = defaultComponentNamespace
 				}
 			} else {
-				componentNamespace = defaultComponentNamespace
+				componentNamespace = co.devfileMetadata.componentNamespace
 			}
 		}
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -367,7 +367,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// Set devfileMetadata struct
 		co.devfileMetadata.componentType = componentType
 		co.devfileMetadata.componentName = strings.ToLower(componentName)
-		co.devfileMetadata.componentNamespace = componentNamespace
+		co.devfileMetadata.componentNamespace = strings.ToLower(componentNamespace)
 
 		// Since we need to support both devfile and s2i, so we have to check if the component type is
 		// supported by devfile, if it is supported we return, but if it is not supported we still need to
@@ -598,6 +598,11 @@ func (co *CreateOptions) Validate() (err error) {
 			}
 
 			err = util.ValidateK8sResourceName("component name", co.devfileMetadata.componentName)
+			if err != nil {
+				return err
+			}
+
+			err := util.ValidateK8sResourceName("component namespace", co.devfileMetadata.componentNamespace)
 			if err != nil {
 				return err
 			}

--- a/tests/integration/cmd_devfile_create_test.go
+++ b/tests/integration/cmd_devfile_create_test.go
@@ -56,6 +56,14 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
+	Context("When executing odo create with devfile component type argument and --namespace flag", func() {
+		It("should successfully create the devfile component", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			componentNamespace := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "openLiberty", "--namespace", componentNamespace)
+		})
+	})
+
 	Context("When executing odo create with devfile component name that contains unsupported character", func() {
 		It("should failed with component name is not valid and prompt supported character", func() {
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -56,14 +56,6 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
-	Context("When executing odo create with devfile component type argument and --namespace flag", func() {
-		It("should successfully create the devfile component", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-			componentNamespace := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "openLiberty", "--namespace", componentNamespace)
-		})
-	})
-
 	Context("When executing odo create with devfile component name that contains unsupported character", func() {
 		It("should failed with component name is not valid and prompt supported character", func() {
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -56,6 +56,14 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
+	Context("When executing odo create with devfile component type argument and --namespace flag", func() {
+		It("should successfully create the devfile component", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			componentNamespace := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "openLiberty", "--namespace", componentNamespace)
+		})
+	})
+
 	Context("When executing odo create with devfile component name that contains unsupported character", func() {
 		It("should failed with component name is not valid and prompt supported character", func() {
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
`odo create` with `--namespace` doesn't work properly, this PR fix the issue.

**Which issue(s) this PR fixes**:
Fixes #2796 