### PR TITLE
set ODO_LOG_LEVEL=4 on CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+    - ODO_LOG_LEVEL=4
 jobs:
   include:
     # YAML alias, for settings shared across the tests

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -13,6 +13,7 @@ go get -u github.com/onsi/ginkgo/ginkgo
 export PATH="$PATH:$(pwd):$GOPATH/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
+export ODO_LOG_LEVEL=4
 
 # Integration tests
 make test-integration

--- a/scripts/openshiftci-presubmit-integration-tests.sh
+++ b/scripts/openshiftci-presubmit-integration-tests.sh
@@ -13,6 +13,7 @@ go get -u github.com/onsi/ginkgo/ginkgo
 export PATH="$PATH:$(pwd):$GOPATH/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
+export ODO_LOG_LEVEL=4
 
 # Integration tests
 make test-integration


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What does does this PR do / why we need it**:
To make debugging failing tests easier this PR sets env variable `ODO_LOG_LEVEL=4` on both our CIs (OpenShift CI, Travis). This should be equivalent to running all odo commands with `-v 4`.



**How to test changes / Special notes to the reviewer**:

When test on CI fails you should see verbose logs from odo in ci log output
