### PR TITLE
[Devfile] Add a spinner for deployment rollout

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -86,7 +86,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	}
 
 	// Wait for Pod to be in running state otherwise we can't sync data or exec commands to it.
-	pod, err := a.waitAndGetComponentPod(false)
+	pod, err := a.waitAndGetComponentPod(true)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
 	}

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -47,6 +47,7 @@ func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deploy
 	glog.V(4).Infof("Waiting for %s deployment rollout", deploymentName)
 	s := log.Spinner("Waiting for component to start")
 	defer s.End(false)
+
 	w, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Watch(metav1.ListOptions{FieldSelector: "metadata.name=" + deploymentName})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to watch deployment")

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -43,8 +44,9 @@ func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.Depl
 
 // WaitForDeploymentRollout waits for deployment to finish rollout. Returns the state of the deployment after rollout.
 func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deployment, error) {
-	glog.V(4).Infof("Waiting for %s deployment roll out", deploymentName)
-
+	glog.V(4).Infof("Waiting for %s deployment rollout", deploymentName)
+	s := log.Spinner("Waiting for component to start")
+	defer s.End(false)
 	w, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Watch(metav1.ListOptions{FieldSelector: "metadata.name=" + deploymentName})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to watch deployment")
@@ -77,6 +79,7 @@ func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deploy
 					} else if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
 						glog.V(4).Infof("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
 					} else {
+						s.End(true)
 						glog.V(4).Infof("Deployment %q successfully rolled out\n", deployment.Name)
 						success <- deployment
 					}


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
/area devfile

**What does does this PR do / why we need it**:
This PR adds a spinner to the `WaitForDeploymentRollout` function in kclient. Previously, since there was no spinner, the user would be looking at

```
Johns-MacBook-Pro-3:springboot johncollier$ odo push
 •  Push devfile component java-spring-boot  ...
```

While they waited for the component to rollout. Now they will see:
```
Johns-MacBook-Pro-3:springboot johncollier$ odo push
 •  Push devfile component java-spring-boot  ...
 ◓  Waiting for component to start
```

and 

```
Johns-MacBook-Pro-3:springboot johncollier$ odo push
 •  Push devfile component java-spring-boot  ...
 ✓  Waiting for component to start [8s]
 ✓  Checking files for pushing [6ms]
 ✓  Syncing files to the component [2s]
 ✓  Executing devbuild command "/artifacts/bin/build-container-full.sh" [28s]
 ✓  Executing devrun command "/artifacts/bin/start-server.sh" [2s]
 ✓  Push devfile component java-spring-boot [42s]
 ✓  Changes successfully pushed to component
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2827

**How to test changes / Special notes to the reviewer**:
Run `odo push` with a devfile, and verify that the spinner shows up while the deployment rolls out