### PR TITLE
Adds debug command for devfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ jobs:
     # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test
       stage: test
-      name: "devfile catalog, watch, push, delete and create command integration tests on kubernetes cluster"
+      name: "devfile catalog, watch, push, debug, delete and create command integration tests on kubernetes cluster"
       env:
         - MINIKUBE_WANTUPDATENOTIFICATION=false
         - MINIKUBE_WANTREPORTERRORPROMPT=false
@@ -193,5 +193,6 @@ jobs:
         - travis_wait make test-cmd-devfile-catalog
         - travis_wait make test-cmd-devfile-watch
         - travis_wait make test-cmd-devfile-push
+        - travis_wait make test-cmd-devfile-debug
         - travis_wait make test-cmd-devfile-delete
         - travis_wait make test-cmd-devfile-create

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
         - travis_wait make test-cmd-url
         - travis_wait make test-cmd-devfile-url
         - travis_wait make test-cmd-debug
+        - travis_wait make test-cmd-devfile-debug
         - odo logout
 
     # Run service-catalog e2e tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,8 @@ jobs:
         - touch $KUBECONFIG
         - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.0
         - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
       script:
         - kubectl cluster-info
         - make bin

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ test-cmd-devfile-url:
 .PHONY: test-cmd-devfile-debug
 test-cmd-devfile-debug:
 	ginkgo $(GINKGO_FLAGS) -focus="odo devfile debug command tests" tests/integration/devfile/
+	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo devfile debug command serial tests" tests/integration/devfile/debug
 
 # Run odo push docker devfile command tests
 .PHONY: test-cmd-docker-devfile-push

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,11 @@ test-cmd-url:
 test-cmd-devfile-url:
 	ginkgo $(GINKGO_FLAGS) -focus="odo devfile url command tests" tests/integration/devfile/
 
+# Run odo debug devfile command tests
+.PHONY: test-cmd-devfile-debug
+test-cmd-devfile-debug:
+	ginkgo $(GINKGO_FLAGS) -focus="odo devfile debug command tests" tests/integration/devfile/
+
 # Run odo push docker devfile command tests
 .PHONY: test-cmd-docker-devfile-push
 test-cmd-docker-devfile-push:

--- a/pkg/debug/info_test.go
+++ b/pkg/debug/info_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/testingutil"
 	"github.com/openshift/odo/pkg/testingutil/filesystem"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +58,7 @@ func Test_createDebugInfoFile(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					componentName: "nodejs-ex",
 					appName:       "app",
+					projectName:   "testing-1",
 				},
 				portPair: "5858:9001",
 				fs:       fs,
@@ -88,6 +88,7 @@ func Test_createDebugInfoFile(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					componentName: "nodejs-ex",
 					appName:       "app",
+					projectName:   "testing-1",
 				},
 				portPair: "5758:9004",
 				fs:       fs,
@@ -115,12 +116,7 @@ func Test_createDebugInfoFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			// Fake the client with the appropriate arguments
-			client, _ := occlient.FakeNew()
-			client.Namespace = "testing-1"
-			tt.args.defaultPortForwarder.client = client
-
-			debugFilePath := GetDebugInfoFilePath(client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)
+			debugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName, tt.args.defaultPortForwarder.projectName)
 			// create a already existing file
 			if tt.alreadyExistFile {
 				_, err := testingutil.MkFileWithContent(debugFilePath, "blah", fs)
@@ -177,6 +173,7 @@ func Test_getDebugInfo(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					appName:       "app",
 					componentName: "nodejs-ex",
+					projectName:   "testing-1",
 				},
 				fs: fs,
 			},
@@ -222,6 +219,7 @@ func Test_getDebugInfo(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					appName:       "app",
 					componentName: "nodejs-ex",
+					projectName:   "testing-1",
 				},
 				fs: fs,
 			},
@@ -237,6 +235,7 @@ func Test_getDebugInfo(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					appName:       "app",
 					componentName: "nodejs-ex",
+					projectName:   "testing-1",
 				},
 				fs: fs,
 			},
@@ -267,6 +266,7 @@ func Test_getDebugInfo(t *testing.T) {
 				defaultPortForwarder: &DefaultPortForwarder{
 					appName:       "app",
 					componentName: "nodejs-ex",
+					projectName:   "testing-1",
 				},
 				fs: fs,
 			},
@@ -295,11 +295,6 @@ func Test_getDebugInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			// Fake the client with the appropriate arguments
-			client, _ := occlient.FakeNew()
-			client.Namespace = "testing-1"
-			tt.args.defaultPortForwarder.client = client
-
 			freePort, err := util.HttpGetFreePort()
 			if err != nil {
 				t.Errorf("error occured while getting a free port, cause: %v", err)
@@ -313,7 +308,7 @@ func Test_getDebugInfo(t *testing.T) {
 				tt.wantDebugFile.Spec.LocalPort = freePort
 			}
 
-			odoDebugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.client, tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName)
+			odoDebugFilePath := GetDebugInfoFilePath(tt.args.defaultPortForwarder.componentName, tt.args.defaultPortForwarder.appName, tt.args.defaultPortForwarder.projectName)
 			if tt.fileExists {
 				fakeString, err := fakeOdoDebugFileString(tt.readDebugFile.TypeMeta,
 					tt.readDebugFile.Spec.DebugProcessID,

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -135,7 +135,7 @@ func GetBuildCommand(data data.DevfileData, devfileBuildCmd string) (buildComman
 
 // GetDebugCommand iterates through the components in the devfile and returns the build command
 func GetDebugCommand(data data.DevfileData, devfileDebugCmd string) (debugCommand common.DevfileCommand, err error) {
-	return 	getCommand(data, devfileDebugCmd, common.DebugCommandGroupType)
+	return getCommand(data, devfileDebugCmd, common.DebugCommandGroupType)
 }
 
 // GetRunCommand iterates through the components in the devfile and returns the run command

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -133,7 +133,7 @@ func GetBuildCommand(data data.DevfileData, devfileBuildCmd string) (buildComman
 	return getCommand(data, devfileBuildCmd, common.BuildCommandGroupType)
 }
 
-// GetDebugCommand iterates through the components in the devfile and returns the build command
+// GetDebugCommand iterates through the components in the devfile and returns the debug command
 func GetDebugCommand(data data.DevfileData, devfileDebugCmd string) (debugCommand common.DevfileCommand, err error) {
 	return getCommand(data, devfileDebugCmd, common.DebugCommandGroupType)
 }

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -133,6 +133,11 @@ func GetBuildCommand(data data.DevfileData, devfileBuildCmd string) (buildComman
 	return getCommand(data, devfileBuildCmd, common.BuildCommandGroupType)
 }
 
+// GetDebugCommand iterates through the components in the devfile and returns the build command
+func GetDebugCommand(data data.DevfileData, devfileDebugCmd string) (debugCommand common.DevfileCommand, err error) {
+	return 	getCommand(data, devfileDebugCmd, common.DebugCommandGroupType)
+}
+
 // GetRunCommand iterates through the components in the devfile and returns the run command
 func GetRunCommand(data data.DevfileData, devfileRunCmd string) (runCommand common.DevfileCommand, err error) {
 
@@ -208,4 +213,26 @@ func updateGroupforCommand(groupType common.DevfileCommandGroupType, command com
 		return command
 	}
 	return command
+}
+
+// ValidateAndGetDebugDevfileCommands validates the debug command
+func ValidateAndGetDebugDevfileCommands(data data.DevfileData, devfileDebugCmd string) (pushDebugCommand common.DevfileCommand, err error) {
+	var emptyCommand common.DevfileCommand
+
+	isDebugCommandValid := false
+	debugCommand, debugCmdErr := GetDebugCommand(data, devfileDebugCmd)
+	if debugCmdErr == nil && !reflect.DeepEqual(emptyCommand, debugCommand) {
+		isDebugCommandValid = true
+		klog.V(3).Infof("Debug command: %v", debugCommand.Exec.Id)
+	}
+
+	if !isDebugCommandValid {
+		commandErrors := ""
+		if debugCmdErr != nil {
+			commandErrors += debugCmdErr.Error()
+		}
+		return common.DevfileCommand{}, fmt.Errorf(commandErrors)
+	}
+
+	return debugCommand, nil
 }

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -661,10 +661,17 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 			}
 
 			debugCommand, err := ValidateAndGetDebugDevfileCommands(devObj.Data, tt.debugCommand)
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestValidateAndGetDebugDevfileCommands unexpected error when validating commands wantErr: %v err: %v", tt.wantErr, err)
-			} else if tt.wantErr && err != nil {
-				return
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Error was expected but got no error")
+				} else {
+					return
+				}
+			} else if !tt.wantErr {
+				if err != nil {
+					t.Errorf("TestValidateAndGetDebugDevfileCommands: unexpected error %v", err)
+				}
 			}
 
 			if !reflect.DeepEqual(nil, debugCommand) && debugCommand.Exec.Id != tt.debugCommand {

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -498,12 +498,15 @@ func TestGetDebugCommand(t *testing.T) {
 
 			command, err := GetDebugCommand(devObj.Data, tt.commandName)
 
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestGetDebugCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-			} else if !tt.wantErr && reflect.DeepEqual(emptyCommand, command) {
-				t.Errorf("TestGetDebugCommand: unexpected empty command returned for command: %v", tt.commandName)
+			if tt.wantErr && err == nil {
+				t.Errorf("Error was expected but got no error")
+			} else if !tt.wantErr {
+				if err != nil {
+					t.Errorf("TestGetDebugCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
+				} else if reflect.DeepEqual(emptyCommand, command) {
+					t.Errorf("TestGetDebugCommand: unexpected empty command returned for command: %v", tt.commandName)
+				}
 			}
-
 		})
 	}
 }

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -668,7 +668,7 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 				} else {
 					return
 				}
