### PR TITLE
Adds route support of URLs for openshift clusters

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -542,7 +542,18 @@ func ValidateComponentCreateRequest(client *occlient.Client, componentSettings c
 // Returns:
 //	err: Errors if any else nil
 func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool) (err error) {
-	if !experimental.IsExperimentalModeEnabled() {
+	isExperimentalModeEnabled := experimental.IsExperimentalModeEnabled()
+
+	if client == nil {
+		var err error
+		client, err = occlient.New()
+		if err != nil {
+			return err
+		}
+		client.Namespace = envSpecificInfo.GetNamespace()
+	}
+
+	if !isExperimentalModeEnabled {
 		// if component exist then only call the update function
 		if cmpExist {
 			if err = Update(client, componentConfig, componentConfig.GetSourceLocation(), stdout); err != nil {
@@ -551,101 +562,29 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 		}
 	}
 
-	showChanges, pushedURLMap, err := checkIfURLChangesWillBeMade(client, kClient, componentConfig, envSpecificInfo)
+	var componentName string
+	var applicationName string
+	if !isExperimentalModeEnabled {
+		componentName = componentConfig.GetName()
+		applicationName = componentConfig.GetApplication()
+	} else {
+		componentName = envSpecificInfo.GetName()
+	}
+
+	isRouteSupported := false
+	isRouteSupported, err = client.IsRouteSupported()
 	if err != nil {
-		return err
+		isRouteSupported = false
 	}
 
-	if showChanges {
-		log.Info("\nApplying URL changes")
-		// Create any URLs that have been added to the component
-		err = ApplyConfigCreateURL(client, kClient, componentConfig, envSpecificInfo, pushedURLMap)
-		if err != nil {
-			return err
-		}
-
-		// Delete any URLs
-		err = applyConfigDeleteURL(client, kClient, componentConfig, envSpecificInfo, pushedURLMap)
-		if err != nil {
-			return err
-		}
-	}
-
-	return
-}
-
-// ApplyConfigDeleteURL applies url config deletion onto component
-func applyConfigDeleteURL(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, pushedURLMap map[string]bool) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		localURLList := envSpecificInfo.GetURL()
-		tempMap := make(map[string]envinfo.EnvInfoURL)
-		for _, urlElement := range localURLList {
-			tempMap[urlElement.Name] = urlElement
-		}
-		// urlName is the key of each element
-		for urlName := range pushedURLMap {
-			if _, exist := tempMap[urlName]; !exist {
-				err = urlpkg.Delete(client, kClient, urlName, componentConfig.GetApplication())
-				if err != nil {
-					return err
-				}
-				log.Successf("URL %s successfully deleted", urlName)
-			}
-		}
-	} else {
-		localURLList := componentConfig.GetURL()
-		tempMap := make(map[string]config.ConfigURL)
-		for _, urlElement := range localURLList {
-			tempMap[urlElement.Name] = urlElement
-		}
-		// urlName is the key of each element
-		for urlName := range pushedURLMap {
-			if _, exist := tempMap[urlName]; !exist {
-				err = urlpkg.Delete(client, kClient, urlName, componentConfig.GetApplication())
-				if err != nil {
-					return err
-				}
-				log.Successf("URL %s successfully deleted", urlName)
-			}
-		}
-	}
-	return nil
-}
-
-// ApplyConfigCreateURL applies url config onto component
-func ApplyConfigCreateURL(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, pushedURLMap map[string]bool) error {
-	if experimental.IsExperimentalModeEnabled() {
-		urls := envSpecificInfo.GetURL()
-		componentName := envSpecificInfo.GetName()
-		for _, urlo := range urls {
-			_, exist := pushedURLMap[urlo.Name]
-			if exist {
-				log.Successf("URL %s already exists", urlo.Name)
-			} else {
-				host, err := urlpkg.Create(client, kClient, urlo.Name, urlo.Port, urlo.Secure, componentName, "", urlo.Host, urlo.TLSSecret)
-				if err != nil {
-					return errors.Wrapf(err, "unable to create url")
-				}
-				log.Successf("URL %s: %s created", urlo.Name, host)
-			}
-		}
-	} else {
-		urls := componentConfig.GetURL()
-		for _, urlo := range urls {
-			_, exist := pushedURLMap[urlo.Name]
-			if exist {
-				log.Successf("URL %s already exists", urlo.Name)
-			} else {
-				host, err := urlpkg.Create(client, kClient, urlo.Name, urlo.Port, urlo.Secure, componentConfig.GetName(), componentConfig.GetApplication(), "", "")
-				if err != nil {
-					return errors.Wrapf(err, "unable to create url")
-				}
-				log.Successf("URL %s: %s created", urlo.Name, host)
-			}
-		}
-	}
-
-	return nil
+	return urlpkg.Push(client, kClient, urlpkg.PushParameters{
+		ComponentName:             componentName,
+		ApplicationName:           applicationName,
+		ConfigURLs:                componentConfig.GetURL(),
+		EnvURLS:                   envSpecificInfo.GetURL(),
+		IsRouteSupported:          isRouteSupported,
+		IsExperimentalModeEnabled: isExperimentalModeEnabled,
+	})
 }
 
 // PushLocal push local code to the cluster and trigger build there.
@@ -1494,45 +1433,6 @@ func getStorageFromConfig(localConfig *config.LocalConfigInfo) storage.StorageLi
 		storageList.Items = append(storageList.Items, storage.GetMachineReadableFormat(storageVar.Name, storageVar.Size, storageVar.Path))
 	}
 	return storageList
