### PR TITLE
add source type field in all odo list variants ( json and standard )

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -936,10 +936,11 @@ func GetComponentFromConfig(localConfig *config.LocalConfigInfo) (Component, err
 		component.Namespace = localConfig.GetProject()
 
 		component.Spec = ComponentSpec{
-			App:    localConfig.GetApplication(),
-			Type:   localConfig.GetType(),
-			Source: localConfig.GetSourceLocation(),
-			Ports:  localConfig.GetPorts(),
+			App:        localConfig.GetApplication(),
+			Type:       localConfig.GetType(),
+			Source:     localConfig.GetSourceLocation(),
+			Ports:      localConfig.GetPorts(),
+			SourceType: string(localConfig.GetSourceType()),
 		}
 
 		if localConfig.GetSourceType() == "local" || localConfig.GetSourceType() == "binary" {
@@ -989,6 +990,7 @@ func ListIfPathGiven(client *occlient.Client, paths []string) (ComponentList, er
 				a.Namespace = data.GetProject()
 				a.Spec.App = data.GetApplication()
 				a.Spec.Ports = data.GetPorts()
+				a.Spec.SourceType = string(data.GetSourceType())
 				a.Status.Context = con
 				if client != nil {
 					a.Status.State = GetComponentState(client, data.GetName(), data.GetApplication())
@@ -1022,7 +1024,6 @@ func GetComponentSource(client *occlient.Client, componentName string, applicati
 	}
 
 	sourceType := deploymentConfig.ObjectMeta.Annotations[ComponentSourceTypeAnnotation]
-
 	if !validateSourceType(sourceType) {
 		return "", "", fmt.Errorf("unsupported component source type %s", sourceType)
 	}
@@ -1348,7 +1349,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 		return component, errors.Wrap(err, "unable to get source type")
 	}
 	// Source
-	_, path, err := GetComponentSource(client, componentName, applicationName)
+	sourceType, path, err := GetComponentSource(client, componentName, applicationName)
 	if err != nil {
 		return component, errors.Wrap(err, "unable to get source path")
 	}
@@ -1417,6 +1418,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 	component.Spec.App = applicationName
 	component.Spec.Source = path
 	component.Spec.URL = urls
+	component.Spec.SourceType = sourceType
 	component.Spec.Storage = storage
 	component.Spec.Env = filteredEnv
 	component.Status.LinkedComponents = linkedComponents

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -664,7 +664,7 @@ func TestGetComponentFromConfig(t *testing.T) {
 
 	localExistingConfigInfoValue := config.GetOneExistingConfigInfo("comp", "app", "project")
 	localNonExistingConfigInfoValue := config.GetOneNonExistingConfigInfo()
-	localGitExistingConfigInfoValue := config.GetOneGitExistingConfigInfo("comp", "app", "project")
+	gitExistingConfigInfoValue := config.GetOneGitExistingConfigInfo("comp", "app", "project")
 
 	tests := []struct {
 		name           string
@@ -697,7 +697,8 @@ func TestGetComponentFromConfig(t *testing.T) {
 							Value: localExistingConfigInfoValue.LocalConfig.GetEnvs()[1].Value,
 						},
 					},
-					Ports: localExistingConfigInfoValue.LocalConfig.GetPorts(),
+					SourceType: "local",
+					Ports:      localExistingConfigInfoValue.LocalConfig.GetPorts(),
 				},
 			},
 		},
@@ -710,29 +711,30 @@ func TestGetComponentFromConfig(t *testing.T) {
 		{
 			name:           "case 3: config file exists",
 			isConfigExists: true,
-			existingConfig: localGitExistingConfigInfoValue,
+			existingConfig: gitExistingConfigInfoValue,
 			wantSpec: Component{
 				Spec: ComponentSpec{
-					App:    localGitExistingConfigInfoValue.GetApplication(),
-					Type:   localGitExistingConfigInfoValue.GetType(),
-					Source: localGitExistingConfigInfoValue.GetSourceLocation(),
+					App:    gitExistingConfigInfoValue.GetApplication(),
+					Type:   gitExistingConfigInfoValue.GetType(),
+					Source: gitExistingConfigInfoValue.GetSourceLocation(),
 					URL: []string{
-						localGitExistingConfigInfoValue.LocalConfig.GetURL()[0].Name, localGitExistingConfigInfoValue.LocalConfig.GetURL()[1].Name,
+						gitExistingConfigInfoValue.LocalConfig.GetURL()[0].Name, gitExistingConfigInfoValue.LocalConfig.GetURL()[1].Name,
 					},
 					Storage: []string{
-						localGitExistingConfigInfoValue.LocalConfig.GetStorage()[0].Name, localExistingConfigInfoValue.LocalConfig.GetStorage()[1].Name,
+						gitExistingConfigInfoValue.LocalConfig.GetStorage()[0].Name, localExistingConfigInfoValue.LocalConfig.GetStorage()[1].Name,
 					},
 					Env: []corev1.EnvVar{
 						{
-							Name:  localGitExistingConfigInfoValue.LocalConfig.GetEnvs()[0].Name,
-							Value: localGitExistingConfigInfoValue.LocalConfig.GetEnvs()[0].Value,
+							Name:  gitExistingConfigInfoValue.LocalConfig.GetEnvs()[0].Name,
+							Value: gitExistingConfigInfoValue.LocalConfig.GetEnvs()[0].Value,
 						},
 						{
-							Name:  localGitExistingConfigInfoValue.LocalConfig.GetEnvs()[1].Name,
-							Value: localGitExistingConfigInfoValue.LocalConfig.GetEnvs()[1].Value,
+							Name:  gitExistingConfigInfoValue.LocalConfig.GetEnvs()[1].Name,
+							Value: gitExistingConfigInfoValue.LocalConfig.GetEnvs()[1].Value,
 						},
 					},
-					Ports: localGitExistingConfigInfoValue.LocalConfig.GetPorts(),
+					SourceType: "git",
+					Ports:      gitExistingConfigInfoValue.LocalConfig.GetPorts(),
 				},
 			},
 		},
@@ -871,8 +873,9 @@ func getFakeComponent(compName, namespace, appName, compType string, state State
 			Namespace: namespace,
 		},
 		Spec: ComponentSpec{
-			Type: compType,
-			App:  appName,
+			Type:       compType,
+			App:        appName,
+			SourceType: "local",
 		},
 		Status: ComponentStatus{
 			State:            state,

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -15,13 +15,14 @@ type Component struct {
 
 // ComponentSpec is spec of components
 type ComponentSpec struct {
-	App     string          `json:"app,omitempty"`
-	Type    string          `json:"type,omitempty"`
-	Source  string          `json:"source,omitempty"`
-	URL     []string        `json:"url,omitempty"`
-	Storage []string        `json:"storage,omitempty"`
-	Env     []corev1.EnvVar `json:"env,omitempty"`
-	Ports   []string        `json:"ports,omitempty"`
+	App        string          `json:"app,omitempty"`
+	Type       string          `json:"type,omitempty"`
+	Source     string          `json:"source,omitempty"`
+	SourceType string          `json:"sourceType,omitempty"`
+	URL        []string        `json:"url,omitempty"`
+	Storage    []string        `json:"storage,omitempty"`
+	Env        []corev1.EnvVar `json:"env,omitempty"`
+	Ports      []string        `json:"ports,omitempty"`
 }
 
 // ComponentList is list of components

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -91,9 +91,9 @@ func (lo *ListOptions) Run() (err error) {
 			machineoutput.OutputSuccess(components)
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "CONTEXT")
-			for _, file := range components.Items {
-				fmt.Fprintln(w, file.Spec.App, "\t", file.Name, "\t", file.Namespace, "\t", file.Spec.Type, "\t", file.Status.State, "\t", file.Status.Context)
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE", "\t", "CONTEXT")
+			for _, comp := range components.Items {
+				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State, "\t", comp.Status.Context)
 
 			}
 			w.Flush()
@@ -146,9 +146,9 @@ func (lo *ListOptions) Run() (err error) {
 			return
 		}
 		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
 		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State)
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
 		}
 		w.Flush()
 	}

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -78,7 +78,7 @@ var _ = Describe("odo app command tests", func() {
 			Expect(appListOutput).To(ContainSubstring(appName))
 			actualCompListJSON := helper.CmdShouldPass("odo", "list", "-o", "json")
 
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","creationTimestamp":null, "namespace":"%s"},"spec":{"type":"nodejs","app":"app","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 
 			helper.CmdShouldPass("odo", "app", "describe")

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -135,7 +135,7 @@ func componentTests(args ...string) {
 				contextPath = strings.TrimSpace(context)
 			}
 			// this orders the json
-			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
+			desired, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Not Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 
 			actual, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "list", "-o", "json", "--path", filepath.Dir(context))...))