-			} else if !tt.wantErr {
+			} else {
 				if err != nil {
 					t.Errorf("TestValidateAndGetDebugDevfileCommands: unexpected error %v", err)
 				}

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -421,6 +421,93 @@ func TestGetBuildCommand(t *testing.T) {
 
 }
 
+func TestGetDebugCommand(t *testing.T) {
+
+	command := "ls -la"
+	component := "alias1"
+	workDir := "/"
+	emptyString := ""
+
+	var emptyCommand common.DevfileCommand
+
+	tests := []struct {
+		name         string
+		commandName  string
+		execCommands []common.Exec
+		wantErr      bool
+	}{
+		{
+			name:        "Case: Default Debug Command",
+			commandName: emptyString,
+			execCommands: []common.Exec{
+				{
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group: &versionsCommon.Group{
+						IsDefault: true,
+						Kind:      versionsCommon.DebugCommandGroupType,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Case: Custom Debug Command",
+			commandName: "customdebugcommand",
+			execCommands: []common.Exec{
+				{
+					Id:          "customdebugcommand",
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group: &versionsCommon.Group{
+						IsDefault: false,
+						Kind:      versionsCommon.DebugCommandGroupType,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Case: Missing Debug Command",
+			commandName: "customcommand123",
+			execCommands: []common.Exec{
+				{
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group: &versionsCommon.Group{
+						IsDefault: true,
+						Kind:      versionsCommon.BuildCommandGroupType,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					ExecCommands: tt.execCommands,
+				},
+			}
+
+			command, err := GetDebugCommand(devObj.Data, tt.commandName)
+
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("TestGetDebugCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
+			} else if !tt.wantErr && reflect.DeepEqual(emptyCommand, command) {
+				t.Errorf("TestGetDebugCommand: unexpected empty command returned for command: %v", tt.commandName)
+			}
+
+		})
+	}
+}
+
 func TestGetRunCommand(t *testing.T) {
 
 	command := "ls -la"
@@ -504,6 +591,84 @@ func TestGetRunCommand(t *testing.T) {
 		})
 	}
 
+}
+
+func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
+
+	command := "ls -la"
+	component := "alias1"
+	workDir := "/"
+	emptyString := ""
+
+	execCommands := []common.Exec{
+		{
+			CommandLine: command,
+			Component:   component,
+			WorkingDir:  workDir,
+			Group: &common.Group{
+				IsDefault: true,
+				Kind:      common.DebugCommandGroupType,
+			},
+		},
+		{
+			Id:          "customdebugcommand",
+			CommandLine: command,
+			Component:   component,
+			WorkingDir:  workDir,
+			Group: &common.Group{
+				IsDefault: false,
+				Kind:      common.DebugCommandGroupType,
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		debugCommand  string
+		componentType common.DevfileComponentType
+		wantErr       bool
+	}{
+		{
+			name:          "Case: Default Devfile Commands",
+			debugCommand:  emptyString,
+			componentType: common.ContainerComponentType,
+			wantErr:       false,
+		},
+		{
+			name:          "Case: provided debug Command",
+			debugCommand:  "customdebugcommand",
+			componentType: versionsCommon.ContainerComponentType,
+			wantErr:       false,
+		},
+		{
+			name:          "Case: invalid debug Command",
+			debugCommand:  "invaliddebugcommand",
+			componentType: versionsCommon.ContainerComponentType,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					ExecCommands: execCommands,
+				},
+			}
+
+			debugCommand, err := ValidateAndGetDebugDevfileCommands(devObj.Data, tt.debugCommand)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("TestValidateAndGetDebugDevfileCommands unexpected error when validating commands wantErr: %v err: %v", tt.wantErr, err)
+			} else if tt.wantErr && err != nil {
+				return
+			}
+
+			if !reflect.DeepEqual(nil, debugCommand) && debugCommand.Exec.Id != tt.debugCommand {
+				t.Errorf("TestValidateAndGetDebugDevfileCommands name of debug command is wrong want: %v got: %v", tt.debugCommand, debugCommand.Exec.Id)
+			}
+		})
+	}
 }
 
 func TestValidateAndGetPushDevfileCommands(t *testing.T) {

--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -37,7 +37,10 @@ type PushParameters struct {
 	DevfileInitCmd    string                  // DevfileInitCmd takes the init command through the command line and overwrites devfile init command
 	DevfileBuildCmd   string                  // DevfileBuildCmd takes the build command through the command line and overwrites devfile build command
 	DevfileRunCmd     string                  // DevfileRunCmd takes the run command through the command line and overwrites devfile run command
+	DevfileDebugCmd   string                  // DevfileDebugCmd takes the debug command through the command line and overwrites the devfile debug command
 	EnvSpecificInfo   envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
+	Debug             bool                    // Runs the component in debug mode
+	DebugPort         int                     // Port used for remote debugging
 }
 
 // SyncParameters is a struct containing the parameters to be used when syncing a devfile component

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -24,7 +24,7 @@ const (
 	// DefaultDevfileRunCommand is a predefined devfile command for run
 	DefaultDevfileRunCommand PredefinedDevfileCommands = "devrun"
 
-	// DefaultDevfileDebugCommand is a predefined devfile command for build
+	// DefaultDevfileDebugCommand is a predefined devfile command for debug
 	DefaultDevfileDebugCommand PredefinedDevfileCommands = "debugrun"
 
 	// SupervisordInitContainerName The init container name for supervisord

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -24,6 +24,9 @@ const (
 	// DefaultDevfileRunCommand is a predefined devfile command for run
 	DefaultDevfileRunCommand PredefinedDevfileCommands = "devrun"
 
+	// DefaultDevfileDebugCommand is a predefined devfile command for build
+	DefaultDevfileDebugCommand PredefinedDevfileCommands = "debugrun"
+
 	// SupervisordInitContainerName The init container name for supervisord
 	SupervisordInitContainerName = "copy-supervisord"
 
@@ -66,6 +69,15 @@ const (
 
 	// EnvOdoCommandRun is the env defined in the runtime component container which holds the run command to be executed
 	EnvOdoCommandRun = "ODO_COMMAND_RUN"
+
+	// EnvOdoCommandDebugWorkingDir is the env defined in the runtime component container which holds the work dir for the debug command
+	EnvOdoCommandDebugWorkingDir = "ODO_COMMAND_DEBUG_WORKING_DIR"
+
+	// EnvOdoCommandDebug is the env defined in the runtime component container which holds the debug command to be executed
+	EnvOdoCommandDebug = "ODO_COMMAND_DEBUG"
+
+	// EnvDebugPort is the env defined in the runtime component container which holds the debug port for remote debugging
+	EnvDebugPort = "DEBUG_PORT"
 
 	// ShellExecutable is the shell executable
 	ShellExecutable = "/bin/sh"

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -2,10 +2,10 @@ package component
 
 import (
 	"fmt"
-	"reflect"
-
+	"github.com/openshift/odo/pkg/exec"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/storage"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
-	"github.com/openshift/odo/pkg/exec"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
@@ -37,9 +36,11 @@ func New(adapterContext common.AdapterContext, client kclient.Client) Adapter {
 type Adapter struct {
 	Client kclient.Client
 	common.AdapterContext
-	devfileInitCmd  string
-	devfileBuildCmd string
-	devfileRunCmd   string
+	devfileInitCmd   string
+	devfileBuildCmd  string
+	devfileRunCmd    string
+	devfileDebugCmd  string
+	devfileDebugPort int
 }
 
 // Push updates the component if a matching component exists or creates one if it doesn't exist
@@ -50,6 +51,8 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	a.devfileInitCmd = parameters.DevfileInitCmd
 	a.devfileBuildCmd = parameters.DevfileBuildCmd
 	a.devfileRunCmd = parameters.DevfileRunCmd
+	a.devfileDebugCmd = parameters.DevfileDebugCmd
+	a.devfileDebugPort = parameters.DebugPort
 
 	podChanged := false
 	var podName string
@@ -74,6 +77,19 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	s.End(true)
 
 	log.Infof("\nCreating Kubernetes resources for component %s", a.ComponentName)
+
+	if parameters.Debug {
+		pushDevfileDebugCommands, err := common.ValidateAndGetDebugDevfileCommands(a.Devfile.Data, a.devfileDebugCmd)
+		if err != nil {
+			return fmt.Errorf("debug command is not valid")
+		}
+		pushDevfileCommands[versionsCommon.DebugCommandGroupType] = pushDevfileDebugCommands
+	}
+
+	if parameters.Debug {
+		parameters.ForceBuild = true
+	}
+
 	err = a.createOrUpdateComponent(componentExists)
 	if err != nil {
 		return errors.Wrap(err, "unable to create or update component")
@@ -126,7 +142,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 
 	if execRequired {
 		log.Infof("\nExecuting devfile commands for component %s", a.ComponentName)
-		err = a.execDevfile(pushDevfileCommands, componentExists, parameters.Show, pod.GetName(), pod.Spec.Containers)
+		err = a.execDevfile(pushDevfileCommands, componentExists, parameters.Show, pod.GetName(), pod.Spec.Containers, parameters.Debug)
 		if err != nil {
 			return err
 		}
@@ -156,7 +172,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 		return fmt.Errorf("No valid components found in the devfile")
 	}
 
-	containers, err = utils.UpdateContainersWithSupervisord(a.Devfile, containers, a.devfileRunCmd)
+	containers, err = utils.UpdateContainersWithSupervisord(a.Devfile, containers, a.devfileRunCmd, a.devfileDebugCmd, a.devfileDebugPort)
 	if err != nil {
 		return err
 	}
@@ -305,7 +321,7 @@ func (a Adapter) waitAndGetComponentPod(hideSpinner bool) (*corev1.Pod, error) {
 
 // Executes all the commands from the devfile in order: init and build - which are both optional, and a compulsary run.
 // Init only runs once when the component is created.
-func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists, show bool, podName string, containers []corev1.Container) (err error) {
+func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists, show bool, podName string, containers []corev1.Container, isDebug bool) (err error) {
 	// If nothing has been passed, then the devfile is missing the required run command
 	if len(commandsMap) == 0 {
 		return errors.New(fmt.Sprint("error executing devfile commands - there should be at least 1 command"))
@@ -342,7 +358,7 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 
 	// Get Run Command
 	command, ok = commandsMap[versionsCommon.RunCommandGroupType]
-	if ok {
+	if ok && !isDebug {
 		klog.V(4).Infof("Executing devfile command %v", command.Exec.Id)
 		compInfo.ContainerName = command.Exec.Component
 
@@ -361,6 +377,30 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 			return
 		}
 		err = exec.ExecuteDevfileRunAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
+
+	}
+
+	// Get Debug Command
+	command, ok = commandsMap[versionsCommon.DebugCommandGroupType]
+	if ok && isDebug {
+		klog.V(4).Infof("Executing devfile command %v", command.Exec.Id)
+		compInfo.ContainerName = command.Exec.Component
+
+		// Check if the devfile debug component containers have supervisord as the entrypoint.
+		// Start the supervisord if the odo component does not exist
+		if !componentExists {
+			err = a.InitRunContainerSupervisord(command.Exec.Component, podName, containers)
+			if err != nil {
+				return
+			}
+		}
+
+		if componentExists && !common.IsRestartRequired(command) {
+			klog.V(4).Infof("restart:false, Not restarting debugRun Command")
+			err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
+			return
+		}
+		err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
 
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -84,9 +84,6 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 			return fmt.Errorf("debug command is not valid")
 		}
 		pushDevfileCommands[versionsCommon.DebugCommandGroupType] = pushDevfileDebugCommands
-	}
-
-	if parameters.Debug {
 		parameters.ForceBuild = true
 	}
 
@@ -397,7 +394,7 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 
 		if componentExists && !common.IsRestartRequired(command) {
 			klog.V(4).Infof("restart:false, Not restarting debugRun Command")
-			err = exec.ExecuteDevfileRunActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
+			err = exec.ExecuteDevfileDebugActionWithoutRestart(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)
 			return
 		}
 		err = exec.ExecuteDevfileDebugAction(&a.Client, *command.Exec, command.Exec.Id, compInfo, show)

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
@@ -109,9 +110,14 @@ func isEnvPresent(EnvVars []corev1.EnvVar, envVarName string) bool {
 
 // UpdateContainersWithSupervisord updates the run components entrypoint and volume mount
 // with supervisord if no entrypoint has been specified for the component in the devfile
-func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, containers []corev1.Container, devfileRunCmd string) ([]corev1.Container, error) {
+func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, containers []corev1.Container, devfileRunCmd string, devfileDebugCmd string, devfileDebugPort int) ([]corev1.Container, error) {
 
 	runCommand, err := adaptersCommon.GetRunCommand(devfileObj.Data, devfileRunCmd)
+	if err != nil {
+		return nil, err
+	}
+
+	debugCommand, err := adaptersCommon.GetDebugCommand(devfileObj.Data, devfileDebugCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -151,6 +157,56 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 					corev1.EnvVar{
 						Name:  adaptersCommon.EnvOdoCommandRunWorkingDir,
 						Value: runCommand.Exec.WorkingDir,
+					})
+			}
+
+			// Update the containers array since the array is not a pointer to the container
+			containers[i] = container
+		}
+
+		// Check if the container belongs to a debug command component
+		if debugCommand.Exec != nil && container.Name == debugCommand.Exec.Component {
+			// If the run component container has no entrypoint and arguments, override the entrypoint with supervisord
+			if len(container.Command) == 0 && len(container.Args) == 0 {
+				klog.V(3).Infof("Updating container %v entrypoint with supervisord", container.Name)
+				container.Command = append(container.Command, adaptersCommon.SupervisordBinaryPath)
+				container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
+			}
+
+			// Always mount the supervisord volume in the debug component container
+			klog.V(3).Infof("Updating container %v with supervisord volume mounts", container.Name)
+			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+				Name:      adaptersCommon.SupervisordVolumeName,
+				MountPath: adaptersCommon.SupervisordMountPath,
+			})
+
+			// Update the debug container's ENV for work dir and command
+			// only if the env var is not set in the devfile
+			// This is done, so supervisord can use it in it's program
+			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebug) {
+				klog.V(3).Infof("Updating container %v env with run command", container.Name)
+				container.Env = append(container.Env,
+					corev1.EnvVar{
+						Name:  adaptersCommon.EnvOdoCommandDebug,
+						Value: debugCommand.Exec.CommandLine,
+					})
+			}
+
+			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebugWorkingDir) && debugCommand.Exec.WorkingDir != "" {
+				klog.V(3).Infof("Updating container %v env with debug command's workdir", container.Name)
+				container.Env = append(container.Env,
+					corev1.EnvVar{
+						Name:  adaptersCommon.EnvOdoCommandDebugWorkingDir,
+						Value: debugCommand.Exec.WorkingDir,
+					})
+			}
+
+			if !isEnvPresent(container.Env, adaptersCommon.EnvDebugPort) {
+				klog.V(3).Infof("Updating container %v env with debug command's debugPort", container.Name)
+				container.Env = append(container.Env,
+					corev1.EnvVar{
+						Name:  adaptersCommon.EnvDebugPort,
+						Value: strconv.Itoa(devfileDebugPort),
 					})
 			}
 

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -195,7 +195,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 					})
 			}
 
-			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebugWorkingDir) && debugCommand.Exec.WorkingDir != "" {
+			if debugCommand.Exec.WorkingDir != "" && !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebugWorkingDir) {
 				klog.V(3).Infof("Updating container %v env with debug command's workdir", container.Name)
 				container.Env = append(container.Env,
 					corev1.EnvVar{

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -173,12 +173,21 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 				container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
 			}
 
-			// Always mount the supervisord volume in the debug component container
-			klog.V(3).Infof("Updating container %v with supervisord volume mounts", container.Name)
-			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-				Name:      adaptersCommon.SupervisordVolumeName,
-				MountPath: adaptersCommon.SupervisordMountPath,
-			})
+			foundMountPath := false
+			for _, mounts := range container.VolumeMounts {
+				if mounts.Name == adaptersCommon.SupervisordVolumeName && mounts.MountPath == adaptersCommon.SupervisordMountPath {
+					foundMountPath = true
+				}
+			}
+
+			if !foundMountPath {
+				// Always mount the supervisord volume in the debug component container
+				klog.V(3).Infof("Updating container %v with supervisord volume mounts", container.Name)
+				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+					Name:      adaptersCommon.SupervisordVolumeName,
+					MountPath: adaptersCommon.SupervisordMountPath,
+				})
+			}
 
 			// Update the debug container's ENV for work dir and command
 			// only if the env var is not set in the devfile

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -309,7 +309,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					// return since we dont want to test anything further
 					return
 				}
