### PR TITLE
Remove references to OpenShift cluster

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -27,7 +27,7 @@ const createRecommendedCommandName = "create"
 var (
 	urlCreateShortDesc = `Create a URL for a component`
 	urlCreateLongDesc  = ktemplates.LongDesc(`Create a URL for a component.
-	The created URL can be used to access the specified component from outside the OpenShift cluster.
+	The created URL can be used to access the specified component from outside the cluster.
 	`)
 	urlCreateExample = ktemplates.Examples(`  # Create a URL with a specific name by automatically detecting the port used by the component
 	%[1]s example
@@ -206,7 +206,7 @@ func (o *URLCreateOptions) Run() (err error) {
 			return errors.Wrap(err, "failed to push changes")
 		}
 	} else {
-		log.Italic("\nTo create URL on the OpenShift Cluster, please use `odo push`")
+		log.Italic("\nTo create the URL on the cluster, please use `odo push`")
 	}
 
 	return

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -115,7 +115,7 @@ func (o *URLDeleteOptions) Run() (err error) {
 				return err
 			}
 			log.Successf("URL %s removed from the env file", o.urlName)
-			log.Italic("\nTo delete URL on the OpenShift Cluster, please use `odo push`")
+			log.Italic("\nTo delete the URL on the cluster, please use `odo push`")
 		} else {
 			err = o.LocalConfigInfo.DeleteURL(o.urlName)
 			if err != nil {
@@ -128,7 +128,7 @@ func (o *URLDeleteOptions) Run() (err error) {
 					return errors.Wrap(err, "failed to push changes")
 				}
 			} else {
-				log.Italic("\nTo delete URL on the OpenShift Cluster, please use `odo push`")
+				log.Italic("\nTo delete the URL on the cluster, please use `odo push`")
 			}
 		}
 	} else {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup


**What does does this PR do / why we need it**:
This PR changes references to `OpenShift cluster` to `cluster` in places where the code could be referring to either an OpenShift cluster or Kubernetes cluster.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2852

**How to test changes / Special notes to the reviewer**:
1. Build my branch
2. Create / Delete a URL, verify that it says `cluster` instead of `OpenShift cluster`