### PR TITLE
Fix unexpected redeploy when no changes in devfile

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -17,6 +17,22 @@ type DevfileVolume struct {
 	Size          *string
 }
 
+// ComponentVolumesPair is a struct to hold the relationship between components and their volumes
+// Use splices of this struct instead of a map because it is important to maintain order since iteration order of maps is not guaranteed.
+// When maps were used the ordering of the volumes could change in the pod spec causing an unnecessary rollout of the deployment which can be slow.
+type ComponentVolumesPair struct {
+	ComponentAlias string
+	Volumes        []DevfileVolume
+}
+
+// VolumePVCPair is a struct to hold the relationship between volumes and their PVCs
+// Use splices of this struct instead of a map because it is important to maintain order since iteration order of maps is not guaranteed.
+// When maps were used the ordering of the volumes could change in the pod spec causing an unnecessary rollout of the deployment which can be slow.
+type VolumePVCPair struct {
+	Volume string
+	PVC    string
+}
+
 // Storage is a struct that is common to all the adapters
 type Storage struct {
 	Name   string

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -212,12 +212,12 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	componentAliasToVolumes := utils.GetVolumes(a.Devfile)
 
 	var uniqueStorages []common.Storage
-	volumeNameToPVCName := make(map[string]string)
+	volumeNameToPVCName := []common.VolumePVCPair{}
 	processedVolumes := make(map[string]bool)
 
 	// Get a list of all the unique volume names and generate their PVC names
-	for _, volumes := range componentAliasToVolumes {
-		for _, vol := range volumes {
+	for _, volumeData := range componentAliasToVolumes {
+		for _, vol := range volumeData.Volumes {
 			if _, ok := processedVolumes[*vol.Name]; !ok {
 				processedVolumes[*vol.Name] = true
 
@@ -236,6 +236,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 				if len(existingPVCName) > 0 {
 					glog.V(3).Infof("Found an existing PVC for %v, PVC %v will be re-used", *vol.Name, existingPVCName)
 					generatedPVCName = existingPVCName
+
 				}
 
 				pvc := common.Storage{
@@ -243,7 +244,11 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 					Volume: vol,
 				}
 				uniqueStorages = append(uniqueStorages, pvc)
-				volumeNameToPVCName[*vol.Name] = generatedPVCName
+				pairData := common.VolumePVCPair{
+					Volume: *vol.Name,
+					PVC:    generatedPVCName,
+				}
+				volumeNameToPVCName = append(volumeNameToPVCName, pairData)
 			}
 		}
 	}

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -174,19 +174,26 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 
 // GetVolumes iterates through the components in the devfile and returns a map of component alias to the devfile volumes
 func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]adaptersCommon.DevfileVolume {
-	// componentAliasToVolumes is a map of the Devfile Component Alias to the Devfile Component Volumes
-	componentAliasToVolumes := make(map[string][]adaptersCommon.DevfileVolume)
+	// componentAliasToVolumes maps the Devfile Component Alias to the Devfile Component Volumes
+	componentAliasToVolumes := []adaptersCommon.ComponentVolumesPair{}
 	size := volumeSize
 	for _, comp := range adaptersCommon.GetSupportedComponents(devfileObj.Data) {
 		if comp.Volumes != nil {
+			volumes := []adaptersCommon.DevfileVolume{}
 			for _, volume := range comp.Volumes {
 				vol := adaptersCommon.DevfileVolume{
 					Name:          volume.Name,
 					ContainerPath: volume.ContainerPath,
 					Size:          &size,
 				}
-				componentAliasToVolumes[*comp.Alias] = append(componentAliasToVolumes[*comp.Alias], vol)
+				volumes = append(volumes, vol)
 			}
+
+			volumeData := adaptersCommon.ComponentVolumesPair{
+				ComponentAlias: *comp.Alias,
+				Volumes:        volumes,
+			}
+			componentAliasToVolumes = append(componentAliasToVolumes, volumeData)
 		}
 	}
 	return componentAliasToVolumes

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -173,7 +173,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 }
 
 // GetVolumes iterates through the components in the devfile and returns a map of component alias to the devfile volumes
-func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]adaptersCommon.DevfileVolume {
+func GetVolumes(devfileObj devfileParser.DevfileObj) []adaptersCommon.ComponentVolumesPair {
 	// componentAliasToVolumes maps the Devfile Component Alias to the Devfile Component Volumes
 	componentAliasToVolumes := []adaptersCommon.ComponentVolumesPair{}
 	size := volumeSize

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -76,20 +76,20 @@ func AddVolumeMountToPodTemplateSpec(podTemplateSpec *corev1.PodTemplateSpec, vo
 // AddPVCAndVolumeMount adds PVC and volume mount to the pod template spec
 // volumeNameToPVCName is a map of volume name to the PVC created
 // componentAliasToVolumes is a map of the Devfile component alias to the Devfile Volumes
-func AddPVCAndVolumeMount(podTemplateSpec *corev1.PodTemplateSpec, volumeNameToPVCName map[string]string, componentAliasToVolumes map[string][]common.DevfileVolume) error {
-	for volName, pvcName := range volumeNameToPVCName {
-		generatedVolumeName, err := generateVolumeNameFromPVC(pvcName)
+func AddPVCAndVolumeMount(podTemplateSpec *corev1.PodTemplateSpec, volumeNameToPVCName []common.VolumePVCPair, componentAliasToVolumes []common.ComponentVolumesPair) error {
+	for _, pair := range volumeNameToPVCName {
+		generatedVolumeName, err := generateVolumeNameFromPVC(pair.PVC)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to generate volume name from pvc name")
 		}
-		AddPVCToPodTemplateSpec(podTemplateSpec, generatedVolumeName, pvcName)
+		AddPVCToPodTemplateSpec(podTemplateSpec, generatedVolumeName, pair.PVC)
 
 		// componentAliasToMountPaths is a map of the Devfile container alias to their Devfile Volume Mount Paths for a given Volume Name
 		componentAliasToMountPaths := make(map[string][]string)
-		for containerName, volumes := range componentAliasToVolumes {
-			for _, volume := range volumes {
-				if volName == *volume.Name {
-					componentAliasToMountPaths[containerName] = append(componentAliasToMountPaths[containerName], *volume.ContainerPath)
+		for _, volumeData := range componentAliasToVolumes {
+			for _, volume := range volumeData.Volumes {
+				if pair.Volume == *volume.Name {
+					componentAliasToMountPaths[volumeData.ComponentAlias] = append(componentAliasToMountPaths[volumeData.ComponentAlias], *volume.ContainerPath)
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
The ordering of the volumes was inconsistent from one push to another. This PR changes to iterate over slices instead of structs to ensure ordering is consistent. See https://github.com/openshift/odo/issues/2662 for more details.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openshift/odo/issues/2662

**How to test changes / Special notes to the reviewer**:
1. Use a project with a devfile that defines at least 3 volumes
2. Run `kubectl get rs -w` in a separate terminal to watch for any ReplicaSet changes. If a redeploy occurs you will see new events during the push.
3. Run `odo push` and observe that the watch output creates some ReplicaSets
4. After the last push has completed, run `odo push` again
5. The watch output should not change

Sample devfile:
```
---
apiVersion: 1.0.0
metadata:
  generateName: openLiberty
projects:
  -
    name: openLiberty
    source:
      type: git
      location: "https://github.com/rajivnathan/openLiberty.git"
components:
  -
    type: chePlugin
    id: redhat/java/latest
    memoryLimit: 1512Mi
  -
    type: dockerimage
    image: jeevandroid/open-liberty-dev:latest
    alias: runtime
    memoryLimit: 768Mi
    command: ['tail']
    args: [ '-f', '/dev/null']
    env:
      - name: "MODE"
        value: "TEST"
      - name: "myprop"
        value: "myval"
    endpoints:
      - name: '9090/tcp'
        port: 9090
    mountSources: true
    volumes:
      - name: m2
        containerPath: /home/user/.m2
      - name: m3
        containerPath: /home/user/.m3
      - name: m4
        containerPath: /home/user/.m4
  commands:
  -
    name: Build
    actions:
      -
        type: exec
        component: runtime
        command: "TEST_ENV=true /artifacts/bin/build.sh"
        workdir: /projects/openLiberty
  -
    name: Run
    actions:
      -
        type: exec
        component: runtime
        command: "/artifacts/bin/run.sh"
        workdir: /projects/openLiberty
```