-			} else if !tt.wantErr {
+			} else {
 				if err != nil {
 					t.Errorf("TestUpdateContainersWithSupervisord: unexpected error %v", err)
 				}

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -302,13 +302,17 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 
 			containers, err := UpdateContainersWithSupervisord(devObj, tt.containers, tt.runCommand, tt.debugCommand, tt.debugPort)
 
-			if !tt.wantErr && err != nil {
-				t.Errorf("TestUpdateContainersWithSupervisord unxpected error: %v", err)
-			} else if tt.wantErr && err != nil {
-				// return since we dont want to test anything further
-				return
-			} else if tt.wantErr && err == nil {
-				t.Error("wanted error but got not error")
+			if tt.wantErr {
+				if err == nil {
+					t.Error("wanted error but got no error")
+				} else {
+					// return since we dont want to test anything further
+					return
+				}
+			} else if !tt.wantErr {
+				if err != nil {
+					t.Errorf("TestUpdateContainersWithSupervisord: unexpected error %v", err)
+				}
 			}
 
 			// Check if the supervisord volume has been mounted

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -17,13 +17,21 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 
 	command := "ls -la"
 	component := "alias1"
+
+	debugCommand := "nodemon --inspect={DEBUG_PORT}"
+	debugComponent := "alias2"
+
 	image := "image1"
 	workDir := "/root"
 	emptyString := ""
 	defaultCommand := []string{"tail"}
-	execGroup := versionsCommon.Group{
+	execRunGroup := versionsCommon.Group{
 		IsDefault: true,
 		Kind:      versionsCommon.RunCommandGroupType,
+	}
+	execDebugGroup := versionsCommon.Group{
+		IsDefault: true,
+		Kind:      versionsCommon.DebugCommandGroupType,
 	}
 	defaultArgs := []string{"-f", "/dev/null"}
 	supervisordCommand := []string{adaptersCommon.SupervisordBinaryPath}
@@ -32,6 +40,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 	tests := []struct {
 		name                    string
 		runCommand              string
+		debugCommand            string
 		containers              []corev1.Container
 		execCommands            []common.Exec
 		componentType           common.DevfileComponentType
@@ -56,7 +65,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					CommandLine: command,
 					Component:   component,
 					WorkingDir:  workDir,
-					Group:       &execGroup,
+					Group:       &execRunGroup,
 				},
 			},
 			componentType:           common.ContainerComponentType,
@@ -80,7 +89,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 				{
 					CommandLine: command,
 					Component:   component,
-					Group:       &execGroup,
+					Group:       &execRunGroup,
 				},
 			},
 			componentType:           common.ContainerComponentType,
@@ -103,7 +112,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					CommandLine: command,
 					Component:   component,
 					WorkingDir:  workDir,
-					Group:       &execGroup,
+					Group:       &execRunGroup,
 				},
 			},
 			componentType:           common.ContainerComponentType,
