### PR TITLE
Should be using glog.V(4) not glog.V(3)

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -40,7 +40,7 @@ func getCommand(data data.DevfileData, commandName string, required bool) (suppo
 		err = fmt.Errorf(msg)
 	} else {
 		// Not found and optional, so just log it
-		glog.V(3).Info(msg)
+		glog.V(4).Info(msg)
 	}
 
 	return
@@ -49,14 +49,14 @@ func getCommand(data data.DevfileData, commandName string, required bool) (suppo
 // getSupportedCommandActions returns the supported actions for a given command and any errors
 // If some actions are supported and others have errors both the supported actions and an aggregated error will be returned.
 func getSupportedCommandActions(data data.DevfileData, command common.DevfileCommand) (supportedCommandActions []common.DevfileCommandAction, err error) {
-	glog.V(3).Infof("Validating actions for command: %v ", command.Name)
+	glog.V(4).Infof("Validating actions for command: %v ", command.Name)
 
 	problemMsg := ""
 	for i, action := range command.Actions {
 		// Check if the command action is of type exec
 		err := validateAction(data, action)
 		if err == nil {
-			glog.V(3).Infof("Action %d maps to component %v", i+1, *action.Component)
+			glog.V(4).Infof("Action %d maps to component %v", i+1, *action.Component)
 			supportedCommandActions = append(supportedCommandActions, action)
 		} else {
 			problemMsg += fmt.Sprintf("Problem with command \"%v\" action #%d: %v", command.Name, i+1, err)
@@ -143,18 +143,18 @@ func ValidateAndGetPushDevfileCommands(data data.DevfileData, devfileBuildCmd, d
 	if reflect.DeepEqual(emptyCommand, buildCommand) && buildCmdErr == nil {
 		// If there was no build command specified through odo push and no default build command in the devfile, default validate to true since the build command is optional
 		isBuildCommandValid = true
-		glog.V(3).Infof("No build command was provided")
+		glog.V(4).Infof("No build command was provided")
 	} else if !reflect.DeepEqual(emptyCommand, buildCommand) && buildCmdErr == nil {
 		isBuildCommandValid = true
 		pushDevfileCommands = append(pushDevfileCommands, buildCommand)
-		glog.V(3).Infof("Build command: %v", buildCommand.Name)
+		glog.V(4).Infof("Build command: %v", buildCommand.Name)
 	}
 
 	runCommand, runCmdErr := GetRunCommand(data, devfileRunCmd)
 	if runCmdErr == nil && !reflect.DeepEqual(emptyCommand, runCommand) {
 		pushDevfileCommands = append(pushDevfileCommands, runCommand)
 		isRunCommandValid = true
-		glog.V(3).Infof("Run command: %v", runCommand.Name)
+		glog.V(4).Infof("Run command: %v", runCommand.Name)
 	}
 
 	// If either command had a problem, return an empty list of commands and an error

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -68,7 +68,7 @@ func GetSupportedComponents(data data.DevfileData) []common.DevfileComponent {
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetAliasedComponents() {
 		if isComponentSupported(comp) {
-			glog.V(3).Infof("Found component \"%v\" with alias \"%v\"\n", comp.Type, *comp.Alias)
+			glog.V(4).Infof("Found component \"%v\" with alias \"%v\"\n", comp.Type, *comp.Alias)
 			components = append(components, comp)
 		}
 	}

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -76,13 +76,13 @@ func (a Adapter) createComponent() (err error) {
 			return errors.Wrapf(err, "unable to pull and start container %s for component %s", *comp.Alias, componentName)
 		}
 	}
-	glog.V(3).Infof("Successfully created all containers for component %s", componentName)
+	glog.V(4).Infof("Successfully created all containers for component %s", componentName)
 
 	return nil
 }
 
 func (a Adapter) updateComponent() (err error) {
-	glog.V(3).Info("The component already exists, attempting to update it")
+	glog.V(4).Info("The component already exists, attempting to update it")
 	componentName := a.ComponentName
 
 	// Get the project source volume
@@ -159,7 +159,7 @@ func (a Adapter) updateComponent() (err error) {
 				if err != nil {
 					return errors.Wrapf(err, "Unable to start container for devfile component %s", *comp.Alias)
 				}
-				glog.V(3).Infof("Successfully created container %s for component %s", *comp.Image, componentName)
+				glog.V(4).Infof("Successfully created container %s for component %s", *comp.Image, componentName)
 				s.End(true)
 			}
 		} else {
@@ -187,7 +187,7 @@ func (a Adapter) pullAndStartContainer(mounts []mount.Mount, projectVolumeName s
 	if err != nil {
 		return errors.Wrapf(err, "Unable to start container for devfile component %s", *comp.Alias)
 	}
-	glog.V(3).Infof("Successfully created container %s for component %s", *comp.Image, a.ComponentName)
+	glog.V(4).Infof("Successfully created container %s for component %s", *comp.Image, a.ComponentName)
 	return nil
 }
 

--- a/pkg/devfile/adapters/docker/storage/utils.go
+++ b/pkg/devfile/adapters/docker/storage/utils.go
@@ -27,7 +27,7 @@ func CreateComponentStorage(Client *lclient.Client, storages []common.Storage, c
 		}
 
 		if len(existingDockerVolName) == 0 {
-			glog.V(3).Infof("Creating a Docker volume for %v", volumeName)
+			glog.V(4).Infof("Creating a Docker volume for %v", volumeName)
 			_, err := Create(Client, volumeName, componentName, dockerVolName)
 			if err != nil {
 				return errors.Wrapf(err, "Error creating Docker volume for "+volumeName)
@@ -46,7 +46,7 @@ func Create(Client *lclient.Client, name, componentName, dockerVolName string) (
 		"storage-name": name,
 	}
 
-	glog.V(3).Infof("Creating a Docker volume with name %v and labels %v", dockerVolName, labels)
+	glog.V(4).Infof("Creating a Docker volume with name %v and labels %v", dockerVolName, labels)
 	vol, err := Client.CreateVolume(dockerVolName, labels)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create Docker volume")
@@ -76,14 +76,14 @@ func GetExistingVolume(Client *lclient.Client, volumeName, componentName string)
 		"storage-name": volumeName,
 	}
 
-	glog.V(3).Infof("Checking Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+	glog.V(4).Infof("Checking Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
 
 	vols, err := Client.GetVolumesByLabel(volumeLabels)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to get Docker volume with selectors %v", volumeLabels)
 	}
 	if len(vols) == 1 {
-		glog.V(3).Infof("Found an existing Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+		glog.V(4).Infof("Found an existing Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
 		existingVolume := vols[0]
 		return existingVolume.Name, nil
 	} else if len(vols) == 0 {
@@ -108,7 +108,7 @@ func ProcessVolumes(client *lclient.Client, componentName string, componentAlias
 				processedVolumes[*vol.Name] = true
 
 				// Generate the volume Names
-				glog.V(3).Infof("Generating Docker volumes name for %v", *vol.Name)
+				glog.V(4).Infof("Generating Docker volumes name for %v", *vol.Name)
 				generatedDockerVolName, err := GenerateVolNameFromDevfileVol(*vol.Name, componentName)
 				if err != nil {
 					return nil, nil, err
@@ -120,7 +120,7 @@ func ProcessVolumes(client *lclient.Client, componentName string, componentAlias
 					return nil, nil, err
 				}
 				if len(existingVolName) > 0 {
-					glog.V(3).Infof("Found an existing Docker volume for %v, volume %v will be re-used", *vol.Name, existingVolName)
+					glog.V(4).Infof("Found an existing Docker volume for %v, volume %v will be re-used", *vol.Name, existingVolName)
 					generatedDockerVolName = existingVolName
 				}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -231,7 +231,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 				processedVolumes[*vol.Name] = true
 
 				// Generate the PVC Names
-				glog.V(3).Infof("Generating PVC name for %v", *vol.Name)
+				glog.V(4).Infof("Generating PVC name for %v", *vol.Name)
 				generatedPVCName, err := storage.GeneratePVCNameFromDevfileVol(*vol.Name, componentName)
 				if err != nil {
 					return err
@@ -243,7 +243,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 					return err
 				}
 				if len(existingPVCName) > 0 {
-					glog.V(3).Infof("Found an existing PVC for %v, PVC %v will be re-used", *vol.Name, existingPVCName)
+					glog.V(4).Infof("Found an existing PVC for %v, PVC %v will be re-used", *vol.Name, existingPVCName)
 					generatedPVCName = existingPVCName
 				}
 
@@ -273,17 +273,17 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 		}
 	}
 	serviceSpec := kclient.GenerateServiceSpec(objectMeta.Name, containerPorts)
-	glog.V(3).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
-	glog.V(3).Infof("The component name is %v", componentName)
+	glog.V(4).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
+	glog.V(4).Infof("The component name is %v", componentName)
 
 	if utils.ComponentExists(a.Client, componentName) {
 		// If the component already exists, get the resource version of the deploy before updating
-		glog.V(3).Info("The component already exists, attempting to update it")
+		glog.V(4).Info("The component already exists, attempting to update it")
 		deployment, err := a.Client.UpdateDeployment(*deploymentSpec)
 		if err != nil {
 			return err
 		}
-		glog.V(3).Infof("Successfully updated component %v", componentName)
+		glog.V(4).Infof("Successfully updated component %v", componentName)
 		oldSvc, err := a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Get(componentName, metav1.GetOptions{})
 		objectMetaTemp := objectMeta
 		ownerReference := kclient.GenerateOwnerReference(deployment)
@@ -295,7 +295,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 				if err != nil {
 					return err
 				}
-				glog.V(3).Infof("Successfully created Service for component %s", componentName)
+				glog.V(4).Infof("Successfully created Service for component %s", componentName)
 			}
 		} else {
 			if len(serviceSpec.Ports) > 0 {
@@ -305,7 +305,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 				if err != nil {
 					return err
 				}
-				glog.V(3).Infof("Successfully update Service for component %s", componentName)
+				glog.V(4).Infof("Successfully update Service for component %s", componentName)
 			} else {
 				err = a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Delete(componentName, &metav1.DeleteOptions{})
 				if err != nil {
@@ -318,7 +318,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 		if err != nil {
 			return err
 		}
-		glog.V(3).Infof("Successfully created component %v", componentName)
+		glog.V(4).Infof("Successfully created component %v", componentName)
 		ownerReference := kclient.GenerateOwnerReference(deployment)
 		objectMetaTemp := objectMeta
 		objectMetaTemp.OwnerReferences = append(objectMeta.OwnerReferences, ownerReference)
@@ -327,7 +327,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 			if err != nil {
 				return err
 			}
-			glog.V(3).Infof("Successfully created Service for component %s", componentName)
+			glog.V(4).Infof("Successfully created Service for component %s", componentName)
 		}
 
 	}
@@ -444,7 +444,7 @@ func (a Adapter) execDevfile(pushDevfileCommands []versionsCommon.DevfileCommand
 
 		// Exec the devBuild command if buildRequired is true
 		if (command.Name == string(common.DefaultDevfileBuildCommand) || command.Name == a.devfileBuildCmd) && buildRequired {
-			glog.V(3).Infof("Executing devfile command %v", command.Name)
+			glog.V(4).Infof("Executing devfile command %v", command.Name)
 
 			for _, action := range command.Actions {
 				// Change to the workdir and execute the command
@@ -477,7 +477,7 @@ func (a Adapter) execDevfile(pushDevfileCommands []versionsCommon.DevfileCommand
 			buildRequired = false
 		} else if (command.Name == string(common.DefaultDevfileRunCommand) || command.Name == a.devfileRunCmd) && !buildRequired {
 			// Always check for buildRequired is false, since the command may be iterated out of order and we always want to execute devBuild first if buildRequired is true. If buildRequired is false, then we don't need to build and we can execute the devRun command
-			glog.V(3).Infof("Executing devfile command %v", command.Name)
+			glog.V(4).Infof("Executing devfile command %v", command.Name)
 
 			for _, action := range command.Actions {
 

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -30,7 +30,7 @@ func CreateComponentStorage(Client *kclient.Client, storages []common.Storage, c
 		}
 
 		if len(existingPVCName) == 0 {
-			glog.V(3).Infof("Creating a PVC for %v", volumeName)
+			glog.V(4).Infof("Creating a PVC for %v", volumeName)
 			_, err := Create(Client, volumeName, volumeSize, componentName, pvcName)
 			if err != nil {
 				return errors.Wrapf(err, "Error creating PVC for "+volumeName)
@@ -68,7 +68,7 @@ func Create(Client *kclient.Client, name, size, componentName, pvcName string) (
 	objectMeta.OwnerReferences = append(objectMeta.OwnerReferences, ownerReference)
 
 	// Create PVC
-	glog.V(3).Infof("Creating a PVC with name %v and labels %v", pvcName, labels)
+	glog.V(4).Infof("Creating a PVC with name %v and labels %v", pvcName, labels)
 	pvc, err := Client.CreatePVC(objectMeta, *pvcSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create PVC")
@@ -95,14 +95,14 @@ func GetExistingPVC(Client *kclient.Client, volumeName, componentName string) (s
 
 	label := "component=" + componentName + ",storage-name=" + volumeName
 
-	glog.V(3).Infof("Checking PVC for volume %v and label %v\n", volumeName, label)
+	glog.V(4).Infof("Checking PVC for volume %v and label %v\n", volumeName, label)
 
 	PVCs, err := Client.GetPVCsFromSelector(label)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to get PVC with selectors "+label)
 	}
 	if len(PVCs) == 1 {
-		glog.V(3).Infof("Found an existing PVC for volume %v and label %v\n", volumeName, label)
+		glog.V(4).Infof("Found an existing PVC for volume %v and label %v\n", volumeName, label)
 		existingPVC := &PVCs[0]
 		return existingPVC.Name, nil
 	} else if len(PVCs) == 0 {

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -128,13 +128,13 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			if container.Name == *action.Component {
 				// If the run component container has no entrypoint and arguments, override the entrypoint with supervisord
 				if len(container.Command) == 0 && len(container.Args) == 0 {
-					glog.V(3).Infof("Updating container %v entrypoint with supervisord", container.Name)
+					glog.V(4).Infof("Updating container %v entrypoint with supervisord", container.Name)
 					container.Command = append(container.Command, adaptersCommon.SupervisordBinaryPath)
 					container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
 				}
 
 				// Always mount the supervisord volume in the run component container
-				glog.V(3).Infof("Updating container %v with supervisord volume mounts", container.Name)
+				glog.V(4).Infof("Updating container %v with supervisord volume mounts", container.Name)
 				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 					Name:      adaptersCommon.SupervisordVolumeName,
 					MountPath: adaptersCommon.SupervisordMountPath,
@@ -144,7 +144,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 				// only if the env var is not set in the devfile
 				// This is done, so supervisord can use it in it's program
 				if !isEnvPresent(container.Env, envOdoCommandRun) {
-					glog.V(3).Infof("Updating container %v env with run command", container.Name)
+					glog.V(4).Infof("Updating container %v env with run command", container.Name)
 					container.Env = append(container.Env,
 						corev1.EnvVar{
 							Name:  envOdoCommandRun,
@@ -153,7 +153,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 				}
 
 				if !isEnvPresent(container.Env, envOdoCommandRunWorkingDir) && action.Workdir != nil {
-					glog.V(3).Infof("Updating container %v env with run command's workdir", container.Name)
+					glog.V(4).Infof("Updating container %v env with run command's workdir", container.Name)
 					container.Env = append(container.Env,
 						corev1.EnvVar{
 							Name:  envOdoCommandRunWorkingDir,

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -20,7 +20,7 @@ func ExecuteCommand(client ExecClient, podName, containerName string, command []
 	reader, writer := io.Pipe()
 	var cmdOutput string
 
-	glog.V(3).Infof("Executing command %v for pod: %v in container: %v", command, podName, containerName)
+	glog.V(4).Infof("Executing command %v for pod: %v in container: %v", command, podName, containerName)
 
 	// This Go routine will automatically pipe the output from ExecCMDInContainer to
 	// our logger.


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does does this PR do / why we need it**:

No idea what happened, but some of the code switched to using
`glog.V(3)` for verbose output. We should only be using `V(0)` or
`V(4)`.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>