### PR TITLE
Create operator backed service from a yaml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,4 +314,4 @@ openshiftci-presubmit-unittests:
 # Run OperatorHub tests
 .PHONY: test-operator-hub
 test-operator-hub:
-	ginkgo $(GINKGO_FLAGS) -focus="odo service command tests" tests/integration/operatorhub/
+	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo service command tests" tests/integration/operatorhub/

--- a/Makefile
+++ b/Makefile
@@ -314,4 +314,4 @@ openshiftci-presubmit-unittests:
 # Run OperatorHub tests
 .PHONY: test-operator-hub
 test-operator-hub:
-	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo service command tests" tests/integration/operatorhub/
+	ginkgo $(GINKGO_FLAGS) -focus="odo service command tests" tests/integration/operatorhub/

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -245,6 +245,9 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			// Check if the operator and the CR exist on cluster
 			o.CustomResource = o.CustomResourceDefinition["kind"].(string)
 			csvs, err := o.KClient.GetClusterServiceVersionList()
+			if err != nil {
+				return err
+			}
 
 			csv, err := doesCRExist(o.CustomResource, csvs)
 			if err != nil {

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"text/template"
 
@@ -90,6 +92,9 @@ type ServiceCreateOptions struct {
 	resource string
 	// If set to true, DryRun prints the yaml that will create the service
 	DryRun bool
+	// Location of the file in which yaml specification of CR is stored.
+	// TODO: remove this after service create's interactive mode supports creating operator backed services
+	fromFile string
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -112,6 +117,12 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 	client := o.Client
 
 	var class scv1beta1.ClusterServiceClass
+
+	if experimental.IsExperimentalModeEnabled() && o.fromFile != "" {
+		o.interactive = false
+		return
+	}
+
 	if o.interactive {
 		classesByCategory, err := client.GetServiceClassesByCategory()
 		if err != nil {
@@ -212,6 +223,40 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 
 	// we want to find an Operator only if something's passed to the crd flag on CLI
 	if experimental.IsExperimentalModeEnabled() {
+		// if the user wants to create service from a file, we check for
+		// existence of file and validate if the requested operator and CR
+		// exist on the cluster
+		if o.fromFile != "" {
+			if _, err := os.Stat(o.fromFile); err != nil {
+				return errors.Wrap(err, "unable to find specified file")
+			}
+
+			// Parse the file to find Operator and CR info
+			fileContents, err := ioutil.ReadFile(o.fromFile)
+			if err != nil {
+				return err
+			}
+			// var jsonCR map[string]interface{}
+			err = yaml.Unmarshal(fileContents, &o.CustomResourceDefinition)
+			if err != nil {
+				return err
+			}
+
+			// Check if the operator and the CR exist on cluster
+			o.CustomResource = o.CustomResourceDefinition["kind"].(string)
+			csvs, err := o.KClient.GetClusterServiceVersionList()
+
+			csv, err := isCRInCluster(o.CustomResource, csvs)
+			if err != nil {
+				return errors.New(fmt.Sprintf("Could not find specified service/custom resource: %s\nPlease check the \"kind\" field in the yaml (it's case-sensitive)", o.CustomResource))
+			}
+
+			// all is well, let's populate the fields required for creating operator backed service
+			o.group, o.version = groupVersionALMExample(o.CustomResourceDefinition)
+			o.resource = resourceFromCSV(csv, o.CustomResource)
+			o.ServiceName = serviceNameFromCRD(o.CustomResourceDefinition, o.ServiceName)
+			return err
+		}
 		if o.CustomResource != "" {
 			// make sure that CSV of the specified ServiceType exists
 			csv, err := o.KClient.GetClusterServiceVersion(o.ServiceType)
@@ -240,6 +285,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			o.CustomResourceDefinition = almExample
 			o.group, o.version = groupVersionALMExample(almExample)
 			o.resource = resourceFromCSV(csv, o.CustomResource)
+			o.ServiceName = serviceNameFromCRD(o.CustomResourceDefinition, o.ServiceName)
 			return nil
 		} else {
 			// prevent user from executing `odo service create <operator-name>`
@@ -303,7 +349,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		// experimental mode but we're taking a bet against that for now, so
 		// the user won't get to see service name in the log message
 		if !o.DryRun {
-			log.Infof("Deploying service of type: %s", o.ServiceType)
+			log.Infof("Deploying service of type: %s", o.CustomResource)
 			s = log.Spinner("Deploying service")
 			defer s.End(false)
 		}
@@ -383,6 +429,8 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		serviceCreateCmd.Example += fmt.Sprintf("\n\n") + fmt.Sprintf(createOperatorExample, fullName)
 		serviceCreateCmd.Flags().StringVar(&o.CustomResource, "crd", "", "The name of the CRD of the operator to be used to create the service")
 		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
+		// remove this feature after enabling service create interactive mode for operator backed services
+		serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
 	}
 
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
@@ -424,4 +472,28 @@ func getAlmExample(almExamples []map[string]interface{}, crd, operator string) (
 		}
 	}
 	return nil, errors.Errorf("Could not find example yaml definition for %q service in %q operator's definition.\nPlease provide a file containing yaml specification to start the service from operator\n", crd, operator)
+}
+
+func isCRInCluster(kind string, csvs *olmv1alpha1.ClusterServiceVersionList) (olmv1alpha1.ClusterServiceVersion, error) {
+	for _, csv := range csvs.Items {
+		for _, operatorCR := range csv.Spec.CustomResourceDefinitions.Owned {
+			if kind == operatorCR.Kind {
+				return csv, nil
+			}
+		}
+	}
+	return olmv1alpha1.ClusterServiceVersion{}, errors.New("Could not find the requested cluster resource")
+
+}
+
+func serviceNameFromCRD(crd map[string]interface{}, serviceName string) string {
+	metadata, ok := crd["metadata"].(map[string]interface{})
+	if !ok {
+		return serviceName
+	}
+
+	if name, ok := metadata["name"].(string); ok {
+		return name
+	}
+	return serviceName
 }

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -246,9 +246,9 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			o.CustomResource = o.CustomResourceDefinition["kind"].(string)
 			csvs, err := o.KClient.GetClusterServiceVersionList()
 
-			csv, err := isCRInCluster(o.CustomResource, csvs)
+			csv, err := doesCRExist(o.CustomResource, csvs)
 			if err != nil {
-				return errors.New(fmt.Sprintf("Could not find specified service/custom resource: %s\nPlease check the \"kind\" field in the yaml (it's case-sensitive)", o.CustomResource))
+				return fmt.Errorf("Could not find specified service/custom resource: %s\nPlease check the \"kind\" field in the yaml (it's case-sensitive)", o.CustomResource)
 			}
 
 			// all is well, let's populate the fields required for creating operator backed service
@@ -474,7 +474,7 @@ func getAlmExample(almExamples []map[string]interface{}, crd, operator string) (
 	return nil, errors.Errorf("Could not find example yaml definition for %q service in %q operator's definition.\nPlease provide a file containing yaml specification to start the service from operator\n", crd, operator)
 }
 
-func isCRInCluster(kind string, csvs *olmv1alpha1.ClusterServiceVersionList) (olmv1alpha1.ClusterServiceVersion, error) {
+func doesCRExist(kind string, csvs *olmv1alpha1.ClusterServiceVersionList) (olmv1alpha1.ClusterServiceVersion, error) {
 	for _, csv := range csvs.Items {
 		for _, operatorCR := range csv.Spec.CustomResourceDefinitions.Owned {
 			if kind == operatorCR.Kind {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -61,10 +64,43 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
 
-			stdout := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
-			Expect(stdout).To(ContainSubstring("apiVersion"))
-			Expect(stdout).To(ContainSubstring("kind"))
+			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			Expect(stdOut).To(ContainSubstring("apiVersion"))
+			Expect(stdOut).To(ContainSubstring("kind"))
 		})
 	})
 
+	Context("When using from-file option", func() {
+		It("should be able to create a service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+
+			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			// stdOut contains the yaml specification. Store it to a file
+			randomFileName := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join("/tmp", randomFileName)
+			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+				fmt.Errorf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
+
+			// now create operator backed service
+			stdOut = helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", CI_OPERATOR_HUB_PROJECT}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// Delete the pods created. This should idealy be done by `odo
+			// service delete` but that's not implemented for operator backed
+			// services yet.
+			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+		})
+	})
 })

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -54,7 +55,11 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
 			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+			// Wait for the pods of EtcdCluster service to get cleared off
+			// cluster. This is to avoid CI flakes because in next test, we're
+			// again doing similar regex check which picks up terminating pod
+			// from this run instead of initiating pod from that run
+			helper.CmdShouldRunWithTimeout(time.Duration(30)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
 		})
 	})
 
