### PR TITLE
Fixes now flag push.

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -182,6 +182,7 @@ func (cpo *CommonPushOptions) Push() (err error) {
 
 	cmpName := cpo.LocalConfigInfo.GetName()
 	appName := cpo.LocalConfigInfo.GetApplication()
+	cpo.sourceType = cpo.LocalConfigInfo.GetSourceType()
 
 	if cpo.componentContext == "" {
 		cpo.componentContext = strings.TrimSuffix(filepath.Dir(cpo.LocalConfigInfo.Filename), ".odo")

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -353,6 +353,7 @@ var _ = Describe("odo preference and config command tests", func() {
 
 		It("should successfully set and unset variables", func() {
 			//set env var
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--now", "--env", "hello=world", "--context", context)
 			//*Check config


### PR DESCRIPTION
Signed-off-by: mik-dass <mrinald7@gmail.com>

**What type of PR is this?**

/kind flake

**What does does this PR do / why we need it**:

It also fixes the integration test of now flag for config.

**Which issue(s) this PR fixes**:

Fixes #2642 

**How to test changes / Special notes to the reviewer**:
- `make test-cmd-pref-config` should pass locally and on the CI
- any `-now` operation should build and push the component e.g

Current behaviour
```
[mrinaldas@localhost nodejs-ex]$ odo url create example --now
 ✓  Checking component [2s]
 ✓  URL example created for component: nodejs-nodejs-ex-alyi

Configuration changes
 ✓  Initializing component
 ✓  Creating component [4s]

Applying URL changes
 ✓  URL example: http://example-app-nwfjoupivp.b6ff.rh-idev.openshiftapps.com created

Pushing to component nodejs-nodejs-ex-alyi of type 
 ✓  Checking files for pushing [55ms]
 ✓  Changes successfully pushed to component
```

Expected
```
[mrinaldas@localhost nodejs-ex]$ odo url create example --now
 ✓  Checking component [12s]
 ✓  URL example created for component: nodejs-nodejs-ex-dsbe

Configuration changes
 ✓  Initializing component
 ✓  Creating component [11s]

Applying URL changes
 ✓  URL example: http://example-app-nwfjoupivp.b6ff.rh-idev.openshiftapps.com created

Pushing to component nodejs-nodejs-ex-dsbe of type local
 ✓  Checking files for pushing [17ms]
 ✓  Waiting for component to start [16s]
 ✓  Syncing files to the component [27s]
 ✓  Building component [9s]
 ✓  Changes successfully pushed to component
```