### PR TITLE
Address failing Gosec G601

### DIFF
--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -120,7 +120,8 @@ var ServiceParameterCompletionHandler = func(cmd *cobra.Command, args parsedArgs
 	} else {
 		for _, servicePlan := range servicePlans {
 			if servicePlan.Name == inputPlanName {
-				matchingServicePlan = &servicePlan
+				readServicePlan := servicePlan
+				matchingServicePlan = &readServicePlan
 				break
 			}
 		}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -118,10 +118,10 @@ var ServiceParameterCompletionHandler = func(cmd *cobra.Command, args parsedArgs
 	} else if len(servicePlans) == 1 && inputPlanName == "" {
 		matchingServicePlan = &servicePlans[0]
 	} else {
-		for _, servicePlan := range servicePlans {
+		for _, sp := range servicePlans {
+			servicePlan := sp
 			if servicePlan.Name == inputPlanName {
-				readServicePlan := servicePlan
-				matchingServicePlan = &readServicePlan
+				matchingServicePlan = &servicePlan
 				break
 			}
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -160,20 +160,20 @@ func List(client *occlient.Client, componentName string, applicationName string)
 	}
 
 	var storage []Storage
-	for _, pvc := range pvcs {
+	for i := range pvcs {
+		pvc := pvcs[i]
 		pvcComponentName, ok := pvc.Labels[componentlabels.ComponentLabel]
 		pvcAppName, okApp := pvc.Labels[applabels.ApplicationLabel]
 		// first check if component label does not exists indicating that the storage is not mounted in any component
 		// if the component label exists, then check if the component is the current active component
 		// also check if the app label exists and is equal to the current application
 		if (!ok || pvcComponentName == componentName) && (okApp && pvcAppName == applicationName) {
-			readPVC := pvc
-			if readPVC.Name == "" {
+			if pvc.Name == "" {
 				return StorageList{}, fmt.Errorf("no PVC associated")
 			}
-			storageName := getStorageFromPVC(&readPVC)
-			storageSize := readPVC.Spec.Resources.Requests[corev1.ResourceStorage]
-			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&readPVC),
+			storageName := getStorageFromPVC(&pvc)
+			storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&pvc),
 				storageSize.String(),
 				mountedStorageMap[storageName],
 			)
@@ -206,18 +206,18 @@ func ListUnmounted(client *occlient.Client, applicationName string) (StorageList
 		return StorageList{}, errors.Wrapf(err, "unable to get PVC using selector %v", storagelabels.StorageLabel)
 	}
 	var storage []Storage
-	for _, pvc := range pvcs {
+	for i := range pvcs {
+		pvc := pvcs[i]
 		_, ok := pvc.Labels[componentlabels.ComponentLabel]
 		pvcAppName, okApp := pvc.Labels[applabels.ApplicationLabel]
 		// first check if component label does not exists indicating that the storage is not mounted in any component
 		// also check if the app label exists and is equal to the current application
 		if !ok && (okApp && pvcAppName == applicationName) {
-			readPVC := pvc
-			if readPVC.Name == "" {
+			if pvc.Name == "" {
 				return StorageList{}, fmt.Errorf("no PVC associated")
 			}
-			storageSize := readPVC.Spec.Resources.Requests[corev1.ResourceStorage]
-			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&readPVC),
+			storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&pvc),
 				storageSize.String(),
 				"",
 			)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -167,12 +167,13 @@ func List(client *occlient.Client, componentName string, applicationName string)
 		// if the component label exists, then check if the component is the current active component
 		// also check if the app label exists and is equal to the current application
 		if (!ok || pvcComponentName == componentName) && (okApp && pvcAppName == applicationName) {
-			if pvc.Name == "" {
+			readPVC := pvc
+			if readPVC.Name == "" {
 				return StorageList{}, fmt.Errorf("no PVC associated")
 			}
-			storageName := getStorageFromPVC(&pvc)
-			storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&pvc),
+			storageName := getStorageFromPVC(&readPVC)
+			storageSize := readPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&readPVC),
 				storageSize.String(),
 				mountedStorageMap[storageName],
 			)
@@ -211,11 +212,12 @@ func ListUnmounted(client *occlient.Client, applicationName string) (StorageList
 		// first check if component label does not exists indicating that the storage is not mounted in any component
 		// also check if the app label exists and is equal to the current application
 		if !ok && (okApp && pvcAppName == applicationName) {
-			if pvc.Name == "" {
+			readPVC := pvc
+			if readPVC.Name == "" {
 				return StorageList{}, fmt.Errorf("no PVC associated")
 			}
-			storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&pvc),
+			storageSize := readPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&readPVC),
 				storageSize.String(),
 				"",
 			)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
The G601 check in `gosec` started failing today with the following:
```
/go/bin/gosec
gosec -severity medium -confidence medium -exclude G304,G204 -quiet  ./...
Results:


[�[30;43m/go/src/github.com/openshift/odo/pkg/odo/util/completion/completionhandlers.go:123�[0m] - G601 (CWE-): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
  > &servicePlan


[�[30;43m/go/src/github.com/openshift/odo/pkg/storage/storage.go:218�[0m] - G601 (CWE-): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
  > &pvc


[�[30;43m/go/src/github.com/openshift/odo/pkg/storage/storage.go:175�[0m] - G601 (CWE-): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
  > &pvc


[�[30;43m/go/src/github.com/openshift/odo/pkg/storage/storage.go:173�[0m] - G601 (CWE-): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
  > &pvc


�[1;36mSummary:�[0m
   Files: 210
   Lines: 34936
   Nosec: 9
  Issues: �[1;31m4�[0m

make[1]: *** [sec] Error 1
make[1]: Leaving directory `/go/src/github.com/openshift/odo'
make: *** [openshiftci-presubmit-unittests] Error 2
---
```

I noticed that the following was not failing:
https://github.com/openshift/odo/blob/master/pkg/storage/storage.go#L130

So it seems that if we assign the current value in the for loop to a variable, we're fine.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2987

**How to test changes / Special notes to the reviewer**:
