### PR TITLE
avoid list component name in s2i mode 

### DIFF
--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -31,11 +31,15 @@ import (
 const WatchRecommendedCommandName = "watch"
 
 var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on change.`)
-var watchExample = ktemplates.Examples(`  # Watch for changes in directory for current component
+var watchExampleWithComponentName = ktemplates.Examples(`  # Watch for changes in directory for current component
 %[1]s
 
 # Watch for changes in directory for component called frontend 
 %[1]s frontend
+  `)
+
+var watchExample = ktemplates.Examples(`  # Watch for changes in directory for current component
+%[1]s
   `)
 
 // WatchOptions contains attributes of the watch command
@@ -216,11 +220,19 @@ func (wo *WatchOptions) Run() (err error) {
 func NewCmdWatch(name, fullName string) *cobra.Command {
 	wo := NewWatchOptions()
 
+	example := fmt.Sprintf(watchExample, fullName)
+	usage := name
+
+	if experimental.IsExperimentalModeEnabled() {
+		example = fmt.Sprintf(watchExampleWithComponentName, fullName)
+		usage = fmt.Sprintf("%s [component name]", name)
+	}
+
 	var watchCmd = &cobra.Command{
-		Use:         fmt.Sprintf("%s [component name]", name),
+		Use:         usage,
 		Short:       "Watch for changes, update component on change",
 		Long:        watchLongDesc,
-		Example:     fmt.Sprintf(watchExample, fullName),
+		Example:     example,
 		Args:        cobra.MaximumNArgs(1),
 		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
which is only valid in devfile mode

**What type of PR is this?**

/kind bug
**What does does this PR do / why we need it**:

```
in devfile mode:

[root@xyimgr77 ftq]# ./odo watch -h
Watch for changes, update component on change.

Usage:
  odo watch [component name] [flags]

Examples:
  # Watch for changes in directory for current component
  odo watch

  # Watch for changes in directory for component called frontend
  odo watch frontend



in s2i mode

Watch for changes, update component on change.

Usage:
  odo watch [flags]

Examples:
  # Watch for changes in directory for current component
  odo watch

Flags:

```

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
