### PR TITLE
add json output for listing operator backed services

### DIFF
--- a/pkg/machineoutput/services.go
+++ b/pkg/machineoutput/services.go
@@ -1,0 +1,25 @@
+package machineoutput
+
+import (
+	"github.com/openshift/odo/pkg/catalog"
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CatalogListOutput struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Services          *catalog.ServiceTypeList `json:"services,omitempty"`
+	// list of clusterserviceversions (installed by Operators)
+	Operators *olm.ClusterServiceVersionList `json:"operators,omitempty"`
+}
+
+func NewCatalogListOutput(services *catalog.ServiceTypeList, operators *olm.ClusterServiceVersionList) CatalogListOutput {
+	return CatalogListOutput{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CatalogListOutput",
+		},
+		Services:  services,
+		Operators: operators,
+	}
+}

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -93,7 +93,7 @@ func (o *ListServicesOptions) Validate() (err error) {
 // Run contains the logic for the command associated with ListServicesOptions
 func (o *ListServicesOptions) Run() (err error) {
 	if log.IsJSON() {
-		machineoutput.OutputSuccess(o.services)
+		machineoutput.OutputSuccess(machineoutput.NewCatalogListOutput(&o.services, o.csvs))
 	} else {
 		if experimental.IsExperimentalModeEnabled() {
 			if len(o.csvs.Items) > 0 {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -158,4 +158,12 @@ spec:
 
 		})
 	})
+
+	Context("JSON output", func() {
+		It("listing catalog of services", func() {
+			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+			Expect(jsonOut).To(ContainSubstring("mongodb-enterprise"))
+			Expect(jsonOut).To(ContainSubstring("etcdoperator"))
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


/kind feature

> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
add json output for operator backed services.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2619

**How to test changes / Special notes to the reviewer**:
Run CRC, install some operators then 

```
odo catalog list services -o json
```