### PR TITLE
Push support: Event notification support for build and application status for IDE integration for devfile scenarios

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -694,7 +694,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 	compInfo := common.ComponentInfo{
 		PodName: pod.Name,
 	}
-	err = exec.ExecuteCommand(client, compInfo, cmdArr, show)
+	err = exec.ExecuteCommand(client, compInfo, cmdArr, show, nil, nil)
 
 	if err != nil {
 		s.End(false)

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -14,14 +14,25 @@ import (
 	"github.com/openshift/odo/pkg/devfile/adapters/docker/utils"
 	"github.com/openshift/odo/pkg/lclient"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/sync"
 )
 
 // New instantiantes a component adapter
 func New(adapterContext common.AdapterContext, client lclient.Client) Adapter {
+
+	var loggingClient machineoutput.MachineEventLoggingClient
+
+	if log.IsJSON() {
+		loggingClient = machineoutput.NewConsoleMachineEventLoggingClient()
+	} else {
+		loggingClient = machineoutput.NewNoOpMachineEventLoggingClient()
+	}
+
 	return Adapter{
-		Client:         client,
-		AdapterContext: adapterContext,
+		Client:             client,
+		AdapterContext:     adapterContext,
+		machineEventLogger: loggingClient,
 	}
 }
 
@@ -38,6 +49,7 @@ type Adapter struct {
 	devfileRunCmd             string
 	supervisordVolumeName     string
 	projectVolumeName         string
+	machineEventLogger        machineoutput.MachineEventLoggingClient
 }
 
 // Push updates the component if a matching component exists or creates one if it doesn't exist

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -318,9 +318,6 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 		return errors.New(fmt.Sprint("error executing devfile commands - there should be at least 1 command"))
 	}
 
-	stdoutWriter := a.machineEventLogger.CreateContainerOutputWriter(false)
-	stderrWriter := a.machineEventLogger.CreateContainerOutputWriter(true)
-
 	// Only add runinit to the expected commands if the component doesn't already exist
 	// This would be the case when first running the container
 	if !componentExists {
@@ -330,7 +327,7 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 
 			containerID := utils.GetContainerIDForAlias(containers, command.Exec.Component)
 			compInfo := common.ComponentInfo{ContainerName: containerID}
-			err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+			err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			if err != nil {
 				return err
 			}
@@ -342,7 +339,7 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 	if ok {
 		containerID := utils.GetContainerIDForAlias(containers, command.Exec.Component)
 		compInfo := common.ComponentInfo{ContainerName: containerID}
-		err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+		err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 		if err != nil {
 			return err
 		}
@@ -367,10 +364,10 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 		compInfo := common.ComponentInfo{ContainerName: containerID}
 		if componentExists && !common.IsRestartRequired(command) {
 			klog.V(4).Info("restart:false, Not restarting DevRun Command")
-			err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+			err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			return
 		}
-		err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+		err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 	}
 
 	return

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -389,19 +389,19 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 
 		if componentExists && !common.IsRestartRequired(command) {
 			klog.V(4).Infof("restart:false, Not restarting %v Command", command.Exec.Id)
-
 			if isDebug {
-				err = exec.ExecuteDevfileDebugActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
+				err = exec.ExecuteDevfileDebugActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			} else {
 				err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			}
 			return
 		}
 		if isDebug {
-			err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
+			err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 		} else {
 			err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 		}
+
 	}
 
 	return

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -341,10 +341,6 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 		PodName: podName,
 	}
 
-	// an io.Writer if machine readable is enabled, else nil
-	stdoutWriter := a.machineEventLogger.CreateContainerOutputWriter(false)
-	stderrWriter := a.machineEventLogger.CreateContainerOutputWriter(true)
-
 	// only execute Init command, if it is first run of container.
 	if !componentExists {
 
@@ -352,9 +348,8 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 		command, ok := commandsMap[versionsCommon.InitCommandGroupType]
 		if ok {
 			compInfo.ContainerName = command.Exec.Component
-			err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+			err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			if err != nil {
-				// a.machineEventLogger.DevFileCommandExecutionComplete(command.Name, machineoutput.TimestampNow())
 				return err
 			}
 
@@ -366,7 +361,7 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 	command, ok := commandsMap[versionsCommon.BuildCommandGroupType]
 	if ok {
 		compInfo.ContainerName = command.Exec.Component
-		err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+		err = exec.ExecuteDevfileBuildAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 		if err != nil {
 			return err
 		}
@@ -394,17 +389,18 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 
 		if componentExists && !common.IsRestartRequired(command) {
 			klog.V(4).Infof("restart:false, Not restarting %v Command", command.Exec.Id)
+
 			if isDebug {
-				err = exec.ExecuteDevfileDebugActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+				err = exec.ExecuteDevfileDebugActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
 			} else {
-				err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+				err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 			}
 			return
 		}
 		if isDebug {
-			err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+			err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
 		} else {
-			err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, stdoutWriter, stderrWriter, a.machineEventLogger)
+			err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show, a.machineEventLogger)
 		}
 	}
 

--- a/pkg/exec/devfile.go
+++ b/pkg/exec/devfile.go
@@ -138,7 +138,7 @@ func ExecuteDevfileRunActionWithoutRestart(client ExecClient, exec common.Exec, 
 }
 
 // ExecuteDevfileDebugAction executes the devfile debug command action using the supervisord debugrun program
