### PR TITLE
Add support for command attribute `restart`

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -29,6 +29,7 @@ func getCommand(data data.DevfileData, commandName string, required bool) (suppo
 			// The command is supported, use it
 			supportedCommand.Name = command.Name
 			supportedCommand.Actions = supportedCommandActions
+			supportedCommand.Attributes = command.Attributes
 			return supportedCommand, nil
 		}
 	}

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -149,25 +148,7 @@ func IsPortPresent(endpoints []common.DockerimageEndpoint, port int) bool {
 	return false
 }
 
-// IsComponentBuildRequired checks if a component build is required based on the push commands, it throws an error
-// if the push commands does not meet the expected criteria
-func IsComponentBuildRequired(pushDevfileCommands []common.DevfileCommand) (bool, error) {
-	var buildRequired bool
-
-	switch len(pushDevfileCommands) {
-	case 1: // if there is one command, it is the mandatory run command. No need to build.
-		buildRequired = false
-	case 2:
-		// if there are two commands, it is the optional build command and the mandatory run command, set buildRequired to true
-		buildRequired = true
-	default:
-		return false, fmt.Errorf("error executing devfile commands - there should be at least 1 command or at most 2 commands, currently there are %d commands", len(pushDevfileCommands))
-	}
-
-	return buildRequired, nil
-}
-
-// IsRestartRequired returns if restarted required for devrun command
+// IsRestartRequired returns if restart is required for devrun command
 func IsRestartRequired(command common.DevfileCommand) bool {
 	var restart = true
 	var err error

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -167,7 +167,7 @@ func IsComponentBuildRequired(pushDevfileCommands []common.DevfileCommand) (bool
 	return buildRequired, nil
 }
 
-// IsRestartRequired gets command attributes.
+// IsRestartRequired returns if restarted required for devrun command
 func IsRestartRequired(command common.DevfileCommand) bool {
 	var restart = true
 	var err error

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -390,12 +390,17 @@ func (a Adapter) execDevfile(pushDevfileCommands []versionsCommon.DevfileCommand
 							ContainerName: containerID,
 						}
 
-						err = exec.ExecuteDevfileRunAction(&a.Client, action, command.Name, compInfo, show)
-						if err != nil {
-							return err
+						if componentExists && !common.IsRestartRequired(command) {
+							glog.V(4).Info("restart:false, Not restarting DevRun Command")
+							err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, action, command.Name, compInfo, show)
+							return
 						}
+
+						err = exec.ExecuteDevfileRunAction(&a.Client, action, command.Name, compInfo, show)
+
 					}
 				}
+
 			}
 		}
 	}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -369,10 +369,13 @@ func (a Adapter) execDevfile(pushDevfileCommands []versionsCommon.DevfileCommand
 							PodName:       podName,
 						}
 
-						err = exec.ExecuteDevfileRunAction(&a.Client, action, command.Name, compInfo, show)
-						if err != nil {
-							return err
+						if componentExists && !common.IsRestartRequired(command) {
+							glog.V(4).Infof("restart:false, Not restarting DevRun Command")
+							err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, action, command.Name, compInfo, show)
+							return
 						}
+
+						err = exec.ExecuteDevfileRunAction(&a.Client, action, command.Name, compInfo, show)
 					}
 				}
 			}

