### PR TITLE
Fix `odo component describe <component-name>` for not pushed components 

### DIFF
--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -92,6 +92,10 @@ func (do *DeleteOptions) Validate() (err error) {
 	}
 	if !do.isCmpExists {
 		log.Errorf("Component %s does not exist on the cluster", do.ComponentOptions.componentName)
+		// If request is to delete non existing component without all flag, exit with exit code 1
+		if !do.componentDeleteAllFlag {
+			os.Exit(1)
+		}
 	}
 	return
 }
@@ -179,11 +183,6 @@ func (do *DeleteOptions) Run() (err error) {
 		} else {
 			return fmt.Errorf("Aborting deletion of config for component: %s", do.componentName)
 		}
-	}
-
-	// If request is to delete non existing component exit with exit code 1
-	if !do.isCmpExists && !do.componentDeleteAllFlag {
-		os.Exit(1)
 	}
 
 	return

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/openshift/odo/pkg/envinfo"
@@ -178,6 +179,11 @@ func (do *DeleteOptions) Run() (err error) {
 		} else {
 			return fmt.Errorf("Aborting deletion of config for component: %s", do.componentName)
 		}
+	}
+
+	// If request is to delete non existing component exit with exit code 1
+	if !do.isCmpExists && !do.componentDeleteAllFlag {
+		os.Exit(1)
 	}
 
 	return

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -61,11 +61,18 @@ func (do *DescribeOptions) Run() (err error) {
 	state := component.GetComponentState(do.Context.Client, do.componentName, do.Context.Application)
 
 	if state == component.StateTypeNotPushed || state == component.StateTypeUnknown {
+		if !do.LocalConfigInfo.ConfigFileExists() {
+			return fmt.Errorf("Component %v does not exist", do.componentName)
+		}
 		componentDesc, err = component.GetComponentFromConfig(do.LocalConfigInfo)
 		componentDesc.Status.State = state
 		if err != nil {
 			return err
 		}
+		if componentDesc.Name != do.componentName {
+			return fmt.Errorf("Component %v does not exist", do.componentName)
+		}
+
 	} else {
 		componentDesc, err = component.GetComponent(do.Context.Client, do.componentName, do.Context.Application, do.Context.Project)
 		if err != nil {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -531,11 +531,7 @@ func (o *Context) ComponentAllowingEmpty(allowEmpty bool, optionalComponent ...s
 		}
 	case 1:
 		cmp := optionalComponent[0]
-		// only check the component if we passed a non-empty string, otherwise return the current component set in NewContext
-		if len(cmp) > 0 {
-			o.checkComponentExistsOrFail(cmp)
-			o.cmp = cmp // update context
-		}
+		o.cmp = cmp
 	default:
 		// safeguard: fail if more than one optional string is passed because it would be a programming error
 		log.Errorf("ComponentAllowingEmpty function only accepts one optional argument, was given: %v", optionalComponent)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -250,6 +250,11 @@ func componentTests(args ...string) {
 			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
+
+			// odo should describe not pushed component if component name is given.
+			helper.CmdShouldPass("odo", append(args, "describe", "cmp-git", "--context", context)...)
+			Expect(cmpDescribe).To(ContainSubstring("cmp-git"))
+
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2689 

**How to test changes / Special notes to the reviewer**:
$ `odo create nodejs component1`
`odo describe <component-name>` should work for not pushed components, provided context is given or running from odo component directory. previously `odo describe` was working but `odo describe <component-name>` was failing.
$ `odo describe component1`