### PR TITLE
Update some recursive logs to V(5)

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -30,7 +30,7 @@ func CopyFile(client SyncClient, localPath string, targetPodName string, targetC
 	dest := filepath.ToSlash(filepath.Join(targetPath, filepath.Base(localPath)))
 	targetPath = filepath.ToSlash(targetPath)
 
-	glog.V(4).Infof("CopyFile arguments: localPath %s, dest %s, copyFiles %s, globalExps %s", localPath, dest, copyFiles, globExps)
+	glog.V(5).Infof("CopyFile arguments: localPath %s, dest %s, copyFiles %s, globalExps %s", localPath, dest, copyFiles, globExps)
 	reader, writer := io.Pipe()
 	// inspired from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L235
 	go func() {
@@ -120,13 +120,13 @@ func makeTar(srcPath, destPath string, writer io.Writer, files []string, globExp
 
 // recursiveTar function is copied from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L319
 func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *taro.Writer, globExps []string) error {
-	glog.V(4).Infof("recursiveTar arguments: srcBase: %s, srcFile: %s, destBase: %s, destFile: %s", srcBase, srcFile, destBase, destFile)
+	glog.V(5).Infof("recursiveTar arguments: srcBase: %s, srcFile: %s, destBase: %s, destFile: %s", srcBase, srcFile, destBase, destFile)
 
 	// The destination is a LINUX container and thus we *must* use ToSlash in order
 	// to get the copying over done correctly..
 	destBase = filepath.ToSlash(destBase)
 	destFile = filepath.ToSlash(destFile)
-	glog.V(4).Infof("Corrected destinations: base: %s file: %s", destBase, destFile)
+	glog.V(5).Infof("Corrected destinations: base: %s file: %s", destBase, destFile)
 
 	joinedPath := filepath.Join(srcBase, srcFile)
 	matchedPathsDir, err := filepath.Glob(joinedPath)

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -217,13 +217,13 @@ func RunIndexer(directory string, ignoreRules []string) (filesChanged []string, 
 
 		if _, ok := existingFileIndex.Files[relativeFilename]; !ok {
 			filesChanged = append(filesChanged, fn)
-			glog.V(4).Infof("file added: %s", fn)
+			glog.V(5).Infof("file added: %s", fn)
 		} else if !fi.ModTime().Equal(existingFileIndex.Files[relativeFilename].LastModifiedDate) {
 			filesChanged = append(filesChanged, fn)
-			glog.V(4).Infof("last modified date changed: %s", fn)
+			glog.V(5).Infof("last modified date changed: %s", fn)
 		} else if fi.Size() != existingFileIndex.Files[relativeFilename].Size {
 			filesChanged = append(filesChanged, fn)
-			glog.V(4).Infof("size changed: %s", fn)
+			glog.V(5).Infof("size changed: %s", fn)
 		}
 
 		newFileMap[relativeFilename] = FileData{


### PR DESCRIPTION
**What type of PR is this?**
 
/kind code-refactoring

**What does does this PR do / why we need it**:
These are some recursive logs related to sync and file indexer.  They are printed continuously  at V(4)  while `odo push`, making it difficult to check other debug logs. They are trace kind of logs, should be at V(5)

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