@@ -127,7 +136,7 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					CommandLine: command,
 					Component:   component,
 					WorkingDir:  workDir,
-					Group:       &execGroup,
+					Group:       &execRunGroup,
 				},
 			},
 			componentType:           common.ContainerComponentType,
@@ -150,7 +159,114 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 					CommandLine: command,
 					Component:   component,
 					WorkingDir:  workDir,
-					Group:       &execGroup,
+					Group:       &execRunGroup,
+				},
+			},
+			componentType:           common.ContainerComponentType,
+			isSupervisordEntrypoint: true,
+			wantErr:                 true,
+		},
+
+		{
+			name:         "Case: empty debug command",
+			runCommand:   emptyString,
+			debugCommand: emptyString,
+			containers: []corev1.Container{
+				{
+					Name:            component,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Env:             []corev1.EnvVar{},
+				},
+				{
+					Name:            debugComponent,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Env:             []corev1.EnvVar{},
+				},
+			},
+			execCommands: []versionsCommon.Exec{
+				{
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group:       &execRunGroup,
+				},
+				{
+					CommandLine: debugCommand,
+					Component:   debugComponent,
+					WorkingDir:  workDir,
+					Group:       &execDebugGroup,
+				},
+			},
+			componentType:           common.ContainerComponentType,
+			isSupervisordEntrypoint: true,
+			wantErr:                 false,
+		},
+		{
+			name:         "Case: custom debug command",
+			runCommand:   "",
+			debugCommand: "customdebugcommand",
+			containers: []corev1.Container{
+				{
+					Name:            component,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Env:             []corev1.EnvVar{},
+				},
+			},
+			execCommands: []versionsCommon.Exec{
+				{
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group:       &execRunGroup,
+				},
+				{
+					Id:          "customdebugcommand",
+					CommandLine: debugCommand,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group:       &execDebugGroup,
+				},
+			},
+			componentType:           common.ContainerComponentType,
+			isSupervisordEntrypoint: true,
+			wantErr:                 false,
+		},
+		{
+			name:         "Case: wrong custom debug command",
+			runCommand:   "",
+			debugCommand: "customdebugcommand123",
+			containers: []corev1.Container{
+				{
+					Name:            component,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Env:             []corev1.EnvVar{},
+				},
+				{
+					Name:            debugComponent,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Env:             []corev1.EnvVar{},
+				},
+			},
+			execCommands: []versionsCommon.Exec{
+				{
+					CommandLine: command,
+					Component:   component,
+					WorkingDir:  workDir,
+					Group:       &execRunGroup,
+				},
+				{
+					CommandLine: debugCommand,
+					Component:   debugComponent,
+					WorkingDir:  workDir,
+					Group: &versionsCommon.Group{
+						IsDefault: true,
+						Kind:      versionsCommon.BuildCommandGroupType,
+					},
 				},
 			},
 			componentType:           common.ContainerComponentType,
@@ -168,61 +284,85 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 								Name: component,
 							},
 						},
