### PR TITLE
Remove oc setup for devfile push docker target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,13 +126,15 @@ jobs:
 
     - <<: *base-test
       stage: test
+      # Docker push target test command does not need a running cluster at all, however few test
+      # scenario of docker devfile url testing needs only Kube config file. So the test has been
+      # added here just to make sure docker devfile url command test gets a proper kube config file.
+      # without creating a separate OpenShift cluster.
       name: "devfile catalog, create, push, delete and docker devfile url command integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
-        # Push target is set to kube environment in some test scenarios like
-        # docker devfile url testing which only needs Kube config. So no cluster login is needed.
         - travis_wait make test-cmd-docker-devfile-url
         # These tests need cluster login as they will be interacting with a Kube environment
         - odo login -u developer

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - MINIKUBE_WANTREPORTERRORPROMPT=false
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
-    - KUBECONFIG=$HOME/.kube/config 
+    - KUBECONFIG=$HOME/.kube/config
 jobs:
   include:
     # YAML alias, for settings shared across the tests
@@ -131,6 +131,10 @@ jobs:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
+        # Push target is set to kube environment in some test scenarios like
+        # docker devfile url testing which only needs Kube config. So no cluster login is needed.
+        - travis_wait make test-cmd-docker-devfile-url
+        # These tests need cluster login as they will be interacting with a Kube environment
         - odo login -u developer
         - travis_wait make test-cmd-devfile-catalog
         - travis_wait make test-cmd-devfile-create
@@ -138,9 +142,6 @@ jobs:
         - travis_wait make test-cmd-devfile-watch
         - travis_wait make test-cmd-devfile-delete
         - odo logout
-        # Push target is set to kube environment in some test scenarios for
-        # docker devfile url testing which only needs kube config. So no cluster login is needed.
-        - travis_wait make test-cmd-docker-devfile-url
 
     - <<: *base-test
       stage: test
@@ -163,8 +164,9 @@ jobs:
         - make bin
         - sudo cp odo /usr/bin
         - travis_wait make test-cmd-docker-devfile-push
+        - travis_wait make test-cmd-docker-devfile-catalog
         - travis_wait make test-cmd-docker-devfile-delete
-    
+
     # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "generic, login, component command integration tests"
+      name: "generic, login and component command integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
@@ -98,7 +98,7 @@ jobs:
     # Run service-catalog e2e tests
     - <<: *base-test
       stage: test
-      name: "service, link, component sub-commands command integration tests"
+      name: "service, link and component sub-commands command integration tests"
       script:
         - ./scripts/oc-cluster.sh service-catalog
         - make bin
@@ -111,7 +111,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "watch, storage, app, project, push, devfile catalog, devfile create, devfile push, devfile delete command integration tests"
+      name: "watch, storage, app, project and push command integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make bin
@@ -122,12 +122,23 @@ jobs:
         - travis_wait make test-cmd-app
         - travis_wait make test-cmd-push
         - travis_wait make test-cmd-project
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "devfile catalog, create, push, delete and docker devfile url command integration tests"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-cmd-devfile-catalog
         - travis_wait make test-cmd-devfile-create
         - travis_wait make test-cmd-devfile-push
         - travis_wait make test-cmd-devfile-watch
         - travis_wait make test-cmd-devfile-delete
         - odo logout
+        - travis_wait make test-cmd-docker-devfile-url
 
     - <<: *base-test
       stage: test
@@ -145,12 +156,11 @@ jobs:
     
     - <<: *base-test
       stage: test
-      name: "docker devfile push command integration tests"
+      name: "docker devfile push and delete command integration tests"
       script:
         - make bin
         - sudo cp odo /usr/bin
         - travis_wait make test-cmd-docker-devfile-push
-        - travis_wait make test-cmd-docker-devfile-url
         - travis_wait make test-cmd-docker-devfile-delete
     
     # Run devfile integration test on Kubernetes cluster    

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,8 @@ jobs:
         - travis_wait make test-cmd-devfile-watch
         - travis_wait make test-cmd-devfile-delete
         - odo logout
+        # Push target is set to kube environment in some test scenarios for
+        # docker devfile url testing which only needs kube config. So no cluster login is needed.
         - travis_wait make test-cmd-docker-devfile-url
 
     - <<: *base-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,13 +147,11 @@ jobs:
       stage: test
       name: "docker devfile push command integration tests"
       script:
-        - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
         - travis_wait make test-cmd-docker-devfile-push
         - travis_wait make test-cmd-docker-devfile-url
-        - travis_wait make test-cmd-docker-devfile-catalog
-
+        - travis_wait make test-cmd-docker-devfile-delete
     
     # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,6 @@ test-cmd-docker-devfile-delete:
 test-cmd-docker-devfile-catalog:
 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile catalog command tests" tests/integration/devfile/docker/
 
-
 # Run odo watch command tests
 .PHONY: test-cmd-watch
 test-cmd-watch:

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
@@ -79,7 +79,7 @@ var _ = Describe("odo docker devfile url command tests", func() {
 			// url1 exists with push target set to docker, create url with same name should fail if push target is set to kube
 			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
 			stdout = helper.CmdShouldFail("odo", "url", "create", url1, "--host", "1.2.3.4.com")
-			Expect(stdout).To(ContainSubstring("no configuration has been provided"))
+			Expect(stdout).To(ContainSubstring("already exists for a different push target"))
 
 			// url2 exists with push target set to kube, create url with same name should fail if push target is set to docker
 			helper.CmdShouldPass("odo", "url", "create", url2, "--host", "1.2.3.4.com")

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
@@ -85,7 +85,7 @@ var _ = Describe("odo docker devfile url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", url2, "--host", "1.2.3.4.com")
 			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker", "-f")
 			stdout = helper.CmdShouldFail("odo", "url", "create", url2)
-			Expect(stdout).To(ContainSubstring("no configuration has been provided"))
+			Expect(stdout).To(ContainSubstring("already exists for a different push target"))
 
 		})
 

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
@@ -79,13 +79,13 @@ var _ = Describe("odo docker devfile url command tests", func() {
 			// url1 exists with push target set to docker, create url with same name should fail if push target is set to kube
 			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
 			stdout = helper.CmdShouldFail("odo", "url", "create", url1, "--host", "1.2.3.4.com")
-			Expect(stdout).To(ContainSubstring("already exists for a different push target"))
+			Expect(stdout).To(ContainSubstring("no configuration has been provided"))
 
 			// url2 exists with push target set to kube, create url with same name should fail if push target is set to docker
 			helper.CmdShouldPass("odo", "url", "create", url2, "--host", "1.2.3.4.com")
 			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker", "-f")
 			stdout = helper.CmdShouldFail("odo", "url", "create", url2)
-			Expect(stdout).To(ContainSubstring("already exists for a different push target"))
+			Expect(stdout).To(ContainSubstring("no configuration has been provided"))
 
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What does does this PR do / why we need it**:
Removing unnecessary ```oc cluster up```
https://github.com/openshift/odo/pull/2921#issuecomment-617240185
**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
Test job ```docker devfile push command integration tests``` should pass in travis CI