### PR TITLE
Don't set a default value for -o flag and fix `ODO_LOG_LEVEL` check

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -49,7 +49,7 @@ func main() {
 	// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
 	v := flag.CommandLine.Lookup("v").Value.String()
 
-	// if the output flag is set to `json` (only valid value), we don't turn on ODO_LOG_LEVEL
+	// if the output flag is set, we don't turn on ODO_LOG_LEVEL
 	outputFlag := pflag.Lookup("o")
 	hasFlagChanged := outputFlag != nil && outputFlag.Changed
 	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" && hasFlagChanged {

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -45,17 +45,6 @@ func main() {
 		}
 	}
 
-	// Override the logging level by the value (if set) by the ODO_LOG_LEVEL env
-	// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
-	v := flag.CommandLine.Lookup("v").Value.String()
-
-	// if the output flag is set, we don't turn on ODO_LOG_LEVEL
-	outputFlag := pflag.Lookup("o")
-	hasFlagChanged := outputFlag != nil && outputFlag.Changed
-	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" && hasFlagChanged {
-		_ = flag.CommandLine.Set("v", level)
-	}
-
 	// run the completion, in case that the completion was invoked
 	// and ran as a completion script or handled a flag that passed
 	// as argument, the Run method will return true,

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli"
@@ -49,9 +48,11 @@ func main() {
 	// Override the logging level by the value (if set) by the ODO_LOG_LEVEL env
 	// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
 	v := flag.CommandLine.Lookup("v").Value.String()
-	// if the json flag is passed and is valid, we don't turn on ODO_LOG_LEVEL
-	jsonFlagValue := flag.CommandLine.Lookup("o").Value.String()
-	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" && strings.ToLower(jsonFlagValue) != "json" {
+
+	// if the output flag is set to `json` (only valid value), we don't turn on ODO_LOG_LEVEL
+	outputFlag := pflag.Lookup("o")
+	hasFlagChanged := outputFlag != nil && outputFlag.Changed
+	if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" && hasFlagChanged {
 		_ = flag.CommandLine.Set("v", level)
 	}
 

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -145,7 +145,7 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 	// We use "flag" in order to make this accessible throughtout ALL of odo, rather than the
 	// above traditional "persistentflags" usage that does not make it a pointer within the 'pflag'
 	// package
-	flag.CommandLine.String("o", "json", "Specify output format, supported format: json")
+	flag.CommandLine.String("o", "", "Specify output format, supported format: json")
 
 	// Here we add the necessary "logging" flags.. However, we choose to hide some of these from the user
 	// as they are not necessarily needed and more for advanced debugging

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -94,5 +94,12 @@ func CheckMachineReadableOutputCommand(cmd *cobra.Command) {
 	// is not malformed / mixed in with normal logging
 	if log.IsJSON() {
 		_ = flag.Set("v", "0")
+	} else {
+		// Override the logging level by the value (if set) by the ODO_LOG_LEVEL env
+		// The "-v" flag set on command line will take precedence over ODO_LOG_LEVEL env
+		v := flag.CommandLine.Lookup("v").Value.String()
+		if level, ok := os.LookupEnv("ODO_LOG_LEVEL"); ok && v == "0" {
+			_ = flag.CommandLine.Set("v", level)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
Removes the default value of `json` for the `-o` / `--output` flag in odo. Since our default output is not in json, we don't need to be setting the default value for that flag to that.

Previously, it was being set and causing the `ODO_LOG_LEVEL` env var not to work, due to the check here:

https://github.com/openshift/odo/blob/master/cmd/odo/odo.go#L54

See the discussion in https://github.com/openshift/odo/pull/3115

**Which issue(s) this PR fixes**:

No issue, but I can open one.

**How to test changes / Special notes to the reviewer**:
```
Johns-MacBook-Pro-3:odo johncollier$ ODO_LOG_LEVEL=4 ./odo catalog list components
I0507 22:37:13.433129   65620 preference.go:165] The path for preference file is /Users/johncollier/.odo/preference.yaml
I0507 22:37:13.433317   65620 preference.go:165] The path for preference file is /Users/johncollier/.odo/preference.yaml
I0507 22:37:14.387035   65620 preference.go:165] The path for preference file is /Users/johncollier/.odo/preference.yaml
Odo OpenShift Components:
NAME              PROJECT       TAGS                        SUPPORTED
java              openshift     11,8,latest                 YES
nodejs            openshift     10-SCL,8,8-RHOAR,latest     YES
dotnet            openshift     2.1,2.2,3.0,latest          NO
golang            openshift     1.11.5,latest               NO
httpd             openshift     2.4,latest                  NO
modern-webapp     openshift     10.x,latest                 NO
nginx             openshift     1.10,1.12,latest            NO
perl              openshift     5.24,5.26,latest            NO
php               openshift     7.0,7.1,7.2,latest          NO
python            openshift     2.7,3.6,latest              NO
ruby              openshift     2.4,2.5,latest              NO

Odo Devfile Components:
NAME                 DESCRIPTION                           SUPPORTED
maven                Upstream Maven and OpenJDK 11         YES
nodejs               Stack with NodeJS 10                  YES
openLiberty          Open Liberty microservice in Java     YES
java-spring-boot     Spring Boot® using Java               YES

```

```
Johns-MacBook-Pro-3:odo johncollier$ ./odo catalog list components -o json
{
    "kind": "List",
    "apiVersion": "odo.openshift.io/v1alpha1",
    "metadata": {
        "creationTimestamp": null
    },
    "items": [
        {
            "kind": "ComponentType",
            "apiVersion": "odo.openshift.io/v1alpha1",
            "metadata": {
                "name": "dotnet",
                "namespace": "openshift",
                "creationTimestamp": null
            },
            "spec": {
                "allTags": [
                    "2.1",
                    "2.2",
                    "3.0",
                    "latest"
                ],
                "nonHiddenTags": [
                    "2.1",
                    "2.2",
                    "3.0",
                    "latest"
                ],
                "supportedTags": []
            }
        },
```

```
Johns-MacBook-Pro-3:odo johncollier$ ./odo catalog list components -o yaml
 ✗  Please input a valid output format for -o, available format: json
```