+						{
+							Container: &versionsCommon.Container{
+								Name: debugComponent,
+							},
+						},
 					},
 					ExecCommands: tt.execCommands,
 				},
 			}
 
-			containers, err := UpdateContainersWithSupervisord(devObj, tt.containers, tt.runCommand)
+			containers, err := UpdateContainersWithSupervisord(devObj, tt.containers, tt.runCommand, tt.debugCommand, 5858)
 
 			if !tt.wantErr && err != nil {
 				t.Errorf("TestUpdateContainersWithSupervisord unxpected error: %v", err)
 			} else if tt.wantErr && err != nil {
 				// return since we dont want to test anything further
 				return
+			} else if tt.wantErr && err == nil {
+				t.Error("wanted error but got not error")
 			}
 
 			// Check if the supervisord volume has been mounted
 			supervisordVolumeMountMatched := false
 			envRunMatched := false
 			envWorkDirMatched := false
+			envDebugMatched := false
+			envDebugWorkDirMatched := false
 
 			if tt.execCommands[0].WorkingDir == "" {
 				// if workdir is not present, dont test for matching the env
 				envWorkDirMatched = true
 			}
 
+			if len(tt.execCommands) >= 2 && tt.execCommands[1].WorkingDir == "" {
+				// if workdir is not present, dont test for matching the env
+				envDebugWorkDirMatched = true
+			}
+
 			for _, container := range containers {
-				if container.Name == component {
-					for _, volumeMount := range container.VolumeMounts {
-						if volumeMount.Name == adaptersCommon.SupervisordVolumeName && volumeMount.MountPath == adaptersCommon.SupervisordMountPath {
-							supervisordVolumeMountMatched = true
+				for _, testContainer := range tt.containers {
+					if container.Name == testContainer.Name {
+						for _, volumeMount := range container.VolumeMounts {
+							if volumeMount.Name == adaptersCommon.SupervisordVolumeName && volumeMount.MountPath == adaptersCommon.SupervisordMountPath {
+								supervisordVolumeMountMatched = true
+							}
 						}
-					}
 
-					for _, envVar := range container.Env {
-						if envVar.Name == adaptersCommon.EnvOdoCommandRun && envVar.Value == tt.execCommands[0].CommandLine {
-							envRunMatched = true
+						for _, envVar := range container.Env {
+							if envVar.Name == adaptersCommon.EnvOdoCommandRun && envVar.Value == tt.execCommands[0].CommandLine {
+								envRunMatched = true
+							}
+							if tt.execCommands[0].WorkingDir != "" && envVar.Name == adaptersCommon.EnvOdoCommandRunWorkingDir && envVar.Value == tt.execCommands[0].WorkingDir {
+								envWorkDirMatched = true
+							}
+							if len(tt.execCommands) >= 2 && envVar.Name == adaptersCommon.EnvOdoCommandDebug && envVar.Value == tt.execCommands[1].CommandLine {
+								envDebugMatched = true
+							}
+							if len(tt.execCommands) >= 2 && tt.execCommands[1].WorkingDir != "" && envVar.Name == adaptersCommon.EnvOdoCommandDebugWorkingDir && envVar.Value == tt.execCommands[1].WorkingDir {
+								envDebugWorkDirMatched = true
+							}
 						}
-						if tt.execCommands[0].WorkingDir != "" && envVar.Name == adaptersCommon.EnvOdoCommandRunWorkingDir && envVar.Value == tt.execCommands[0].WorkingDir {
-							envWorkDirMatched = true
+
+						if tt.isSupervisordEntrypoint && (!reflect.DeepEqual(container.Command, supervisordCommand) || !reflect.DeepEqual(container.Args, supervisordArgs)) {
+							t.Errorf("TestUpdateContainersWithSupervisord error: commands and args mismatched for container %v, expected command: %v actual command: %v, expected args: %v actual args: %v", component, supervisordCommand, container.Command, supervisordArgs, container.Args)
+						} else if !tt.isSupervisordEntrypoint && (!reflect.DeepEqual(container.Command, defaultCommand) || !reflect.DeepEqual(container.Args, defaultArgs)) {
+							t.Errorf("TestUpdateContainersWithSupervisord error: commands and args mismatched for container %v, expected command: %v actual command: %v, expected args: %v actual args: %v", component, defaultCommand, container.Command, defaultArgs, container.Args)
 						}
-					}
-
-					if tt.isSupervisordEntrypoint && (!reflect.DeepEqual(container.Command, supervisordCommand) || !reflect.DeepEqual(container.Args, supervisordArgs)) {
-						t.Errorf("TestUpdateContainersWithSupervisord error: commands and args mismatched for container %v, expected command: %v actual command: %v, expected args: %v actual args: %v", component, supervisordCommand, container.Command, supervisordArgs, container.Args)
-					} else if !tt.isSupervisordEntrypoint && (!reflect.DeepEqual(container.Command, defaultCommand) || !reflect.DeepEqual(container.Args, defaultArgs)) {
-						t.Errorf("TestUpdateContainersWithSupervisord error: commands and args mismatched for container %v, expected command: %v actual command: %v, expected args: %v actual args: %v", component, defaultCommand, container.Command, defaultArgs, container.Args)
-
 					}
 				}
 			}
-
 			if !supervisordVolumeMountMatched {
 				t.Errorf("TestUpdateContainersWithSupervisord error: could not find supervisord volume mounts for container %v", component)
 			}
 			if !envRunMatched || !envWorkDirMatched {
 				t.Errorf("TestUpdateContainersWithSupervisord error: could not find env vars for supervisord in container %v, found command env: %v, found work dir env: %v", component, envRunMatched, envWorkDirMatched)
+			}
+
+			if len(tt.execCommands) >= 2 && (!envDebugMatched || !envDebugWorkDirMatched) {
+				t.Errorf("TestUpdateContainersWithSupervisord error: could not find env vars for supervisord in container %v, found debug env: %v, found work dir env: %v", component, envDebugMatched, envDebugWorkDirMatched)
 			}
 		})
 	}

--- a/pkg/devfile/parser/data/1.0.0/components.go
+++ b/pkg/devfile/parser/data/1.0.0/components.go
@@ -221,6 +221,11 @@ func getGroup(name string) *common.Group {
 			Kind:      common.InitCommandGroupType,
 			IsDefault: true,
 		}
+	case "debugrun":
+		return &common.Group{
+			Kind:      common.DebugCommandGroupType,
+			IsDefault: true,
+		}
 	}
 
 	return nil

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -20,6 +20,9 @@ type ComponentSettings struct {
 	Namespace   string              `yaml:"Namespace,omitempty"`
 	URL         *[]EnvInfoURL       `yaml:"Url,omitempty"`
 	PushCommand *EnvInfoPushCommand `yaml:"PushCommand,omitempty"`
+
+	// DebugPort controls the port used by the pod to run the debugging agent on
+	DebugPort *int `yaml:"DebugPort,omitempty"`
 }
 
 // URLKind is an enum to indicate the type of the URL i.e ingress/route
@@ -31,6 +34,9 @@ const (
 	ROUTE           URLKind = "route"
 	envInfoEnvName          = "ENVINFO"
 	envInfoFileName         = "env.yaml"
+
+	// DefaultDebugPort is the default port used for debugging on remote pod
+	DefaultDebugPort = 5858
 )
 
 // EnvInfoURL holds URL related information
@@ -288,6 +294,14 @@ func (ei *EnvInfo) GetName() string {
 		return ""
 	}
 	return ei.componentSettings.Name
+}
+
+// GetDebugPort returns the DebugPort, returns default if nil
+func (ei *EnvInfo) GetDebugPort() int {
+	if ei.componentSettings.DebugPort == nil {
+		return DefaultDebugPort
+	}
+	return *ei.componentSettings.DebugPort
 }
 
 // GetNamespace returns component namespace

