### PR TITLE
Don't list imagestreams when using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,7 @@ jobs:
         - sudo cp odo /usr/bin
         - travis_wait make test-cmd-docker-devfile-push
         - travis_wait make test-cmd-docker-devfile-url
+        - travis_wait make test-cmd-docker-devfile-catalog
 
     
     # Run devfile integration test on Kubernetes cluster    

--- a/Makefile
+++ b/Makefile
@@ -242,10 +242,16 @@ test-cmd-docker-devfile-push:
 .PHONY: test-cmd-docker-devfile-url
 test-cmd-docker-devfile-url:
 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url command tests" tests/integration/devfile/docker/
+
 # Run odo docker devfile delete command tests
 .PHONY: test-cmd-docker-devfile-delete
 test-cmd-docker-devfile-delete:
 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile delete command tests" tests/integration/devfile/docker/
+
+# Run odo catalog devfile command tests
+.PHONY: test-cmd-docker-devfile-catalog
+test-cmd-docker-devfile-catalog:
+	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile catalog command tests" tests/integration/devfile/docker/
 
 
 # Run odo watch command tests

--- a/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
@@ -1,0 +1,49 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/tests/helper"
+)
+
+var _ = Describe("odo docker devfile catalog command tests", func() {
+	var context string
+	var currentWorkingDirectory string
+
+	// This is run after every Spec (It)
+	var _ = BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		context = helper.CreateNewContext()
+		currentWorkingDirectory = helper.Getwd()
+		helper.Chdir(context)
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+
+		// Devfile commands require experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+		helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker")
+	})
+
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.Chdir(currentWorkingDirectory)
+		helper.DeleteDir(context)
+	})
+
+	Context("When executing catalog list components on Docker", func() {
+		It("should list all supported devfile components", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
+			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-spring-boot", "openLiberty"})
+		})
+	})
+
+	Context("When executing catalog list components with -a flag on Docker", func() {
+		It("should list all supported and unsupported devfile components", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-a")
+			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-spring-boot", "java-maven", "php-mysql"})
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
/kind bug
/area devfile
/area local

**What does does this PR do / why we need it**:
This PR updates the `odo catalog list component` code to only instantiate an occlient/kclient when the pushtarget is **not** set to Docker. This prevents a bug from occurring if no valid kube context exists and the user is just trying to use odo with Docker

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3038

**How to test changes / Special notes to the reviewer**:
Remove or move `~/.kube` and run `odo catalog list components` from master, you should see the following:
```
Johns-MacBook-Pro-3:odo johncollier$ ./odo catalog list components -v4
 ✗  invalid configuration: no configuration has been provided
Please login to your server: 

odo login https://mycluster.mydomain.com

```

and if you build from my branch, the error is gone:
```
Johns-MacBook-Pro-3:odo johncollier$ ./odo catalog list components -v4
I0428 17:59:50.740431   16720 preference.go:165] The path for preference file is /Users/johncollier/.odo/preference.yaml
I0428 17:59:50.740576   16720 preference.go:165] The path for preference file is /Users/johncollier/.odo/preference.yaml
Odo Devfile Components:
NAME                 DESCRIPTION                           SUPPORTED
maven                Upstream Maven and OpenJDK 11         YES
nodejs               Stack with NodeJS 10                  YES
openLiberty          Open Liberty microservice in Java     YES
java-spring-boot     Spring Boot® using Java               YES
```