### PR TITLE
Add a blank to align with other command

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -31,6 +31,7 @@ var (
 	`)
 	urlCreateExample = ktemplates.Examples(`  # Create a URL with a specific name by automatically detecting the port used by the component
 	%[1]s example
+
 	# Create a URL for the current component with a specific port
 	%[1]s --port 8080
   


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup

**What does does this PR do / why we need it**:
before the change the command looks like following, to align with other command's format
```
Examples:
  # Create a URL with a specific name by automatically detecting the port used by the component
  odo url create example
  # Create a URL for the current component with a specific port
  odo url create --port 8080

```
**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
