### PR TITLE
Add devfile and community documentation to /public

### DIFF
--- a/docs/public/community.adoc
+++ b/docs/public/community.adoc
@@ -1,0 +1,67 @@
+== Events
+
+=== Upcoming events
+
+* https://www.redhat.com/en/summit[April 28-29 2020 - Red Hat Summit]
+* https://www.ibm.com/events/think/[May 5-6 2020 - IBM Think Digital]
+
+== Slack
+
+Join us on Slack via our
+https://join.slack.com/t/openshiftdo/shared_invite/enQtODUwMjIzMzE2MjYyLWM3YjlkNTViOGNjZGQ5YjFlMzc2N2RhZjVmMDQ5NWY5ZDQ3NzMzZjYxMTE1MjY5OTVmZjgxZWMyMGRmOTc4Y2I[invite
+link]
+
+* https://openshiftdo.slack.com/messages/odo-dev[Odo Dev Channel] -
+Discuss odo development
+* https://openshiftdo.slack.com/messages/odo-users[Odo Users Channel] -
+Ask questions and discuss your use cases with odo
+
+== Email list
+
+For general help and inquiries as well as developmental discussion, we
+use Google Groups as our email list.
+
+* https://groups.google.com/forum/#!forum/odo-users[odo-users Google
+group] - General help and inquiries
+* https://groups.google.com/forum/#!forum/odo-dev[odo-dev Google group]
+- Developmental discussion
+
+== Issues
+
+* If you have any issues with odo, please
+https://github.com/openshift/odo/issues[file a GitHub issue]
+* Documentation issues can be filed with the
+https://github.com/openshift/odo/issues/new?template=Documentation.md[documentation
+template]
+
+== Public meetings
+
+Every two weeks, we have a contributors call meeting.
+
+Every three weeks, we have two planning calls:
+
+* ``Sprint Planning Preparation and Issue Triage'' - on Monday
+* ``Sprint Planning'' - on Wednesday
+
+You can find the exact dates of all scheduled odo calls together with
+sprint dates in the
+https://calendar.google.com/calendar/embed?src=gi0s0v5ukfqkjpnn26p6va3jfc%40group.calendar.google.com[odo
+calendar].
+
+To automatically get invites to the calls, add yourself to the
+https://groups.google.com/forum/#!forum/odo-dev[odo-dev Google group].
+
+== Contributing
+
+=== Where do I start?
+
+Odo is a complex project that touches both Kubernetes, OpenShift and
+Docker. We have a list of
+https://github.com/openshift/odo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22[good
+first issues] to help start.
+
+=== How do I contribute code?
+
+Want to submit your code? Have a look at our
+https://github.com/openshift/odo/blob/master/docs/dev/development.adoc[development
+guide]. It goes over every aspect from submitting to writing tests.

