### PR TITLE
Fix URL create on Docker with no Kube config

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -100,25 +100,27 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 		o.Context = genericclioptions.NewContext(cmd)
 	}
 
-	o.Client = genericclioptions.Client(cmd)
-
-	routeSupported, err := o.Client.IsRouteSupported()
-	if err != nil {
-		return err
-	}
-	if routeSupported {
-		o.isRouteSupported = true
-	}
-
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
-		if o.wantIngress || (!o.isRouteSupported) {
-			o.urlType = envinfo.INGRESS
-		} else {
-			o.urlType = envinfo.ROUTE
-		}
+		if !pushtarget.IsPushTargetDocker() {
+			o.Client = genericclioptions.Client(cmd)
 
-		if o.tlsSecret != "" && (!o.wantIngress || !o.secureURL) {
-			return fmt.Errorf("tls secret is only available for secure URLs of ingress kind")
+			routeSupported, err := o.Client.IsRouteSupported()
+			if err != nil {
+				return err
+			}
+			if routeSupported {
+				o.isRouteSupported = true
+			}
+
+			if o.wantIngress || (!o.isRouteSupported) {
+				o.urlType = envinfo.INGRESS
+			} else {
+				o.urlType = envinfo.ROUTE
+			}
+
+			if o.tlsSecret != "" && (!o.wantIngress || !o.secureURL) {
+				return fmt.Errorf("tls secret is only available for secure URLs of ingress kind")
+			}
 		}
 
 		err = o.InitEnvInfoFromContext()

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -104,12 +104,9 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 		if !pushtarget.IsPushTargetDocker() {
 			o.Client = genericclioptions.Client(cmd)
 
-			routeSupported, err := o.Client.IsRouteSupported()
+			o.isRouteSupported, err = o.Client.IsRouteSupported()
 			if err != nil {
 				return err
-			}
-			if routeSupported {
-				o.isRouteSupported = true
 			}
 
 			if o.wantIngress || (!o.isRouteSupported) {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
/area devfile
/area local

**What does does this PR do / why we need it**:
This PR fixes an issue seen when using odo with Docker and no kube config was set up on the user's machine, and `odo url create` would fail. Rather than always initializing an oc client on `odo url create` commands, it will only initialize it if the pushtarget is unset, or set to Kube.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3074

**How to test changes / Special notes to the reviewer**:
1. Move `~/.kube` to another folder if one exists on your machine
2. Set pushtarget to Docker
3. Run `odo create`, and `odo url create`. It should run fine
4. Run `odo push`, exposed port should get created