### PR TITLE
[Local] Create docker volumes from volumes defined in devfile

### DIFF
--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -125,13 +125,13 @@ func (a Adapter) updateComponent() (err error) {
 			containerID := containers[0].ID
 
 			// Get the associated container config from the container ID
-			containerConfig, err := a.Client.GetContainerConfig(containerID)
+			containerConfig, mounts, err := a.Client.GetContainerConfigAndMounts(containerID)
 			if err != nil {
 				return errors.Wrapf(err, "unable to get the container config for component %s", componentName)
 			}
 
 			// See if the container needs to be updated
-			if utils.DoesContainerNeedUpdating(comp, containerConfig) {
+			if utils.DoesContainerNeedUpdating(comp, containerConfig, dockerVolumeMounts, mounts) {
 				s := log.Spinner("Updating the component " + *comp.Alias)
 				defer s.End(false)
 				// Remove the container

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -35,7 +35,9 @@ func (a Adapter) createComponent() (err error) {
 	// Get the storage adapter and create the volumes if it does not exist
 	stoAdapter := storage.New(a.AdapterContext, a.Client)
 	err = stoAdapter.Create(uniqueStorage)
-
+	if err != nil {
+		return errors.Wrapf(err, "Unable to create Docker storage adapter for component %s", componentName)
+	}
 	// Additionally create a docker volume to store the project source code
 	volume, err := a.Client.CreateVolume("", projectVolumeLabels)
 	if err != nil {

--- a/pkg/devfile/adapters/docker/component/utils_test.go
+++ b/pkg/devfile/adapters/docker/component/utils_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"testing"
 
+	"github.com/docker/docker/api/types/mount"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
@@ -144,19 +145,50 @@ func TestPullAndStartContainer(t *testing.T) {
 		name          string
 		componentType versionsCommon.DevfileComponentType
 		client        *lclient.Client
+		mounts        []mount.Mount
 		wantErr       bool
 	}{
 		{
-			name:          "Case 1: Successfully start container",
+			name:          "Case 1: Successfully start container, no mount",
 			componentType: versionsCommon.DevfileComponentTypeDockerimage,
 			client:        fakeClient,
+			mounts:        []mount.Mount{},
 			wantErr:       false,
 		},
 		{
 			name:          "Case 2: Docker client error",
 			componentType: versionsCommon.DevfileComponentTypeDockerimage,
 			client:        fakeErrorClient,
+			mounts:        []mount.Mount{},
 			wantErr:       true,
+		},
+		{
+			name:          "Case 3: Successfully start container, one mount",
+			componentType: versionsCommon.DevfileComponentTypeDockerimage,
+			client:        fakeClient,
+			mounts: []mount.Mount{
+				{
+					Source: "test-vol",
+					Target: "/path",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Case 4: Successfully start container, multiple mounts",
+			componentType: versionsCommon.DevfileComponentTypeDockerimage,
+			client:        fakeClient,
+			mounts: []mount.Mount{
+				{
+					Source: "test-vol",
+					Target: "/path",
+				},
+				{
+					Source: "test-vol-two",
+					Target: "/path-two",
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -173,7 +205,7 @@ func TestPullAndStartContainer(t *testing.T) {
 			}
 
 			componentAdapter := New(adapterCtx, *tt.client)
-			err := componentAdapter.pullAndStartContainer(testComponentName, testVolumeName, adapterCtx.Devfile.Data.GetAliasedComponents()[0])
+			err := componentAdapter.pullAndStartContainer(tt.mounts, testVolumeName, adapterCtx.Devfile.Data.GetAliasedComponents()[0])
 
 			// Checks for unexpected error cases
 			if !tt.wantErr == (err != nil) {
@@ -196,19 +228,50 @@ func TestStartContainer(t *testing.T) {
 		name          string
 		componentType versionsCommon.DevfileComponentType
 		client        *lclient.Client
+		mounts        []mount.Mount
 		wantErr       bool
 	}{
 		{
-			name:          "Case 1: Successfully start container",
+			name:          "Case 1: Successfully start container, no mount",
 			componentType: versionsCommon.DevfileComponentTypeDockerimage,
 			client:        fakeClient,
+			mounts:        []mount.Mount{},
 			wantErr:       false,
 		},
 		{
 			name:          "Case 2: Docker client error",
 			componentType: versionsCommon.DevfileComponentTypeDockerimage,
 			client:        fakeErrorClient,
+			mounts:        []mount.Mount{},
 			wantErr:       true,
+		},
+		{
+			name:          "Case 3: Successfully start container, one mount",
+			componentType: versionsCommon.DevfileComponentTypeDockerimage,
+			client:        fakeClient,
+			mounts: []mount.Mount{
+				{
+					Source: "test-vol",
+					Target: "/path",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "Case 4: Successfully start container, multiple mount",
+			componentType: versionsCommon.DevfileComponentTypeDockerimage,
+			client:        fakeClient,
+			mounts: []mount.Mount{
+				{
+					Source: "test-vol",
+					Target: "/path",
+				},
+				{
+					Source: "test-vol-two",
+					Target: "/path-two",
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -225,7 +288,7 @@ func TestStartContainer(t *testing.T) {
 			}
 
 			componentAdapter := New(adapterCtx, *tt.client)
-			err := componentAdapter.startContainer(testComponentName, testVolumeName, adapterCtx.Devfile.Data.GetAliasedComponents()[0])
+			err := componentAdapter.startContainer(tt.mounts, testVolumeName, adapterCtx.Devfile.Data.GetAliasedComponents()[0])
 
 			// Checks for unexpected error cases
 			if !tt.wantErr == (err != nil) {

--- a/pkg/devfile/adapters/docker/storage/adapter.go
+++ b/pkg/devfile/adapters/docker/storage/adapter.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/lclient"
+)
+
+// New instantiantes a storage adapter
+func New(adapterContext common.AdapterContext, client lclient.Client) common.StorageAdapter {
+	return &Adapter{
+		Client:         client,
+		AdapterContext: adapterContext,
+	}
+}
+
+// Adapter is a storage adapter implementation for Kubernetes
+type Adapter struct {
+	Client lclient.Client
+	common.AdapterContext
+}
+
+// Create creates the component pvc storage if it does not exist
+func (a *Adapter) Create(storages []common.Storage) (err error) {
+
+	// createComponentStorage creates PVC from the unique Devfile volumes if it does not exist
+	err = CreateComponentStorage(&a.Client, storages, a.ComponentName)
+	if err != nil {
+		return err
+	}
+
+	return
+}

--- a/pkg/devfile/adapters/docker/storage/adapter_test.go
+++ b/pkg/devfile/adapters/docker/storage/adapter_test.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
+	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
+	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/openshift/odo/pkg/lclient"
+	"github.com/openshift/odo/pkg/testingutil"
+)
+
+func TestCreate(t *testing.T) {
+
+	testComponentName := "test"
+	fakeClient := lclient.FakeNew()
+	fakeErrorClient := lclient.FakeErrorNew()
+
+	volNames := [...]string{"vol1", "vol2"}
+	volSize := "5Gi"
+
+	tests := []struct {
+		name    string
+		storage []common.Storage
+		client  *lclient.Client
+		wantErr bool
+	}{
+		{
+			name:    "Case 1: No volumes",
+			storage: nil,
+			client:  fakeClient,
+			wantErr: false,
+		},
+		{
+			name: "Case 2: Multiple volumes",
+			storage: []common.Storage{
+				{
+					Name: "vol1",
+					Volume: common.DevfileVolume{
+						Name: &volNames[0],
+						Size: &volSize,
+					},
+				},
+				{
+					Name: "vol2",
+					Volume: common.DevfileVolume{
+						Name: &volNames[1],
+						Size: &volSize,
+					},
+				},
+			},
+			client:  fakeClient,
+			wantErr: false,
+		},
+		{
+			name: "Case 3: Docker client error",
+			storage: []common.Storage{
+				{
+					Name: "vol1",
+					Volume: common.DevfileVolume{
+						Name: &volNames[0],
+						Size: &volSize,
+					},
+				},
+				{
+					Name: "vol2",
+					Volume: common.DevfileVolume{
+						Name: &volNames[1],
+						Size: &volSize,
+					},
+				},
+			},
+			client:  fakeErrorClient,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					ComponentType: versionsCommon.DevfileComponentTypeDockerimage,
+				},
+			}
+
+			adapterCtx := adaptersCommon.AdapterContext{
+				ComponentName: testComponentName,
+				Devfile:       devObj,
+			}
+
+			storageAdapter := New(adapterCtx, *tt.client)
+			// ToDo: Add more meaningful unit tests once Push actually does something with its parameters
+			err := storageAdapter.Create(tt.storage)
+
+			// Checks for unexpected error cases
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("component adapter create unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+}

--- a/pkg/devfile/adapters/docker/storage/utils.go
+++ b/pkg/devfile/adapters/docker/storage/utils.go
@@ -1,0 +1,137 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/lclient"
+	"github.com/openshift/odo/pkg/util"
+)
+
+const volNameMaxLength = 45
+
+// CreateComponentStorage creates a Docker volume with the given list of storages if it does not exist, else it uses the existing volume
+func CreateComponentStorage(Client *lclient.Client, storages []common.Storage, componentName string) (err error) {
+
+	for _, storage := range storages {
+		volumeName := *storage.Volume.Name
+		dockerVolName := storage.Name
+
+		existingDockerVolName, err := GetExistingVolume(Client, volumeName, componentName)
+		if err != nil {
+			return err
+		}
+
+		if len(existingDockerVolName) == 0 {
+			glog.V(3).Infof("Creating a Docker volume for %v", volumeName)
+			_, err := Create(Client, volumeName, componentName, dockerVolName)
+			if err != nil {
+				return errors.Wrapf(err, "Error creating Docker volume for "+volumeName)
+			}
+		}
+	}
+
+	return
+}
+
+// Create creates the Docker volume for the given volume name and component name
+func Create(Client *lclient.Client, name, componentName, dockerVolName string) (*types.Volume, error) {
+
+	labels := map[string]string{
+		"component":    componentName,
+		"storage-name": name,
+	}
+
+	glog.V(3).Infof("Creating a Docker volume with name %v and labels %v", dockerVolName, labels)
+	vol, err := Client.CreateVolume(dockerVolName, labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create Docker volume")
+	}
+	return &vol, nil
+}
+
+// GenerateVolNameFromDevfileVol generates a Docker volume name from the Devfile volume name and component name
+func GenerateVolNameFromDevfileVol(volName, componentName string) (string, error) {
+
+	dockerVolName := fmt.Sprintf("%v-%v", volName, componentName)
+	dockerVolName = util.TruncateString(dockerVolName, volNameMaxLength)
+	randomChars := util.GenerateRandomString(4)
+	dockerVolName, err := util.NamespaceOpenShiftObject(dockerVolName, randomChars)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to create namespaced name")
+	}
+
+	return dockerVolName, nil
+}
+
+// GetExistingVolume checks if a Docker volume is present and return the name if it exists
+func GetExistingVolume(Client *lclient.Client, volumeName, componentName string) (string, error) {
+
+	volumeLabels := map[string]string{
+		"component":    componentName,
+		"storage-name": volumeName,
+	}
+
+	glog.V(3).Infof("Checking Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+
+	vols, err := Client.GetVolumesByLabel(volumeLabels)
+	if err != nil {
+		return "", errors.Wrapf(err, "Unable to get Docker volume with selectors %v", volumeLabels)
+	}
+	if len(vols) == 1 {
+		glog.V(3).Infof("Found an existing Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+		existingVolume := vols[0]
+		return existingVolume.Name, nil
+	} else if len(vols) == 0 {
+		return "", nil
+	} else {
+		err = errors.New("More than 1 Docker volume found")
+		return "", err
+	}
+}
+
+// ProcessVolumes takes in a list of component volumes and for each unique volume in the devfile, creates a Docker volume name for it
+// It returns a list of unique volumes, a mapping of devfile volume names to docker volume names, and an error if applicable
+func ProcessVolumes(client *lclient.Client, componentName string, componentAliasToVolumes map[string][]common.DevfileVolume) ([]common.Storage, map[string]string, error) {
+	var uniqueStorages []common.Storage
+	volumeNameToDockerVolName := make(map[string]string)
+	processedVolumes := make(map[string]bool)
+
+	// Get a list of all the unique volume names and generate their Docker volume names
+	for _, volumes := range componentAliasToVolumes {
+		for _, vol := range volumes {
+			if _, ok := processedVolumes[*vol.Name]; !ok {
+				processedVolumes[*vol.Name] = true
+
+				// Generate the volume Names
+				glog.V(3).Infof("Generating Docker volumes name for %v", *vol.Name)
+				generatedDockerVolName, err := GenerateVolNameFromDevfileVol(*vol.Name, componentName)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				// Check if we have an existing volume with the labels, overwrite the generated name with the existing name if present
+				existingVolName, err := GetExistingVolume(client, *vol.Name, componentName)
+				if err != nil {
+					return nil, nil, err
+				}
+				if len(existingVolName) > 0 {
+					glog.V(3).Infof("Found an existing Docker volume for %v, volume %v will be re-used", *vol.Name, existingVolName)
+					generatedDockerVolName = existingVolName
+				}
+
+				dockerVol := common.Storage{
+					Name:   generatedDockerVolName,
+					Volume: vol,
+				}
+				uniqueStorages = append(uniqueStorages, dockerVol)
+				volumeNameToDockerVolName[*vol.Name] = generatedDockerVolName
+			}
+		}
+	}
+	return uniqueStorages, volumeNameToDockerVolName, nil
+}

--- a/pkg/devfile/adapters/docker/storage/utils_test.go
+++ b/pkg/devfile/adapters/docker/storage/utils_test.go
@@ -1,0 +1,327 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/lclient"
+)
+
+func TestCreateComponentStorage(t *testing.T) {
+	fakeClient := lclient.FakeNew()
+	fakeErrorClient := lclient.FakeErrorNew()
+
+	testComponentName := "test"
+	volNames := [...]string{"vol1", "vol2"}
+	volSize := "5Gi"
+
+	tests := []struct {
+		name     string
+		storages []common.Storage
+		client   *lclient.Client
+		wantErr  bool
+	}{
+		{
+			name: "Case 1: Multiple volumes defined, no Docker client error",
+			storages: []common.Storage{
+				{
+					Name: "vol1",
+					Volume: common.DevfileVolume{
+						Name: &volNames[0],
+						Size: &volSize,
+					},
+				},
+				{
+					Name: "vol2",
+					Volume: common.DevfileVolume{
+						Name: &volNames[1],
+						Size: &volSize,
+					},
+				},
+			},
+			client:  fakeClient,
+			wantErr: false,
+		},
+		{
+			name: "Case 1: Multiple volumes defined, Docker client error",
+			storages: []common.Storage{
+				{
+					Name: "vol1",
+					Volume: common.DevfileVolume{
+						Name: &volNames[0],
+						Size: &volSize,
+					},
+				},
+				{
+					Name: "vol2",
+					Volume: common.DevfileVolume{
+						Name: &volNames[1],
+						Size: &volSize,
+					},
+				},
+			},
+			client:  fakeErrorClient,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CreateComponentStorage(tt.client, tt.storages, testComponentName)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("Storage adapter create unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+}
+
+func TestStorageCreate(t *testing.T) {
+	fakeClient := lclient.FakeNew()
+	fakeErrorClient := lclient.FakeErrorNew()
+
+	testComponentName := "test"
+	volNames := [...]string{"vol1", "vol2"}
+	volSize := "5Gi"
+
+	tests := []struct {
+		name    string
+		storage common.Storage
+		client  *lclient.Client
+		wantErr bool
+	}{
+		{
+			name: "Case 1: Valid volume, no Docker client error",
+			storage: common.Storage{
+				Name: "vol1",
+				Volume: common.DevfileVolume{
+					Name: &volNames[0],
+					Size: &volSize,
+				},
+			},
+			client:  fakeClient,
+			wantErr: false,
+		},
+		{
+			name: "Case 2: Docker client error",
+			storage: common.Storage{
+				Name: "vol-name",
+				Volume: common.DevfileVolume{
+					Name: &volNames[0],
+					Size: &volSize,
+				},
+			},
+			client:  fakeErrorClient,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Create one of the test volumes
+			_, err := Create(tt.client, *tt.storage.Volume.Name, testComponentName, tt.storage.Name)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("Docker volume create unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+		})
+	}
+
+}
+
+func TestProcessVolumes(t *testing.T) {
+	fakeClient := lclient.FakeNew()
+	fakeErrorClient := lclient.FakeErrorNew()
+
+	testComponentName := "test"
+	volumeNames := []string{"vol1", "vol2", "vol3"}
+	volumePaths := []string{"/path1", "/path2", "/path3"}
+	volumeSizes := []string{"1Gi", "2Gi", "3Gi"}
+	tests := []struct {
+		name               string
+		client             *lclient.Client
+		aliasVolumeMapping map[string][]common.DevfileVolume
+		wantErr            bool
+		wantStorage        []common.Storage
+	}{
+		{
+			name:               "Case 1: No volumes defined",
+			aliasVolumeMapping: nil,
+			client:             fakeClient,
+			wantStorage:        nil,
+			wantErr:            false,
+		},
+		{
+			name: "Case 2: One volume defined, one component",
+			aliasVolumeMapping: map[string][]common.DevfileVolume{
+				"some-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+			},
+			client: fakeClient,
+			wantStorage: []common.Storage{
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 3: Multiple volumes defined, one component",
+			aliasVolumeMapping: map[string][]common.DevfileVolume{
+				"some-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+					{
+						Name:          &volumeNames[1],
+						ContainerPath: &volumePaths[1],
+						Size:          &volumeSizes[1],
+					},
+					{
+						Name:          &volumeNames[2],
+						ContainerPath: &volumePaths[2],
+						Size:          &volumeSizes[2],
+					},
+				},
+			},
+			client: fakeClient,
+			wantStorage: []common.Storage{
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[1],
+						ContainerPath: &volumePaths[1],
+						Size:          &volumeSizes[1],
+					},
+				},
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[2],
+						ContainerPath: &volumePaths[2],
+						Size:          &volumeSizes[2],
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 4: Multiple volumes defined, multiple components",
+			aliasVolumeMapping: map[string][]common.DevfileVolume{
+				"some-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+					{
+						Name:          &volumeNames[1],
+						ContainerPath: &volumePaths[1],
+						Size:          &volumeSizes[1],
+					},
+				},
+				"second-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+				"third-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[1],
+						ContainerPath: &volumePaths[1],
+						Size:          &volumeSizes[1],
+					},
+					{
+						Name:          &volumeNames[2],
+						ContainerPath: &volumePaths[2],
+						Size:          &volumeSizes[2],
+					},
+				},
+			},
+			client: fakeClient,
+			wantStorage: []common.Storage{
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[1],
+						ContainerPath: &volumePaths[1],
+						Size:          &volumeSizes[1],
+					},
+				},
+				{
+					Volume: common.DevfileVolume{
+						Name:          &volumeNames[2],
+						ContainerPath: &volumePaths[2],
+						Size:          &volumeSizes[2],
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 5: Docker client error",
+			aliasVolumeMapping: map[string][]common.DevfileVolume{
+				"some-component": []common.DevfileVolume{
+					{
+						Name:          &volumeNames[0],
+						ContainerPath: &volumePaths[0],
+						Size:          &volumeSizes[0],
+					},
+				},
+			},
+			client:      fakeErrorClient,
+			wantStorage: nil,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Create one of the test volumes
+			uniqueStorage, _, err := ProcessVolumes(tt.client, testComponentName, tt.aliasVolumeMapping)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("Docker volume create unexpected error %v, wantErr %v", err, tt.wantErr)
+			}
+
+			storageLength := len(uniqueStorage)
+			wantStorageLength := len(tt.wantStorage)
+			if storageLength != wantStorageLength {
+				t.Errorf("expected %v, wanted %v", storageLength, wantStorageLength)
+			}
+
+			if storageLength > 0 {
+				for index := range uniqueStorage {
+					if !reflect.DeepEqual(uniqueStorage[index].Volume, tt.wantStorage[index].Volume) {
+						t.Errorf("expected %v, wanted %v", uniqueStorage[index].Volume, tt.wantStorage[index].Volume)
+					}
+				}
+			}
+
+		})
+	}
+
+}

--- a/pkg/devfile/adapters/docker/storage/utils_test.go
+++ b/pkg/devfile/adapters/docker/storage/utils_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
@@ -314,9 +313,16 @@ func TestProcessVolumes(t *testing.T) {
 			}
 
 			if storageLength > 0 {
-				for index := range uniqueStorage {
-					if !reflect.DeepEqual(uniqueStorage[index].Volume, tt.wantStorage[index].Volume) {
-						t.Errorf("expected %v, wanted %v", uniqueStorage[index].Volume, tt.wantStorage[index].Volume)
+				for i := range uniqueStorage {
+					var volExists bool
+					for j := range tt.wantStorage {
+						if *uniqueStorage[i].Volume.Name == *tt.wantStorage[j].Volume.Name && uniqueStorage[i].Volume.ContainerPath == tt.wantStorage[j].Volume.ContainerPath {
+							volExists = true
+						}
+					}
+
+					if !volExists {
+						t.Errorf("expected %v, wanted %v", uniqueStorage[i].Volume, tt.wantStorage[i].Volume)
 					}
 				}
 			}

--- a/pkg/devfile/adapters/docker/utils/utils.go
+++ b/pkg/devfile/adapters/docker/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -44,7 +43,13 @@ func DoesContainerNeedUpdating(component common.DevfileComponent, containerConfi
 	// Update the container if the env vars were updated in the devfile
 	// Need to convert the devfile envvars to the format expected by Docker
 	devfileEnvVars := ConvertEnvs(component.Env)
-	return !reflect.DeepEqual(devfileEnvVars, containerConfig.Env)
+	for _, envVar := range devfileEnvVars {
+		if !containerHasEnvVar(envVar, containerConfig.Env) {
+			return true
+		}
+	}
+	return false
+
 }
 
 func AddProjectVolumeToComp(projectVolumeName string, hostConfig *container.HostConfig) *container.HostConfig {
@@ -65,4 +70,15 @@ func GetProjectVolumeLabels(componentName string) map[string]string {
 		"type":      "projects",
 	}
 	return volumeLabels
+}
+
+// containerHasEnvVar returns true if the specified env var (and value) exist in the list of container env vars
+func containerHasEnvVar(envVar string, containerEnv []string) bool {
+	for _, env := range containerEnv {
+		fmt.Println("Here")
+		if envVar == env {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/devfile/adapters/docker/utils/utils.go
+++ b/pkg/devfile/adapters/docker/utils/utils.go
@@ -44,7 +44,6 @@ func DoesContainerNeedUpdating(component common.DevfileComponent, containerConfi
 	// Update the container if the volumes were updated in the devfile
 	for _, devfileMount := range devfileMounts {
 		if !containerHasMount(devfileMount, containerMounts) {
-			fmt.Println("HERE!")
 			return true
 		}
 	}

--- a/pkg/devfile/adapters/docker/utils/utils_test.go
+++ b/pkg/devfile/adapters/docker/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
@@ -102,11 +103,17 @@ func TestConvertEnvs(t *testing.T) {
 func TestDoesContainerNeedUpdating(t *testing.T) {
 	envVarsNames := []string{"test", "sample-var", "myvar"}
 	envVarsValues := []string{"value1", "value2", "value3"}
+
+	volNames := []string{"vol1", "vol2", "vol3"}
+	volPaths := []string{"/path1", "/path2", "/path3"}
+
 	tests := []struct {
 		name            string
 		envVars         []common.DockerimageEnv
+		mounts          []mount.Mount
 		image           string
 		containerConfig container.Config
+		containerMounts []types.MountPoint
 		want            bool
 	}{
 		{
@@ -121,10 +128,22 @@ func TestDoesContainerNeedUpdating(t *testing.T) {
 					Value: &envVarsValues[1],
 				},
 			},
+			mounts: []mount.Mount{
+				{
+					Source: volNames[0],
+					Target: volPaths[0],
+				},
+			},
 			image: "golang",
 			containerConfig: container.Config{
 				Image: "golang",
 				Env:   []string{"test=value1", "sample-var=value2"},
+			},
+			containerMounts: []types.MountPoint{
+				{
+					Name:        volNames[0],
+					Destination: volPaths[0],
+				},
 			},
 			want: false,
 		},
@@ -144,7 +163,7 @@ func TestDoesContainerNeedUpdating(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Case 2: Update required, image changed",
+			name: "Case 3: Update required, image changed",
 			envVars: []common.DockerimageEnv{
 				{
 					Name:  &envVarsNames[2],
@@ -158,6 +177,41 @@ func TestDoesContainerNeedUpdating(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "Case 4: Update required, volumes changed",
+			envVars: []common.DockerimageEnv{
+				{
+					Name:  &envVarsNames[0],
+					Value: &envVarsValues[0],
+				},
+				{
+					Name:  &envVarsNames[1],
+					Value: &envVarsValues[1],
+				},
+			},
+			mounts: []mount.Mount{
+				{
+					Source: volNames[0],
+					Target: volPaths[0],
+				},
+				{
+					Source: volNames[1],
+					Target: volPaths[1],
+				},
+			},
+			image: "golang",
+			containerConfig: container.Config{
+				Image: "golang",
+				Env:   []string{"test=value1", "sample-var=value2"},
+			},
+			containerMounts: []types.MountPoint{
+				{
+					Name:        volNames[0],
+					Destination: volPaths[0],
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -167,7 +221,7 @@ func TestDoesContainerNeedUpdating(t *testing.T) {
 				Env:   tt.envVars,
 			},
 		}
-		needsUpdating := DoesContainerNeedUpdating(component, &tt.containerConfig)
+		needsUpdating := DoesContainerNeedUpdating(component, &tt.containerConfig, tt.mounts, tt.containerMounts)
 		if needsUpdating != tt.want {
 			t.Errorf("expected %v, wanted %v", needsUpdating, tt.want)
 		}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/odo/pkg/exec"
 
+	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
@@ -217,7 +218,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 
 	kclient.AddBootstrapSupervisordInitContainer(podTemplateSpec)
 
-	componentAliasToVolumes := utils.GetVolumes(a.Devfile)
+	componentAliasToVolumes := adaptersCommon.GetVolumes(a.Devfile)
 
 	var uniqueStorages []common.Storage
 	volumeNameToPVCName := make(map[string]string)

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	volumeSize                 = "5Gi"
 	envCheProjectsRoot         = "CHE_PROJECTS_ROOT"
 	envOdoCommandRunWorkingDir = "ODO_COMMAND_RUN_WORKING_DIR"
 	envOdoCommandRun           = "ODO_COMMAND_RUN"

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -172,26 +172,6 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 
 }
 
-// GetVolumes iterates through the components in the devfile and returns a map of component alias to the devfile volumes
-func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]adaptersCommon.DevfileVolume {
-	// componentAliasToVolumes is a map of the Devfile Component Alias to the Devfile Component Volumes
-	componentAliasToVolumes := make(map[string][]adaptersCommon.DevfileVolume)
-	size := volumeSize
-	for _, comp := range adaptersCommon.GetSupportedComponents(devfileObj.Data) {
-		if comp.Volumes != nil {
-			for _, volume := range comp.Volumes {
-				vol := adaptersCommon.DevfileVolume{
-					Name:          volume.Name,
-					ContainerPath: volume.ContainerPath,
-					Size:          &size,
-				}
-				componentAliasToVolumes[*comp.Alias] = append(componentAliasToVolumes[*comp.Alias], vol)
-			}
-		}
-	}
-	return componentAliasToVolumes
-}
-
 // GetResourceReqs creates a kubernetes ResourceRequirements object based on resource requirements set in the devfile
 func GetResourceReqs(comp common.DevfileComponent) corev1.ResourceRequirements {
 	reqs := corev1.ResourceRequirements{}

--- a/pkg/lclient/containers.go
+++ b/pkg/lclient/containers.go
@@ -74,12 +74,11 @@ func (dc *Client) RemoveContainer(containerID string) error {
 	return nil
 }
 
-// GetContainerConfig takes in a given container ID and retrieves its corresponding container config
-func (dc *Client) GetContainerConfig(containerID string) (*container.Config, error) {
+// GetContainerConfigAndMounts takes in a given container ID and retrieves its corresponding container config
+func (dc *Client) GetContainerConfigAndMounts(containerID string) (*container.Config, []types.MountPoint, error) {
 	containerJSON, err := dc.Client.ContainerInspect(dc.Context, containerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to inspect container %s", containerID)
+		return nil, nil, errors.Wrapf(err, "unable to inspect container %s", containerID)
 	}
-
-	return containerJSON.Config, nil
+	return containerJSON.Config, containerJSON.Mounts, err
 }

--- a/pkg/lclient/storage.go
+++ b/pkg/lclient/storage.go
@@ -10,8 +10,9 @@ import (
 )
 
 // CreateVolume creates a Docker volume with the given labels and the default Docker storage driver
-func (dc *Client) CreateVolume(labels map[string]string) (types.Volume, error) {
+func (dc *Client) CreateVolume(name string, labels map[string]string) (types.Volume, error) {
 	volume, err := dc.Client.VolumeCreate(dc.Context, volumeTypes.VolumeCreateBody{
+		Name:   name,
 		Driver: DockerStorageDriver,
 		Labels: labels,
 	})

--- a/pkg/lclient/storage_test.go
+++ b/pkg/lclient/storage_test.go
@@ -55,7 +55,7 @@ func TestCreateVolume(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		volume, err := tt.client.CreateVolume(tt.labels)
+		volume, err := tt.client.CreateVolume("", tt.labels)
 		if !tt.wantErr == (err != nil) {
 			t.Errorf("expected %v, wanted %v", err, tt.wantErr)
 		}

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -74,6 +74,50 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
 		})
 
+		It("Check that odo push works with a devfile that has volumes defined", func() {
+			// Local devfile push requires experimental mode to be set and the pushtarget set to docker
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker")
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
+			helper.RenameFile("devfile-with-volumes.yaml", "devfile.yaml")
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// Verify the volumes got created successfully (and 3 volumes exist: one source and two defined in devfile)
+			label := "component=" + cmpName
+			volumes := dockerClient.GetVolumesByLabel(label)
+			Expect(len(volumes)).To(Equal(3))
+		})
+
+		It("Check that odo push mounts the docker volumes in the container", func() {
+			// Local devfile push requires experimental mode to be set and the pushtarget set to docker
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker")
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
+			helper.RenameFile("devfile-with-volumes.yaml", "devfile.yaml")
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// Retrieve the volume from one of the aliases in the devfile
+			volumes := dockerClient.GetVolumesByCompStorageName(cmpName, "myvol")
+			Expect(len(volumes)).To(Equal(1))
+			vol := volumes[0]
+
+			// Verify the volume is mounted
+			volMounted := dockerClient.IsVolumeMountedInContainer(vol, cmpName, "runtime")
+			Expect(volMounted).To(Equal(true))
+		})
+
 	})
 
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature
/area devfile
/area local

**What does does this PR do / why we need it**:
This PR implements a storage adapter (based off of the Kube storage adapter code) for odo when deploying components to Docker. When deploying or updating local Docker containers, odo determines the unique number of volumes in the devfile and creates Docker volumes for them. Then, when odo is deploying each container, it determines which volumes need to be mounted to it and where. When determining if a container needs to be updated, odo will compare the volumes for the container in the devfile against the volumes mounted in the container, if any differ, odo will update the container with the new (or modified) volume.

Unit tests provided for the new storage adapter, as well as new integration test scenarios to verify the volume gets created and is mounted to the container.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2849

**How to test changes / Special notes to the reviewer**:
- Run `make test` and `make test-cmd-docker-devfile-push` to verify the unit and integration tests pass (if running integration tests, make sure pushtarget set to Docker and Docker is installed)

Manual verification:
1. Enable experimental mode and set pushtarget to Docker
2. Run `odo create java-spring-boot`
3. Run `odo push`
4. Verify that the containers deploy successfully and that a "springbootpvc" volume exists (`docker volume ls`)
5. Exec into one of the containers that mount the volume and verify the mount path is there.
