### PR TITLE
Add push target into sample

### DIFF
--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -28,6 +28,7 @@ var (
    %[1]s %[4]s 20
    %[1]s %[5]s 30
    %[1]s %[6]s true
+   %[1]s %[7]s docker
 	`)
 )
 
@@ -92,7 +93,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName,
 			preference.UpdateNotificationSetting, preference.NamePrefixSetting,
 			preference.TimeoutSetting, preference.PushTimeoutSetting,
-			preference.ExperimentalSetting),
+			preference.ExperimentalSetting, preference.PushTargetSetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return fmt.Errorf("please provide a parameter name and value")

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -29,6 +29,7 @@ var (
    %[1]s %[4]s
    %[1]s %[5]s
    %[1]s %[6]s
+   %[1]s %[7]s
 	`)
 )
 
@@ -92,7 +93,7 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		Use:     name,
 		Short:   "Unset a value in odo preference file",
 		Long:    fmt.Sprintf(unsetLongDesc, preference.FormatSupportedParameters()),
-		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName, preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting, preference.PushTimeoutSetting, preference.ExperimentalSetting),
+		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName, preference.UpdateNotificationSetting, preference.NamePrefixSetting, preference.TimeoutSetting, preference.PushTimeoutSetting, preference.ExperimentalSetting, preference.PushTargetSetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("please provide a parameter name")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
the PushTarget is able to show in `preference view` but not in set/unset example

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
