### PR TITLE
Adding eventually duration in operator test file

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -20,6 +21,8 @@ const (
 var _ = Describe("odo service command tests for OperatorHub", func() {
 
 	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		SetDefaultConsistentlyDuration(30 * time.Second)
 		helper.CmdShouldPass("odo", "project", "set", CI_OPERATOR_HUB_PROJECT)
 		// TODO: remove this when OperatorHub integration is fully baked into odo
 		os.Setenv("ODO_EXPERIMENTAL", "true")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
By default, Eventually will poll every 10 milliseconds for up to 1 second for each ```helper.CmdShouldPass```. In our case we are customizing the max poll time to 10 min to make sure whatever the command we execute should finish before 10 min otherwise test script reports as timeout failure. 

I am surprised how operator test file was infact is running successfully in CI.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
