### PR TITLE
Shortens warning output for event information

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1856,7 +1856,7 @@ func (c *Client) CollectEvents(selector string, events map[string]corev1.Event, 
 						(events)[e.Name] = *newEvent
 						glog.V(4).Infof("Warning Event: Count: %d, Reason: %s, Message: %s", e.Count, e.Reason, e.Message)
 						// Change the spinner message to show the warning
-						spinner.WarningStatus(fmt.Sprintf("WARNING x%d: %s, use `-v` for more information.", e.Count, e.Reason))
+						spinner.WarningStatus(fmt.Sprintf("WARNING x%d: %s", e.Count, e.Reason))
 					}
 
 				}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind code-refactoring

**What does does this PR do / why we need it**:

Updates the warning output to have less information (remove the part
about using `-v` for more information).

This is needed in order to reduce the width of text so we don't run into
any issues with output being resized due to small terminals.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2782

**How to test changes / Special notes to the reviewer**:

Run it :)

```sh

git clone https://github.com/openshift/nodejs-ex
odo create node js
odo preference set PushTimeout

watch -n 1 oc delete pvc --all

odo push -f
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>