### PR TITLE
Debug json flake fix

### DIFF
--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -55,9 +56,11 @@ var _ = Describe("odo debug command tests", func() {
 			// Make sure that the debug information output, outputs correctly.
 			// We do *not* check the json output since the debugProcessID will be different each time.
 			helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context, "-o", "json"}, 1, true, func(output string) bool {
-				Expect(output).To(ContainSubstring(`"kind": "OdoDebugInfo"`))
-				Expect(output).To(ContainSubstring(`"localPort": ` + freePort))
-				return true
+				if strings.Contains(output, `"kind": "OdoDebugInfo"`) &&
+					strings.Contains(output, `"localPort": `+freePort) {
+					return true
+				}
+				return false
 			})
 
 			stopChannel <- true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What does does this PR do / why we need it**:

Fixes test for debug info json output. Using `Expect` won't respect the timeout and exit immediately.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
- debug info json integration test should pass
