### PR TITLE
Add storage volume deletion to 'odo delete' docker devfile deletion

### DIFF
--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types"

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -1,7 +1,7 @@
 package component
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/mount"
@@ -160,20 +160,48 @@ func (a Adapter) Delete(labels map[string]string) error {
 		return errors.Wrap(err, "unable to retrieve container list for delete operation")
 	}
 
+	// A unique list of volumes NOT to delete, because they are still mapped into other containers.
+	// map key is volume name.
+	volumesNotToDelete := map[string]string{}
+
+	// Go through the containers which are NOT part of this component, and make a list of all
+	// their volumes so we don't delete them.
+	for _, container := range list {
+
+		if container.Labels["component"] == componentName {
+			continue
+		}
+
+		for _, mount := range container.Mounts {
+			volumesNotToDelete[mount.Name] = mount.Name
+		}
+	}
+
 	componentContainer := a.Client.GetContainersByComponent(componentName, list)
 
 	if len(componentContainer) == 0 {
 		return errors.Errorf("the component %s doesn't exist", a.ComponentName)
 	}
 
-	// Get all volumes that match our component label
-	volumeLabels := utils.GetProjectVolumeLabels(componentName)
-	vols, err := a.Client.GetVolumesByLabel(volumeLabels)
+	allVolumes, err := a.Client.GetVolumes()
 	if err != nil {
-		return errors.Wrapf(err, "unable to retrieve source volume for component "+componentName)
+		return errors.Wrapf(err, "unable to retrieve volume list")
 	}
-	if len(vols) == 0 {
-		return fmt.Errorf("unable to find source volume for component %s", componentName)
+
+	// Look for this component's volumes that contain either a storage-name label or a type label
+	var vols []types.Volume
+	for _, vol := range allVolumes {
+
+		if vol.Labels["component"] == componentName {
+
+			if snVal := vol.Labels["storage-name"]; len(strings.TrimSpace(snVal)) > 0 {
+				vols = append(vols, vol)
+			} else {
+				if typeVal := vol.Labels["type"]; typeVal == "projects" {
+					vols = append(vols, vol)
+				}
+			}
+		}
 	}
 
 	// A unique list of volumes to delete; map key is volume name.
@@ -198,6 +226,12 @@ func (a Adapter) Delete(labels map[string]string) error {
 		}
 
 		for _, vol := range vols {
+
+			// Don't delete any volumes which are mapped into other containers
+			if _, exists := volumesNotToDelete[vol.Name]; exists {
+				continue
+			}
+
 			// If the volume was found to be attached to the component's container, then add the volume
 			// to the deletion list.
 			if _, ok := volumeNames[vol.Name]; ok {

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -230,17 +230,17 @@ func (a Adapter) Delete(labels map[string]string) error {
 
 			// Don't delete any volumes which are mapped into other containers
 			if _, exists := volumesNotToDelete[vol.Name]; exists {
-				glog.V(4).Infof("Skipping volume %s as it is mapped into a non-odo managed container", vol.Name)
+				klog.V(4).Infof("Skipping volume %s as it is mapped into a non-odo managed container", vol.Name)
 				continue
 			}
 
 			// If the volume was found to be attached to the component's container, then add the volume
 			// to the deletion list.
 			if _, ok := volumeNames[vol.Name]; ok {
-				glog.V(4).Infof("Adding volume %s to deletion list", vol.Name)
+				klog.V(4).Infof("Adding volume %s to deletion list", vol.Name)
 				volumesToDelete[vol.Name] = vol.Name
 			} else {
-				glog.V(4).Infof("Skipping volume %s as it was not attached to the component's container", vol.Name)
+				klog.V(4).Infof("Skipping volume %s as it was not attached to the component's container", vol.Name)
 			}
 		}
 	}

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -230,13 +230,17 @@ func (a Adapter) Delete(labels map[string]string) error {
 
 			// Don't delete any volumes which are mapped into other containers
 			if _, exists := volumesNotToDelete[vol.Name]; exists {
+				glog.V(4).Infof("Skipping volume %s as it is mapped into another container", vol.Name, componentName)
 				continue
 			}
 
 			// If the volume was found to be attached to the component's container, then add the volume
 			// to the deletion list.
 			if _, ok := volumeNames[vol.Name]; ok {
+				glog.V(4).Infof("Adding volume %s to deletion list", vol.Name)
 				volumesToDelete[vol.Name] = vol.Name
+			} else {
+				glog.V(4).Infof("Skipping volume %s as it was not attached to the component's container", vol.Name)
 			}
 		}
 	}

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -230,7 +230,7 @@ func (a Adapter) Delete(labels map[string]string) error {
 
 			// Don't delete any volumes which are mapped into other containers
 			if _, exists := volumesNotToDelete[vol.Name]; exists {
-				glog.V(4).Infof("Skipping volume %s as it is mapped into another container", vol.Name, componentName)
+				glog.V(4).Infof("Skipping volume %s as it is mapped into another container", vol.Name)
 				continue
 			}
 

--- a/pkg/lclient/storage.go
+++ b/pkg/lclient/storage.go
@@ -40,3 +40,18 @@ func (dc *Client) GetVolumesByLabel(labels map[string]string) ([]types.Volume, e
 
 	return volumes, nil
 }
+
+// GetVolumes returns the list of all volumes
+func (dc *Client) GetVolumes() ([]types.Volume, error) {
+	var volumes []types.Volume
+	volumeList, err := dc.Client.VolumeList(dc.Context, filters.Args{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get list of docker volumes")
+	}
+
+	for _, vol := range volumeList.Volumes {
+		volumes = append(volumes, *vol)
+	}
+
+	return volumes, nil
+}

--- a/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
@@ -15,6 +15,8 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 	var currentWorkingDirectory string
 	var cmpName string
 
+	var fakeVolumes []string
+
 	dockerClient := helper.NewDockerRunner("docker")
 
 	// This is run after every Spec (It)
@@ -29,17 +31,42 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 		// Devfile commands require experimental mode to be set
 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 		helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker")
+
+		// With our docker delete code, we want to avoid deleting volumes that we didn't create. So
+		// next we create a set of fake volumes, none of which should be deleted (eg they are out of scope) by any of the tests.
+
+		// 1) Create volume with fake component but valid type
+		volname1 := cmpName + "-fakevol1"
+		fakeVolumes = append(fakeVolumes, volname1)
+		dockerClient.CreateVolume(volname1, []string{"component=fake", "type=projects"})
+
+		// 2) Create volume with fake component but valid storage
+		volname2 := cmpName + "-fakevol2"
+		fakeVolumes = append(fakeVolumes, volname2)
+		dockerClient.CreateVolume(volname2, []string{"component=fake", "storage-name=" + volname2})
+
+		// 3) Create volume with real component but neither valid source ("type") nor valid storage
+		volname3 := cmpName + "-fakevol3"
+		fakeVolumes = append(fakeVolumes, volname3)
+		dockerClient.CreateVolume(volname3, []string{"component=" + cmpName, "type=not-projects", "storage-name-fake=" + volname3})
+
 	})
 
 	// Clean up after the test
 	// This is run after every Spec (It)
 	var _ = AfterEach(func() {
 
+		// Ensure that our fake volumes all still exist, then clean them up.
+		for _, fakeVolume := range fakeVolumes {
+			Expect(dockerClient.VolumeExists(fakeVolume)).To(Equal(true))
+			dockerClient.RemoveVolumeByName(fakeVolume)
+		}
+
 		// Stop all containers labeled with the component name
 		label := "component=" + cmpName
 		dockerClient.StopContainers(label)
 
-		dockerClient.RemoveVolumesByComponentAndType(cmpName, "projects")
+		dockerClient.RemoveVolumesByComponent(cmpName)
 
 		helper.Chdir(currentWorkingDirectory)
 		helper.DeleteDir(context)
@@ -59,15 +86,46 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 
 			Expect(dockerClient.GetRunningContainersByLabel("component=" + cmpName)).To(HaveLen(1))
 
-			Expect(dockerClient.ListVolumesOfComponentAndType(cmpName, "projects")).To(HaveLen(1))
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(1))
 
 			helper.CmdShouldPass("odo", "delete", "--devfile", "devfile.yaml", "-f")
 
 			Expect(dockerClient.GetRunningContainersByLabel("component=" + cmpName)).To(HaveLen(0))
 
-			Expect(dockerClient.ListVolumesOfComponentAndType(cmpName, "projects")).To(HaveLen(0))
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(0))
 
 		})