--- a/pkg/kclient/fakeclient.go
+++ b/pkg/kclient/fakeclient.go
@@ -30,7 +30,8 @@ func FakeNew() (*Client, *FakeClientset) {
 func FakePodStatus(status corev1.PodPhase, podName string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
+			Name:   podName,
+			Labels: map[string]string{},
 		},
 		Status: corev1.PodStatus{
 			Phase: status,

--- a/pkg/kclient/generators.go
+++ b/pkg/kclient/generators.go
@@ -2,6 +2,7 @@ package kclient
 
 import (
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"k8s.io/client-go/rest"
 
 	// api resource types
 
@@ -248,4 +249,14 @@ func GenerateOwnerReference(deployment *appsv1.Deployment) metav1.OwnerReference
 	}
 
 	return ownerReference
+}
+
+// GeneratePortForwardReq builds a port forward request
+func (c *Client) GeneratePortForwardReq(podName string) *rest.Request {
+	return c.KubeClient.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(c.Namespace).
+		Name(podName).
+		SubResource("portforward")
 }

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -2,6 +2,7 @@ package kclient
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -146,4 +147,28 @@ func (c *Client) ExtractProjectToComponent(compInfo common.ComponentInfo, target
 		return err
 	}
 	return nil
+}
+
+// GetPodUsingComponentName gets a pod using the component name
+func (c *Client) GetPodUsingComponentName(componentName string) (*corev1.Pod, error) {
+	podSelector := fmt.Sprintf("component=%s", componentName)
+	return c.GetOnePodFromSelector(podSelector)
+}
+
+// GetOnePodFromSelector gets a pod from the selector
+func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
+	pods, err := c.KubeClient.CoreV1().Pods(c.Namespace).List(metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get Pod for the selector: %v", selector)
+	}
+	numPods := len(pods.Items)
+	if numPods == 0 {
+		return nil, fmt.Errorf("no Pod was found for the selector: %v", selector)
+	} else if numPods > 1 {
+		return nil, fmt.Errorf("multiple Pods exist for the selector: %v. Only one must be present", selector)
+	}
+
+	return &pods.Items[0], nil
 }

