### PR TITLE
Fix sync when the pod gets re-created

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -314,10 +314,12 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		return errors.New(fmt.Sprintf("Directory / file %s is empty", path))
 	}
 
+	podSelector := fmt.Sprintf("component=%s", a.ComponentName)
+
 	// Wait for Pod to be in running state otherwise we can't sync data to it.
 	pod, err := a.waitAndGetComponentPod()
 	if err != nil {
-		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
+		return errors.Wrapf(err, "error retrieve pod %s for component %s", podSelector, a.ComponentName)
 	}
 
 	// Find at least one pod with the source volume mounted, error out if none can be found

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -511,7 +511,7 @@ func TestWaitAndGetComponentPod(t *testing.T) {
 			})
 
 			componentAdapter := New(adapterCtx, *fkclient)
-			_, err := componentAdapter.waitAndGetComponentPod()
+			_, err := componentAdapter.waitAndGetComponentPod(false)
 
 			// Checks for unexpected error cases
 			if !tt.wantErr == (err != nil) {

--- a/pkg/kclient/pods_test.go
+++ b/pkg/kclient/pods_test.go
@@ -63,7 +63,7 @@ func TestWaitAndGetPod(t *testing.T) {
 				LabelSelector:  podSelector,
 				TimeoutSeconds: &timeout,
 			}
-			pod, err := fkclient.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start")
+			pod, err := fkclient.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start", false)
 
 			if !tt.wantErr == (err != nil) {
 				t.Fatalf(" client.WaitAndGetPod(string) unexpected error %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does does this PR do / why we need it**:
This PR fixes the issue seen in https://github.com/openshift/odo/issues/2807, where if something in the devfile changed that resulted in a new pod, the source code would get lost (as the emptyDir volume went away). Odo wouldn't detect this and wouldn't do a full sync, only a sync of the files that changed on the user's disk.

To fix this, if the component already exists, this PR compares the pod name before and after the call to `a.createOrUpdateComponent`. If the pod names are different, the pod has been re-created and a full sync is needed.

**Which issue(s) this PR fixes**: 

Fixes https://github.com/openshift/odo/issues/2807

**How to test changes / Special notes to the reviewer**:
1) Build my branch
2) Create a devfile component
3) Run `odo push`
4) Make a change in the devfile to cause a new pod to get created
5) Run `odo push` again, verify the entire source code is where it should be on the container(s)

@maysunfaisal is working on integration tests for devfile exec that will have this scenario covered