### PR TITLE
Performance improvement for odo catalog list components when using devfiles

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -22,6 +22,8 @@ var DevfileRegistries = []string{
 	"https://che-devfile-registry.openshift.io/",
 }
 
+var devfileIndicesMutex sync.Mutex
+
 func getDevfileIndexWith(link string, entries *[]DevfileIndexEntry, err error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
@@ -30,7 +32,9 @@ func getDevfileIndexWith(link string, entries *[]DevfileIndexEntry, err error, w
 	for i := range indexEntries {
 		indexEntries[i].Links.base = link
 	}
+	devfileIndicesMutex.Lock()
 	*entries = append(*entries, indexEntries...)
+	devfileIndicesMutex.Unlock()
 }
 
 // GetDevfileIndex loads the devfile registry index.json
@@ -50,7 +54,7 @@ func GetDevfileIndex(devfileIndexLink string) ([]DevfileIndexEntry, error) {
 	return devfileIndex, nil
 }
 
-var mutex = &sync.Mutex{}
+var devfileMutex = &sync.Mutex{}
 
 func getDevfileWith(link string, devfileIndexEntry DevfileIndexEntry, catalogDevfileList *DevfileComponentTypeList, err error, wg *sync.WaitGroup) {
 	defer wg.Done()
@@ -67,9 +71,9 @@ func getDevfileWith(link string, devfileIndexEntry DevfileIndexEntry, catalogDev
 		Registry:    devfileIndexEntry.Links.base,
 	}
 
-	mutex.Lock()
+	devfileMutex.Lock()
 	catalogDevfileList.Items = append(catalogDevfileList.Items, catalogDevfile)
-	mutex.Unlock()
+	devfileMutex.Unlock()
 }
 
 // GetDevfile loads the devfile

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -175,19 +175,19 @@ func ListDevfileComponents() (DevfileComponentTypeList, error) {
 	// 1. Load each devfile concurrently from the previously retrieved devfile index entries
 	// 2. Populate devfile components with devfile data
 	// 3. Add devfile component types to the catalog devfile list
-	var wg sync.WaitGroup
+	var devfileWG sync.WaitGroup
 	for _, devfileIndexEntry := range devfileIndex {
 		// Load the devfile
-		wg.Add(1)
+		devfileWG.Add(1)
 		var err error
 		// Note that this issues an HTTP get per devfile entry in the catalog, while doing it concurrently instead of
 		// sequentially improves the performance, caching that information would improve the performance even more
-		go getDevfileWith(devfileIndexEntry, catalogDevfileList, err, &wg)
+		go getDevfileWith(devfileIndexEntry, catalogDevfileList, err, &devfileWG)
 		if err != nil {
 			return DevfileComponentTypeList{}, err
 		}
 	}
-	wg.Wait()
+	devfileWG.Wait()
 
 	return *catalogDevfileList, nil
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -180,9 +180,7 @@ func ListDevfileComponents(registryName string) (DevfileComponentTypeList, error
 	for _, reg := range catalogDevfileList.DevfileRegistries {
 		// Load the devfile registry index.json
 		registry := reg // needed to prevent the lambda from capturing the value
-		retrieveRegistryIndices.Add(util.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-			defer wg.Done()
-
+		retrieveRegistryIndices.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 			indexEntries, e := getDevfileIndexEntries(registry)
 			if e != nil {
 				log.Warningf("Registry %s is not set up properly with error: %v", registryName, err)
@@ -208,8 +206,7 @@ func ListDevfileComponents(registryName string) (DevfileComponentTypeList, error
 		// Load the devfile
 		devfileIndex := index // needed to prevent the lambda from capturing the value
 		link := devfileIndex.Registry.URL + devfileIndex.Links.Link
-		retrieveDevfiles.Add(util.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-			defer wg.Done()
+		retrieveDevfiles.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 
 			// Note that this issues an HTTP get per devfile entry in the catalog, while doing it concurrently instead of
 			// sequentially improves the performance, caching that information would improve the performance even more

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -55,17 +55,7 @@ func GetDevfileRegistries(registryName string) (map[string]Registry, error) {
 
 const indexPath = "/devfiles/index.json"
 
-// GetDevfileIndex loads the devfile registry index.json
-func GetDevfileIndex(registryName string) ([]DevfileIndexEntry, error) {
-	registries, err2 := GetDevfileRegistries(registryName)
-	if err2 != nil {
-		return nil, err2
-	}
-
-	registry := registries[registryName]
-	return getDevfileIndexEntries(registry)
-}
-
+// getDevfileIndexEntriesFrom retrieves the devfile entries associated with the specified name, url associated with a registry
 func getDevfileIndexEntriesFrom(registryName, registryURL string) ([]DevfileIndexEntry, error) {
 	registry := Registry{
 		Name: registryName,
@@ -74,6 +64,7 @@ func getDevfileIndexEntriesFrom(registryName, registryURL string) ([]DevfileInde
 	return getDevfileIndexEntries(registry)
 }
 
+// getDevfileIndexEntries retrieves the devfile entries associated with the specified registry
 func getDevfileIndexEntries(registry Registry) ([]DevfileIndexEntry, error) {
 	var devfileIndex []DevfileIndexEntry
 	indexLink := registry.URL + indexPath

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -56,9 +56,10 @@ func GetDevfileIndex(devfileIndexLink string) ([]DevfileIndexEntry, error) {
 
 var devfileMutex = &sync.Mutex{}
 
-func getDevfileWith(link string, devfileIndexEntry DevfileIndexEntry, catalogDevfileList *DevfileComponentTypeList, err error, wg *sync.WaitGroup) {
+func getDevfileWith(devfileIndexEntry DevfileIndexEntry, catalogDevfileList *DevfileComponentTypeList, err error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	link := devfileIndexEntry.Links.base + devfileIndexEntry.Links.Link
 	devfile, err := GetDevfile(link)
 
 	// Populate devfile component with devfile data and form devfile component list
@@ -163,8 +164,6 @@ func ListDevfileComponents() (DevfileComponentTypeList, error) {
 	// 3. Form devfile component list
 	var wg sync.WaitGroup
 	for _, devfileIndexEntry := range devfileIndex {
-		devfileLink := devfileIndexEntry.Links.base + devfileIndexEntry.Links.Link
-
 		// Load the devfile
 		// TODO: We send http get resquest in this function mutiple times
 		// since devfile registry uses different links to host different devfiles,
@@ -172,7 +171,7 @@ func ListDevfileComponents() (DevfileComponentTypeList, error) {
 		// big registry. We may need to rethink and optimize this in the future
 		wg.Add(1)
 		var err error
-		go getDevfileWith(devfileLink, devfileIndexEntry, catalogDevfileList, err, &wg)
+		go getDevfileWith(devfileIndexEntry, catalogDevfileList, err, &wg)
 		if err != nil {
 			return DevfileComponentTypeList{}, err
 		}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -55,15 +55,6 @@ func GetDevfileRegistries(registryName string) (map[string]Registry, error) {
 
 const indexPath = "/devfiles/index.json"
 
-// getDevfileIndexEntriesFrom retrieves the devfile entries associated with the specified name, url associated with a registry
-func getDevfileIndexEntriesFrom(registryName, registryURL string) ([]DevfileIndexEntry, error) {
-	registry := Registry{
-		Name: registryName,
-		URL:  registryURL,
-	}
-	return getDevfileIndexEntries(registry)
-}
-
 // getDevfileIndexEntries retrieves the devfile entries associated with the specified registry
 func getDevfileIndexEntries(registry Registry) ([]DevfileIndexEntry, error) {
 	var devfileIndex []DevfileIndexEntry

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -283,8 +283,10 @@ func TestGetDevfileIndex(t *testing.T) {
 					Icon:              "/images/angular.svg",
 					GlobalMemoryLimit: "2686Mi",
 					Links: struct {
+						base string
 						Link string `json:"self"`
 					}{
+						base: server.URL,
 						Link: "/devfiles/angular/devfile.yaml",
 					},
 				},

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -241,7 +241,7 @@ OdoSettings:
 	}
 }
 
-func TestGetDevfileIndex(t *testing.T) {
+func TestGetDevfileIndexEntries(t *testing.T) {
 	// Start a local HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Send response to be tested
@@ -274,15 +274,13 @@ func TestGetDevfileIndex(t *testing.T) {
 
 	const registryName = "some registry"
 	tests := []struct {
-		name         string
-		registryURL  string
-		registryName string
-		want         []DevfileIndexEntry
+		name     string
+		registry Registry
+		want     []DevfileIndexEntry
 	}{
 		{
-			name:         "Test NodeJS devfile index",
-			registryURL:  server.URL,
-			registryName: registryName,
+			name:     "Test NodeJS devfile index",
+			registry: Registry{Name: registryName, URL: server.URL},
 			want: []DevfileIndexEntry{
 				{
 					DisplayName: "NodeJS Angular Web Application",
@@ -310,7 +308,7 @@ func TestGetDevfileIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getDevfileIndexEntriesFrom(tt.registryName, tt.registryURL)
+			got, err := getDevfileIndexEntries(tt.registry)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Got: %v, want: %v", got, tt.want)

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -199,21 +199,30 @@ OdoSettings:
 	tests := []struct {
 		name         string
 		registryName string
-		want         map[string]string
+		want         map[string]Registry
 	}{
 		{
 			name:         "Case 1: Test get all devfile registries",
 			registryName: "",
-			want: map[string]string{
-				"CheDevfileRegistry":     "https://che-devfile-registry.openshift.io/",
-				"DefaultDevfileRegistry": "https://raw.githubusercontent.com/elsony/devfile-registry/master",
+			want: map[string]Registry{
+				"CheDevfileRegistry": {
+					Name: "CheDevfileRegistry",
+					URL:  "https://che-devfile-registry.openshift.io/",
+				},
+				"DefaultDevfileRegistry": {
+					Name: "DefaultDevfileRegistry",
+					URL:  "https://raw.githubusercontent.com/elsony/devfile-registry/master",
+				},
 			},
 		},
 		{
 			name:         "Case 2: Test get specific devfile registry",
 			registryName: "CheDevfileRegistry",
-			want: map[string]string{
-				"CheDevfileRegistry": "https://che-devfile-registry.openshift.io/",
+			want: map[string]Registry{
+				"CheDevfileRegistry": {
+					Name: "CheDevfileRegistry",
+					URL:  "https://che-devfile-registry.openshift.io/",
+				},
 			},
 		},
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -263,14 +263,17 @@ func TestGetDevfileIndex(t *testing.T) {
 	// Close the server when test finishes
 	defer server.Close()
 
+	const registryName = "some registry"
 	tests := []struct {
-		name             string
-		devfileIndexLink string
-		want             []DevfileIndexEntry
+		name         string
+		registryURL  string
+		registryName string
+		want         []DevfileIndexEntry
 	}{
 		{
-			name:             "Test NodeJS devfile index",
-			devfileIndexLink: server.URL,
+			name:         "Test NodeJS devfile index",
+			registryURL:  server.URL,
+			registryName: registryName,
 			want: []DevfileIndexEntry{
 				{
 					DisplayName: "NodeJS Angular Web Application",
@@ -282,11 +285,13 @@ func TestGetDevfileIndex(t *testing.T) {
 					},
 					Icon:              "/images/angular.svg",
 					GlobalMemoryLimit: "2686Mi",
+					Registry: Registry{
+						Name: registryName,
+						URL:  server.URL,
+					},
 					Links: struct {
-						base string
 						Link string `json:"self"`
 					}{
-						base: server.URL,
 						Link: "/devfiles/angular/devfile.yaml",
 					},
 				},
@@ -296,7 +301,7 @@ func TestGetDevfileIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetDevfileIndex(tt.devfileIndexLink)
+			got, err := getDevfileIndexEntriesFrom(tt.registryName, tt.registryURL)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Got: %v, want: %v", got, tt.want)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -36,6 +36,7 @@ type DevfileIndexEntry struct {
 	Icon              string   `json:"icon"`
 	GlobalMemoryLimit string   `json:"globalMemoryLimit"`
 	Links             struct {
+		base string
 		Link string `json:"self"`
 	} `json:"links"`
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -35,8 +35,8 @@ type DevfileIndexEntry struct {
 	Tags              []string `json:"tags"`
 	Icon              string   `json:"icon"`
 	GlobalMemoryLimit string   `json:"globalMemoryLimit"`
+	Registry          Registry `json:"registry"`
 	Links             struct {
-		base string
 		Link string `json:"self"`
 	} `json:"links"`
 }
@@ -73,7 +73,7 @@ type ComponentTypeList struct {
 
 // DevfileComponentTypeList lists all the DevfileComponentType's
 type DevfileComponentTypeList struct {
-	DevfileRegistries map[string]string
+	DevfileRegistries map[string]Registry
 	Items             []DevfileComponentType
 }
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -5,11 +5,11 @@ import (
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
-	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
+	catalogutil "github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
-	util2 "github.com/openshift/odo/pkg/util"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"io"
 	"k8s.io/klog"
@@ -43,12 +43,12 @@ func NewListComponentsOptions() *ListComponentsOptions {
 // Complete completes ListComponentsOptions after they've been created
 func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 
-	tasks := util2.NewConcurrentTasks(2)
+	tasks := util.NewConcurrentTasks(2)
 
 	if !pushtarget.IsPushTargetDocker() {
 		o.Context = genericclioptions.NewContext(cmd)
 
-		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error) {
+		tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 			o.catalogList, err = catalog.ListComponents(o.Client)
 			if err != nil {
 				if experimental.IsExperimentalModeEnabled() {
@@ -57,13 +57,13 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 					errChannel <- err
 				}
 			} else {
-				o.catalogList.Items = util.FilterHiddenComponents(o.catalogList.Items)
+				o.catalogList.Items = catalogutil.FilterHiddenComponents(o.catalogList.Items)
 			}
 		}})
 	}
 
 	if experimental.IsExperimentalModeEnabled() {
-		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error) {
+		tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 			o.catalogDevfileList, err = catalog.ListDevfileComponents("")
 			if o.catalogDevfileList.DevfileRegistries == nil {
 				log.Warning("Please run 'odo registry add <registry name> <registry URL>' to add registry for listing devfile components\n")

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -50,10 +50,10 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 
 		wg.Add(1)
 		var err error
-		go func(err error) {
+		go func() {
 			defer wg.Done()
 			o.catalogList, err = catalog.ListComponents(o.Client)
-		}(err)
+		}()
 		if err != nil {
 			if experimental.IsExperimentalModeEnabled() {
 				klog.V(4).Info("Please log in to an OpenShift cluster to list OpenShift/s2i components")
@@ -68,10 +68,10 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	if experimental.IsExperimentalModeEnabled() {
 		wg.Add(1)
 		var err error
-		go func(err error) {
+		go func() {
 			defer wg.Done()
 			o.catalogDevfileList, err = catalog.ListDevfileComponents("")
-		}(err)
+		}()
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/klog"
 	"os"
 	"strings"
-	"sync"
 	"text/tabwriter"
 )
 
@@ -49,8 +48,7 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	if !pushtarget.IsPushTargetDocker() {
 		o.Context = genericclioptions.NewContext(cmd)
 
-		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-			defer wg.Done()
+		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error) {
 			o.catalogList, err = catalog.ListComponents(o.Client)
 			if err != nil {
 				if experimental.IsExperimentalModeEnabled() {
@@ -65,8 +63,7 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	}
 
 	if experimental.IsExperimentalModeEnabled() {
-		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-			defer wg.Done()
+		tasks.Add(util2.ConcurrentTask{ToRun: func(errChannel chan error) {
 			o.catalogDevfileList, err = catalog.ListDevfileComponents("")
 			if o.catalogDevfileList.DevfileRegistries == nil {
 				log.Warning("Please run 'odo registry add <registry name> <registry URL>' to add registry for listing devfile components\n")

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -60,9 +60,9 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 			} else {
 				return err
 			}
+		} else {
+			o.catalogList.Items = util.FilterHiddenComponents(o.catalogList.Items)
 		}
-
-		o.catalogList.Items = util.FilterHiddenComponents(o.catalogList.Items)
 	}
 
 	if experimental.IsExperimentalModeEnabled() {
@@ -82,7 +82,6 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 	}
 
 	wg.Wait()
-
 	return
 }
 

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"strings"
-	"sync"
 )
 
 // ServiceCompletionHandler provides service name completion for the current project and application
@@ -274,9 +273,7 @@ var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 	found := false
 
 	tasks := util.NewConcurrentTasks(2)
-	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-		defer wg.Done()
-
+	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 		catalogList, _ := catalog.ListComponents(context.Client)
 		for _, builder := range catalogList.Items {
 			if args.commands[builder.Name] {
@@ -288,9 +285,7 @@ var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 			}
 		}
 	}})
-	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error, wg *sync.WaitGroup) {
-		defer wg.Done()
-
+	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
 		components, _ := catalog.ListDevfileComponents("")
 		for _, devfile := range components.Items {
 			if args.commands[devfile.Name] {

--- a/pkg/util/concurrent.go
+++ b/pkg/util/concurrent.go
@@ -37,7 +37,7 @@ func (ct *ConcurrentTasks) Add(task ConcurrentTask) {
 // Based on https://garrypolley.com/2016/02/10/golang-routines-errors/
 func (ct *ConcurrentTasks) Run() error {
 	var wg sync.WaitGroup
-	finished := make(chan bool, 1) // this along with wg.Wait() are why the error handling works and doesn't deadlock
+	finished := make(chan bool, 1) // this along with wg.Wait() is why the error handling works and doesn't deadlock
 	errChannel := make(chan error)
 
 	for _, task := range ct.tasks {

--- a/pkg/util/concurrent.go
+++ b/pkg/util/concurrent.go
@@ -6,12 +6,13 @@ import (
 
 // A task to execute in a go-routine
 type ConcurrentTask struct {
-	ToRun func(errChannel chan error, wg *sync.WaitGroup)
+	ToRun func(errChannel chan error)
 }
 
-// Run encapsulates the work to be done by calling the ToRun function
-func (ct ConcurrentTask) Run(errChannel chan error, wg *sync.WaitGroup) {
-	ct.ToRun(errChannel, wg)
+// run encapsulates the work to be done by calling the ToRun function
+func (ct ConcurrentTask) run(errChannel chan error, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ct.ToRun(errChannel)
 }
 
 // Records tasks to be run concurrently with go-routines
@@ -41,7 +42,7 @@ func (ct *ConcurrentTasks) Run() error {
 
 	for _, task := range ct.tasks {
 		wg.Add(1)
-		go task.Run(errChannel, &wg)
+		go task.run(errChannel, &wg)
 	}
 
 	// Put the wait group in a go routine.

--- a/pkg/util/concurrent.go
+++ b/pkg/util/concurrent.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"sync"
+)
+
+// A task to execute in a go-routine
+type ConcurrentTask struct {
+	ToRun func(errChannel chan error, wg *sync.WaitGroup)
+}
+
+// Run encapsulates the work to be done by calling the ToRun function
+func (ct ConcurrentTask) Run(errChannel chan error, wg *sync.WaitGroup) {
+	ct.ToRun(errChannel, wg)
+}
+
+// Records tasks to be run concurrently with go-routines
+type ConcurrentTasks struct {
+	tasks []ConcurrentTask
+}
+
+// NewConcurrentTasks creates a new ConcurrentTasks instance, dimensioned to accept at least the specified number of tasks
+func NewConcurrentTasks(taskNumber int) *ConcurrentTasks {
+	return &ConcurrentTasks{tasks: make([]ConcurrentTask, 0, taskNumber)}
+}
+
+// Add adds the specified ConcurrentTask to the list of tasks to be run concurrently
+func (ct *ConcurrentTasks) Add(task ConcurrentTask) {
+	if len(ct.tasks) == 0 {
+		ct.tasks = make([]ConcurrentTask, 0, 7)
+	}
+	ct.tasks = append(ct.tasks, task)
+}
+
+// Run concurrently runs the added tasks failing on the first error
+// Based on https://garrypolley.com/2016/02/10/golang-routines-errors/
+func (ct *ConcurrentTasks) Run() error {
+	var wg sync.WaitGroup
+	finished := make(chan bool, 1) // this along with wg.Wait() are why the error handling works and doesn't deadlock
+	errChannel := make(chan error)
+
+	for _, task := range ct.tasks {
+		wg.Add(1)
+		go task.Run(errChannel, &wg)
+	}
+
+	// Put the wait group in a go routine.
+	// By putting the wait group in the go routine we ensure either all pass
+	// and we close the "finished" channel or we wait forever for the wait group
+	// to finish.
+	//
+	// Waiting forever is okay because of the blocking select below.
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+
+	// This select will block until one of the two channels returns a value.
+	// This means on the first failure in the go routines above the errChannel will release a
+	// value first. Because there is a "return" statement in the err check this function will
+	// exit when an error occurs.
+	//
+	// Due to the blocking on wg.Wait() the finished channel will not get a value unless all
+	// the go routines before were successful because not all the wg.Done() calls would have
+	// happened.
+	select {
+	case <-finished:
+	case err := <-errChannel:
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -700,50 +700,6 @@ func HTTPGetRequest(url string) ([]byte, error) {
 	return bytes, err
 }
 
-type ErrorWrapper struct {
-	errors []error
-}
-
-func NewErrorWrapper(capacity ...int) *ErrorWrapper {
-	c := 7
-	if len(capacity) == 1 {
-		c = capacity[0]
-	}
-	return &ErrorWrapper{errors: make([]error, 0, c)}
-}
-
-func (ew *ErrorWrapper) AddError(err error) {
-	ew.errors = append(ew.errors, err)
-}
-
-func (ew *ErrorWrapper) HasError() bool {
-	return len(ew.errors) > 0
-}
-
-func (ew *ErrorWrapper) AsError() string {
-	const sep = "\n\t- "
-	elems := ew.errors
-	switch len(elems) {
-	case 0:
-		return ""
-	case 1:
-		return elems[0].Error()
-	}
-	n := len(sep) * (len(elems) - 1)
-	for i := 0; i < len(elems); i++ {
-		n += len(elems[i].Error())
-	}
-
-	var b strings.Builder
-	b.Grow(n)
-	b.WriteString(elems[0].Error())
-	for _, s := range elems[1:] {
-		b.WriteString(sep)
-		b.WriteString(s.Error())
-	}
-	return b.String()
-}
-
 // filterIgnores applies the glob rules on the filesChanged and filesDeleted and filters them
 // returns the filtered results which match any of the glob rules
 func FilterIgnores(filesChanged, filesDeleted, absIgnoreRules []string) (filesChangedFiltered, filesDeletedFiltered []string) {


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What does does this PR do / why we need it**:
Performance went from more than 4.5 seconds to less than 1.8 seconds on my system.
Also allowed me to fix #3105 as we now also fetch devfiles for completion, which was
previously prohibitively slow. Note that more performance gains could be achieved by caching locally the devfile registry metadata but this current change was a lower-hanging fruit… :)

**Which issue(s) this PR fixes**:

Fixes #3105
Fixes #2967 
Fixes #3123 

**How to test changes / Special notes to the reviewer**:
Just run `odo catalog list components` without the fix then with the fix. One noticeable change, though, is that the order in which devfiles are presented is now random.