### PR TITLE
Avoid racing condition between set and unset KUBECONFIG

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -158,4 +159,11 @@ func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, check func(outpu
 			}
 		}
 	}
+}
+
+// GetUserHomeDir gets the user home directory
+func GetUserHomeDir() string {
+	homeDir, err := os.UserHomeDir()
+	Expect(err).NotTo(HaveOccurred())
+	return homeDir
 }

--- a/tests/helper/kubernetes_utils.go
+++ b/tests/helper/kubernetes_utils.go
@@ -9,8 +9,10 @@ import (
 )
 
 // CopyKubeConfigFile copies default kubeconfig file into current context config file
-func CopyKubeConfigFile(kubeConfigFile, tempConfigFile string, info os.FileInfo) string {
-	err := copyFile(kubeConfigFile, tempConfigFile, info)
+func CopyKubeConfigFile(kubeConfigFile, tempConfigFile string) string {
+	info, err := os.Stat(kubeConfigFile)
+	Expect(err).NotTo(HaveOccurred())
+	err = copyFile(kubeConfigFile, tempConfigFile, info)
 	Expect(err).NotTo(HaveOccurred())
 	os.Setenv("KUBECONFIG", tempConfigFile)
 	return tempConfigFile

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -22,7 +22,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 		if os.Getenv("KUBERNETES") == "true" {
-			homeDir, _ := os.UserHomeDir()
+			homeDir := helper.GetUserHomeDir()
 			kubeConfigFile := helper.CopyKubeConfigFile(filepath.Join(homeDir, ".kube", "config"), filepath.Join(context, "config"))
 			project = helper.CreateRandNamespace(kubeConfigFile)
 		} else {

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -22,9 +22,8 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 		if os.Getenv("KUBERNETES") == "true" {
-			info, err := os.Stat(os.Getenv("KUBECONFIG"))
-			Expect(err).NotTo(HaveOccurred())
-			kubeConfigFile := helper.CopyKubeConfigFile(os.Getenv("KUBECONFIG"), filepath.Join(context, "config"), info)
+			homeDir, _ := os.UserHomeDir()
+			kubeConfigFile := helper.CopyKubeConfigFile(filepath.Join(homeDir, ".kube", "config"), filepath.Join(context, "config"))
 			project = helper.CreateRandNamespace(kubeConfigFile)
 		} else {
 			project = helper.CreateRandProject()

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -24,7 +24,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 		if os.Getenv("KUBERNETES") == "true" {
-			homeDir, _ := os.UserHomeDir()
+			homeDir := helper.GetUserHomeDir()
 			kubeConfigFile := helper.CopyKubeConfigFile(filepath.Join(homeDir, ".kube", "config"), filepath.Join(context, "config"))
 			namespace = helper.CreateRandNamespace(kubeConfigFile)
 		} else {

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -24,9 +24,8 @@ var _ = Describe("odo devfile watch command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 		if os.Getenv("KUBERNETES") == "true" {
-			info, err := os.Stat(os.Getenv("KUBECONFIG"))
-			Expect(err).NotTo(HaveOccurred())
-			kubeConfigFile := helper.CopyKubeConfigFile(os.Getenv("KUBECONFIG"), filepath.Join(context, "config"), info)
+			homeDir, _ := os.UserHomeDir()
+			kubeConfigFile := helper.CopyKubeConfigFile(filepath.Join(homeDir, ".kube", "config"), filepath.Join(context, "config"))
 			namespace = helper.CreateRandNamespace(kubeConfigFile)
 		} else {
 			namespace = helper.CreateRandProject()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Avoid racing condition between set and unset KUBECONFIG while running test in parallel.

**Which issue(s) this PR fixes**:

Fixes #3032 

**How to test changes / Special notes to the reviewer**:

```make test-cmd-devfile-watch``` should pass on kubernetes cluster