--- a/pkg/kclient/pods_test.go
+++ b/pkg/kclient/pods_test.go
@@ -2,6 +2,8 @@ package kclient
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -79,6 +81,128 @@ func TestWaitAndGetPod(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestGetOnePodFromSelector(t *testing.T) {
+	fakePod := FakePodStatus(corev1.PodRunning, "nodejs")
+	fakePod.Labels["component"] = "nodejs"
+
+	type args struct {
+		selector string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		returnedPods *corev1.PodList
+		want         *corev1.Pod
+		wantErr      bool
+	}{
+		{
+			name: "valid number of pods",
+			args: args{selector: fmt.Sprintf("component=%s", "nodejs")},
+			returnedPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					*fakePod,
+				},
+			},
+			want:    fakePod,
+			wantErr: false,
+		},
+		{
+			name: "zero pods",
+			args: args{selector: fmt.Sprintf("component=%s", "nodejs")},
+			returnedPods: &corev1.PodList{
+				Items: []corev1.Pod{},
+			},
+			want:    &corev1.Pod{},
+			wantErr: true,
+		},
+		{
+			name: "mutiple pods",
+			args: args{selector: fmt.Sprintf("component=%s", "nodejs")},
+			returnedPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					*fakePod,
+					*fakePod,
+				},
+			},
+			want:    &corev1.Pod{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			fkclient, fkclientset := FakeNew()
+
+			fkclientset.Kubernetes.PrependReactor("list", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action.(ktesting.ListAction).GetListRestrictions().Labels.String() != fmt.Sprintf("component=%s", "nodejs") {
+					t.Errorf("list called with different selector want:%s, got:%s", fmt.Sprintf("component=%s", "nodejs"), action.(ktesting.ListAction).GetListRestrictions().Labels.String())
+				}
+				return true, tt.returnedPods, nil
+			})
+
+			got, err := fkclient.GetOnePodFromSelector(tt.args.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOnePodFromSelector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			} else if tt.wantErr && err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetOnePodFromSelector() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodUsingComponentName(t *testing.T) {
+	fakePod := FakePodStatus(corev1.PodRunning, "nodejs")
+	fakePod.Labels["component"] = "nodejs"
+
+	type args struct {
+		componentName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *corev1.Pod
+		wantErr bool
+	}{
+		{
+			name: "list called with same component name",
+			args: args{
+				componentName: "nodejs",
+			},
+			want:    fakePod,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fkclient, fkclientset := FakeNew()
+
+			fkclientset.Kubernetes.PrependReactor("list", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action.(ktesting.ListAction).GetListRestrictions().Labels.String() != fmt.Sprintf("component=%s", tt.args.componentName) {
+					t.Errorf("list called with different selector want:%s, got:%s", fmt.Sprintf("component=%s", tt.args.componentName), action.(ktesting.ListAction).GetListRestrictions().Labels.String())
+				}
+				return true, &corev1.PodList{
+					Items: []corev1.Pod{
+						*fakePod,
+					},
+				}, nil
+			})
+
+			got, err := fkclient.GetPodUsingComponentName(tt.args.componentName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPodUsingComponentName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPodUsingComponentName() got = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/occlient/pods.go
+++ b/pkg/occlient/pods.go
@@ -1,0 +1,22 @@
+package occlient
+
+import (
+	"fmt"
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
+	"github.com/openshift/odo/pkg/util"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (c *Client) GetPodUsingComponentName(componentName, appName string) (*corev1.Pod, error) {
+	componentLabels := componentlabels.GetLabels(componentName, appName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+	dc, err := c.GetOneDeploymentConfigFromSelector(componentSelector)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get deployment for component")
+	}
+	// Find Pod for component
+	podSelector := fmt.Sprintf("deploymentconfig=%s", dc.Name)
+
+	return c.GetOnePodFromSelector(podSelector)
+}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -81,6 +81,9 @@ func (po *PushOptions) DevfilePush() (err error) {
 		DevfileInitCmd:  strings.ToLower(po.devfileInitCommand),
 		DevfileBuildCmd: strings.ToLower(po.devfileBuildCommand),
 		DevfileRunCmd:   strings.ToLower(po.devfileRunCommand),
+		DevfileDebugCmd: strings.ToLower(po.devfileDebugCommand),
+		Debug:           po.debugRun,
+		DebugPort:       po.EnvSpecificInfo.GetDebugPort(),
 	}
 
 	warnIfURLSInvalid(po.EnvSpecificInfo.GetURL())

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -49,7 +49,10 @@ type PushOptions struct {
 	devfileInitCommand  string
 	devfileBuildCommand string
 	devfileRunCommand   string
-	namespace           string
+	devfileDebugCommand string
+	debugRun            bool
+
+	namespace string
 }
 
 // NewPushOptions returns new instance of PushOptions
@@ -187,6 +190,8 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 		pushCmd.Flags().StringVar(&po.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
 		pushCmd.Flags().StringVar(&po.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
 		pushCmd.Flags().StringVar(&po.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
+		pushCmd.Flags().BoolVar(&po.debugRun, "debug", false, "Runs the component in debug mode")
+		pushCmd.Flags().StringVar(&po.devfileDebugCommand, "debug-command", "", "Devfile Debug Command to execute")
 	}
 
 	//Adding `--project` flag

--- a/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
@@ -1,40 +1,44 @@
-apiVersion: 1.0.0
+schemaVersion: 2.0.0
 metadata:
   name: test-devfile
 projects:
-  -
-    name: nodejs-web-app
-    source:
-      type: git
+  - name: nodejs-web-app
+    git:
       location: "https://github.com/che-samples/web-nodejs-sample.git"
 components:
-  - type: dockerimage
-    image: quay.io/eclipse/che-nodejs10-ubi:nightly
-    endpoints:
-      - name: "3000/tcp"
-        port: 3000
-    alias: runtime
-    env:
-      - name: FOO
-        value: "bar"
-    memoryLimit: 1024Mi
-    mountSources: true
+  - container:
+      name: runtime
+      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000/tcp"
+          configuration:
+            protocol: tcp
+            scheme: http
+          targetPort: 3000
+      mountSources: true
 commands:
-  - name: devbuild
-    actions:
-      - type: exec
-        component: runtime
-        command: "npm install"
-        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
-  - name: devrun
-    actions:
-      - type: exec
-        component: runtime
-        command: "nodemon app.js"
-        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
-  - name: debugrun
-    actions:
-      - type: exec
-        component: runtime
-        command: "nodemon --inspect=${DEBUG_PORT}"
-        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/
+  - exec:
+      id: devbuild
+      component: runtime
+      commandLine: "npm install"
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+      group:
+        kind: build
+        isDefault: true
+  - exec:
+      id: devrun
+      component: runtime
+      commandLine: "nodemon app.js"
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+      group:
+        kind: run
+        isDefault: true
+  - exec:
+      id: debugrun
+      component: runtime
+      commandLine: "nodemon --inspect=${DEBUG_PORT}"
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/
+      group:
+        kind: debug
+        isDefault: true

--- a/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
@@ -1,0 +1,40 @@
+apiVersion: 1.0.0
+metadata:
+  name: test-devfile
+projects:
+  -
+    name: nodejs-web-app
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-nodejs-sample.git"
+components:
+  - type: dockerimage
+    image: quay.io/eclipse/che-nodejs10-ubi:nightly
+    endpoints:
+      - name: "3000/tcp"
+        port: 3000
+    alias: runtime
+    env:
+      - name: FOO
+        value: "bar"
+    memoryLimit: 1024Mi
+    mountSources: true
+commands:
+  - name: devbuild
+    actions:
+      - type: exec
+        component: runtime
+        command: "npm install"
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: devrun
+    actions:
+      - type: exec
+        component: runtime
+        command: "nodemon app.js"
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: debugrun
+    actions:
+      - type: exec
+        component: runtime
+        command: "nodemon --inspect=${DEBUG_PORT}"
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/

--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odo debug command tests", func() {
 
 			// Make sure that the debug information output, outputs correctly.
 			// We do *not* check the json output since the debugProcessID will be different each time.
-			helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context, "-o", "json"}, 1, true, func(output string) bool {
+			helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context, "-o", "json"}, 1, false, func(output string) bool {
 				if strings.Contains(output, `"kind": "OdoDebugInfo"`) &&
 					strings.Contains(output, `"localPort": `+freePort) {
 					return true

--- a/tests/integration/debug/cmd_debug_test.go
+++ b/tests/integration/debug/cmd_debug_test.go
@@ -24,6 +24,9 @@ var _ = Describe("odo debug command serial tests", func() {
 	var namespace, componentName, projectDirPath string
 	var projectDir = "/projectDir"
 
+	//  current directory and project (before eny test is run) so it can restored  after all testing is done
+	var originalDir string
+
 	// Setup up state for each test spec
 	// create new project (not set as active) and new context directory for each test spec
 	// This is before every spec (It)
@@ -34,13 +37,14 @@ var _ = Describe("odo debug command serial tests", func() {
 		namespace = helper.CreateRandProject()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 		componentName = helper.RandString(6)
-
+		originalDir = helper.Getwd()
 		projectDirPath = context + projectDir
 	})
 
 	// Clean up after the test
 	// This is run after every Spec (It)
 	AfterEach(func() {
+		helper.Chdir(originalDir)
 		helper.DeleteProject(namespace)
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -1,0 +1,171 @@
+package devfile
+
+import (
+	"github.com/openshift/odo/pkg/util"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openshift/odo/tests/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo devfile debug command tests", func() {
+	var namespace, context, componentName, currentWorkingDirectory, projectDirPath string
+	var projectDir = "/projectDir"
+
+	// This is run after every Spec (It)
+	var _ = BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		SetDefaultConsistentlyDuration(30 * time.Second)
+		namespace = helper.CreateRandProject()
+		context = helper.CreateNewContext()
+		currentWorkingDirectory = helper.Getwd()
+		projectDirPath = context + projectDir
+		componentName = helper.RandString(6)
+
+		helper.Chdir(context)
+
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+
+		// Devfile push requires experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.DeleteProject(namespace)
+		helper.Chdir(currentWorkingDirectory)
+		helper.DeleteDir(context)
+		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	Context("odo debug on a nodejs:latest component", func() {
+		It("check that machine output debug information works", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+			helper.Chdir(projectDirPath)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile-with-debugrun.yaml", "--debug")
+
+			httpPort, err := util.HttpGetFreePort()
+			Expect(err).NotTo(HaveOccurred())
+			freePort := strconv.Itoa(httpPort)
+
+			stopChannel := make(chan bool)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort)
+			}()
+
+			// Make sure that the debug information output, outputs correctly.
+			// We do *not* check the json output since the debugProcessID will be different each time.
+			helper.WaitForCmdOut("odo", []string{"debug", "info", "-o", "json"}, 1, false, func(output string) bool {
+				if strings.Contains(output, `"kind": "OdoDebugInfo"`) &&
+					strings.Contains(output, `"localPort": `+freePort) {
+					return true
+				}
+				return false
+			})
+
+			stopChannel <- true
+		})
+
+		It("should expect a ws connection when tried to connect on default debug port locally", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+			helper.Chdir(projectDirPath)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile-with-debugrun.yaml")
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile-with-debugrun.yaml", "--debug")
+
+			stopChannel := make(chan bool)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward")
+			}()
+
+			// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+			// We are just using this to validate if nodejs agent is listening on the other side
+			helper.HttpWaitForWithStatus("http://localhost:5858", "WebSockets request was expected", 12, 5, 400)
+			stopChannel <- true
+		})
+
+	})
+
+	Context("odo debug info should work on a odo component", func() {
+		It("should start a debug session and run debug info on a running debug session", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+			helper.Chdir(projectDirPath)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp-"+namespace, "--project", namespace)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile-with-debugrun.yaml", "--debug")
+
+			httpPort, err := util.HttpGetFreePort()
+			Expect(err).NotTo(HaveOccurred())
+			freePort := strconv.Itoa(httpPort)
+
+			stopChannel := make(chan bool)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort)
+			}()
+
+			// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+			// We are just using this to validate if nodejs agent is listening on the other side
+			helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
+			runningString := helper.CmdShouldPass("odo", "debug", "info")
+			Expect(runningString).To(ContainSubstring(freePort))
+			Expect(helper.ListFilesInDir(os.TempDir())).To(ContainElement(namespace + "-nodejs-cmp-" + namespace + "-odo-debug.json"))
+			stopChannel <- true
+		})
+
+		It("should start a debug session and run debug info on a closed debug session", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+			helper.Chdir(projectDirPath)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile-with-debugrun.yaml", "--debug")
+
+			httpPort, err := util.HttpGetFreePort()
+			Expect(err).NotTo(HaveOccurred())
+			freePort := strconv.Itoa(httpPort)
+
+			stopChannel := make(chan bool)
+			go func() {
+				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--local-port", freePort)
+			}()
+
+			// 400 response expected because the endpoint expects a websocket request and we are doing a HTTP GET
+			// We are just using this to validate if nodejs agent is listening on the other side
+			helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
+			runningString := helper.CmdShouldPass("odo", "debug", "info")
+			Expect(runningString).To(ContainSubstring(freePort))
+			stopChannel <- true
+			failString := helper.CmdShouldFail("odo", "debug", "info")
+			Expect(failString).To(ContainSubstring("not running"))
+
+			// according to https://golang.org/pkg/os/#Signal On Windows, sending os.Interrupt to a process with os.Process.Signal is not implemented
+			// discussion on the go repo https://github.com/golang/go/issues/6720
+			// session.Interrupt() will not work as it internally uses syscall.SIGINT
+			// thus debug port-forward won't stop running
+			// the solution is to use syscall.SIGKILL for windows but this will kill the process immediately
+			// and the cleaning and closing tasks for debug port-forward won't run and the debug info file won't be cleared
+			// thus we skip this last check
+			// CTRL_C_EVENTS from the terminal works fine https://github.com/golang/go/issues/6720#issuecomment-66087737
+			// here's a hack to generate the event https://golang.org/cl/29290044
+			// but the solution is unacceptable https://github.com/golang/go/issues/6720#issuecomment-66087749
+			if runtime.GOOS != "windows" {
+				Expect(helper.ListFilesInDir(os.TempDir())).To(Not(ContainElement(namespace + "-app" + "-nodejs-cmp-" + namespace + "-odo-debug.json")))
+			}
+
+		})
+	})
+})

