### PR TITLE
warn --app and --all-apps coexist

### DIFF
--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -64,6 +64,10 @@ func (lo *ListOptions) Validate() (err error) {
 
 	var project, app string
 
+	if len(lo.Application) != 0 && lo.allAppsFlag {
+		klog.V(4).Infof("either --app and --all-apps both provided or provided --all-apps in a folder has app, use --all-apps anyway")
+	}
+
 	if !util.CheckKubeConfigExist() {
 		project = lo.LocalConfigInfo.GetProject()
 		app = lo.LocalConfigInfo.GetApplication()


### PR DESCRIPTION
 /kind bug
**What does does this PR do / why we need it**:
--app and --all-apps exist should report error

`odo list --all-apps --app sdaf`

There's a edge case that I can run --all-apps in a folder has .odo subfolder
so --app will be set .. thus we can't prevent run --all-apps in this folder so we have to warn
user about this action but not block it

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
