### PR TITLE
Don't panic when an invalid component name is passed in

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -64,7 +64,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 			return errors.Wrap(err, "unable to retrieve configuration information")
 		}
 		po.EnvSpecificInfo = envinfo
-		po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+		po.Context = genericclioptions.NewDevfileContext(cmd)
 		return nil
 	}
 

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -58,7 +58,9 @@ func NewURLCreateOptions() *URLCreateOptions {
 
 // Complete completes URLCreateOptions after they've been Created
 func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if o.now {
+	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+	} else if o.now {
 		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -40,7 +40,7 @@ func NewURLDeleteOptions() *URLDeleteOptions {
 // Complete completes URLDeleteOptions after they've been Deleted
 func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	if experimental.IsExperimentalModeEnabled() {
-		o.Context = genericclioptions.NewContext(cmd)
+		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.urlName = args[0]
 		err = o.InitEnvInfoFromContext()
 		if err != nil {

--- a/pkg/odo/cli/url/describe.go
+++ b/pkg/odo/cli/url/describe.go
@@ -41,7 +41,11 @@ func NewURLDescribeOptions() *URLDescribeOptions {
 
 // Complete completes URLDescribeOptions after they've been Listed
 func (o *URLDescribeOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
+	if experimental.IsExperimentalModeEnabled() {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+	} else {
+		o.Context = genericclioptions.NewContext(cmd)
+	}
 	o.localConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed initialize local config")

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -43,7 +43,11 @@ func NewURLListOptions() *URLListOptions {
 
 // Complete completes URLListOptions after they've been Listed
 func (o *URLListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
+	if experimental.IsExperimentalModeEnabled() {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+	} else {
+		o.Context = genericclioptions.NewContext(cmd)
+	}
 	o.LocalConfigInfo, err = config.NewLocalConfigInfo(o.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed intiating local config")

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -82,4 +82,14 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.MatchAllInOutput(output, []string{"Contain at most 63 characters"})
 		})
 	})
+
+	Context("When executing odo create with an invalid devfile component", func() {
+		It("should fail with please run 'odo catalog list components'", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			fakeComponentName := "fake-component"
+			output := helper.CmdShouldFail("odo", "create", fakeComponentName)
+			expectedString := "\"" + fakeComponentName + "\" not found"
+			helper.MatchAllInOutput(output, []string{expectedString})
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug


**What does does this PR do / why we need it**:
This PR fixes the issue seen in https://github.com/openshift/odo/issues/2826 when `odo` would panic if experimental mode was enabled and an invalid component name was passed into `odo create`.

The issue was caused by a partially initialized CLI context being created when experimental mode is true, which caused fields needed for odo-s2i like `LocalConfigInfo` to be nil in the CLI context. When an invalid/non-existent devfile component name is passed in, odo would fall back to trying to create an s2i-style component. But since the CLI context wasn't properly initialized, a null pointer exception would occur and odo would panic.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2826

**How to test changes / Special notes to the reviewer**:
1. Build my branch
2. Run `odo create fake-component`, you should see something like this:
```
Johns-MacBook-Pro-3:odo johncollier$ ./odo create fake-component
 ✗  Checking if the specified component type is supported devfile component type [352140ns]

Please run 'odo catalog list components' for a list of supported devfile component types
 ✗  imagestreams.image.openshift.io "fake-component" not found
```
3. Run `make test-cmd-devfile-create` to verify the updated functional tests that capture this scenario