### PR TITLE
Set ResponseHeaderTimeout for GET requests

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -680,7 +680,10 @@ func GetRemoteFilesMarkedForDeletion(delSrcRelPaths []string, remoteFolder strin
 
 // HTTPGetRequest uses url to get file contents
 func HTTPGetRequest(url string) ([]byte, error) {
-	var httpClient = &http.Client{Timeout: HTTPRequestTimeout}
+	var httpClient = &http.Client{Transport: &http.Transport{
+		ResponseHeaderTimeout: HTTPRequestTimeout,
+	},
+		Timeout: HTTPRequestTimeout}
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,8 +34,8 @@ import (
 
 // HTTPRequestTimeout configures timeout of all HTTP requests
 const (
-	HTTPRequestTimeout    = 20 * time.Second
-	ResponseHeaderTimeout = 10 * time.Second
+	HTTPRequestTimeout    = 20 * time.Second // HTTPRequestTimeout configures timeout of all HTTP requests
+	ResponseHeaderTimeout = 10 * time.Second // ResponseHeaderTimeout is the timeout to retrieve the server's response headers
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -927,7 +927,9 @@ func DownloadFile(url string, filepath string) error {
 	defer out.Close() // #nosec G307
 
 	// Get the data
-	var httpClient = &http.Client{Timeout: HTTPRequestTimeout}
+	var httpClient = &http.Client{Transport: &http.Transport{
+		ResponseHeaderTimeout: HTTPRequestTimeout,
+	}, Timeout: HTTPRequestTimeout}
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,7 +33,10 @@ import (
 )
 
 // HTTPRequestTimeout configures timeout of all HTTP requests
-const HTTPRequestTimeout = 10 * time.Second
+const (
+	HTTPRequestTimeout    = 20 * time.Second
+	ResponseHeaderTimeout = 10 * time.Second
+)
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 
@@ -681,7 +684,7 @@ func GetRemoteFilesMarkedForDeletion(delSrcRelPaths []string, remoteFolder strin
 // HTTPGetRequest uses url to get file contents
 func HTTPGetRequest(url string) ([]byte, error) {
 	var httpClient = &http.Client{Transport: &http.Transport{
-		ResponseHeaderTimeout: HTTPRequestTimeout,
+		ResponseHeaderTimeout: ResponseHeaderTimeout,
 	},
 		Timeout: HTTPRequestTimeout}
 	resp, err := httpClient.Get(url)
@@ -928,7 +931,7 @@ func DownloadFile(url string, filepath string) error {
 
 	// Get the data
 	var httpClient = &http.Client{Transport: &http.Transport{
-		ResponseHeaderTimeout: HTTPRequestTimeout,
+		ResponseHeaderTimeout: ResponseHeaderTimeout,
 	}, Timeout: HTTPRequestTimeout}
 	resp, err := httpClient.Get(url)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
/area devfile

**What does does this PR do / why we need it**:
This PR fixes a fairly intermittent issue seen when we trying to pull down the index.json for a devfile registry (such as during `odo create` or `odo catalog list components`):
```
$ odo create nodejs
Experimental mode is enabled, use at your own risk
 ✗  Get https://raw.githubusercontent.com/elsony/devfile-registry/master/devfiles/index.json: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

This was highly intermittent, and not easily reproducible. After working with @gmarcy (who could consistently reproduce it on his network), we narrowed it down to the default time out given for retrieving the headers. So I updated `util.HTTPGetRequest` to add a timeout of 10 seconds, and that fixed things for him.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3073

**How to test changes / Special notes to the reviewer**:
TBH, I'm really not sure how to easily reproduce the bug seen in #3073, since it's so highly intermittent and dependent on network conditions.