--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -1,0 +1,332 @@
+== Introduction to devfile
+
+What is a devfile?
+
+A https://redhat-developer.github.io/devfile/[devfile] is a portable file that describes your development environment. It allows for a _portable_ developmental environment without the need of reconfiguration.
+
+With a devfile you can describe:
+
+* The source code being used
+* Development components such as IDE tools (VSCode) and application runtimes (Yarn / NPM)
+* A list of pre-defined commands that can be ran
+* Projects to initially clone
+
+Odo takes this devfile and transforms it into a workspace of multiple containers running on OpenShift, Kubernetes or Docker.
+
+Devfile's are YAML files with a defined structure, take a look at the general https://github.com/redhat-developer/devfile/blob/master/docs/devfile.md[schema] of devfile.
+
+== Odo and devfile
+
+When deploying a devfile using odo, odo will automatically look at the default https://github.com/elsony/devfile-registry[devfile] https://github.com/eclipse/che-devfile-registry/[registries]. Interacting with the devfile registries allows a user to pull a standard `devfile.yaml` and begin development immediately.
+
+An example deployment scenario:
+
+. `odo create` will look at devfile registry and pull down the `devfile.yaml` file
+. odo push  parses and then deploys the component in the following order:
+ .. Parses and validates the YAML file
+ .. Deploys the development environment to your OpenShift cluster
+ .. Synchronizes your source code to the containers
+ .. Executes any prerequisite commands
+
+== Deploying your first devfile
+
+[discrete]
+===== Prerequisites
+
+* Before proceeding, you must know your ingress domain cluster name. For example: `apps-crc.testing` is the cluster domain name for https://github.com/code-ready/crc[Red Hat CodeReady Containers]
+* Enable experimental mode for odo. This can be done by: `odo preference set experimental true`
+
+== Creating a project
+
+Create a project to keep your source code, tests, and libraries
+organized in a separate single unit.
+
+. Log in to a OpenShift cluster:
++
+[source,sh]
+----
+  $ odo login -u developer -p developer
+----
+
+. Create a project:
++
+[source,sh]
+----
+  $ odo project create myproject
+   ✓  Project 'myproject' is ready for use
+   ✓  New project created and now using project : myproject
+----
++
+
+== Listing all available devfile components
+
+* Before deploying your first component, have a look at what is available:
++
+[source,sh]
+----
+  $ odo catalog list components
+  Odo OpenShift Components:
+  NAME              PROJECT       TAGS                        SUPPORTED
+  java              openshift     11,8,latest                 YES
+  nodejs            openshift     10-SCL,8,8-RHOAR,latest     YES
+  dotnet            openshift     2.1,2.2,3.0,latest          NO
+  golang            openshift     1.11.5,latest               NO
+  httpd             openshift     2.4,latest                  NO
+  modern-webapp     openshift     10.x,latest                 NO
+  nginx             openshift     1.10,1.12,latest            NO
+  perl              openshift     5.24,5.26,latest            NO
+  php               openshift     7.0,7.1,7.2,latest          NO
+  python            openshift     2.7,3.6,latest              NO
+  ruby              openshift     2.4,2.5,latest              NO
+
+  Odo Devfile Components:
+  NAME                 DESCRIPTION                           SUPPORTED
+  maven                Upstream Maven and OpenJDK 11         YES
+  nodejs               Stack with NodeJS 10                  YES
+  openLiberty          Open Liberty microservice in Java     YES
+  java-spring-boot     Spring Boot® using Java               YES
+----
+
+In our example, we will be using `java-spring-boot` to deploy a sample https://spring.io/projects/spring-boot[Springboot] component.
+
+== Deploying a Java Spring Boot® component to an OpenShift cluster
+
+In this example we will be deploying an https://github.com/odo-devfiles/springboot-ex[example Springboot component] that uses https://maven.apache.org/install.html[Maven] and Java 8 JDK.
+
+. Download the example Spring Boot® component
++
+[source,sh]
+----
+ $ git clone https://github.com/odo-devfiles/springboot-ex
+----
+
+. Change the current directory to the component directory:
++
+[source,sh]
+----
+ $ cd <directory-name>
+----
+
+. List the contents of the directory to see that the front end is a Java application:
++
+[source,sh]
+----
+ $ ls
+ chart  Dockerfile  Dockerfile-build  Dockerfile-tools  Jenkinsfile  pom.xml  README.md  src
+----
+
+. Create a component configuration of Spring Boot component-type named myspring:
++
+[source,sh]
+----
+   $ odo create java-spring-boot myspring
+   Experimental mode is enabled, use at your own risk
+
+   Validation
+    ✓  Checking devfile compatibility [71105ns]
+    ✓  Validating devfile component [153481ns]
+
+   Please use odo push command to create the component with source deployed
+----
+
+. Create a URL in order to access the deployed component:
++
+[source,sh]
+----
+ $ odo url create --host apps-crc.testing
+  ✓  URL myspring-8080.apps-crc.testing created for component: myspring
+
+ To apply the URL configuration changes, please use odo push
+----
++
+NOTE: You must use your cluster host domain name when creating your URL.
+
+. Push the component to the cluster:
++
+[source,sh]
+----
+   $ odo push
+    •  Push devfile component myspring  ...
+    ✓  Waiting for component to start [30s]
+
+   Applying URL changes
+    ✓  URL myspring-8080: http://myspring-8080.apps-crc.testing created
+    ✓  Checking files for pushing [752719ns]
+    ✓  Syncing files to the component [887ms]
+    ✓  Executing devbuild command "/artifacts/bin/build-container-full.sh" [23s]
+    ✓  Executing devrun command "/artifacts/bin/start-server.sh" [2s]
+    ✓  Push devfile component myspring [57s]
+    ✓  Changes successfully pushed to component
+----
+
+. List the URLs of the component:
++
+[source,sh]
+----
+ $ odo url list
+ Found the following URLs for component myspring
+ NAME              URL                                       PORT     SECURE
+ myspring-8080     http://myspring-8080.apps-crc.testing     8080     false
+----
+
+. View your deployed application using the generated URL:
++
+[source,sh]
+----
+  $ curl http://myspring-8080.apps-crc.testing
+----
+
+== Deploying a Node.js® component to an OpenShift cluster
+
+In this example we will be deploying an https://github.com/odo-devfiles/nodejs-ex[example Node.js® component] that uses https://www.npmjs.com/[NPM].
+
+. Download the example Node.js® component
++
+[source,sh]
+----
+ $ git clone https://github.com/odo-devfiles/nodejs-ex
+----
+
+. Change the current directory to the component directory:
++
+[source,sh]
+----
+ $ cd <directory-name>
+----
+
+. List the contents of the directory to see that the front end is a Node.js application:
++
+[source,sh]
+----
+ $ ls
+ app  LICENSE  package.json  package-lock.json  README.md
+----
+
+. Create a component configuration of Node.js component-type named mynodejs:
++
+[source,sh]
+----
+ $ odo create nodejs mynodejs
+ Experimental mode is enabled, use at your own risk
+
+ Validation
+ ✓  Checking devfile compatibility [106956ns]
+ ✓  Validating devfile component [250318ns]
+
+ Please use odo push command to create the component with source deployed
+----
+
+. Create a URL in order to access the deployed component:
++
+[source,sh]
+----
+ $ odo url create --host apps-crc.testing
+  ✓  URL mynodejs-8080.apps-crc.testing created for component: mynodejs
+
+ To apply the URL configuration changes, please use odo push
+----
++
+NOTE: You must use your cluster host domain name when creating your URL.
+
+. Push the component to the cluster:
++
+[source,sh]
+----
+ $ odo push
+  •  Push devfile component mynodejs  ...
+  ✓  Waiting for component to start [27s]
+
+ Applying URL changes
+  ✓  URL mynodejs-3000: http://mynodejs-3000.apps-crc.testing created
+  ✓  Checking files for pushing [1ms]
+  ✓  Syncing files to the component [839ms]
+  ✓  Executing devbuild command "npm install" [3s]
+  ✓  Executing devrun command "nodemon app.js" [2s]
+  ✓  Push devfile component mynodejs [33s]
+  ✓  Changes successfully pushed to component
+----
+
+. List the URLs of the component:
++
+[source,sh]
+----
+ $ odo url list
+     Found the following URLs for component mynodejs
+     NAME              URL                                       PORT     SECURE
+     mynodejs-8080     http://mynodejs-8080.apps-crc.testing     8080     false
+----
+
+. View your deployed application using the generated URL:
++
+[source,sh]
+----
+   $ curl http://mynodejs-8080.apps-crc.testing
+----
+
+== Deploying a Java Spring Boot® component locally to Docker
+
+In this example, we will be deploying the same Java Spring Boot® component we did earlier, but to a locally running Docker instance.
+
+*Prerequisites:* Docker `17.05` or higher installed
+
+. Enabling the separate pushtarget preference:
++
+[source,sh]
+----
+ $ odo preference set pushtarget docker
+ Global preference was successfully updated
+----
++
+You can configure a separate push target by making use of the `pushtarget` preference.
+
+. Create a component configuration of Spring Boot component-type named mydockerspringboot:
++
+[source,sh]
+----
+  $ odo create java-spring-boot mydockerspringboot
+  Experimental mode is enabled, use at your own risk
+
+  Validation
+   ✓  Checking devfile compatibility [26759ns]
+   ✓  Validating devfile component [75889ns]
+
+  Please use odo push command to create the component with source deployed
+----
+
+. Create a URL in order to access the deployed component:
++
+[source,sh]
+----
+ $ odo url create --port 8080
+  ✓  URL local-mydockerspringboot-8080 created for component: mydockerspringboot with exposed port: 37833
+
+ To apply the URL configuration changes, please use odo push
+----
++
+In order to access the docker application, exposed ports are required and automatically generated by odo.
+
+. Deploy the Spring Boot devfile component to Docker:
++
+[source,sh]
+----
+  $ odo push
+   •  Push devfile component mydockerspringboot  ...
+   ✓  Pulling image maysunfaisal/springbootbuild [601ms]
+
+  Applying URL configuration
+   ✓  URL 127.0.0.1:37833 created
+   ✓  Starting container for maysunfaisal/springbootbuild [550ms]
+   ✓  Pulling image maysunfaisal/springbootruntime [581ms]
+
+  Applying URL configuration
+   ✓  URL 127.0.0.1:37833 created
+   ✓  Starting container for maysunfaisal/springbootruntime [505ms]
+   ✓  Push devfile component mydockerspringboot [2s]
+   ✓  Changes successfully pushed to component
+----
++
+When odo deploys a devfile component, it pulls the images for each `dockercontainer` in `devfile.yaml` and deploys them.
++
+Each docker container that is deployed is labeled with the name of the odo component.
++
+Docker volumes are created for the project source, and any other volumes defined in the devfile and mounted to the necessary containers.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

This moves the "upstream" documentation that we have here:
https://github.com/openshift/odo/tree/gh-pages/chosen-docs/upstream to
our main `master` branch to we have one central place for documentation
changes.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>