-}
-
-// checkIfURLChangesWillBeMade checks to see if there are going to be any changes
-// to the URLs when deploying and returns a true / false
-func checkIfURLChangesWillBeMade(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo) (bool, map[string]bool, error) {
-	if experimental.IsExperimentalModeEnabled() {
-		componentName := envSpecificInfo.GetName()
-		urlList, err := urlpkg.ListPushedIngress(kClient, componentName)
-		if err != nil {
-			return false, nil, err
-		}
-
-		// If envinfo has URL(s) (since we check) or if the cluster has URL's but
-		// envinfo does not (deleting)
-		if len(envSpecificInfo.GetURL()) > 0 || len(envSpecificInfo.GetURL()) == 0 && (len(urlList.Items) > 0) {
-			pushedURLMap := make(map[string]bool)
-			for _, element := range urlList.Items {
-				pushedURLMap[element.Name] = true
-			}
-			return true, pushedURLMap, nil
-		}
-	} else {
-		urlList, err := urlpkg.ListPushed(client, componentConfig.GetName(), componentConfig.GetApplication())
-		if err != nil {
-			return false, nil, err
-		}
-
-		// If envinfo has URL(s) (since we check) or if the cluster has URL's but
-		// envinfo does not (deleting)
-		if len(componentConfig.GetURL()) > 0 || len(componentConfig.GetURL()) == 0 && (len(urlList.Items) > 0) {
-			pushedURLMap := make(map[string]bool)
-			for _, element := range urlList.Items {
-				pushedURLMap[element.Name] = true
-			}
-			return true, pushedURLMap, nil
-		}
-	}
-
-	return false, nil, nil
 }
 
 func addDebugPortToEnv(envVarList *config.EnvVarList, componentConfig config.LocalConfigInfo) {

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -564,7 +564,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 
 	var componentName string
 	var applicationName string
-	if !isExperimentalModeEnabled {
+	if !isExperimentalModeEnabled || kClient == nil {
 		componentName = componentConfig.GetName()
 		applicationName = componentConfig.GetApplication()
 	} else {

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -26,6 +26,14 @@ type ComponentSettings struct {
 	URL       *[]EnvInfoURL `yaml:"Url,omitempty"`
 }
 
+// URLType is an enum to indicate the type of the URL i.e ingress/route
+type URLKind string
+
+const (
+	INGRESS URLKind = "ingress"
+	ROUTE   URLKind = "route"
+)
+
 // EnvInfoURL holds URL related information
 type EnvInfoURL struct {
 	// Name of the URL
@@ -34,12 +42,14 @@ type EnvInfoURL struct {
 	Port int `yaml:"Port,omitempty"`
 	// Indicates if the URL should be a secure https one
 	Secure bool `yaml:"Secure,omitempty"`
-	// Clutser host
+	// Cluster host
 	Host string `yaml:"host,omitempty"`
 	// TLS secret name to create ingress to provide a secure URL
 	TLSSecret string `yaml:"TLSSecret,omitempty"`
 	// Exposed port number for docker container, required for local scenarios
 	ExposedPort int `yaml:"ExposedPort,omitempty"`
+	// Kind is the kind of the URL
+	Kind URLKind `yaml:"Kind,omitempty"`
 }
 
 // EnvInfo holds all the env specific infomation relavent to a specific Component.

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -26,7 +26,7 @@ type ComponentSettings struct {
 	URL       *[]EnvInfoURL `yaml:"Url,omitempty"`
 }
 
-// URLType is an enum to indicate the type of the URL i.e ingress/route
+// URLKind is an enum to indicate the type of the URL i.e ingress/route
 type URLKind string
 
 const (

--- a/pkg/kclient/fake/ingress.go
+++ b/pkg/kclient/fake/ingress.go
@@ -1,0 +1,62 @@
+package fake
+
+import (
+	applabels "github.com/openshift/odo/pkg/application/labels"
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/url/labels"
+	"github.com/openshift/odo/pkg/version"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func GetIngressListWithMultiple(componentName string) *extensionsv1.IngressList {
+	return &extensionsv1.IngressList{
+		Items: []extensionsv1.Ingress{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example-0",
+					Labels: map[string]string{
+						applabels.ApplicationLabel:     "",
+						componentlabels.ComponentLabel: componentName,
+						applabels.OdoManagedBy:         "odo",
+						applabels.OdoVersion:           version.VERSION,
+						labels.URLLabel:                "example-0",
+					},
+				},
+				Spec: *kclient.GenerateIngressSpec(kclient.IngressParameter{ServiceName: "example-0", PortNumber: intstr.FromInt(8080)}),
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example-1",
+					Labels: map[string]string{
+						applabels.ApplicationLabel:     "",
+						componentlabels.ComponentLabel: componentName,
+						applabels.OdoManagedBy:         "odo",
+						applabels.OdoVersion:           version.VERSION,
+						labels.URLLabel:                "example-1",
+					},
+				},
+				Spec: *kclient.GenerateIngressSpec(kclient.IngressParameter{ServiceName: "example-1", PortNumber: intstr.FromInt(8080)}),
+			},
+		},
+	}
+}
+
+func GetSingleIngress(urlName, componentName string) *extensionsv1.Ingress {
+	return &extensionsv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: urlName,
+			Labels: map[string]string{
+				applabels.ApplicationLabel:     "",
+				componentlabels.ComponentLabel: componentName,
+				applabels.OdoManagedBy:         "odo",
+				applabels.OdoVersion:           version.VERSION,
+				labels.URLLabel:                urlName,
+				applabels.App:                  "",
+			},
+		},
+		Spec: *kclient.GenerateIngressSpec(kclient.IngressParameter{ServiceName: urlName, PortNumber: intstr.FromInt(8080)}),
+	}
+}

--- a/pkg/kclient/fake/secrets.go
+++ b/pkg/kclient/fake/secrets.go
@@ -1,0 +1,15 @@
+package fake
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetSecret(secretName string) *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+	}
+}

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3255,7 +3255,11 @@ func isSubDir(baseDir, otherDir string) bool {
 
 // IsRouteSupported checks if route resource type is present on the cluster
 func (c *Client) IsRouteSupported() (bool, error) {
-	list, err := c.discoveryClient.ServerResourcesForGroupVersion("route.openshift.io/v1")
+	const ClusterVersionGroup = "route.openshift.io"
+	const ClusterVersionVersion = "v1"
+	groupVersion := metav1.GroupVersion{Group: ClusterVersionGroup, Version: ClusterVersionVersion}.String()
+
+	list, err := c.discoveryClient.ServerResourcesForGroupVersion(groupVersion)
 	if kerrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -608,13 +608,13 @@ func TestCreateRoute(t *testing.T) {
 			// initialising the fakeclient
 			fkclient, fkclientset := FakeNew()
 
+			ownerReferences := GenerateOwnerReference(&tt.existingDC)
+
 			fkclientset.AppsClientset.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
-				dc := &appsv1.DeploymentConfig{}
-				dc.Name = tt.service
-				return true, dc, nil
+				return true, &tt.existingDC, nil
 			})
 
-			createdRoute, err := fkclient.CreateRoute(tt.urlName, tt.service, tt.portNumber, tt.labels, tt.secureURL)
+			createdRoute, err := fkclient.CreateRoute(tt.urlName, tt.service, tt.portNumber, tt.labels, tt.secureURL, ownerReferences)
 
 			if tt.secureURL {
 				wantedTLSConfig := &routev1.TLSConfig{

--- a/pkg/occlient/volumes_test.go
+++ b/pkg/occlient/volumes_test.go
@@ -270,7 +270,7 @@ func Test_updateStorageOwnerReference(t *testing.T) {
 			args: args{
 				pvc: testingutil.FakePVC("pvc-1", "1Gi", map[string]string{}),
 				ownerReference: []v1.OwnerReference{
-					generateOwnerReference(fakeDC),
+					GenerateOwnerReference(fakeDC),
 				},
 			},
 			wantErr: false,

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -329,7 +329,7 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 			urlCreateCmd.Flags().StringVar(&o.tlsSecret, "tls-secret", "", "tls secret name for the url of the component if the user bring his own tls secret")
 			urlCreateCmd.Flags().StringVarP(&o.host, "host", "", "", "Cluster ip for this URL")
 			urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "creates a secure https url")
-			urlCreateCmd.Flags().BoolVar(&o.wantIngress, "ingress", false, "Ingress creates a ingress instead of route on OpenShift clusters")
+			urlCreateCmd.Flags().BoolVar(&o.wantIngress, "ingress", false, "Creates an ingress instead of Route on OpenShift clusters")
 			urlCreateCmd.Example = fmt.Sprintf(urlCreateExampleExperimental, fullName)
 		}
 		urlCreateCmd.Flags().StringVar(&o.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -50,7 +50,7 @@ var (
 	# Create a URL for the current component with a specific port and host (using CRC as an example)
 	%[1]s --port 8080 --host apps-crc.testing
 
-	# Create a URL for the current component with a host (using CRC as an example) and a ingress
+	# Create a URL of ingress kind for the current component with a host (using CRC as an example)
 	%[1]s --host apps-crc.testing --ingress
 
 	# Create a secured URL for the current component with a specific host (using CRC as an example)
@@ -102,11 +102,11 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 
 	o.Client = genericclioptions.Client(cmd)
 
-	serverInfo, err := o.Client.IsRouteSupported()
+	routeSupported, err := o.Client.IsRouteSupported()
 	if err != nil {
 		return err
 	}
-	if serverInfo {
+	if routeSupported {
 		o.isRouteSupported = true
 	}
 

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -44,13 +44,16 @@ var (
 	urlCreateExampleExperimental = ktemplates.Examples(`  # Create a URL with a specific host by automatically detecting the port used by the component (using CRC as an exampple)
 	%[1]s example  --host apps-crc.testing
   
-	# Create a URL with a specific name and host (using CRC as an exampple)
+	# Create a URL with a specific name and host (using CRC as an example)
 	%[1]s example --host apps-crc.testing
 
-	# Create a URL for the current component with a specific port and host (using CRC as an exampple)
+	# Create a URL for the current component with a specific port and host (using CRC as an example)
 	%[1]s --port 8080 --host apps-crc.testing
 
-	# Create a secured URL for the current component with a specific host (using CRC as an exampple)
+	# Create a URL for the current component with a host (using CRC as an example) and a ingress
+	%[1]s --host apps-crc.testing --ingress
+
+	# Create a secured URL for the current component with a specific host (using CRC as an example)
 	%[1]s --host apps-crc.testing --secured
 	  `)
 
@@ -68,15 +71,18 @@ var (
 // URLCreateOptions encapsulates the options for the odo url create command
 type URLCreateOptions struct {
 	*clicomponent.PushOptions
-	urlName       string
-	urlPort       int
-	secureURL     bool
-	componentPort int
-	now           bool
-	host          string
-	tlsSecret     string
-	exposedPort   int
-	forceFlag     bool
+	urlName          string
+	urlPort          int
+	secureURL        bool
+	componentPort    int
+	now              bool
+	host             string
+	tlsSecret        string
+	exposedPort      int
+	forceFlag        bool
+	isRouteSupported bool
+	wantIngress      bool
+	urlType          envinfo.URLKind
 }
 
 // NewURLCreateOptions creates a new URLCreateOptions instance
@@ -93,7 +99,28 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
 	}
+
+	o.Client = genericclioptions.Client(cmd)
+
+	serverInfo, err := o.Client.IsRouteSupported()
+	if err != nil {
+		return err
+	}
+	if serverInfo {
+		o.isRouteSupported = true
+	}
+
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+		if o.wantIngress || (!o.isRouteSupported) {
+			o.urlType = envinfo.INGRESS
+		} else {
+			o.urlType = envinfo.ROUTE
+		}
+
+		if o.tlsSecret != "" && (!o.wantIngress || !o.secureURL) {
+			return fmt.Errorf("tls secret is only available for secure URLs of ingress kind")
+		}
+
 		err = o.InitEnvInfoFromContext()
 		if err != nil {
 			return err
@@ -180,7 +207,7 @@ func (o *URLCreateOptions) Validate() (err error) {
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
 		// if experimental mode is enabled, and devfile is provided.
 		// check if valid host is provided
-		if !pushtarget.IsPushTargetDocker() && len(o.host) <= 0 {
+		if !pushtarget.IsPushTargetDocker() && len(o.host) <= 0 && (!o.isRouteSupported || o.wantIngress) {
 			return fmt.Errorf("host must be provided in order to create ingress")
 		}
 		for _, localURL := range o.EnvSpecificInfo.GetURL() {
@@ -245,7 +272,7 @@ func (o *URLCreateOptions) Run() (err error) {
 				}
 			}
 		}
-		err = o.EnvSpecificInfo.SetConfiguration("url", envinfo.EnvInfoURL{Name: o.urlName, Port: o.componentPort, Host: o.host, Secure: o.secureURL, TLSSecret: o.tlsSecret, ExposedPort: o.exposedPort})
+		err = o.EnvSpecificInfo.SetConfiguration("url", envinfo.EnvInfoURL{Name: o.urlName, Port: o.componentPort, Host: o.host, Secure: o.secureURL, TLSSecret: o.tlsSecret, ExposedPort: o.exposedPort, Kind: o.urlType})
 	} else {
 		err = o.LocalConfigInfo.SetConfiguration("url", config.ConfigURL{Name: o.urlName, Port: o.componentPort, Secure: o.secureURL})
 	}
@@ -257,8 +284,7 @@ func (o *URLCreateOptions) Run() (err error) {
 		if pushtarget.IsPushTargetDocker() {
 			log.Successf("URL %s created for component: %v with exposed port: %v", o.urlName, componentName, o.exposedPort)
 		} else {
-			curIngressDomain := fmt.Sprintf("%v.%v", o.urlName, o.host)
-			log.Successf("URL %s created for component: %v", curIngressDomain, componentName)
+			log.Successf("URL %s created for component: %v", o.urlName, componentName)
 		}
 	} else {
 		log.Successf("URL %s created for component: %v", o.urlName, o.Component())
@@ -303,11 +329,13 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 			urlCreateCmd.Flags().StringVar(&o.tlsSecret, "tls-secret", "", "tls secret name for the url of the component if the user bring his own tls secret")
 			urlCreateCmd.Flags().StringVarP(&o.host, "host", "", "", "Cluster ip for this URL")
 			urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "creates a secure https url")
+			urlCreateCmd.Flags().BoolVar(&o.wantIngress, "ingress", false, "Ingress creates a ingress instead of route on OpenShift clusters")
 			urlCreateCmd.Example = fmt.Sprintf(urlCreateExampleExperimental, fullName)
 		}
 		urlCreateCmd.Flags().StringVar(&o.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
 	} else {
 		urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "creates a secure https url")
+		urlCreateCmd.Example = fmt.Sprintf(urlCreateExample, fullName)
 	}
 	genericclioptions.AddNowFlag(urlCreateCmd, &o.now)
 	o.AddContextFlag(urlCreateCmd)

--- a/pkg/odo/cli/url/describe.go
+++ b/pkg/odo/cli/url/describe.go
@@ -73,7 +73,7 @@ func (o *URLDescribeOptions) Run() (err error) {
 			tabWriterURL := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			fmt.Fprintln(tabWriterURL, "NAME", "\t", "URL", "\t", "PORT")
 
-			fmt.Fprintln(tabWriterURL, u.Name, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, u), "", u.Spec.Rules[0].Host), "\t", u.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.ServicePort.IntVal)
+			fmt.Fprintln(tabWriterURL, u.Name, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, u, experimental.IsExperimentalModeEnabled()), "", u.Spec.Rules[0].Host, experimental.IsExperimentalModeEnabled()), "\t", u.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.ServicePort.IntVal)
 			tabWriterURL.Flush()
 		}
 	} else {
@@ -91,7 +91,7 @@ func (o *URLDescribeOptions) Run() (err error) {
 
 			// are there changes between local and cluster states?
 			outOfSync := false
-			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, ""), "\t", u.Spec.Port)
+			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", experimental.IsExperimentalModeEnabled()), "\t", u.Spec.Port)
 			if u.Status.State != url.StateTypePushed {
 				outOfSync = true
 			}

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -88,7 +88,7 @@ func (o *URLListOptions) Run() (err error) {
 				var present bool
 				for _, u := range urls.Items {
 					if i.Name == u.Name {
-						fmt.Fprintln(tabWriterURL, u.Name, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, u), "", u.Spec.Rules[0].Host), "\t", u.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.ServicePort.IntVal, "\t", u.Spec.TLS != nil)
+						fmt.Fprintln(tabWriterURL, u.Name, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, u, experimental.IsExperimentalModeEnabled()), "", u.Spec.Rules[0].Host, experimental.IsExperimentalModeEnabled()), "\t", u.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.ServicePort.IntVal, "\t", u.Spec.TLS != nil)
 						present = true
 					}
 				}