@@ -100,7 +105,12 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
 			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+			// Wait for the pods of EtcdCluster service to get cleared off
+			// cluster. This is to avoid CI flakes because in next test, we're
+			// again doing similar regex check which picks up terminating pod
+			// from this run instead of initiating pod from that run
+			helper.CmdShouldRunWithTimeout(time.Duration(30)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
+
 		})
 
 		It("should fail to create service if metadata doesn't exist or is invalid", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -85,7 +85,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			}
 
 			// now create operator backed service
-			stdOut = helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
+			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
@@ -102,6 +102,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// services yet.
 			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
 		})
+
 		It("should fail to create service if metadata doesn't exist or is invalid", func() {
 			noMetadata := `
 apiVersion: etcd.database.coreos.com/v1beta2

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -59,7 +59,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// cluster. This is to avoid CI flakes because in next test, we're
 			// again doing similar regex check which picks up terminating pod
 			// from this run instead of initiating pod from that run
-			helper.CmdShouldRunWithTimeout(time.Duration(30)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
+			helper.CmdShouldRunWithTimeout(time.Duration(15)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
 		})
 	})
 
@@ -109,7 +109,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// cluster. This is to avoid CI flakes because in next test, we're
 			// again doing similar regex check which picks up terminating pod
 			// from this run instead of initiating pod from that run
-			helper.CmdShouldRunWithTimeout(time.Duration(30)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
+			helper.CmdShouldRunWithTimeout(time.Duration(15)*time.Second, "oc", "delete", "--wait", "EtcdCluster", "example")
 
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
This PR lets users create operator backed service from a yaml file. We need it
because till we implement interactive mode for operator backed service, users
need to have a way to configure a service before spinning it up.

**Which issue(s) this PR fixes**:

Fixes #2723 

**How to test changes / Special notes to the reviewer**:
1. Enable the experimental mode: 
    ```
    $ export ODO_EXPERIMENTAL=true 
    OR 
    $ odo preference set Experimental true
    ```
2. Make sure an operator is installed on your cluster. I used etcdoperator during development since it has a working alm-example available for `EtcdCluster` CR:
    ```
    $ odo catalog list services
    Operators available in the cluster
    NAME                          CRDs
    etcdoperator.v0.9.4           EtcdCluster, EtcdBackup, EtcdRestore
    ```
3. Grab the yaml into a file:
    ```
    $ odo service create etcdoperator.v0.9.4 --crd EtcdCluster --dry-run > /tmp/etcd
    ```
4. Spin up a service using the yaml file created above:
    ```
    $ odo service create --from-file /tmp/etcd
    ```