--- a/pkg/exec/devfile.go
+++ b/pkg/exec/devfile.go
@@ -75,6 +75,8 @@ func ExecuteDevfileRunAction(client ExecClient, action common.DevfileCommandActi
 func ExecuteDevfileRunActionWithoutRestart(client ExecClient, action common.DevfileCommandAction, commandName string, compInfo adaptersCommon.ComponentInfo, show bool) error {
 	var s *log.Status
 
+	var s *log.Status
+
 	type devRunExecutable struct {
 		command []string
 	}

--- a/pkg/exec/devfile.go
+++ b/pkg/exec/devfile.go
@@ -75,8 +75,6 @@ func ExecuteDevfileRunAction(client ExecClient, action common.DevfileCommandActi
 func ExecuteDevfileRunActionWithoutRestart(client ExecClient, action common.DevfileCommandAction, commandName string, compInfo adaptersCommon.ComponentInfo, show bool) error {
 	var s *log.Status
 
-	var s *log.Status
-
 	type devRunExecutable struct {
 		command []string
 	}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-restart.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-restart.yaml
@@ -1,0 +1,30 @@
+apiVersion: 1.0.0
+metadata:
+  name: test-devfile
+projects:
+  -
+    name: nodejs-web-app
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-nodejs-sample.git"
+components:
+  - type: dockerimage
+    image: quay.io/eclipse/che-nodejs10-ubi:nightly
+    alias: runtime
+    memoryLimit: 1024Mi
+    mountSources: true
+commands:
+  - name: devbuild
+    actions:
+      - type: exec
+        component: runtime
+        command: "npm install"
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: devrun
+    attributes:
+        restart: "false"
+    actions:
+      - type: exec
+        component: runtime
+        command: "nodemon app.js"
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -267,6 +267,10 @@ var _ = Describe("odo devfile push command tests", func() {
 			utils.ExecWithWrongCustomCommand(projectDirPath, cmpName, namespace)
 		})
 
+		It("should not restart the application if restart is false", func() {
+			utils.ExecWithRestartAttribute(projectDirPath, cmpName, namespace)
+		})
+
 		It("should create pvc and reuse if it shares the same devfile volume name", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
 			helper.Chdir(projectDirPath)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -192,10 +192,11 @@ func ExecWithRestartAttribute(projectDirPath, cmpName, namespace string) {
 	args = []string{"push", "--devfile", "devfile.yaml"}
 	args = useProjectIfAvailable(args, namespace)
 	output := helper.CmdShouldPass("odo", args...)
-	Expect(output).To(ContainSubstring("Executing devrun command \"npm install && nodemon app.js\""))
+	Expect(output).To(ContainSubstring("Executing devrun command \"nodemon app.js\""))
 
 	args = []string{"push", "-f", "--devfile", "devfile.yaml"}
 	args = useProjectIfAvailable(args, namespace)
+	output = helper.CmdShouldPass("odo", args...)
 	Expect(output).To(ContainSubstring("if not running"))
 
 }

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -177,3 +177,25 @@ func ExecPushWithNewFileAndDir(projectDirPath, cmpName, namespace, newFilePath, 
 	args = useProjectIfAvailable(args, namespace)
 	helper.CmdShouldPass("odo", args...)
 }
+
+// ExecWithRestartAttribute executes odo push with a command attribute restart
+func ExecWithRestartAttribute(projectDirPath, cmpName, namespace string) {
+	helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+	helper.Chdir(projectDirPath)
+
+	args := []string{"create", "nodejs", cmpName}
+	args = useProjectIfAvailable(args, namespace)
+	helper.CmdShouldPass("odo", args...)
+
+	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-restart.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
+
+	args = []string{"push", "--devfile", "devfile.yaml"}
+	args = useProjectIfAvailable(args, namespace)
+	output := helper.CmdShouldPass("odo", args...)
+	Expect(output).To(ContainSubstring("Executing devrun command \"npm install && nodemon app.js\""))
+
+	args = []string{"push", "-f", "--devfile", "devfile.yaml"}
+	args = useProjectIfAvailable(args, namespace)
+	Expect(output).To(ContainSubstring("if not running"))
+
+}


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What does does this PR do / why we need it**:
There are some applications which do not require restart of `devRun` command with each odo push. for those applications `restart: false` can be specified as command attributes in devfile.yaml. If `restart:false` then odo would  run `devRun` command only for first push, for subsequent push odo would run only if command is in stopped state. 

To handle this, for `restart:false`  we are running only `supervisord ctl start` for devRun command (as opposed to running stop and then start in regular case) , it would not restart the command if running, would start if stopped.

**Which issue(s) this PR fixes**
Fixes #2820 

**How to test changes / Special notes to the reviewer**:
- Create a odo component with devfile
   `odo create nodejs myapp`, `odo push`
- Edit the devfile include the devrun command attribute `restart: false` [Note: Editing devfile is just to test these changes, for components actually require not to restart devrun (e.g. quarkus dev), it would be already added in odo supported devfiles]
- Run `odo push -f`, you should see the output ` Executing devrun command "mvn quarkus:dev", if not running`
```
[adisky@localhost hello-quarkus]$ odo push -f 

Validation
 ✓  Validating the devfile [27988ns]

Creating Kubernetes resources for component q-demo
 ✓  Waiting for component to start [1ms]

Applying URL changes
 ✓  URL q-demo-8080 already exists

Syncing to component q-demo
 ✓  Syncing files to the component [76ms]

Executing devfile commands for component q-demo
 ✓  Executing devrun command "mvn quarkus:dev", if not running [70ms]

Pushing devfile component q-demo
 ✓  Changes successfully pushed to component

```