### PR TITLE
Support context in `odo push` commands

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -8,6 +8,7 @@ import (
 // AdapterContext is a construct that is common to all adapters
 type AdapterContext struct {
 	ComponentName string                   // ComponentName is the odo component name, it is NOT related to any devfile components
+	Context       string                   // Context is the given directory containing the source code and configs
 	Devfile       devfileParser.DevfileObj // Devfile is the object returned by the Devfile parser
 }
 

--- a/pkg/devfile/adapters/helper.go
+++ b/pkg/devfile/adapters/helper.go
@@ -13,10 +13,11 @@ import (
 )
 
 // NewPlatformAdapter returns a Devfile adapter for the targeted platform
-func NewPlatformAdapter(componentName string, devObj devfileParser.DevfileObj, platformContext interface{}) (PlatformAdapter, error) {
+func NewPlatformAdapter(componentName string, context string, devObj devfileParser.DevfileObj, platformContext interface{}) (PlatformAdapter, error) {
 
 	adapterContext := common.AdapterContext{
 		ComponentName: componentName,
+		Context:       context,
 		Devfile:       devObj,
 	}
 

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -68,7 +68,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 		platformContext = kc
 	}
 
-	devfileHandler, err := adapters.NewPlatformAdapter(componentName, devObj, platformContext)
+	devfileHandler, err := adapters.NewPlatformAdapter(componentName, po.componentContext, devObj, platformContext)
 
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 	labels := map[string]string{
 		"component": componentName,
 	}
-	devfileHandler, err := adapters.NewPlatformAdapter(componentName, devObj, kc)
+	devfileHandler, err := adapters.NewPlatformAdapter(componentName, do.componentContext, devObj, kc)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -41,7 +41,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 		return err
 	}
 
-	componentName, err := getComponentName()
+	componentName, err := getComponentName(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to get component name")
 	}
@@ -102,12 +102,18 @@ func (po *PushOptions) DevfilePush() (err error) {
 }
 
 // Get component name from env.yaml file
-func getComponentName() (string, error) {
-	// Todo: Use context to get the approraite envinfo after context is supported in experimental mode
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
+func getComponentName(context string) (string, error) {
+	var dir string
+	var err error
+	if context == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		dir = context
 	}
+
 	envInfo, err := envinfo.NewEnvSpecificInfo(dir)
 	if err != nil {
 		return "", err
@@ -124,7 +130,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		return err
 	}
 
-	componentName, err := getComponentName()
+	componentName, err := getComponentName(do.componentContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/openshift/odo/pkg/envinfo"
@@ -47,7 +46,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 	}
 
 	// Set the source path to either the context or current working directory (if context not set)
-	po.sourcePath, err = util.GetAbsPath(filepath.Dir(po.componentContext))
+	po.sourcePath, err = util.GetAbsPath(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source path")
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
@@ -58,6 +59,7 @@ func NewPushOptions() *PushOptions {
 
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	po.DevfilePath = filepath.Join(po.componentContext, po.DevfilePath)
 
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
@@ -72,6 +74,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 			// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
 			po.namespace = po.KClient.Namespace
 		}
+
 		return nil
 	}
 

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -72,6 +72,8 @@ func NewWatchOptions() *WatchOptions {
 
 // Complete completes watch args
 func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	wo.devfilePath = filepath.Join(wo.componentContext, wo.devfilePath)
+
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
 		envinfo, err := envinfo.NewEnvSpecificInfo(wo.componentContext)
@@ -94,7 +96,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		}
 
 		// Get the component name
-		wo.componentName, err = getComponentName()
+		wo.componentName, err = getComponentName(wo.componentContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -117,7 +117,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		} else {
 			platformContext = nil
 		}
-		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.componentName, devObj, platformContext)
+		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.componentName, wo.componentContext, devObj, platformContext)
 
 		return err
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -84,7 +84,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		wo.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// Set the source path to either the context or current working directory (if context not set)
-		wo.sourcePath, err = util.GetAbsPath(filepath.Dir(wo.componentContext))
+		wo.sourcePath, err = util.GetAbsPath(wo.componentContext)
 		if err != nil {
 			return errors.Wrap(err, "unable to get source path")
 		}

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -100,7 +100,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			// update devfile and push again
 			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
-			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace, "--context", projectDirPath)
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", projectDirPath)
 		})
 
 	})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -95,7 +95,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
 
-			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace, "--context", projectDirPath)
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", projectDirPath)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			// update devfile and push again

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -97,10 +97,6 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", projectDirPath)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// update devfile and push again
-			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
-			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", projectDirPath)
 		})
 
 	})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -88,6 +88,21 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace)
 		})
 
+		It("checks that odo push works outside of the context directory", func() {
+			helper.CmdShouldPass("git", "clone", "https://github.com/che-samples/web-nodejs-sample.git", projectDirPath)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", projectDirPath, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs"), projectDirPath)
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace, "--context", projectDirPath)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// update devfile and push again
+			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
+			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace, "--context", projectDirPath)
+		})
+
 	})
 
 	Context("When devfile push command is executed", func() {

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -63,10 +63,9 @@ var _ = Describe("odo devfile watch command tests", func() {
 			// Devfile push requires experimental mode to be set
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 			cmpName := helper.RandString(6)
-			projectDir := helper.CreateNewContext()
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", projectDir, cmpName)
-
-			output := helper.CmdShouldFail("odo", "watch", "--context", projectDir)
+			helper.Chdir(currentWorkingDirectory)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+			output := helper.CmdShouldFail("odo", "watch", "--context", context)
 			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -63,9 +63,10 @@ var _ = Describe("odo devfile watch command tests", func() {
 			// Devfile push requires experimental mode to be set
 			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 			cmpName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+			projectDir := helper.CreateNewContext()
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", projectDir, cmpName)
 
-			output := helper.CmdShouldFail("odo", "watch", "--devfile", filepath.Join(context, "devfile.yaml"), "--context", context)
+			output := helper.CmdShouldFail("odo", "watch", "--context", projectDir)
 			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature
/area devfile

**What does does this PR do / why we need it**:
This PR adds support for the `--context` flag to `odo push` commands. Before this PR, `--context` didn't do anything, and the devfile and env info file would only be read from the current directory odo is run from.

I've also added an integration test case for the `--context` flag.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2744

**How to test changes / Special notes to the reviewer**:
- Run integration tests
- Manual test:
    1) Create a devfile component
    2) Change to a different directory
    3) Run `odo push --context <dir-containing-component>`