-func ExecuteDevfileDebugAction(client ExecClient, exec common.Exec, commandName string, compInfo adaptersCommon.ComponentInfo, show bool) error {
+func ExecuteDevfileDebugAction(client ExecClient, exec common.Exec, commandName string, compInfo adaptersCommon.ComponentInfo, show bool, machineEventLogger machineoutput.MachineEventLoggingClient) error {
 	var s *log.Status
 
 	// Exec the supervisord ctl stop and start for the debugRun program
@@ -159,18 +159,32 @@ func ExecuteDevfileDebugAction(client ExecClient, exec common.Exec, commandName 
 
 	for _, debugRunExec := range debugRunExecs {
 
-		err := ExecuteCommand(client, compInfo, debugRunExec.command, show)
+		// Emit DevFileCommandExecutionBegin JSON event (if machine output logging is enabled)
+		machineEventLogger.DevFileCommandExecutionBegin(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow())
+
+		// Capture container text and log to the screen as JSON events (machine output only)
+		stdoutWriter, stdoutChannel, stderrWriter, stderrChannel := machineEventLogger.CreateContainerOutputWriter()
+
+		err := ExecuteCommand(client, compInfo, debugRunExec.command, show, stdoutWriter, stderrWriter)
+
+		// Close the writers and wait for an acknowledgement that the reader loop has exited (to ensure we get ALL container output)
+		closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
+
+		// Emit close event
+		machineEventLogger.DevFileCommandExecutionComplete(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow(), err)
+
 		if err != nil {
 			return errors.Wrapf(err, "unable to execute the run command")
 		}
 	}
+
 	s.End(true)
 
 	return nil
 }
 
 // ExecuteDevfileDebugActionWithoutRestart executes devfile run command without restarting.
-func ExecuteDevfileDebugActionWithoutRestart(client ExecClient, exec common.Exec, commandName string, compInfo adaptersCommon.ComponentInfo, show bool) error {
+func ExecuteDevfileDebugActionWithoutRestart(client ExecClient, exec common.Exec, commandName string, compInfo adaptersCommon.ComponentInfo, show bool, machineEventLogger machineoutput.MachineEventLoggingClient) error {
 	var s *log.Status
 
 	type devDebugExecutable struct {
@@ -182,10 +196,23 @@ func ExecuteDevfileDebugActionWithoutRestart(client ExecClient, exec common.Exec
 		command: []string{adaptersCommon.SupervisordBinaryPath, adaptersCommon.SupervisordCtlSubCommand, "start", string(adaptersCommon.DefaultDevfileDebugCommand)},
 	}
 
+	// Emit DevFileCommandExecutionBegin JSON event (if machine output logging is enabled)
+	machineEventLogger.DevFileCommandExecutionBegin(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow())
+
+	// Capture container text and log to the screen as JSON events (machine output only)
+	stdoutWriter, stdoutChannel, stderrWriter, stderrChannel := machineEventLogger.CreateContainerOutputWriter()
+
 	s = log.Spinnerf("Executing %s command %q, if not running", commandName, exec.CommandLine)
 	defer s.End(false)
 
-	err := ExecuteCommand(client, compInfo, devDebugExec.command, show)
+	err := ExecuteCommand(client, compInfo, devDebugExec.command, show, stdoutWriter, stderrWriter)
+
+	// Close the writers and wait for an acknowledgement that the reader loop has exited (to ensure we get ALL container output)
+	closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
+
+	// Emit close event
+	machineEventLogger.DevFileCommandExecutionComplete(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow(), err)
+
 	if err != nil {
 		return errors.Wrapf(err, "unable to execute the run command")
 	}

--- a/pkg/exec/devfile.go
+++ b/pkg/exec/devfile.go
@@ -40,7 +40,7 @@ func ExecuteDevfileBuildAction(client ExecClient, exec common.Exec, commandName 
 
 	err := ExecuteCommand(client, compInfo, cmdArr, show, stdoutWriter, stderrWriter)
 
-	// Close the writers and wait for an acknowledgement that the reader loop has exitted (to ensure we get ALL container output)
+	// Close the writers and wait for an acknowledgement that the reader loop has exited (to ensure we get ALL container output)
 	closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
 
 	// Emit close event
@@ -76,12 +76,18 @@ func ExecuteDevfileRunAction(client ExecClient, exec common.Exec, commandName st
 
 	for _, devRunExec := range devRunExecs {
 
+		// Emit DevFileCommandExecutionBegin JSON event (if machine output logging is enabled)
 		machineEventLogger.DevFileCommandExecutionBegin(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow())
+
+		// Capture container text and log to the screen as JSON events (machine output only)
 		stdoutWriter, stdoutChannel, stderrWriter, stderrChannel := machineEventLogger.CreateContainerOutputWriter()
 
 		err := ExecuteCommand(client, compInfo, devRunExec.command, show, stdoutWriter, stderrWriter)
 
+		// Close the writers and wait for an acknowledgement that the reader loop has exited (to ensure we get ALL container output)
 		closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
+
+		// Emit close event
 		machineEventLogger.DevFileCommandExecutionComplete(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow(), err)
 		if err != nil {
 			return errors.Wrapf(err, "unable to execute the run command")
@@ -109,12 +115,18 @@ func ExecuteDevfileRunActionWithoutRestart(client ExecClient, exec common.Exec, 
 	s = log.Spinnerf("Executing %s command %q, if not running", commandName, exec.CommandLine)
 	defer s.End(false)
 
+	// Emit DevFileCommandExecutionBegin JSON event (if machine output logging is enabled)
 	machineEventLogger.DevFileCommandExecutionBegin(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow())
+
+	// Capture container text and log to the screen as JSON events (machine output only)
 	stdoutWriter, stdoutChannel, stderrWriter, stderrChannel := machineEventLogger.CreateContainerOutputWriter()
 
 	err := ExecuteCommand(client, compInfo, devRunExec.command, show, stdoutWriter, stderrWriter)
 
+	// Close the writers and wait for an acknowledgement that the reader loop has exited (to ensure we get ALL container output)
 	closeWriterAndWaitForAck(stdoutWriter, stdoutChannel, stderrWriter, stderrChannel)
+
+	// Emit close event
 	machineEventLogger.DevFileCommandExecutionComplete(exec.Id, exec.Component, exec.CommandLine, convertGroupKindToString(exec), machineoutput.TimestampNow(), err)
 	if err != nil {
 		return errors.Wrapf(err, "unable to execute the run command")

--- a/pkg/machineoutput/event_logging.go
+++ b/pkg/machineoutput/event_logging.go
@@ -77,7 +77,6 @@ func (c *ConsoleMachineEventLoggingClient) DevFileCommandExecutionBegin(commandI
 			ComponentName:    componentName,
 			CommandLine:      commandLine,
 			GroupKind:        groupKind,
-			Timestamp:        timestamp,
 			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
 		},
 	}
@@ -100,7 +99,6 @@ func (c *ConsoleMachineEventLoggingClient) DevFileCommandExecutionComplete(comma
 			ComponentName:    componentName,
 			CommandLine:      commandLine,
 			GroupKind:        groupKind,
-			Timestamp:        timestamp,
 			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
 			Error:            errorStr,
 		},

--- a/pkg/machineoutput/event_logging.go
+++ b/pkg/machineoutput/event_logging.go
@@ -1,0 +1,218 @@
+package machineoutput
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"k8s.io/klog"
+)
+
+// formatTime returns time in UTC Unix Epoch Seconds and then the microsecond portion of that time.
+func formatTime(time time.Time) string {
+	result := fmt.Sprintf("%d.%06d", time.Unix(), time.Nanosecond()/1000)
+	return result
+
+}
+
+// TimestampNow returns timestamp in format of (seconds since UTC Unix epoch).(microseconds time component)
+func TimestampNow() string {
+	return formatTime(time.Now())
+}
+
+// NewNoOpMachineEventLoggingClient creates a new instance of NoOpMachineEventLoggingClient,
+// which will ignore any provided events.
+func NewNoOpMachineEventLoggingClient() *NoOpMachineEventLoggingClient {
+	return &NoOpMachineEventLoggingClient{}
+}
+
+// DevFileCommandExecutionBegin ignores the provided event.
+func (c *NoOpMachineEventLoggingClient) DevFileCommandExecutionBegin(commandName string, timestamp string) {
+}
+
+// DevFileCommandExecutionComplete ignores the provided event.
+func (c *NoOpMachineEventLoggingClient) DevFileCommandExecutionComplete(commandName string, timestamp string, errorVal error) {
+}
+
+// CreateContainerOutputWriter ignores the provided event.
+func (c *NoOpMachineEventLoggingClient) CreateContainerOutputWriter(stderr bool) io.Writer {
+	return nil
+}
+
+// ReportError ignores the provided event.
+func (c *NoOpMachineEventLoggingClient) ReportError(errorVal error, timestamp string) {}
+
+// NewConsoleMachineEventLoggingClient creates a new instance of ConsoleMachineEventLoggingClient,
+// which will output events as JSON to the console.
+func NewConsoleMachineEventLoggingClient() *ConsoleMachineEventLoggingClient {
+	return &ConsoleMachineEventLoggingClient{}
+}
+
+// DevFileCommandExecutionBegin outputs the provided event as JSON to the console.
+func (c *ConsoleMachineEventLoggingClient) DevFileCommandExecutionBegin(commandName string, timestamp string) {
+
+	json := MachineEventWrapper{
+		DevFileCommandExecutionBegin: &DevFileCommandExecutionBegin{
+			CommandName:      commandName,
+			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
+		},
+	}
+
+	OutputSuccessUnindented(json)
+}
+
+// DevFileCommandExecutionComplete outputs the provided event as JSON to the console.
+func (c *ConsoleMachineEventLoggingClient) DevFileCommandExecutionComplete(commandName string, timestamp string, errorVal error) {
+
+	var errorStr string
+
+	if errorVal != nil {
+		errorStr = errorVal.Error()
+	}
+
+	json := MachineEventWrapper{
+		DevFileCommandExecutionComplete: &DevFileCommandExecutionComplete{
+			CommandName:      commandName,
+			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
+			Error:            errorStr,
+		},
+	}
+
+	OutputSuccessUnindented(json)
+}
+
+// CreateContainerOutputWriter returns an io.Writer for which the devfile command/action process output should be
+// written (for example by passing the io.Writer to exec.ExecuteCommand).
+//
+// All text written to the returned object will be output as a log text event.
+func (c *ConsoleMachineEventLoggingClient) CreateContainerOutputWriter(stderr bool) io.Writer {
+	reader, writer := io.Pipe()
+
+	stream := "stdout"
+	if stderr {
+		stream = "stderr"
+	}
+
+	go func() {
+
+		bufReader := bufio.NewReader(reader)
+		for {
+			line, _, err := bufReader.ReadLine()
+			if err != nil {
+				klog.V(4).Infof("Unexpected error on reading container output reader: %v", err)
+				return
+			}
+
+			json := MachineEventWrapper{
+				LogText: &LogText{
+					AbstractLogEvent: AbstractLogEvent{Timestamp: TimestampNow()},
+					Text:             string(line),
+					Stream:           stream,
+				},
+			}
+			OutputSuccessUnindented(json)
+		}
+
+	}()
+
+	return writer
+}
+
+// ReportError ignores the provided event.
+func (c *ConsoleMachineEventLoggingClient) ReportError(errorVal error, timestamp string) {
+	json := MachineEventWrapper{
+		ReportError: &ReportError{
+			Error:            errorVal.Error(),
+			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
+		},
+	}
+
+	OutputSuccessUnindented(json)
+}
+
+// GetEntry will return the JSON event parsed from a single line of '-o json' machine readable console output.
+func (w MachineEventWrapper) GetEntry() (MachineEventLogEntry, error) {
+
+	if w.DevFileCommandExecutionBegin != nil {
+		return w.DevFileCommandExecutionBegin, nil
+
+	} else if w.DevFileCommandExecutionComplete != nil {
+		return w.DevFileCommandExecutionComplete, nil
+
+	} else if w.LogText != nil {
+		return w.LogText, nil
+
+	} else if w.ReportError != nil {
+		return w.ReportError, nil
+
+	} else {
+		return nil, errors.New("unexpected machine event log entry")
+	}
+
+}
+
+// GetTimestamp returns the timestamp element for this event.
+func (c AbstractLogEvent) GetTimestamp() string { return c.Timestamp }
+
+// GetType returns the event type for this event.
+func (c DevFileCommandExecutionBegin) GetType() MachineEventLogEntryType {
+	return TypeDevFileCommandExecutionBegin
+}
+
+// GetType returns the event type for this event.
+func (c DevFileCommandExecutionComplete) GetType() MachineEventLogEntryType {
+	return TypeDevFileCommandExecutionComplete
+}
+
+// GetType returns the event type for this event.
+func (c LogText) GetType() MachineEventLogEntryType { return TypeLogText }
+
+// GetType returns the event type for this event.
+func (c ReportError) GetType() MachineEventLogEntryType { return TypeReportError }
+
+// MachineEventLogEntryType indicates the machine-readable event type from an ODO operation
+type MachineEventLogEntryType int
+
+const (
+	// TypeDevFileCommandExecutionBegin is the entry type for that event.
+	TypeDevFileCommandExecutionBegin MachineEventLogEntryType = 0
+	// TypeDevFileCommandExecutionComplete is the entry type for that event.
+	TypeDevFileCommandExecutionComplete MachineEventLogEntryType = 1
+	// TypeLogText is the entry type for that event.
+	TypeLogText MachineEventLogEntryType = 2
+	// TypeReportError is the entry type for that event.
+	TypeReportError MachineEventLogEntryType = 3
+)
+
+// GetCommandName returns a command if the MLE supports that field (otherwise empty string is returned).
+// Currently used for test purposes only.
+func GetCommandName(entry MachineEventLogEntry) string {
+
+	if entry.GetType() == TypeDevFileCommandExecutionBegin {
+		return entry.(*DevFileCommandExecutionBegin).CommandName
+	} else if entry.GetType() == TypeDevFileCommandExecutionComplete {
+		return entry.(*DevFileCommandExecutionComplete).CommandName
+	} else {
+		return ""
+	}
+
+}
+
+// FindNextEntryByType locates the next entry of a given type within a slice. Currently used for test purposes only.
+func FindNextEntryByType(initialIndex int, typeToFind MachineEventLogEntryType, entries []MachineEventLogEntry) (MachineEventLogEntry, int) {
+
+	for index, entry := range entries {
+		if index < initialIndex {
+			continue
+		}
+
+		if entry.GetType() == typeToFind {
+			return entry, index
+		}
+	}
+
+	return nil, -1
+
+}

--- a/pkg/machineoutput/event_logging.go
+++ b/pkg/machineoutput/event_logging.go
@@ -95,12 +95,14 @@ func (c *ConsoleMachineEventLoggingClient) DevFileCommandExecutionComplete(comma
 
 	json := MachineEventWrapper{
 		DevFileCommandExecutionComplete: &DevFileCommandExecutionComplete{
-			CommandID:        commandID,
-			ComponentName:    componentName,
-			CommandLine:      commandLine,
-			GroupKind:        groupKind,
-			AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
-			Error:            errorStr,
+			DevFileCommandExecutionBegin: DevFileCommandExecutionBegin{
+				CommandID:        commandID,
+				ComponentName:    componentName,
+				CommandLine:      commandLine,
+				GroupKind:        groupKind,
+				AbstractLogEvent: AbstractLogEvent{Timestamp: timestamp},
+			},
+			Error: errorStr,
 		},
 	}
 
@@ -173,6 +175,7 @@ func (c *ConsoleMachineEventLoggingClient) ReportError(errorVal error, timestamp
 }
 
 // GetEntry will return the JSON event parsed from a single line of '-o json' machine readable console output.
+// Currently used for test purposes only.
 func (w MachineEventWrapper) GetEntry() (MachineEventLogEntry, error) {
 
 	if w.DevFileCommandExecutionBegin != nil {
@@ -237,22 +240,5 @@ func GetCommandName(entry MachineEventLogEntry) string {
 	} else {
 		return ""
 	}
-
-}
-
-// FindNextEntryByType locates the next entry of a given type within a slice. Currently used for test purposes only.
-func FindNextEntryByType(initialIndex int, typeToFind MachineEventLogEntryType, entries []MachineEventLogEntry) (MachineEventLogEntry, int) {
-
-	for index, entry := range entries {
-		if index < initialIndex {
-			continue
-		}
-
-		if entry.GetType() == typeToFind {
-			return entry, index
-		}
-	}
-
-	return nil, -1
 
 }

--- a/pkg/machineoutput/types_event_logging.go
+++ b/pkg/machineoutput/types_event_logging.go
@@ -33,7 +33,6 @@ type DevFileCommandExecutionBegin struct {
 	ComponentName string `json:"componentName"`
 	CommandLine   string `json:"commandLine"`
 	GroupKind     string `json:"groupKind"`
-	Timestamp     string `json:"timestamp"`
 	AbstractLogEvent
 }
 
@@ -43,7 +42,6 @@ type DevFileCommandExecutionComplete struct {
 	ComponentName string `json:"componentName"`
 	CommandLine   string `json:"commandLine"`
 	GroupKind     string `json:"groupKind"`
-	Timestamp     string `json:"timestamp"`
 	Error         string `json:"error,omitempty"`
 	AbstractLogEvent
 }

--- a/pkg/machineoutput/types_event_logging.go
+++ b/pkg/machineoutput/types_event_logging.go
@@ -1,0 +1,81 @@
+package machineoutput
+
+import (
+	"io"
+)
+
+// MachineEventLoggingClient is an interface which is used by consuming code to
+// output machine-readable event JSON to the console. Both no-op and non-no-op
+// implementations of this interface exist.
+type MachineEventLoggingClient interface {
+	DevFileCommandExecutionBegin(commandName string, timestamp string)
+	DevFileCommandExecutionComplete(commandName string, timestamp string, errorVal error)
+	ReportError(errorVal error, timestamp string)
+
+	CreateContainerOutputWriter(stderr bool) io.Writer
+}
+
+// MachineEventWrapper - a single line of machine-readable event console output must contain only one
+// of these commands; the MachineEventWrapper is used to create (and parse, for tests) these lines.
+type MachineEventWrapper struct {
+	DevFileCommandExecutionBegin    *DevFileCommandExecutionBegin    `json:"devFileCommandExecutionBegin,omitempty"`
+	DevFileCommandExecutionComplete *DevFileCommandExecutionComplete `json:"devFileCommandExecutionComplete,omitempty"`
+	LogText                         *LogText                         `json:"logText,omitempty"`
+	ReportError                     *ReportError                     `json:"reportError,omitempty"`
+}
+
+// DevFileCommandExecutionBegin is the JSON event that is emitted when a dev file command begins execution.
+type DevFileCommandExecutionBegin struct {
+	CommandName string `json:"commandName"`
+	AbstractLogEvent
+}
+
+// DevFileCommandExecutionComplete is the JSON event that is emitted when a dev file command completes execution.
+type DevFileCommandExecutionComplete struct {
+	CommandName string `json:"commandName"`
+	Error       string `json:"error,omitempty"`
+	AbstractLogEvent
+}
+
+// ReportError is the JSON event that is emitted when an error occurs during push command
+type ReportError struct {
+	Error string `json:"error"`
+	AbstractLogEvent
+}
+
+// LogText is the JSON event that is emitted when a dev file action outputs text to the console.
+type LogText struct {
+	Text   string `json:"text"`
+	Stream string `json:"stream"`
+	AbstractLogEvent
+}
+
+// AbstractLogEvent is the base struct for all events; all events must at a minimum contain a timestamp.
+type AbstractLogEvent struct {
+	Timestamp string `json:"timestamp"`
+}
+
+// Ensure the various events correctly implement the desired interface.
+var _ MachineEventLogEntry = &DevFileCommandExecutionBegin{}
+var _ MachineEventLogEntry = &DevFileCommandExecutionComplete{}
+var _ MachineEventLogEntry = &LogText{}
+var _ MachineEventLogEntry = &ReportError{}
+
+// MachineEventLogEntry contains the expected methods for every event that is emitted.
+// (This is mainly used for test purposes.)
+type MachineEventLogEntry interface {
+	GetTimestamp() string
+	GetType() MachineEventLogEntryType
+}
+
+// Ensure these clients are interface compatible
+var _ MachineEventLoggingClient = &NoOpMachineEventLoggingClient{}
+var _ MachineEventLoggingClient = &ConsoleMachineEventLoggingClient{}
+
+// NoOpMachineEventLoggingClient will ignore (eg not output) all events passed to it
+type NoOpMachineEventLoggingClient struct {
+}
+
+// ConsoleMachineEventLoggingClient will output all events to the console as JSON
+type ConsoleMachineEventLoggingClient struct {
+}

--- a/pkg/machineoutput/types_event_logging.go
+++ b/pkg/machineoutput/types_event_logging.go
@@ -38,12 +38,8 @@ type DevFileCommandExecutionBegin struct {
 
 // DevFileCommandExecutionComplete is the JSON event that is emitted when a dev file command completes execution.
 type DevFileCommandExecutionComplete struct {
-	CommandID     string `json:"commandId"`
-	ComponentName string `json:"componentName"`
-	CommandLine   string `json:"commandLine"`
-	GroupKind     string `json:"groupKind"`
-	Error         string `json:"error,omitempty"`
-	AbstractLogEvent
+	DevFileCommandExecutionBegin
+	Error string `json:"error,omitempty"`
 }
 
 // ReportError is the JSON event that is emitted when an error occurs during push command

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -43,8 +43,11 @@ func (po *PushOptions) DevfilePush() error {
 		eventLoggingClient := machineoutput.NewConsoleMachineEventLoggingClient()
 		eventLoggingClient.ReportError(err, machineoutput.TimestampNow())
 
-		// Supress the error to prevent it from being output by the generic machine-readable handler
+		// Suppress the error to prevent it from being output by the generic machine-readable handler (which will produce invalid JSON for our purposes)
 		err = nil
+
+		// os.Exit(1) since we are suppressing the generic machine-readable handler's exit code logic
+		os.Exit(1)
 	}
 
 	return err

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
@@ -18,11 +19,9 @@ import (
 	"github.com/spf13/cobra"
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-
-	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
-var pushCmdExample = ktemplates.Examples(`  # Push source code to the current component
+var pushCmdExample = (`  # Push source code to the current component
 %[1]s
 
 # Push data to the current component from the original source
@@ -33,6 +32,11 @@ var pushCmdExample = ktemplates.Examples(`  # Push source code to the current co
 
 # Push source code with custom devfile commands using --build-command and --run-command for experimental mode
 %[1]s --build-command="mybuild" --run-command="myrun"
+  `)
+
+var pushCmdExampleExperimentalOnly = (`
+# Output JSON events corresponding to devfile command execution and log text
+%[1]s -o json
   `)
 
 // PushRecommendedCommandName is the recommended push command name
@@ -168,16 +172,21 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 
 	annotations := map[string]string{"command": "component"}
 
-	// The '-o json' option should only appear in help output when experimental mode is enabled.
+	pushCmdExampleText := pushCmdExample
+
 	if experimental.IsExperimentalModeEnabled() {
+		// The '-o json' option should only appear in help output when experimental mode is enabled.
 		annotations["machineoutput"] = "json"
+
+		// The '-o json' example should likewise only appear in experimental only.
+		pushCmdExampleText += pushCmdExampleExperimentalOnly
 	}
 
 	var pushCmd = &cobra.Command{
 		Use:         fmt.Sprintf("%s [component name]", name),
 		Short:       "Push source code to a component",
 		Long:        `Push source code to a component.`,
-		Example:     fmt.Sprintf(pushCmdExample, fullName),
+		Example:     fmt.Sprintf(ktemplates.Examples(pushCmdExampleText), fullName),
 		Args:        cobra.MaximumNArgs(1),
 		Annotations: annotations,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -166,17 +166,25 @@ func (po *PushOptions) Run() (err error) {
 func NewCmdPush(name, fullName string) *cobra.Command {
 	po := NewPushOptions()
 
+	annotations := map[string]string{"command": "component"}
+
+	// The '-o json' option should only appear in help output when experimental mode is enabled.
+	if experimental.IsExperimentalModeEnabled() {
+		annotations["machineoutput"] = "json"
+	}
+
 	var pushCmd = &cobra.Command{
 		Use:         fmt.Sprintf("%s [component name]", name),
 		Short:       "Push source code to a component",
 		Long:        `Push source code to a component.`,
 		Example:     fmt.Sprintf(pushCmdExample, fullName),
 		Args:        cobra.MaximumNArgs(1),
-		Annotations: map[string]string{"command": "component"},
+		Annotations: annotations,
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(po, cmd, args)
 		},
 	}
+
 	genericclioptions.AddContextFlag(pushCmd, &po.componentContext)
 	pushCmd.Flags().BoolVar(&po.show, "show-log", false, "If enabled, logs will be shown when built")
 	pushCmd.Flags().StringSliceVar(&po.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -151,7 +151,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		klog.V(4).Infof("Creating %s on the remote container if it doesn't already exist", syncFolder)
 		cmdArr := getCmdToCreateSyncFolder(syncFolder)
 
-		err = exec.ExecuteCommand(a.Client, compInfo, cmdArr, false)
+		err = exec.ExecuteCommand(a.Client, compInfo, cmdArr, false, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	if len(delFiles) > 0 {
 		cmdArr := getCmdToDeleteFiles(delFiles, syncFolder)
 
-		err = exec.ExecuteCommand(a.Client, compInfo, cmdArr, false)
+		err = exec.ExecuteCommand(a.Client, compInfo, cmdArr, false, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/tests/helper/kubernetes_utils.go
+++ b/tests/helper/kubernetes_utils.go
@@ -3,6 +3,8 @@ package helper
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,4 +19,19 @@ func copyKubeConfigFile(kubeConfigFile, tempConfigFile string) {
 	Expect(err).NotTo(HaveOccurred())
 	os.Setenv("KUBECONFIG", tempConfigFile)
 	fmt.Fprintf(GinkgoWriter, "Setting KUBECONFIG=%s\n", tempConfigFile)
+}
+
+// GetExistingKubeConfigPath retrieves the Kubernetes configuration from the most appropriate location
+func GetExistingKubeConfigPath() string {
+
+	// 1) If KUBECONFIG env var is specified, return that path
+	kubeconfigEnv := strings.TrimSpace(os.Getenv("KUBECONFIG"))
+	if len(kubeconfigEnv) != 0 {
+		return kubeconfigEnv
+	}
+
+	// 2) Otherwise return the default config path
+	homeDir := GetUserHomeDir()
+	return filepath.Join(homeDir, ".kube", "config")
+
 }

--- a/tests/helper/kubernetes_utils.go
+++ b/tests/helper/kubernetes_utils.go
@@ -3,8 +3,6 @@ package helper
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,19 +17,4 @@ func copyKubeConfigFile(kubeConfigFile, tempConfigFile string) {
 	Expect(err).NotTo(HaveOccurred())
 	os.Setenv("KUBECONFIG", tempConfigFile)
 	fmt.Fprintf(GinkgoWriter, "Setting KUBECONFIG=%s\n", tempConfigFile)
-}
-
-// GetExistingKubeConfigPath retrieves the Kubernetes configuration from the most appropriate location
-func GetExistingKubeConfigPath() string {
-
-	// 1) If KUBECONFIG env var is specified, return that path
-	kubeconfigEnv := strings.TrimSpace(os.Getenv("KUBECONFIG"))
-	if len(kubeconfigEnv) != 0 {
-		return kubeconfigEnv
-	}
-
-	// 2) Otherwise return the default config path
-	homeDir := GetUserHomeDir()
-	return filepath.Join(homeDir, ".kube", "config")
-
 }

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -24,7 +24,6 @@ var _ = Describe("odo devfile push command tests", func() {
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
-		// kubeConfigFile := helper.CopyKubeConfigFile(helper.GetExistingKubeConfigPath(), filepath.Join(context, "config"))
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
 		// Devfile push requires experimental mode to be set

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -106,12 +106,12 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml", "--project", namespace)
+			output := helper.CmdShouldPass("odo", "push", "-o", "json", "--project", namespace)
 			utils.AnalyzePushConsoleOutput(output)
 
 			// update devfile and push again
 			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
-			output = helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml", "--project", namespace)
+			output = helper.CmdShouldPass("odo", "push", "-o", "json", "--project", namespace)
 			utils.AnalyzePushConsoleOutput(output)
 
 		})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -113,12 +113,12 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
 
-			output := helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml")
+			output := helper.CmdShouldPass("odo", "push", "-o", "json")
 			utils.AnalyzePushConsoleOutput(output)
 
 			// update devfile and push again
 			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
-			output = helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml")
+			output = helper.CmdShouldPass("odo", "push", "-o", "json")
 			utils.AnalyzePushConsoleOutput(output)
 
 		})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -108,6 +108,21 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			Expect(volMounted).To(Equal(true))
 		})
 
+		It("checks that odo push with -o json displays machine readable JSON event output", func() {
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), context)
+
+			output := helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml")
+			utils.AnalyzePushConsoleOutput(output)
+
+			// update devfile and push again
+			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
+			output = helper.CmdShouldPass("odo", "push", "-o", "json", "--devfile", "devfile.yaml")
+			utils.AnalyzePushConsoleOutput(output)
+
+		})
+
 		It("should not build when no changes are detected in the directory and build when a file change is detected", func() {
 			utils.ExecPushToTestFileChanges(context, cmpName, "")
 		})

--- a/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
+++ b/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
@@ -112,7 +112,7 @@ func AnalyzePushConsoleOutput(pushConsoleOutput string) {
 	}
 	currIndex := -1
 	for _, nextEventOrder := range expectedEventOrder {
-		entry, newIndex := machineoutput.FindNextEntryByType(currIndex, nextEventOrder.entryType, entries)
+		entry, newIndex := findNextEntryByType(currIndex, nextEventOrder.entryType, entries)
 		Expect(entry).NotTo(BeNil())
 		Expect(newIndex).To(BeNumerically(">=", 0))
 		Expect(newIndex).To(BeNumerically(">", currIndex)) // monotonically increasing index
@@ -123,5 +123,22 @@ func AnalyzePushConsoleOutput(pushConsoleOutput string) {
 
 		currIndex = newIndex
 	}
+
+}
+
+// findNextEntryByType locates the next entry of a given type within a slice. Currently used for test purposes only.
+func findNextEntryByType(initialIndex int, typeToFind machineoutput.MachineEventLogEntryType, entries []machineoutput.MachineEventLogEntry) (machineoutput.MachineEventLogEntry, int) {
+
+	for index, entry := range entries {
+		if index < initialIndex {
+			continue
+		}
+
+		if entry.GetType() == typeToFind {
+			return entry, index
+		}
+	}
+
+	return nil, -1
 
 }

--- a/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
+++ b/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
@@ -1,0 +1,126 @@
+package utils
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/odo/pkg/machineoutput"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// AnalyzePushConsoleOutput analyzes the output of 'odo push -o json' for the machine readable event push test above.
+func AnalyzePushConsoleOutput(pushConsoleOutput string) {
+
+	lines := strings.Split(strings.Replace(pushConsoleOutput, "\r\n", "\n", -1), "\n")
+
+	var entries []machineoutput.MachineEventLogEntry
+
+	// Ensure that all lines can be correctly parsed into their expected JSON structure
+	for _, line := range lines {
+
+		if len(strings.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		// fmt.Println("Processing output line: " + line)
+
+		lineWrapper := machineoutput.MachineEventWrapper{}
+
+		err := json.Unmarshal([]byte(line), &lineWrapper)
+		Expect(err).NotTo(HaveOccurred())
+
+		entry, err := lineWrapper.GetEntry()
+		Expect(err).NotTo(HaveOccurred())
+
+		entries = append(entries, entry)
+
+	}
+
+	if len(entries) < 4 {
+		Fail("Expected at least 4 entries, corresponding to command/action execution.")
+	}
+
+	// Timestamps should be monotonically increasing
+	mostRecentTimestamp := float64(-1)
+	for _, entry := range entries {
+		timestamp, err := strconv.ParseFloat(entry.GetTimestamp(), 64)
+		Expect(err).NotTo(HaveOccurred())
+
+		if timestamp < mostRecentTimestamp {
+			Fail("Timestamp was not monotonically increasing " + entry.GetTimestamp() + " " + strconv.FormatFloat(mostRecentTimestamp, 'E', -1, 64))
+		}
+
+		mostRecentTimestamp = timestamp
+	}
+
+	// First look for the expected devbuild events, then look for the expected devrun events.
+	expectedEventOrder := []struct {
+		entryType   machineoutput.MachineEventLogEntryType
+		commandName string
+	}{
+		// first the devbuild command (and its action) should run
+		{
+			machineoutput.TypeDevFileCommandExecutionBegin,
+			"devbuild",
+		},
+		// {
+		// 	machineoutput.TypeDevFileActionExecutionBegin,
+		// 	"devbuild",
+		// },
+		{
+			// at least one logged line of text
+			machineoutput.TypeLogText,
+			"",
+		},
+		// {
+		// 	machineoutput.TypeDevFileActionExecutionComplete,
+		// 	"devbuild",
+		// },
+		{
+			machineoutput.TypeDevFileCommandExecutionComplete,
+			"devbuild",
+		},
+		// next the devbuild command (and its action) should run
+		{
+			machineoutput.TypeDevFileCommandExecutionBegin,
+			"devrun",
+		},
+		// ,
+		// {
+		// 	machineoutput.TypeDevFileActionExecutionBegin,
+		// 	"devrun",
+		// },
+		{
+			// at least one logged line of text
+			machineoutput.TypeLogText,
+			"",
+		},
+		// ,
+		// {
+		// 	machineoutput.TypeDevFileActionExecutionComplete,
+		// 	"devrun",
+		// },
+		{
+			machineoutput.TypeDevFileCommandExecutionComplete,
+			"devrun",
+		},
+	}
+
+	currIndex := -1
+	for _, nextEventOrder := range expectedEventOrder {
+		entry, newIndex := machineoutput.FindNextEntryByType(currIndex, nextEventOrder.entryType, entries)
+		Expect(entry).NotTo(BeNil())
+		Expect(newIndex).To(BeNumerically(">=", 0))
+		Expect(newIndex).To(BeNumerically(">", currIndex)) // monotonically increasing index
+
+		// We should see devbuild for the first set of events, then devrun
+		commandName := machineoutput.GetCommandName(entry)
+		Expect(commandName).To(Equal(nextEventOrder.commandName))
+
+		currIndex = newIndex
+	}
+
+}

--- a/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
+++ b/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/json"
-	"strconv"
 	"strings"
 
 	"github.com/openshift/odo/pkg/machineoutput"
@@ -42,19 +41,6 @@ func AnalyzePushConsoleOutput(pushConsoleOutput string) {
 	// Ensure we pass a sanity test on the minimum expected entries
 	if len(entries) < 4 {
 		Fail("Expected at least 4 entries, corresponding to command/action execution.")
-	}
-
-	// Ensure that timestamps are monotonically increasing
-	mostRecentTimestamp := float64(-1)
-	for _, entry := range entries {
-		timestamp, err := strconv.ParseFloat(entry.GetTimestamp(), 64)
-		Expect(err).NotTo(HaveOccurred())
-
-		if timestamp < mostRecentTimestamp {
-			Fail("Timestamp was not monotonically increasing " + entry.GetTimestamp() + " " + strconv.FormatFloat(mostRecentTimestamp, 'E', -1, 64))
-		}
-
-		mostRecentTimestamp = timestamp
 	}
 
 	// Ensure that all logText entries are wrapped inside commandExecutionBegin and commandExecutionComplete entries (e.g. no floating logTexts)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:

Short answer: This PR enables JSON events to be emitted, on dev file push, when the `-o json` parameter is passed.

Long answer: Design proposal is [here](https://github.com/openshift/odo/blob/parser-v2/docs/proposals/event-notification.md).

**Parent issue**:
https://github.com/openshift/odo/issues/2550

**How to test changes / Special notes to the reviewer**:

```
# Set docker target OR ensure a valid Kube context is set
export ODO_EXPERIMENTAL=true

git clone https://github.com/odo-devfiles/nodejs-ex.git
cd nodejs-ex
odo create nodejs
odo push -f -o json
```

**Sample output**:
```
{"devFileCommandExecutionBegin":{"commandId":"devbuild","componentName":"runtime","commandLine":"npm install","groupKind":"build","timestamp":"1591336117.632920"}}
{"logText":{"text":"npm WARN nodejs-sample@1.0.0 No repository field.","stream":"stderr","timestamp":"1591336119.140467"}}
{"logText":{"text":"","stream":"stderr","timestamp":"1591336119.147436"}}
{"logText":{"text":"audited 50 packages in 0.892s","stream":"stdout","timestamp":"1591336119.435678"}}
{"logText":{"text":"found 0 vulnerabilities","stream":"stdout","timestamp":"1591336119.484515"}}
{"logText":{"text":"","stream":"stdout","timestamp":"1591336119.491524"}}
{"devFileCommandExecutionComplete":{"commandId":"devbuild","componentName":"runtime","commandLine":"npm install","groupKind":"build","timestamp":"1591336119.497485"}}
{"devFileCommandExecutionBegin":{"commandId":"devrun","componentName":"runtime","commandLine":"nodemon app.js","groupKind":"run","timestamp":"1591336119.505459"}}
{"logText":{"text":"devrun                                     OK","stream":"stdout","timestamp":"1591336120.799012"}}
{"logText":{"text":"debugrun                                   OK","stream":"stdout","timestamp":"1591336120.804983"}}
{"devFileCommandExecutionComplete":{"commandId":"devrun","componentName":"runtime","commandLine":"nodemon app.js","groupKind":"run","timestamp":"1591336120.810968"}}
{"devFileCommandExecutionBegin":{"commandId":"devrun","componentName":"runtime","commandLine":"nodemon app.js","groupKind":"run","timestamp":"1591336120.816952"}}
{"logText":{"text":"devrun: started","stream":"stdout","timestamp":"1591336122.115481"}}
{"devFileCommandExecutionComplete":{"commandId":"devrun","componentName":"runtime","commandLine":"nodemon app.js","groupKind":"run","timestamp":"1591336122.121467"}}
```