@@ -121,7 +121,7 @@ func (o *URLListOptions) Run() (err error) {
 			// are there changes between local and cluster states?
 			outOfSync := false
 			for _, u := range urls.Items {
-				fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, ""), "\t", u.Spec.Port, "\t", u.Spec.Secure)
+				fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", experimental.IsExperimentalModeEnabled()), "\t", u.Spec.Port, "\t", u.Spec.Secure)
 				if u.Status.State != url.StateTypePushed {
 					outOfSync = true
 				}

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -152,7 +152,7 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 				// Gather the output
 				for _, componentURL := range componentDesc.Spec.URL {
 					url := urls.Get(componentURL)
-					output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, ""), url.Spec.Port)
+					output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, "", experimental.IsExperimentalModeEnabled()), url.Spec.Port)
 				}
 
 			}

--- a/pkg/testingutil/routes.go
+++ b/pkg/testingutil/routes.go
@@ -1,0 +1,45 @@
+package testingutil
+
+import (
+	"fmt"
+	routev1 "github.com/openshift/api/route/v1"
+	applabels "github.com/openshift/odo/pkg/application/labels"
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/url/labels"
+	"github.com/openshift/odo/pkg/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func GetRouteListWithMultiple(componentName, applicationName string) *routev1.RouteList {
+	return &routev1.RouteList{
+		Items: []routev1.Route{
+			GetSingleRoute("example", 8080, componentName, applicationName),
+			GetSingleRoute("example-1", 9100, componentName, applicationName),
+		},
+	}
+}
+
+func GetSingleRoute(urlName string, port int, componentName, applicationName string) routev1.Route {
+	return routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: urlName,
+			Labels: map[string]string{
+				applabels.ApplicationLabel:     applicationName,
+				componentlabels.ComponentLabel: componentName,
+				applabels.OdoManagedBy:         "odo",
+				applabels.OdoVersion:           version.VERSION,
+				labels.URLLabel:                urlName,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: fmt.Sprintf("%s-%s", componentName, applicationName),
+			},
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromInt(port),
+			},
+		},
+	}
+}

