### PR TITLE
Add instructions how to do commit signing

### DIFF
--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -42,6 +42,7 @@ A PR must include:
 
  * Descriptive context that outlines what has been changed and why
  * A link to the active or open issue it fixes (if applicable)
+ * (OPTIONAL) A "signed-off" signature is good practice. You may sign your commit using `git commit -s` or `git commit --amend --no-edit -s` to a previously created commit
 
 == Useful make targets
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Adds documentation with regards to creating a pull request / commit
signing. It is good practice to get into the habit of signing each
commit.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>