### PR TITLE
Improves odo delete for devfiles

### DIFF
--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -212,6 +212,15 @@ func (do *DeleteOptions) DevFileRun() (err error) {
 			if err != nil {
 				return err
 			}
+
+			cfg, err := config.NewLocalConfigInfo(do.componentContext)
+			if err != nil {
+				return err
+			}
+			if err = cfg.DeleteConfigDirIfEmpty(); err != nil {
+				return err
+			}
+
 			log.Successf("Successfully deleted env file")
 		} else {
 			log.Error("Aborting deletion of env folder")

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -101,36 +101,7 @@ func (do *DeleteOptions) Run() (err error) {
 	glog.V(4).Infof("args: %#v", do)
 
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
-		// devfile delete
-		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component?")) {
-			err = do.DevfileComponentDelete()
-			if err != nil {
-				log.Errorf("error occurred while deleting component, cause: %v", err)
-			}
-		} else {
-			log.Error("Aborting deletion of component")
-		}
-
-		if do.componentDeleteAllFlag {
-			if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete env folder?")) {
-				if !do.EnvSpecificInfo.EnvInfoFileExists() {
-					return fmt.Errorf("env folder doesn't exist for the component")
-				}
-				err = do.EnvSpecificInfo.DeleteEnvInfoFile()
-				if err != nil {
-					return err
-				}
-				err = do.EnvSpecificInfo.DeleteEnvDirIfEmpty()
-				if err != nil {
-					return err
-				}
-				log.Successf("Successfully deleted env file")
-			} else {
-				log.Error("Aborting deletion of env folder")
-			}
-		}
-
-		return nil
+		return do.DevFileRun()
 	}
 
 	if do.isCmpExists {
@@ -210,6 +181,44 @@ func (do *DeleteOptions) Run() (err error) {
 	}
 
 	return
+}
+
+// Run has the logic to perform the required actions as part of command for devfiles
+func (do *DeleteOptions) DevFileRun() (err error) {
+	// devfile delete
+	if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {
+		err = do.DevfileComponentDelete()
+		if err != nil {
+			log.Errorf("error occurred while deleting component, cause: %v", err)
+		}
+	} else {
+		log.Error("Aborting deletion of component")
+	}
+
+	if do.componentDeleteAllFlag {
+		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete env folder?")) {
+			if !do.EnvSpecificInfo.EnvInfoFileExists() {
+				return fmt.Errorf("env folder doesn't exist for the component")
+			}
+			if err = util.DeleteIndexFile(filepath.Dir(do.devfilePath)); err != nil {
+				return err
+			}
+
+			err = do.EnvSpecificInfo.DeleteEnvInfoFile()
+			if err != nil {
+				return err
+			}
+			err = do.EnvSpecificInfo.DeleteEnvDirIfEmpty()
+			if err != nil {
+				return err
+			}
+			log.Successf("Successfully deleted env file")
+		} else {
+			log.Error("Aborting deletion of env folder")
+		}
+	}
+
+	return nil
 }
 
 // NewCmdDelete implements the delete odo command

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -70,7 +70,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 
 	Context("when devfile delete command is executed with all flag", func() {
 
-		It("should delete the component created from the devfile and also the env folder", func() {
+		It("should delete the component created from the devfile and also the env and odo folders and the odo-index-file.json file", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
 			helper.Chdir(projectDirPath)
 
@@ -86,8 +86,8 @@ var _ = Describe("odo devfile delete command tests", func() {
 
 			oc.WaitAndCheckForExistence("deployments", namespace, 1)
 
-			files := helper.ListFilesInDir(filepath.Join(projectDirPath, ".odo"))
-			Expect(files).To(Not(ContainElement("env")))
+			files := helper.ListFilesInDir(projectDirPath)
+			Expect(files).To(Not(ContainElement(".odo")))
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind code-refactoring

**What does does this PR do / why we need it**:

It improves the `odo delete` command based on suggestions from https://github.com/openshift/odo/pull/2763

**Which issue(s) this PR fixes**:

Fixes: NA

**How to test changes / Special notes to the reviewer**:
- The CI is green 
- `odo delete --all` should also delete the `odo-file-index.json` file.
- `odo delete` prompts should also display the component name