--- a/pkg/url/types.go
+++ b/pkg/url/types.go
@@ -1,6 +1,7 @@
 package url
 
 import (
+	"github.com/openshift/odo/pkg/envinfo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,10 +15,12 @@ type URL struct {
 
 // URLSpec is
 type URLSpec struct {
-	Host     string `json:"host,omitempty"`
-	Protocol string `json:"protocol,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	Secure   bool   `json:"secure"`
+	Host      string `json:"host,omitempty"`
+	Protocol  string `json:"protocol,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	Secure    bool   `json:"secure"`
+	urlKind   envinfo.URLKind
+	tLSSecret string
 }
 
 // AppList is a list of applications

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -397,7 +397,18 @@ func TestCreate(t *testing.T) {
 				return true, testingutil.CreateFakeDeployment("nodejs"), nil
 			})
 
-			got, err := Create(client, fakeKClient, tt.args.urlName, tt.args.portNumber, tt.args.secure, tt.args.componentName, tt.args.applicationName, tt.args.host, tt.args.tlsSecret, tt.args.urlKind, tt.args.isRouteSupported, tt.args.isExperimentalModeEnabled)
+			urlCreateParameters := CreateParameters{
+				urlName:         tt.args.urlName,
+				portNumber:      tt.args.portNumber,
+				secureURL:       tt.args.secure,
+				componentName:   tt.args.componentName,
+				applicationName: tt.args.applicationName,
+				host:            tt.args.host,
+				secretName:      tt.args.tlsSecret,
+				urlKind:         tt.args.urlKind,
+			}
+
+			got, err := Create(client, fakeKClient, urlCreateParameters, tt.args.isRouteSupported, tt.args.isExperimentalModeEnabled)
 
 			if err == nil && !tt.wantErr {
 				if tt.args.urlKind == envinfo.INGRESS {

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -2,18 +2,25 @@ package url
 
 import (
 	"fmt"
-	"reflect"
-	"testing"
-
-	//	"github.com/openshift/odo/pkg/kclient"
-
-	//	"github.com/kylelemons/godebug/pretty"
-	//appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/kylelemons/godebug/pretty"
+	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/envinfo"
+	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/kclient/fake"
 	"github.com/openshift/odo/pkg/occlient"
+	"github.com/openshift/odo/pkg/testingutil"
 	"github.com/openshift/odo/pkg/url/labels"
+	"github.com/openshift/odo/pkg/util"
+	"k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"reflect"
+	"testing"
 	//"github.com/openshift/odo/pkg/util"
 	"github.com/openshift/odo/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,30 +29,38 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
-/*
-TODO: FIX THESE TESTS.
 func TestCreate(t *testing.T) {
 	type args struct {
-		componentName   string
-		applicationName string
-		urlName         string
-		portNumber      int
-		secure          bool
+		componentName             string
+		applicationName           string
+		urlName                   string
+		portNumber                int
+		secure                    bool
+		host                      string
+		urlKind                   envinfo.URLKind
+		isRouteSupported          bool
+		isExperimentalModeEnabled bool
+		tlsSecret                 string
 	}
 	tests := []struct {
-		name          string
-		args          args
-		returnedRoute *routev1.Route
-		want          string
-		wantErr       bool
+		name               string
+		args               args
+		returnedRoute      *routev1.Route
+		returnedIngress    *extensionsv1.Ingress
+		defaultTLSExists   bool
+		userGivenTLSExists bool
+		want               string
+		wantErr            bool
 	}{
 		{
 			name: "Case 1: Component name same as urlName",
 			args: args{
-				componentName:   "nodejs",
-				applicationName: "app",
-				urlName:         "nodejs",
-				portNumber:      8080,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "nodejs",
+				portNumber:       8080,
+				isRouteSupported: true,
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -75,10 +90,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 2: Component name different than urlName",
 			args: args{
-				componentName:   "nodejs",
-				applicationName: "app",
-				urlName:         "example-url",
-				portNumber:      9100,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example-url",
+				portNumber:       9100,
+				isRouteSupported: true,
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -108,11 +125,13 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 3: a secure URL",
 			args: args{
-				componentName:   "nodejs",
-				applicationName: "app",
-				urlName:         "example-url",
-				portNumber:      9100,
-				secure:          true,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example-url",
+				portNumber:       9100,
+				secure:           true,
+				isRouteSupported: true,
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -143,10 +162,189 @@ func TestCreate(t *testing.T) {
 			want:    "https://host",
 			wantErr: false,
 		},
+
+		{
+			name: "Case 4: Create a ingress, with same name as component,instead of route on openshift cluster",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "nodejs",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedIngress: fake.GetSingleIngress("nodejs", "nodejs"),
+			want:            "http://nodejs.com",
+			wantErr:         false,
+		},
+		{
+			name: "Case 5: Create a ingress, with different name as component,instead of route on openshift cluster",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedRoute: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nodejs-app",
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of":  "app",
+						"app.kubernetes.io/instance": "nodejs",
+						applabels.App:                "app",
+						applabels.OdoManagedBy:       "odo",
+						applabels.OdoVersion:         version.VERSION,
+						"odo.openshift.io/url-name":  "nodejs",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: "nodejs-app",
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromInt(8080),
+					},
+				},
+			},
+			returnedIngress: fake.GetSingleIngress("example", "nodejs"),
+			want:            "http://example.com",
+			wantErr:         false,
+		},
+		{
+			name: "Case 6: Create a secure ingress, instead of route on openshift cluster, default tls exists",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				secure:                    true,
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedIngress:  fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists: true,
+			want:             "https://example.com",
+			wantErr:          false,
+		},
+		{
+			name: "Case 7: Create a secure ingress, instead of route on openshift cluster and default tls doesn't exist",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				secure:                    true,
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedIngress:  fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists: false,
+			want:             "https://example.com",
+			wantErr:          false,
+		},
+		{
+			name: "Case 8: Fail when while creating ingress when user given tls secret doesn't exists",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				secure:                    true,
+				tlsSecret:                 "user-secret",
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists:   false,
+			userGivenTLSExists: false,
+			want:               "http://example.com",
+			wantErr:            true,
+		},
+		{
+			name: "Case 9: Create a secure ingress, instead of route on openshift cluster, user tls secret does exists",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				secure:                    true,
+				tlsSecret:                 "user-secret",
+				urlKind:                   envinfo.INGRESS,
+			},
+			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists:   false,
+			userGivenTLSExists: true,
+			want:               "https://example.com",
+			wantErr:            false,
+		},
+
+		{
+			name: "Case 10: invalid url kind",
+			args: args{
+				componentName:             "nodejs",
+				urlName:                   "example",
+				portNumber:                8080,
+				host:                      "com",
+				isRouteSupported:          true,
+				isExperimentalModeEnabled: true,
+				secure:                    true,
+				tlsSecret:                 "user-secret",
+				urlKind:                   "blah",
+			},
+			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists:   false,
+			userGivenTLSExists: true,
+			want:               "",
+			wantErr:            true,
+		},
+		{
+			name: "Case 11: route is not supported on the cluster",
+			args: args{
+				componentName:             "nodejs",
+				applicationName:           "app",
+				urlName:                   "example",
+				isRouteSupported:          false,
+				isExperimentalModeEnabled: true,
+				urlKind:                   envinfo.ROUTE,
+			},
+			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists:   false,
+			userGivenTLSExists: true,
+			want:               "",
+			wantErr:            true,
+		},
+		{
+			name: "Case 11: secretName used without secure flag",
+			args: args{
+				componentName:             "nodejs",
+				applicationName:           "app",
+				urlName:                   "example",
+				isRouteSupported:          false,
+				isExperimentalModeEnabled: true,
+				tlsSecret:                 "secret",
+				urlKind:                   envinfo.ROUTE,
+			},
+			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
+			defaultTLSExists:   false,
+			userGivenTLSExists: true,
+			want:               "",
+			wantErr:            true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, fakeClientSet := occlient.FakeNew()
+			fakeKClient, fakeKClientSet := kclient.FakeNew()
 
 			fakeClientSet.RouteClientset.PrependReactor("create", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
 				route := action.(ktesting.CreateAction).GetObject().(*routev1.Route)
@@ -154,9 +352,39 @@ func TestCreate(t *testing.T) {
 				return true, route, nil
 			})
 
-			serviceName, err := util.NamespaceOpenShiftObject(tt.args.componentName, tt.args.applicationName)
-			if err != nil {
-				t.Error(err)
+			fakeKClientSet.Kubernetes.PrependReactor("get", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+				var secretName string
+				if tt.args.tlsSecret == "" {
+					secretName = tt.args.componentName + "-tlssecret"
+					if action.(ktesting.GetAction).GetName() != secretName {
+						return true, nil, fmt.Errorf("get for secrets called with invalid name, want: %s,got: %s", secretName, action.(ktesting.GetAction).GetName())
+					}
+				} else {
+					secretName = tt.args.tlsSecret
+					if action.(ktesting.GetAction).GetName() != tt.args.tlsSecret {
+						return true, nil, fmt.Errorf("get for secrets called with invalid name, want: %s,got: %s", tt.args.tlsSecret, action.(ktesting.GetAction).GetName())
+					}
+				}
+				if tt.args.tlsSecret != "" {
+					if !tt.userGivenTLSExists {
+						return true, nil, kerrors.NewNotFound(schema.GroupResource{}, "")
+					}
+				} else if !tt.defaultTLSExists {
+					return true, nil, kerrors.NewNotFound(schema.GroupResource{}, "")
+				}
+				return true, fake.GetSecret(secretName), nil
+			})
+
+			var serviceName string
+			if tt.args.urlKind == envinfo.INGRESS {
+				serviceName = tt.args.componentName
+
+			} else if tt.args.urlKind == envinfo.ROUTE {
+				var err error
+				serviceName, err = util.NamespaceOpenShiftObject(tt.args.componentName, tt.args.applicationName)
+				if err != nil {
+					t.Error(err)
+				}
 			}
 
 			fakeClientSet.AppsClientset.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -165,25 +393,102 @@ func TestCreate(t *testing.T) {
 				return true, dc, nil
 			})
 
-			got, err := Create(client, &kclient.Client{}, tt.args.urlName, tt.args.portNumber, tt.args.secure, tt.args.componentName, tt.args.applicationName, "", "")
+			fakeKClientSet.Kubernetes.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, testingutil.CreateFakeDeployment("nodejs"), nil
+			})
+
+			got, err := Create(client, fakeKClient, tt.args.urlName, tt.args.portNumber, tt.args.secure, tt.args.componentName, tt.args.applicationName, tt.args.host, tt.args.tlsSecret, tt.args.urlKind, tt.args.isRouteSupported, tt.args.isExperimentalModeEnabled)
 
 			if err == nil && !tt.wantErr {
-				if len(fakeClientSet.RouteClientset.Actions()) != 1 {
-					t.Errorf("expected 1 RouteClientset.Actions() in CreateService, got: %v", fakeClientSet.RouteClientset.Actions())
-				}
+				if tt.args.urlKind == envinfo.INGRESS {
+					wantKubernetesActionLength := 0
+					if !tt.args.secure {
+						wantKubernetesActionLength = 2
+					} else {
+						if tt.args.tlsSecret != "" && tt.userGivenTLSExists {
+							wantKubernetesActionLength = 3
+						} else if !tt.defaultTLSExists {
+							wantKubernetesActionLength = 4
+						} else {
+							wantKubernetesActionLength = 3
+						}
+					}
+					if len(fakeKClientSet.Kubernetes.Actions()) != wantKubernetesActionLength {
+						t.Errorf("expected %v Kubernetes.Actions() in Create, got: %v", wantKubernetesActionLength, len(fakeKClientSet.Kubernetes.Actions()))
+					}
 
-				createdRoute := fakeClientSet.RouteClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*routev1.Route)
-				if !reflect.DeepEqual(createdRoute.Name, tt.returnedRoute.Name) {
-					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Name, createdRoute.Name)
-				}
-				if !reflect.DeepEqual(createdRoute.Labels, tt.returnedRoute.Labels) {
-					t.Errorf("route name not matching, %v", pretty.Compare(tt.returnedRoute.Labels, createdRoute.Labels))
-				}
-				if !reflect.DeepEqual(createdRoute.Spec.Port, tt.returnedRoute.Spec.Port) {
-					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Spec.Port, createdRoute.Spec.Port)
-				}
-				if !reflect.DeepEqual(createdRoute.Spec.To.Name, tt.returnedRoute.Spec.To.Name) {
-					t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Spec.To.Name, createdRoute.Spec.To.Name)
+					if len(fakeClientSet.RouteClientset.Actions()) != 0 {
+						t.Errorf("expected 0 RouteClientset.Actions() in CreateService, got: %v", fakeClientSet.RouteClientset.Actions())
+					}
+
+					var createdIngress *extensionsv1.Ingress
+					createIngressActionNo := 0
+					if !tt.args.secure {
+						createIngressActionNo = 1
+					} else {
+						if tt.args.tlsSecret != "" {
+							createIngressActionNo = 2
+						} else if !tt.defaultTLSExists {
+							createdDefaultTLS := fakeKClientSet.Kubernetes.Actions()[2].(ktesting.CreateAction).GetObject().(*v1.Secret)
+							if createdDefaultTLS.Name != tt.args.componentName+"-tlssecret" {
+								t.Errorf("default tls created with different name, want: %s,got: %s", tt.args.componentName+"-tlssecret", createdDefaultTLS.Name)
+							}
+							createIngressActionNo = 3
+						} else {
+							createIngressActionNo = 2
+						}
+					}
+					createdIngress = fakeKClientSet.Kubernetes.Actions()[createIngressActionNo].(ktesting.CreateAction).GetObject().(*extensionsv1.Ingress)
+
+					if !reflect.DeepEqual(createdIngress.Name, tt.returnedIngress.Name) {
+						t.Errorf("ingress name not matching, expected: %s, got %s", tt.returnedRoute.Name, createdIngress.Name)
+					}
+					if !reflect.DeepEqual(createdIngress.Labels, tt.returnedIngress.Labels) {
+						t.Errorf("ingress labels not matching, %v", pretty.Compare(tt.returnedIngress.Labels, createdIngress.Labels))
+					}
+
+					wantedIngressParams := kclient.IngressParameter{
+						ServiceName:   serviceName,
+						IngressDomain: tt.args.host,
+						PortNumber:    intstr.FromInt(tt.args.portNumber),
+						TLSSecretName: tt.args.tlsSecret,
+					}
+
+					if !reflect.DeepEqual(createdIngress.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort.IntVal, wantedIngressParams.PortNumber.IntVal) {
+						t.Errorf("ingress port not matching, expected: %s, got %s", tt.returnedRoute.Spec.Port, createdIngress.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort.StrVal)
+					}
+					if tt.args.secure {
+						if wantedIngressParams.TLSSecretName == "" {
+							wantedIngressParams.TLSSecretName = tt.args.componentName + "-tlssecret"
+						}
+						if !reflect.DeepEqual(createdIngress.Spec.TLS[0].SecretName, wantedIngressParams.TLSSecretName) {
+							t.Errorf("ingress tls name not matching, expected: %s, got %s", wantedIngressParams.TLSSecretName, createdIngress.Spec.TLS)
+						}
+					}
+
+				} else {
+					if len(fakeClientSet.RouteClientset.Actions()) != 1 {
+						t.Errorf("expected 1 RouteClientset.Actions() in CreateService, got: %v", fakeClientSet.RouteClientset.Actions())
+					}
+
+					if len(fakeKClientSet.Kubernetes.Actions()) != 0 {
+						t.Errorf("expected 0 Kubernetes.Actions() in CreateService, got: %v", len(fakeKClientSet.Kubernetes.Actions()))
+					}
+
+					createdRoute := fakeClientSet.RouteClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*routev1.Route)
+					if !reflect.DeepEqual(createdRoute.Name, tt.returnedRoute.Name) {
+						t.Errorf("route name not matching, expected: %s, got %s", tt.returnedRoute.Name, createdRoute.Name)
+					}
+					if !reflect.DeepEqual(createdRoute.Labels, tt.returnedRoute.Labels) {
+						t.Errorf("route labels not matching, %v", pretty.Compare(tt.returnedRoute.Labels, createdRoute.Labels))
+					}
+					if !reflect.DeepEqual(createdRoute.Spec.Port, tt.returnedRoute.Spec.Port) {
+						t.Errorf("route port not matching, expected: %s, got %s", tt.returnedRoute.Spec.Port, createdRoute.Spec.Port)
+					}
+					if !reflect.DeepEqual(createdRoute.Spec.To.Name, tt.returnedRoute.Spec.To.Name) {
+						t.Errorf("route spec not matching, expected: %s, got %s", tt.returnedRoute.Spec.To.Name, createdRoute.Spec.To.Name)
+					}
+
 				}
 
 				if !reflect.DeepEqual(got, tt.want) {
@@ -197,49 +502,6 @@ func TestCreate(t *testing.T) {
 		})
 	}
 }
-
-func TestDelete(t *testing.T) {
-	type args struct {
-		urlName         string
-		applicationName string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "first test",
-			args: args{
-				urlName:         "component",
-				applicationName: "appname",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client, fakeClientSet := occlient.FakeNew()
-
-			fakeClientSet.RouteClientset.PrependReactor("delete", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
-				return true, nil, nil
-			})
-
-			err := Delete(client, &kclient.Client{}, tt.args.urlName, tt.args.applicationName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Delete() error = %#v, wantErr %#v", err, tt.wantErr)
-				return
-			}
-
-			// Check for value with which the function has called
-			DeletedURL := fakeClientSet.RouteClientset.Actions()[0].(ktesting.DeleteAction).GetName()
-			if !reflect.DeepEqual(DeletedURL, tt.args.urlName+"-"+tt.args.applicationName) {
-				t.Errorf("Delete is been called with %#v, expected %#v", DeletedURL, tt.args.urlName+"-"+tt.args.applicationName)
-			}
-		})
-	}
-}
-*/
 
 func TestExists(t *testing.T) {
 	tests := []struct {
@@ -457,6 +719,613 @@ func TestGetValidPortNumber(t *testing.T) {
 				t.Error("error was expected, but no error was returned")
 			} else if err != nil && !tt.wantErr {
 				t.Errorf("test failed, no error was expected, but got unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	type args struct {
+		isRouteSupported          bool
+		isExperimentalModeEnabled bool
+	}
+	tests := []struct {
+		name                string
+		args                args
+		componentName       string
+		applicationName     string
+		existingConfigURLs  []config.ConfigURL
+		existingEnvInfoURLs []envinfo.EnvInfoURL
+		returnedRoutes      *routev1.RouteList
+		returnedIngress     *extensionsv1.IngressList
+		deletedURLs         []URL
+		createdURLs         []URL
+		wantErr             bool
+	}{
+		{
+			name: "no urls on local config and cluster",
+			args: args{
+				isRouteSupported: true,
+			},
+			componentName:   "nodejs",
+			applicationName: "app",
+			returnedRoutes:  &routev1.RouteList{},
+		},
+		{
+			name:            "2 urls on local config and 0 on openshift cluster",
+			componentName:   "nodejs",
+			applicationName: "app",
+			args:            args{isRouteSupported: true},
+			existingConfigURLs: []config.ConfigURL{
+				{
+					Name:   "example",
+					Port:   8080,
+					Secure: false,
+				},
+				{
+					Name:   "example-1",
+					Port:   8080,
+					Secure: false,
+				},
+			},
+			returnedRoutes: &routev1.RouteList{},
+		},
+		{
+			name:            "0 url on local config and 2 on openshift cluster",
+			componentName:   "wildfly",
+			applicationName: "app",
+			args:            args{isRouteSupported: true},
+			returnedRoutes:  testingutil.GetRouteListWithMultiple("wildfly", "app"),
+			deletedURLs: []URL{
+				getMachineReadableFormat(testingutil.GetSingleRoute("example-app", 8080, "nodejs", "app")),
+				getMachineReadableFormat(testingutil.GetSingleRoute("example-1-app", 9100, "nodejs", "app")),
+			},
+		},
+		{
+			name:            "2 url on local config and 2 on openshift cluster, but they are different",
+			componentName:   "nodejs",
+			applicationName: "app",
+			args:            args{isRouteSupported: true},
+			existingConfigURLs: []config.ConfigURL{
+				{
+					Name:   "example-local-0",
+					Port:   8080,
+					Secure: false,
+				},
+				{
+					Name:   "example-local-1",
+					Port:   9090,
+					Secure: false,
+				},
+			},
+			returnedRoutes: testingutil.GetRouteListWithMultiple("nodejs", "app"),
+			deletedURLs: []URL{
+				getMachineReadableFormat(testingutil.GetSingleRoute("example-app", 8080, "nodejs", "app")),
+				getMachineReadableFormat(testingutil.GetSingleRoute("example-1-app", 9100, "nodejs", "app")),
+			},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-0-app",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  false,
+						urlKind: envinfo.ROUTE,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-1-app",
+					},
+					Spec: URLSpec{
+						Port:    9090,
+						Secure:  false,
+						urlKind: envinfo.ROUTE,
+					},
+				},
+			},
+		},
+
+		{
+			name:                "0 urls on env file and cluster",
+			componentName:       "nodejs",
+			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
+			returnedRoutes:      &routev1.RouteList{},
+			returnedIngress:     &extensionsv1.IngressList{},
+		},
+		{
+			name:          "2 urls on env file and 0 on openshift cluster",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example",
+					Port:   8080,
+					Secure: false,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+				{
+					Name:   "example-1",
+					Port:   9090,
+					Secure: false,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  false,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-1",
+					},
+					Spec: URLSpec{
+						Port:    9090,
+						Secure:  false,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+			},
+		},
+		{
+			name:                "0 urls on env file and 2 on openshift cluster",
+			componentName:       "nodejs",
+			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
+			returnedRoutes:      &routev1.RouteList{},
+			returnedIngress:     fake.GetIngressListWithMultiple("nodejs"),
+			deletedURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-1",
+					},
+				},
+			},
+		},
+		{
+			name:          "2 urls on env file and 2 on openshift cluster, but they are different",
+			componentName: "wildfly",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example-local-0",
+					Port:   8080,
+					Secure: false,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+				{
+					Name:   "example-local-1",
+					Port:   9090,
+					Secure: false,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: fake.GetIngressListWithMultiple("wildfly"),
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-0",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  false,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-1",
+					},
+					Spec: URLSpec{
+						Port:    9090,
+						Secure:  false,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+			},
+			deletedURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-1",
+					},
+				},
+			},
+		},
+		{
+			name:          "2 (1 ingress,1 route) urls on env file and 2 on openshift cluster (1 ingress,1 route), but they are different",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example-local-0",
+					Port:   8080,
+					Secure: false,
+					Kind:   envinfo.ROUTE,
+				},
+				{
+					Name:   "example-local-1",
+					Port:   9090,
+					Secure: false,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: fake.GetIngressListWithMultiple("nodejs"),
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-0",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  false,
+						urlKind: envinfo.ROUTE,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-local-1",
+					},
+					Spec: URLSpec{
+						Port:    9090,
+						Secure:  false,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+			},
+			deletedURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example-1",
+					},
+				},
+			},
+		},
+		{
+			name:          "create a ingress on a kubernetes cluster",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: false, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:      "example",
+					Port:      8080,
+					Secure:    true,
+					Host:      "com",
+					TLSSecret: "secret",
+					Kind:      envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+					Spec: URLSpec{
+						Port:      8080,
+						Secure:    true,
+						Host:      "com",
+						tLSSecret: "secret",
+						urlKind:   envinfo.INGRESS,
+					},
+				},
+			},
+		},
+
+		{
+			name:          "url with same name exists on env and cluster but with different specs",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example-local-0",
+					Port:   8080,
+					Secure: false,
+					Kind:   envinfo.ROUTE,
+				},
+			},
+			returnedRoutes: &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{
+				Items: []extensionsv1.Ingress{
+					*fake.GetSingleIngress("example-local-0", "nodejs"),
+				},
+			},
+			createdURLs: []URL{},
+			deletedURLs: []URL{},
+			wantErr:     true,
+		},
+		{
+			name:            "url with same name exists on config and cluster but with different specs",
+			componentName:   "nodejs",
+			applicationName: "app",
+			args:            args{isRouteSupported: true, isExperimentalModeEnabled: false},
+			existingConfigURLs: []config.ConfigURL{
+				{
+					Name:   "example-local-0",
+					Port:   8080,
+					Secure: false,
+				},
+			},
+			returnedRoutes: &routev1.RouteList{
+				Items: []routev1.Route{
+					testingutil.GetSingleRoute("example-local-0", 9090, "nodejs", "app"),
+				},
+			},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs:     []URL{},
+			deletedURLs:     []URL{},
+			wantErr:         true,
+		},
+
+		{
+			name:          "create a secure route url",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example",
+					Port:   8080,
+					Secure: true,
+					Kind:   envinfo.ROUTE,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  true,
+						urlKind: envinfo.ROUTE,
+					},
+				},
+			},
+		},
+		{
+			name:          "create a secure ingress url with empty user given tls secret",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:   "example",
+					Port:   8080,
+					Secure: true,
+					Host:   "com",
+					Kind:   envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+					Spec: URLSpec{
+						Port:    8080,
+						Secure:  true,
+						Host:    "com",
+						urlKind: envinfo.INGRESS,
+					},
+				},
+			},
+		},
+		{
+			name:          "create a secure ingress url with user given tls secret",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name:      "example",
+					Port:      8080,
+					Secure:    true,
+					Host:      "com",
+					TLSSecret: "secret",
+					Kind:      envinfo.INGRESS,
+				},
+			},
+			returnedRoutes:  &routev1.RouteList{},
+			returnedIngress: &extensionsv1.IngressList{},
+			createdURLs: []URL{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+					Spec: URLSpec{
+						Port:      8080,
+						Secure:    true,
+						Host:      "com",
+						tLSSecret: "secret",
+						urlKind:   envinfo.INGRESS,
+					},
+				},
+			},
+		},
+	}
+	for testNum, tt := range tests {
+		tt.name = fmt.Sprintf("case %d: ", testNum+1) + tt.name
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, fakeClientSet := occlient.FakeNew()
+			fakeKClient, fakeKClientSet := kclient.FakeNew()
+
+			fakeKClientSet.Kubernetes.PrependReactor("list", "ingresses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tt.returnedIngress, nil
+			})
+
+			fakeKClientSet.Kubernetes.PrependReactor("delete", "ingresses", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+			fakeClientSet.RouteClientset.PrependReactor("list", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, tt.returnedRoutes, nil
+			})
+
+			fakeClientSet.RouteClientset.PrependReactor("delete", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+			fakeKClientSet.Kubernetes.PrependReactor("get", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if tt.existingEnvInfoURLs[0].TLSSecret != "" {
+					return true, fake.GetSecret(tt.existingEnvInfoURLs[0].TLSSecret), nil
+				}
+				return true, fake.GetSecret(tt.componentName + "-tlssecret"), nil
+			})
+
+			fakeClientSet.AppsClientset.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, testingutil.OneFakeDeploymentConfigWithMounts(tt.componentName, "local", tt.applicationName, map[string]*v1.PersistentVolumeClaim{}), nil
+			})
+
+			fakeKClientSet.Kubernetes.PrependReactor("get", "deployments", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, testingutil.CreateFakeDeployment(tt.componentName), nil
+			})
+
+			if err := Push(fakeClient, fakeKClient, PushParameters{
+				ComponentName:             tt.componentName,
+				ApplicationName:           tt.applicationName,
+				ConfigURLs:                tt.existingConfigURLs,
+				EnvURLS:                   tt.existingEnvInfoURLs,
+				IsRouteSupported:          tt.args.isRouteSupported,
+				IsExperimentalModeEnabled: tt.args.isExperimentalModeEnabled,
+			}); (err != nil) != tt.wantErr {
+				t.Errorf("Push() error = %v, wantErr %v", err, tt.wantErr)
+			} else {
+				deletedURLMap := make(map[string]bool)
+				for _, url := range tt.deletedURLs {
+					found := false
+					for _, action := range fakeKClientSet.Kubernetes.Actions() {
+						value, ok := action.(ktesting.DeleteAction)
+						if ok && value.GetVerb() == "delete" {
+							deletedURLMap[value.GetName()] = true
+							if value.GetName() == url.Name {
+								found = true
+								break
+							}
+						}
+					}
+
+					for _, action := range fakeClientSet.RouteClientset.Actions() {
+						value, ok := action.(ktesting.DeleteAction)
+						if ok && value.GetVerb() == "delete" {
+							deletedURLMap[value.GetName()] = true
+							if value.GetName() == url.Name {
+								found = true
+								break
+							}
+						}
+					}
+					if !found {
+						t.Errorf("the url %s was not deleted", url.Name)
+					}
+				}
+
+				if len(deletedURLMap) != len(tt.deletedURLs) {
+					t.Errorf("number of deleted urls is different, want: %d,got: %d", len(tt.deletedURLs), len(deletedURLMap))
+				}
+
+				createdURLMap := make(map[string]bool)
+				for _, url := range tt.createdURLs {
+					found := false
+					for _, action := range fakeKClientSet.Kubernetes.Actions() {
+						value, ok := action.(ktesting.CreateAction)
+						if ok {
+							createdObject, ok := value.GetObject().(*extensionsv1.Ingress)
+							if ok {
+								createdURLMap[createdObject.Name] = true
+								if createdObject.Name == url.Name &&
+									(createdObject.Spec.TLS != nil) == url.Spec.Secure &&
+									int(createdObject.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort.IntVal) == url.Spec.Port &&
+									envinfo.INGRESS == url.Spec.urlKind &&
+									fmt.Sprintf("%v.%v", url.Name, url.Spec.Host) == createdObject.Spec.Rules[0].Host {
+
+									if url.Spec.Secure {
+										secretName := tt.componentName + "-tlssecret"
+										if url.Spec.tLSSecret != "" {
+											secretName = url.Spec.tLSSecret
+										}
+										if createdObject.Spec.TLS[0].SecretName == secretName {
+											found = true
+											break
+										}
+									} else {
+										found = true
+										break
+									}
+								}
+							}
+						}
+					}
+
+					for _, action := range fakeClientSet.RouteClientset.Actions() {
+						value, ok := action.(ktesting.CreateAction)
+						if ok {
+							createdObject, ok := value.GetObject().(*routev1.Route)
+							if ok {
+								createdURLMap[createdObject.Name] = true
+								if createdObject.Name == url.Name &&
+									(createdObject.Spec.TLS != nil) == url.Spec.Secure &&
+									int(createdObject.Spec.Port.TargetPort.IntVal) == url.Spec.Port &&
+									envinfo.ROUTE == url.Spec.urlKind {
+									found = true
+									break
+								}
+							}
+						}
+					}
+					if !found {
+						t.Errorf("the url %s was not created with proper specs", url.Name)
+					}
+				}
+
+				if len(createdURLMap) != len(tt.createdURLs) {
+					t.Errorf("number of created urls is different, want: %d,got: %d", len(tt.deletedURLs), len(deletedURLMap))
+				}
+
+				if !tt.args.isRouteSupported {
+					if len(fakeClientSet.RouteClientset.Actions()) > 0 {
+						t.Errorf("route is not supproted, total actions on the routeClient should be 0")
+					}
+				}
 			}
 		})
 	}

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -146,13 +146,13 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
 
