### PR TITLE
Print yaml definition of CR when asked for dry-run

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -326,7 +326,6 @@ func (o *ServiceCreateOptions) Run() (err error) {
 				return err
 			}
 
-			log.Infof("Following definition will be used to create %s:\n", o.CustomResource)
 			log.Info(string(yamlCR))
 
 			return nil

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -12,6 +12,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	scv1beta1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/openshift/odo/pkg/log"
@@ -87,6 +88,8 @@ type ServiceCreateOptions struct {
 	version string
 	// Resource of the GVR
 	resource string
+	// If set to true, DryRun prints the yaml that will create the service
+	DryRun bool
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -292,23 +295,44 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
+	s := &log.Status{}
 	if experimental.IsExperimentalModeEnabled() {
 		// in case of an opertor backed service, name of the service is
 		// provided by the yaml specification in alm-examples. It might also
 		// happen that a user spins up Service Catalog based service in
 		// experimental mode but we're taking a bet against that for now, so
 		// the user won't get to see service name in the log message
-		log.Infof("Deploying service of type: %s", o.ServiceType)
+		if !o.DryRun {
+			log.Infof("Deploying service of type: %s", o.ServiceType)
+			s = log.Spinner("Deploying service")
+			defer s.End(false)
+		}
 	} else {
 		log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
 	}
 
-	s := log.Spinner("Deploying service")
-	defer s.End(false)
-
 	if experimental.IsExperimentalModeEnabled() && o.CustomResource != "" {
 		// if experimental mode is enabled and o.CustomResource is not empty, we're expected to create an Operator backed service
-		err = svc.CreateOperatorService(o.KClient, o.group, o.version, o.resource, o.CustomResourceDefinition)
+		if o.DryRun {
+			// if it's dry run, only print the alm-example (o.CustomResourceDefinition) and exit
+			jsonCR, err := json.MarshalIndent(o.CustomResourceDefinition, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			// convert json to yaml
+			yamlCR, err := yaml.JSONToYAML(jsonCR)
+			if err != nil {
+				return err
+			}
+
+			log.Infof("Following definition will be used to create %s:\n", o.CustomResource)
+			log.Info(string(yamlCR))
+
+			return nil
+		} else {
+			err = svc.CreateOperatorService(o.KClient, o.group, o.version, o.resource, o.CustomResourceDefinition)
+		}
 	} else {
 		// otherwise just create a ServiceInstance
 		err = svc.CreateService(o.Client, o.ServiceName, o.ServiceType, o.Plan, o.ParametersMap, o.Application)
@@ -359,6 +383,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type> --crd <crd_name> [service_name] [flags]", o.CmdFullName)
 		serviceCreateCmd.Example += fmt.Sprintf("\n\n") + fmt.Sprintf(createOperatorExample, fullName)
 		serviceCreateCmd.Flags().StringVar(&o.CustomResource, "crd", "", "The name of the CRD of the operator to be used to create the service")
+		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
 	}
 
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -49,9 +49,20 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			})
 
 			// Delete the pods created. This should idealy be done by `odo
-			// service delete` but that's implemented for operator backed
+			// service delete` but that's not implemented for operator backed
 			// services yet.
 			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+		})
+	})
+
+	Context("When using dry-run option to create operator backed service", func() {
+		It("should only output the definition of the CR that will be used to start service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+
+			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			Expect(stdOut).To(ContainSubstring("Following definition will be used to create"))
 		})
 	})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -61,8 +61,9 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
-			Expect(stdOut).To(ContainSubstring("Following definition will be used to create"))
+			stdout := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			Expect(stdout).To(ContainSubstring("apiVersion"))
+			Expect(stdout).To(ContainSubstring("kind"))
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:
When user does `odo service create <operator-name> --crd <crd-name> --dry-run`,
it will print only the CR's yaml definition that will be used to bring up the
service.

This is needed because yaml definitions provided in the alm-examples are not
always complete. Sometimes they contain template data which needs to be
modified to be able to start the service. After this PR, we will have another
PR which will let the user specify file containing a yaml definition to bring
up the service. That's where this will yaml output in this PR will be really
helpful.


**Which issue(s) this PR fixes**:

Addresses first acceptance criteria of #2723.

**How to test changes / Special notes to the reviewer**:
1. Make sure you have an operator installed on your cluster.
2. Enable experimental mode `export ODO_EXPERIMENTAL=true`
3. Execute following command:
    ```sh
    $ odo service create etcdoperator.v0.9.4 --crd EtcdCluster --dry-run
    Following definition will be used to create EtcdCluster:

    apiVersion: etcd.database.coreos.com/v1beta2
    kind: EtcdCluster
    metadata:
      name: example
    spec:
      size: 3
      version: 3.2.13
    ```

**NOTE to reviewer & QE**: The output generated by above command is likely to
change when the operator is upgrade by its developers. Hence, the integration
test for this PR only checks for the presence of the line `Following definition
will be used to create`.

**NOTE to approver**: This PR is rebased on top of #2739 and hence that should
go in first.