+
+		It("should delete all the mounted volume types listed in the devfile", func() {
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
+			helper.RenameFile("devfile-with-volumes.yaml", "devfile.yaml")
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// Retrieve the volume from one of the aliases in the devfile
+			volumes := dockerClient.GetVolumesByCompStorageName(cmpName, "myvol")
+			Expect(len(volumes)).To(Equal(1))
+			vol := volumes[0]
+
+			// Verify the volume is mounted
+			volMounted := dockerClient.IsVolumeMountedInContainer(vol, cmpName, "runtime")
+			Expect(volMounted).To(Equal(true))
+
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(3))
+
+			helper.CmdShouldPass("odo", "delete", "--devfile", "devfile.yaml", "-f")
+
+			Expect(dockerClient.GetRunningContainersByLabel("component=" + cmpName)).To(HaveLen(0))
+
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(0))
+
+		})
+
 	})
 
 	Context("when docker devfile delete command is executed with all flag", func() {
@@ -82,13 +140,13 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 
 			Expect(dockerClient.GetRunningContainersByLabel("component=" + cmpName)).To(HaveLen(1))
 
-			Expect(dockerClient.ListVolumesOfComponentAndType(cmpName, "projects")).To(HaveLen(1))
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(1))
 
 			helper.CmdShouldPass("odo", "delete", "--devfile", "devfile.yaml", "-f", "--all")
 
 			Expect(dockerClient.GetRunningContainersByLabel("component=" + cmpName)).To(HaveLen(0))
 
-			Expect(dockerClient.ListVolumesOfComponentAndType(cmpName, "projects")).To(HaveLen(0))
+			Expect(dockerClient.GetSourceAndStorageVolumesByComponent(cmpName)).To(HaveLen(0))
 
 			files := helper.ListFilesInDir(context)
 			Expect(files).To(Not(ContainElement(".odo")))

--- a/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
@@ -61,6 +61,7 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 			Expect(dockerClient.VolumeExists(fakeVolume)).To(Equal(true))
 			dockerClient.RemoveVolumeByName(fakeVolume)
 		}
+		fakeVolumes = []string{}
 
 		// Stop all containers labeled with the component name
 		label := "component=" + cmpName


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:

Currently devfile  odo delete's support for deleting docker volumes is limited to the source volume. This PR adds support for deleting the storage volumes as well.

Parent issue: https://github.com/openshift/odo/issues/2581

**How to test changes / Special notes to the reviewer**:
See #2806 for how to enable a local docker push target and create a component.