-			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
+			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress", "--devfile", "devfile.yaml")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
 		})
 
 		It("should create a automatically route on a openShift cluster", func() {
 
-			if os.Getenv("KUBERNETES") != "true" {
+			if os.Getenv("KUBERNETES") == "true" {
 				Skip("This is a OpenShift specific scenario, skipping")
 			}
 

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -178,6 +178,22 @@ var _ = Describe("odo devfile url command tests", func() {
 			output = helper.CmdShouldPass("oc", "get", "routes", "--namespace", namespace)
 			Expect(output).ShouldNot(ContainSubstring(url1))
 		})
+
+		It("should create a url for a unsupported devfile component", func() {
+			url1 := helper.RandString(5)
+
+			helper.CopyExample(filepath.Join("source", "python"), context)
+			helper.Chdir(context)
+
+			helper.CmdShouldPass("odo", "create", "python", "--project", namespace, componentName)
+
+			helper.CmdShouldPass("odo", "url", "create", url1)
+
+			helper.CmdShouldPass("odo", "push", "--namespace", namespace)
+
+			output := helper.CmdShouldPass("oc", "get", "routes", "--namespace", namespace)
+			Expect(output).Should(ContainSubstring(url1))
+		})
 	})
 
 	Context("Describing urls", func() {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -147,7 +147,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
 
 			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
-			helper.MatchAllInOutput(stdout, []string{"URL created for component", "http:", url1 + "." + host})
+			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
 		})
 
 		It("should create a automatically route on a openShift cluster", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind code-refactoring

**What does does this PR do / why we need it**:

It adds the ability of creation of routes for openshift clusters even when experimental mode is on.

**Which issue(s) this PR fixes**:

Fixes #2727 
Fixes #2816 

**How to test changes / Special notes to the reviewer**:

- execute `odo url create` on a openshift cluster (with experimental mode off) and a route should be created
- execute `odo url create` on a openshift cluster (with experimental mode on) and a route should be created
- execute `odo url create --ingress` on a openshift cluster (with experimental mode on) and a ingress should be created
- execute `odo url create` on a kubernetes cluster (with experimental mode on) and a ingress should be created
