### PR TITLE
Clarifies 1 code reviewer, 1 approver

### DIFF
--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -66,9 +66,9 @@ Read the Makefile itself for more information.
 === PR review process
 
 . Once you submit a PR, the @openshift-ci-robot automatically requests two reviews from reviewers and suggests an approver based on `OWNERS` files.
-. After a reviewer is satisfied with the changes he adds `/lgtm` (looks good to me) as a comment to the PR. This applies the *lgtm* label.
-. The approver then reviews the PR and if satisfied, adds
-`/approve` as a comment to the PR. This applies the *approve* label.
+. Each PR requires *one* code review (lgtm label) and *one* approve (approved label).
+. After a code reviewer is satisfied with the changes he adds `/lgtm` (looks good to me) as a comment to the PR. Which applies the *lgtm* label.
+. The approver reviews the PR and if satisfied, adds `/approve` as a comment to the PR. Which applies the *approve* label.
 * After the PR has *lgtm* and *approve* labels and the required tests pass, the bot automatically merges the PR.
 +
 NOTE: If you are a maintainer and have write access to the `odo` repository, modify your git configuration so that you do not accidentally push to upstream:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Updates the development.adoc documentation with regards to having 1 code
reviewer and 1 approver.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>