### PR TITLE
Fixes odo describe for multiple URLs of unpushed component

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -959,7 +959,7 @@ func GetComponentFromConfig(localConfig *config.LocalConfigInfo) (Component, err
 		if len(urls) > 0 {
 			// We will clean up the existing value of ports and re-populate it so that we don't panic in `odo describe` and don't show inconsistent info
 			// This will also help in the case where there are more URLs created than the number of ports exposed by a component #2776
-			oldPortsProtocol := getPortsProtocol(component.Spec.Ports)
+			oldPortsProtocol := getPortsProtocolMapping(component.Spec.Ports)
 			component.Spec.Ports = []string{}
 
 			for _, url := range urls {
@@ -981,7 +981,10 @@ func GetComponentFromConfig(localConfig *config.LocalConfigInfo) (Component, err
 	return Component{}, nil
 }
 
-func getPortsProtocol(ports []string) map[string]string {
+// This function returns a mapping of port and protocol.
+// So for a value of ports {"8080/TCP", "45/UDP"} it will return a map {"8080":
+// "TCP", "45": "UDP"}
+func getPortsProtocolMapping(ports []string) map[string]string {
 	oldPortsProtocol := make(map[string]string, len(ports))
 	for _, port := range ports {
 		portProtocol := strings.Split(port, "/")

--- a/pkg/config/fakeConfig.go
+++ b/pkg/config/fakeConfig.go
@@ -18,9 +18,11 @@ func GetOneExistingConfigInfo(componentName, applicationName, projectName string
 	urlValue := []ConfigURL{
 		{
 			Name: "example-url-0",
+			Port: 8080,
 		},
 		{
 			Name: "example-url-1",
+			Port: 45,
 		},
 	}
 

--- a/pkg/config/fakeConfig.go
+++ b/pkg/config/fakeConfig.go
@@ -13,7 +13,7 @@ func GetOneExistingConfigInfo(componentName, applicationName, projectName string
 		},
 	}
 
-	portsValue := []string{"8080/TCP,45/UDP"}
+	portsValue := []string{"8080/TCP", "45/UDP"}
 
 	urlValue := []ConfigURL{
 		{

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -33,6 +33,7 @@ var (
    %[1]s %[9]s 0.5
    %[1]s %[10]s 2
    %[1]s %[11]s 1
+   %[1]s %[12]s 8080/TCP,8443/TCP
 
    # Set a env variable in the local config
    %[1]s --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
@@ -159,7 +160,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Short: "Set a value in odo config file",
 		Long:  fmt.Sprintf(setLongDesc, config.FormatLocallySupportedParameters()),
 		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName, config.Type,
-			config.Name, config.MinMemory, config.MaxMemory, config.Memory, config.DebugPort, config.Ignore, config.MinCPU, config.MaxCPU, config.CPU),
+			config.Name, config.MinMemory, config.MaxMemory, config.Memory, config.DebugPort, config.Ignore, config.MinCPU, config.MaxCPU, config.CPU, config.Ports),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if o.envArray != nil {
 				// no args are needed

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -235,6 +235,7 @@ func componentTests(args ...string) {
 		It("should describe the component when it is not pushed", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "url", "create", "url-1", "--context", context)
+			helper.CmdShouldPass("odo", "url", "create", "url-2", "--context", context)
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "URL,0,Name,url-1")
 			cmpDescribe := helper.CmdShouldPass("odo", append(args, "describe", "--context", context)...)
@@ -242,12 +243,13 @@ func componentTests(args ...string) {
 			Expect(cmpDescribe).To(ContainSubstring("cmp-git"))
 			Expect(cmpDescribe).To(ContainSubstring("nodejs"))
 			Expect(cmpDescribe).To(ContainSubstring("url-1"))
+			Expect(cmpDescribe).To(ContainSubstring("url-2"))
 			Expect(cmpDescribe).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
 			Expect(cmpDescribe).To(ContainSubstring("storage-1"))
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.openshift.io/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "https://github.com/openshift/nodejs-ex","sourceType": "git","url": ["url-1", "url-2"],"storage": ["storage-1"],"ports": ["8080/TCP"]},"status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).To(Equal(expected))
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR fixes two bugs. One is panic when doing `odo describe` for an unpushed component that has more URLs than number of ports it exposes. Another is the incorrect mapping of URL and port. Refer https://github.com/openshift/odo/issues/2776#issuecomment-620040493 for more detail

**Which issue(s) this PR fixes**:

Fixes #2776 

**How to test changes / Special notes to the reviewer**:
Create more URLs than the number of exposed ports for a component and run `odo describe`.