--- a/tests/integration/devfile/debug/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/debug/cmd_devfile_debug_test.go
@@ -1,7 +1,7 @@
 package debug
 
 import (
-	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/testingutil"
 	"github.com/openshift/odo/tests/helper"
 	"os"
@@ -14,53 +14,75 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// since during parallel runs of cmd debug, the port might be occupied by the other tests
+// since during parallel runs of cmd devfile debug, the port might be occupied by the other tests
 // we execute these tests serially
-var _ = Describe("odo debug command serial tests", func() {
+var _ = Describe("odo devfile debug command serial tests", func() {
 
 	var context string
 
-	var namespace string
+	var namespace, componentName, projectDirPath, originalKubeconfig string
+	var projectDir = "/projectDir"
 
 	//  current directory and project (before eny test is run) so it can restored  after all testing is done
 	var originalDir string
+
+	// Using program command according to cliRunner in devfile
+	cliRunner := helper.GetCliRunner()
 
 	// Setup up state for each test spec
 	// create new project (not set as active) and new context directory for each test spec
 	// This is before every spec (It)
 	BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
-		SetDefaultConsistentlyDuration(30 * time.Second)
 		context = helper.CreateNewContext()
-		namespace = helper.CreateRandProject()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+
+		// Devfile push requires experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+
+		originalKubeconfig = os.Getenv("KUBECONFIG")
+		helper.LocalKubeconfigSet(context)
+		namespace = cliRunner.CreateRandNamespaceProject()
+		componentName = helper.RandString(6)
+		helper.Chdir(context)
 		originalDir = helper.Getwd()
+		projectDirPath = context + projectDir
 	})
 
 	// Clean up after the test
 	// This is run after every Spec (It)
 	AfterEach(func() {
 		helper.Chdir(originalDir)
-		helper.DeleteProject(namespace)
+		cliRunner.DeleteNamespaceProject(namespace)
+		err := os.Setenv("KUBECONFIG", originalKubeconfig)
+		Expect(err).NotTo(HaveOccurred())
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	It("should auto-select a local debug port when the given local port is occupied", func() {
-		helper.CopyExample(filepath.Join("source", "nodejs"), context)
-		helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+namespace, "--project", namespace, "--context", context)
-		helper.CmdShouldPass("odo", "push", "--context", context)
+	It("should auto-select a local debug port when the given local port is occupied for a devfile component", func() {
+		// Devfile push requires experimental mode to be set
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true", "-f")
+
+		helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+		helper.Chdir(projectDirPath)
+
+		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+		helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
+		helper.CmdShouldPass("odo", "push", "--debug")
 
 		stopChannel := make(chan bool)
 		go func() {
-			helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward", "--context", context)
+			helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward")
 		}()
 
 		stopListenerChan := make(chan bool)
 		startListenerChan := make(chan bool)
 		listenerStarted := false
 		go func() {
-			err := testingutil.FakePortListener(startListenerChan, stopListenerChan, config.DefaultDebugPort)
+			defer GinkgoRecover()
+			err := testingutil.FakePortListener(startListenerChan, stopListenerChan, envinfo.DefaultDebugPort)
 			if err != nil {
 				close(startListenerChan)
 				Expect(err).Should(BeNil())
@@ -72,7 +94,7 @@ var _ = Describe("odo debug command serial tests", func() {
 		}
 
 		freePort := ""
-		helper.WaitForCmdOut("odo", []string{"debug", "info", "--context", context}, 1, false, func(output string) bool {
+		helper.WaitForCmdOut("odo", []string{"debug", "info"}, 1, false, func(output string) bool {
 			if strings.Contains(output, "Debug is running") {
 				splits := strings.SplitN(output, ":", 2)
 				Expect(len(splits)).To(Equal(2))

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -1,0 +1,15 @@
+package debug
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDebug(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Debug Suite")
+	// Keep CustomReporters commented till https://github.com/onsi/ginkgo/issues/628 is fixed
+	// RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

Adds debug commands for devfile components.

**Which issue(s) this PR fixes**:

Fixes #2701 

**How to test changes / Special notes to the reviewer**:

Doc here : #3187  
- add a debug step to the working devfile
- `odo push --debug` should execute the the debug step and start the component in debug mode
- `odo debug port-forward`, `odo debug info` should work normally for the devfile component
- `odo push` should close remote debugging for the component