@@ -175,7 +175,7 @@ func componentTests(args ...string) {
 			helper.DeleteDir(context2)
 			helper.DeleteProject(project2)
 			// this orders the json
-			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
+			expected, err := helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project, contextPath))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 			// this orders the json
@@ -199,7 +199,7 @@ func componentTests(args ...string) {
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--project", project)...)
 			Expect(cmpList).To(ContainSubstring("cmp-git"))
 			actualCompListJSON := helper.CmdShouldPass("odo", append(args, "list", "--project", project, "-o", "json")...)
-			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"cmp-git","namespace":"%s","creationTimestamp":null},"spec":{"app":"testing","type":"nodejs","source":"https://github.com/openshift/nodejs-ex","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
+			desiredCompListJSON := fmt.Sprintf(`{"kind":"List","apiVersion":"odo.openshift.io/v1alpha1","metadata":{},"items":[{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"cmp-git","namespace":"%s","creationTimestamp":null},"spec":{"app":"testing","type":"nodejs","source":"https://github.com/openshift/nodejs-ex","sourceType": "git","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}]}`, project)
 			Expect(desiredCompListJSON).Should(MatchJSON(actualCompListJSON))
 			cmpAllList := helper.CmdShouldPass("odo", append(args, "list", "--all-apps")...)
 			Expect(cmpAllList).To(ContainSubstring("cmp-git"))
@@ -247,7 +247,7 @@ func componentTests(args ...string) {
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","url": ["url-1"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -257,7 +257,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","sourceType": "local","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -267,7 +267,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","sourceType": "local","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
@@ -695,7 +695,7 @@ func componentTests(args ...string) {
 
 			actualDesCompJSON := helper.CmdShouldPass("odo", append(args, "describe", cmpName, "--app", appName, "--project", project, "-o", "json")...)
 
-			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project)
+			desiredDesCompJSON := fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"nodejs","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"nodejs","sourceType": "local","env":[{"name":"DEBUG_PORT","value":"5858"}]},"status":{"state":"Pushed"}}`, project)
 			Expect(desiredDesCompJSON).Should(MatchJSON(actualDesCompJSON))
 
 			helper.CmdShouldPass("odo", append(args, "delete", cmpName, "--app", appName, "--project", project, "-f")...)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -179,7 +179,7 @@ func componentTests(args ...string) {
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 			// this orders the json
-			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
+			expected, err = helper.Unindented(fmt.Sprintf(`{"kind":"Component","apiVersion":"odo.openshift.io/v1alpha1","metadata":{"name":"python","namespace":"%s","creationTimestamp":null},"spec":{"app":"app","type":"python","sourceType": "local","ports":["8080/TCP"]},"status":{"context":"%s","state":"Pushed"}}`, project2, contextPath2))
 			Expect(err).Should(BeNil())
 			Expect(actual).Should(ContainSubstring(expected))
 


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


 /kind feature
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
adds `sourceType` in json output and standard output for `odo list`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2730

**How to test changes / Special notes to the reviewer**:

Create a component and before pushing
`odo list`
`odo list --all-apps`
`odo list --path .`
should give `SOURCETYPE` column and similarly `-o json` variants should give json output.

Now push the component and try the same.

when a component is not pushed the code path is different as the component is not present on the cluster and hence the reviewer should check if `sourceType` shows in that case as well or not.

