### PR TITLE
Updating travis env variable and adding docker version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ sudo: required
 
 language: go
 
-env:
-  global:
-    - MINIKUBE_WANTUPDATENOTIFICATION=false
-    - MINIKUBE_WANTREPORTERRORPROMPT=false
-    - MINIKUBE_HOME=$HOME
-    - CHANGE_MINIKUBE_NONE_USER=true
-    - KUBECONFIG=$HOME/.kube/config
 jobs:
   include:
     # YAML alias, for settings shared across the tests
@@ -176,6 +169,12 @@ jobs:
     - <<: *base-test
       stage: test
       name: "devfile catalog, watch, push and delete command integration tests on kubernetes cluster"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
       before_script:
         # Download kubectl, a cli tool for accessing Kubernetes cluster
         - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/

--- a/scripts/oc-cluster.sh
+++ b/scripts/oc-cluster.sh
@@ -14,6 +14,9 @@ sudo cat /etc/docker/daemon.json
 sudo service docker start
 sudo service docker status
 
+# Docker version that oc cluster up uses
+docker version
+
 ## download oc binaries
 sudo wget $OPENSHIFT_CLIENT_BINARY_URL -O /tmp/openshift-origin-client-tools.tar.gz 2> /dev/null > /dev/null
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does does this PR do / why we need it**:
Unnecessarily minikube env variable are being populated for test jobs that runs on ```oc cluster up```. This pr will update the travis global minikube variable to local test job variable so that these variable won't be available for other OpenShift test job. 

To know on which version of docker we are using for cluster up, i adding docker version info. 
**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
Travis CI should pass
