### PR TITLE
Remedy panic slice-out-bounds error when using `odo update`

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -1686,14 +1686,14 @@ func (c *Client) UpdateDCAnnotations(dcName string, annotations map[string]strin
 func removeTracesOfSupervisordFromDC(dc *appsv1.DeploymentConfig) error {
 	dcName := dc.Name
 
-	found := removeVolumeFromDC(getAppRootVolumeName(dcName), dc)
-	if !found {
-		return errors.New("unable to find volume in dc with name: " + dcName)
+	err := removeVolumeFromDC(getAppRootVolumeName(dcName), dc)
+	if err != nil {
+		return err
 	}
 
-	found = removeVolumeMountsFromDC(getAppRootVolumeName(dcName), dc)
-	if !found {
-		return errors.New("unable to find volume mount in dc with name: " + dcName)
+	err = removeVolumeMountsFromDC(getAppRootVolumeName(dcName), dc)
+	if err != nil {
+		return err
 	}
 
 	// remove the one bootstrapped init container
@@ -2721,15 +2721,18 @@ func (c *Client) RemoveVolumeFromDeploymentConfig(pvc string, dcName string) err
 			return fmt.Errorf("found more than one volume for PVC %v in DC %v, expected one", pvc, dc.Name)
 		}
 		volumeName := volumeNames[0]
+
 		// Remove volume if volume exists in Deployment Config
-		if !removeVolumeFromDC(volumeName, dc) {
-			return fmt.Errorf("could not find volume '%v' in Deployment Config '%v'", volumeName, dc.Name)
+		err = removeVolumeFromDC(volumeName, dc)
+		if err != nil {
+			return err
 		}
 		klog.V(4).Infof("Found volume: %v in Deployment Config: %v", volumeName, dc.Name)
 
 		// Remove at max 2 volume mounts if volume mounts exists
-		if !removeVolumeMountsFromDC(volumeName, dc) {
-			return fmt.Errorf("could not find volumeMount: %v in Deployment Config: %v", volumeName, dc)
+		err = removeVolumeMountsFromDC(volumeName, dc)
+		if err != nil {
+			return err
 		}
 
 		_, updateErr := c.appsClient.DeploymentConfigs(c.Namespace).Update(dc)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:

This PR:

- Fixes the common issue of:
`panic: runtime error: slice bounds out of range [2:1]` when going from
`odo create --local` to `odo update --git`
- Adds way more tests for privatized functions
- Fixes a potential issue with removing volume mounts with

Why?

What was happening was that when removing a volume, if the length of volumes was only **ONE** then an `out of bounds` error occurred. This code checks to see if the length is 1 as well as performing the correct array slicing.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2646

**How to test changes / Special notes to the reviewer**:

To try and recreate the error (which isn't happening anymore):

```sh
git clone https://github.com/openshift/nodejs-ex
odo create nodejs
odo url create
odo push

odo update --git https://github.com/openshift/nodejs-ex
```