### PR TITLE
Listing created devfile component support for kubernetes and major cleanup

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -8,6 +8,7 @@ import (
 // AdapterContext is a construct that is common to all adapters
 type AdapterContext struct {
 	ComponentName string                   // ComponentName is the odo component name, it is NOT related to any devfile components
+	AppName       string                   // AppName is the name of the application under which a component will be created
 	Context       string                   // Context is the given directory containing the source code and configs
 	Devfile       devfileParser.DevfileObj // Devfile is the object returned by the Devfile parser
 }

--- a/pkg/devfile/adapters/helper.go
+++ b/pkg/devfile/adapters/helper.go
@@ -13,10 +13,11 @@ import (
 )
 
 // NewPlatformAdapter returns a Devfile adapter for the targeted platform
-func NewPlatformAdapter(componentName string, context string, devObj devfileParser.DevfileObj, platformContext interface{}) (PlatformAdapter, error) {
+func NewPlatformAdapter(componentName string, appName string, context string, devObj devfileParser.DevfileObj, platformContext interface{}) (PlatformAdapter, error) {
 
 	adapterContext := common.AdapterContext{
 		ComponentName: componentName,
+		AppName:       appName,
 		Context:       context,
 		Devfile:       devObj,
 	}

--- a/pkg/devfile/adapters/helper_test.go
+++ b/pkg/devfile/adapters/helper_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openshift/odo/pkg/testingutil"
 )
 
+const testAppName = "app"
+
 func TestNewPlatformAdapter(t *testing.T) {
 	tests := []struct {
 		adapterType   string

--- a/pkg/devfile/adapters/helper_test.go
+++ b/pkg/devfile/adapters/helper_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/openshift/odo/pkg/testingutil"
 )
 
-const testAppName = "app"
-
 func TestNewPlatformAdapter(t *testing.T) {
 	tests := []struct {
 		adapterType   string

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -146,11 +146,15 @@ func (a Adapter) DoesComponentExist(cmpName string) bool {
 func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	componentName := a.ComponentName
 
-	// dont ask me how I know this
-	componentType := strings.TrimSuffix(*a.AdapterContext.Devfile.Data.GetMetadata().GenerateName, "-")
+	genName := a.AdapterContext.Devfile.Data.GetMetadata().GenerateName
+
 	labels := componentlabels.GetLabels(componentName, a.AppName, true)
 	labels["component"] = componentName
-	labels[componentlabels.ComponentTypeLabel] = componentType
+
+	if genName != nil {
+		componentType := strings.TrimSuffix(*genName, "-")
+		labels[componentlabels.ComponentTypeLabel] = componentType
+	}
 
 	containers, err := utils.GetContainers(a.Devfile)
 	if err != nil {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,8 +145,12 @@ func (a Adapter) DoesComponentExist(cmpName string) bool {
 
 func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	componentName := a.ComponentName
+
+	// dont ask me how I know this
+	componentType := strings.TrimSuffix(*a.AdapterContext.Devfile.Data.GetMetadata().GenerateName, "-")
 	labels := componentlabels.GetLabels(componentName, a.AppName, true)
 	labels["component"] = componentName
+	labels[componentlabels.ComponentTypeLabel] = componentType
 
 	containers, err := utils.GetContainers(a.Devfile)
 	if err != nil {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
+
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
@@ -142,10 +144,8 @@ func (a Adapter) DoesComponentExist(cmpName string) bool {
 
 func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	componentName := a.ComponentName
-
-	labels := map[string]string{
-		"component": componentName,
-	}
+	labels := componentlabels.GetLabels(componentName, a.AppName, true)
+	labels["component"] = componentName
 
 	containers, err := utils.GetContainers(a.Devfile)
 	if err != nil {

--- a/pkg/devfile/parser/data/1.0.0/components.go
+++ b/pkg/devfile/parser/data/1.0.0/components.go
@@ -11,6 +11,10 @@ func (d *Devfile100) GetComponents() []common.DevfileComponent {
 	return d.Components
 }
 
+func (d *Devfile100) GetMetadata() common.DevfileMetadata {
+	return d.Metadata
+}
+
 // GetAliasedComponents returns the slice of DevfileComponent objects that each have an alias
 func (d *Devfile100) GetAliasedComponents() []common.DevfileComponent {
 	var aliasedComponents = []common.DevfileComponent{}

--- a/pkg/devfile/parser/data/interface.go
+++ b/pkg/devfile/parser/data/interface.go
@@ -6,6 +6,7 @@ import (
 
 // DevfileData is an interface that defines functions for Devfile data operations
 type DevfileData interface {
+	GetMetadata() common.DevfileMetadata
 	GetComponents() []common.DevfileComponent
 	GetAliasedComponents() []common.DevfileComponent
 	GetProjects() []common.DevfileProject

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -162,10 +162,6 @@ func newProxyEnvInfo() proxyEnvInfo {
 func (esi *EnvSpecificInfo) SetConfiguration(parameter string, value interface{}) (err error) {
 	if parameter, ok := asLocallySupportedParameter(parameter); ok {
 		switch parameter {
-		case "create":
-			createValue := value.(ComponentSettings)
-			esi.componentSettings.Name = createValue.Name
-			esi.componentSettings.Namespace = createValue.Namespace
 		case "url":
 			urlValue := value.(EnvInfoURL)
 			if esi.componentSettings.URL != nil {
@@ -296,10 +292,6 @@ func (ei *EnvInfo) GetApplication() string {
 }
 
 const (
-	// Create parameter
-	Create = "CREATE"
-	// CreateDescription is the description of Create parameter
-	CreateDescription = "Create parameter is the action to write devfile metadata to env.yaml"
 	// URL
 	URL = "URL"
 	// URLDescription is the description of URL
@@ -308,8 +300,7 @@ const (
 
 var (
 	supportedLocalParameterDescriptions = map[string]string{
-		Create: CreateDescription,
-		URL:    URLDescription,
+		URL: URLDescription,
 	}
 
 	lowerCaseLocalParameters = util.GetLowerCaseParameters(GetLocallySupportedParameters())

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -127,6 +127,7 @@ func newEnvSpecificInfo(envDir string, fs filesystem.Filesystem) (*EnvSpecificIn
 	// if the env.yaml file doesn't exist then we dont worry about it and return
 	if _, err = e.fs.Stat(envInfoFile); os.IsNotExist(err) {
 		e.envinfoFileExists = false
+
 		return &e, nil
 	}
 

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -21,9 +21,13 @@ const (
 
 // ComponentSettings holds all component related information
 type ComponentSettings struct {
-	Name      string        `yaml:"Name,omitempty"`
-	Namespace string        `yaml:"Namespace,omitempty"`
-	URL       *[]EnvInfoURL `yaml:"Url,omitempty"`
+	Name      string `yaml:"Name,omitempty"`
+	Namespace string `yaml:"Namespace,omitempty"`
+
+	// AppName is the application name. Application is a virtual concept present in odo used
+	// for grouping of components. A namespace can contain multiple applications
+	AppName string        `yaml:"AppName,omitempty" json:"AppName,omitempty"`
+	URL     *[]EnvInfoURL `yaml:"Url,omitempty"`
 }
 
 // URLKind is an enum to indicate the type of the URL i.e ingress/route
@@ -161,6 +165,8 @@ func (esi *EnvSpecificInfo) SetConfiguration(parameter string, value interface{}
 			} else {
 				esi.componentSettings.URL = &[]EnvInfoURL{urlValue}
 			}
+		case "appname":
+			esi.componentSettings.AppName = parameter
 		}
 
 		return esi.writeToFile()
@@ -268,18 +274,17 @@ func (ei *EnvInfo) GetURL() []EnvInfoURL {
 
 // GetName returns the component name
 func (ei *EnvInfo) GetName() string {
-	if ei.componentSettings.Name == "" {
-		return ""
-	}
 	return ei.componentSettings.Name
 }
 
 // GetNamespace returns component namespace
 func (ei *EnvInfo) GetNamespace() string {
-	if ei.componentSettings.Namespace == "" {
-		return ""
-	}
 	return ei.componentSettings.Namespace
+}
+
+// GetApplication returns the application name
+func (ei *EnvInfo) GetApplication() string {
+	return ei.componentSettings.AppName
 }
 
 const (

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -19,6 +19,14 @@ const (
 	envInfoFileName = "env.yaml"
 )
 
+// LocalConfigProvider is an interface which all local config providers need to implement
+// currently for openshift there is localConfigInfo and for devfile its EnvInfo.
+// The reason this interface is declared here instead of config package is because
+// some day local config would get deprecated and hence to keep the interfaces in the new package
+type LocalConfigProvider interface {
+	GetApplication() string
+}
+
 // ComponentSettings holds all component related information
 type ComponentSettings struct {
 	Name      string `yaml:"Name,omitempty"`

--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -23,7 +23,6 @@ func TestSetEnvInfo(t *testing.T) {
 	os.Setenv(envInfoEnvName, tempEnvFile.Name())
 	testURL := EnvInfoURL{Name: "testURL", Host: "1.2.3.4.nip.io", TLSSecret: "testTLSSecret"}
 	invalidParam := "invalidParameter"
-	testCreate := ComponentSettings{Name: "componentName", Namespace: "namespace"}
 
 	tests := []struct {
 		name            string
@@ -50,15 +49,6 @@ func TestSetEnvInfo(t *testing.T) {
 			},
 			expectError: true,
 		},
-		{
-			name:      "Case 3: Test fields setup from create parameter",
-			parameter: Create,
-			value:     testCreate,
-			existingEnvInfo: EnvInfo{
-				componentSettings: ComponentSettings{},
-			},
-			expectError: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,19 +65,7 @@ func TestSetEnvInfo(t *testing.T) {
 					t.Error(err)
 				}
 
-				isSet := false
-
-				if tt.parameter == Create {
-					parameters := []string{"Name", "Namespace"}
-					for _, parameter := range parameters {
-						isSet = esi.IsSet(parameter)
-						if !isSet {
-							t.Errorf("the '%v' is not set", parameter)
-						}
-					}
-				} else {
-					isSet = esi.IsSet(tt.parameter)
-				}
+				isSet := esi.IsSet(tt.parameter)
 
 				if !isSet {
 					t.Errorf("the '%v' is not set", tt.parameter)
@@ -235,7 +213,7 @@ func TestDeleteURLFromMultipleURLs(t *testing.T) {
 }
 
 func TestLowerCaseParameterForLocalParameters(t *testing.T) {
-	expected := map[string]bool{"create": true, "url": true}
+	expected := map[string]bool{"url": true}
 	actual := util.GetLowerCaseParameters(GetLocallySupportedParameters())
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected '%v', got '%v'", expected, actual)

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	applabels "github.com/openshift/odo/pkg/application/labels"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,6 +30,18 @@ const (
 func (c *Client) GetDeploymentByName(name string) (*appsv1.Deployment, error) {
 	deployment, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(name, metav1.GetOptions{})
 	return deployment, err
+}
+
+func (c *Client) ListDeployments(appName string) (*appsv1.DeploymentList, error) {
+	applicationSelector := fmt.Sprintf("%s=%s", applabels.ApplicationLabel, appName)
+
+	return c.KubeClient.AppsV1().Deployments(c.Namespace).List(metav1.ListOptions{
+		LabelSelector: applicationSelector,
+	})
+}
+
+func (c *Client) ListAllDeployments() (*appsv1.DeploymentList, error) {
+	return c.KubeClient.AppsV1().Deployments(c.Namespace).List(metav1.ListOptions{})
 }
 
 // getDeploymentCondition returns the condition with the provided type

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3277,6 +3277,28 @@ func (c *Client) IsRouteSupported() (bool, error) {
 	return false, nil
 }
 
+// IsDeploymentConfigSupported checks if DeploymentConfig type is present on the cluster
+func (c *Client) IsDeploymentConfigSupported() (bool, error) {
+	const ClusterVersionGroup = "apps.openshift.io"
+	const ClusterVersionVersion = "v1"
+	groupVersion := metav1.GroupVersion{Group: ClusterVersionGroup, Version: ClusterVersionVersion}.String()
+
+	list, err := c.discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	for _, resources := range list.APIResources {
+
+		if resources.Kind == "DeploymentConfig" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GenerateOwnerReference genertes an ownerReference which can then be set as
 // owner for various OpenShift objects and ensure that when the owner object is
 // deleted from the cluster, all other objects are automatically removed by

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -96,7 +96,7 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 			// the secret should have been created along with the secret
 			_, err = o.Client.GetSecret(o.secretName, o.Project)
 			if err != nil {
-				return fmt.Errorf("The service %s created by 'odo service create' is being provisioned. You may have to wait a few seconds until OpenShift fully provisions it before executing 'odo %s'.", o.secretName, o.operationName)
+				return fmt.Errorf("the service %s created by 'odo service create' is being provisioned. You may have to wait a few seconds until OpenShift fully provisions it before executing 'odo %s'", o.secretName, o.operationName)
 			}
 		}
 	}

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -30,8 +30,6 @@ type CommonPushOptions struct {
 	sourcePath       string
 	componentContext string
 
-	EnvSpecificInfo *envinfo.EnvSpecificInfo
-
 	pushConfig         bool
 	pushSource         bool
 	forceBuild         bool

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RecommendedComponentCommandName is the recommended component command name
+// RecommendedCommandName is the recommended component command name
 const RecommendedCommandName = "component"
 
 // ComponentOptions encapsulates basic component options

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -302,10 +302,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// Add a disclaimer that we are in *experimental mode*
 		log.Experimental("Experimental mode is enabled, use at your own risk")
 
-		if util.CheckPathExists(ConfigFilePath) {
-			return errors.New("This directory already contains a component")
-		}
-
 		if len(args) == 0 {
 			co.interactive = true
 		}
@@ -655,6 +651,10 @@ func (co *CreateOptions) Validate() (err error) {
 			// Validate if the devfile component that user wants to create already exists
 			spinner := log.Spinner("Validating devfile component")
 			defer spinner.End(false)
+
+			if util.CheckPathExists(ConfigFilePath) {
+				return errors.New("This directory already contains a component")
+			}
 
 			if util.CheckPathExists(EnvFilePath) {
 				return errors.New("This workspace directory already contains a devfile component")

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -44,16 +44,15 @@ type CreateOptions struct {
 	componentContext  string
 	componentPorts    []string
 	componentEnvVars  []string
-	// this is the application name specific for devfile
-	devfileAppName string
-	memoryMax      string
-	memoryMin      string
-	memory         string
-	cpuMax         string
-	cpuMin         string
-	cpu            string
-	interactive    bool
-	now            bool
+
+	memoryMax   string
+	memoryMin   string
+	memory      string
+	cpuMax      string
+	cpuMin      string
+	cpu         string
+	interactive bool
+	now         bool
 	*CommonPushOptions
 	devfileMetadata DevfileMetadata
 }
@@ -327,6 +326,8 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			co.CommonPushOptions.componentContext = co.componentContext
 		}
 
+		co.Context = genericclioptions.NewDevfileContext(cmd)
+
 		// One exception of a validation present in Complete code because, this is an optimisation
 		// i.e. if the devfile is present locally then we dont need to list the devfile catalog
 		if util.CheckPathExists(DevfilePath) {
@@ -409,8 +410,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.devfileMetadata.componentType = componentType
 		co.devfileMetadata.componentName = strings.ToLower(componentName)
 		co.devfileMetadata.componentNamespace = strings.ToLower(componentNamespace)
-
-		co.devfileAppName = genericclioptions.ResolveApp(cmd, true, co.EnvSpecificInfo)
 
 		// Categorize the sections
 		log.Info("Validation")
@@ -786,7 +785,7 @@ func (co *CreateOptions) Run() (err error) {
 
 			err = co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{Name: co.devfileMetadata.componentName,
 				Namespace: co.devfileMetadata.componentNamespace,
-				AppName:   co.devfileAppName})
+				AppName:   co.Application})
 			if err != nil {
 				return errors.Wrap(err, "Failed to create env.yaml for devfile component")
 			}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -44,14 +44,16 @@ type CreateOptions struct {
 	componentContext  string
 	componentPorts    []string
 	componentEnvVars  []string
-	memoryMax         string
-	memoryMin         string
-	memory            string
-	cpuMax            string
-	cpuMin            string
-	cpu               string
-	interactive       bool
-	now               bool
+	// this is the application name specific for devfile
+	devfileAppName string
+	memoryMax      string
+	memoryMin      string
+	memory         string
+	cpuMax         string
+	cpuMin         string
+	cpu            string
+	interactive    bool
+	now            bool
 	*CommonPushOptions
 	devfileMetadata DevfileMetadata
 }
@@ -419,6 +421,8 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			return nil
 		}
+
+		co.devfileAppName = genericclioptions.ResolveApp(cmd, true, co.EnvSpecificInfo)
 
 		// Categorize the sections
 		log.Info("Validation")
@@ -793,7 +797,9 @@ func (co *CreateOptions) Run() (err error) {
 				}
 			}
 
-			err := co.EnvSpecificInfo.SetConfiguration("create", envinfo.ComponentSettings{Name: co.devfileMetadata.componentName, Namespace: co.devfileMetadata.componentNamespace})
+			err := co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{Name: co.devfileMetadata.componentName,
+				Namespace: co.devfileMetadata.componentNamespace,
+				AppName:   co.devfileAppName})
 			if err != nil {
 				return errors.Wrap(err, "Failed to create env.yaml for devfile component")
 			}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -327,6 +327,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			co.CommonPushOptions.componentContext = co.componentContext
 		}
 
+		// One exception of a validation present in Complete code because, this is an optimisation
+		// i.e. if the devfile is present locally then we dont need to list the devfile catalog
+		if util.CheckPathExists(DevfilePath) {
+			return errors.New("This directory already contains a devfile.yaml, please delete it and run the component creation command again")
+		}
+
 		catalogDevfileList, err := catalog.ListDevfileComponents(co.devfileMetadata.devfileRegistry.Name)
 		if err != nil {
 			return err
@@ -345,15 +351,13 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			// devfile.yaml is not present, user has to specify the component type
 			// Component type: We provide supported devfile component list then let you choose
-			if !util.CheckPathExists(DevfilePath) {
-				var supDevfileCatalogList []catalog.DevfileComponentType
-				for _, devfileComponent := range catalogDevfileList.Items {
-					if devfileComponent.Support {
-						supDevfileCatalogList = append(supDevfileCatalogList, devfileComponent)
-					}
+			var supDevfileCatalogList []catalog.DevfileComponentType
+			for _, devfileComponent := range catalogDevfileList.Items {
+				if devfileComponent.Support {
+					supDevfileCatalogList = append(supDevfileCatalogList, devfileComponent)
 				}
-				componentType = ui.SelectDevfileComponentType(supDevfileCatalogList)
 			}
+			componentType = ui.SelectDevfileComponentType(supDevfileCatalogList)
 
 			// Component name: User needs to specify the componet name, by default it is component type that user chooses
 			componentName = ui.EnterDevfileComponentName(componentType)
@@ -375,10 +379,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		} else {
 			// Direct mode (User enters the full command)
 			// Get component type, name and namespace from user's full command
-
-			if util.CheckPathExists(DevfilePath) {
-				return errors.New("This directory already contains a devfile.yaml, please delete it and run the component creation command again")
-			}
 
 			// Component type: Get from full command's first argument (mandatory in direct mode)
 			componentType = args[0]
@@ -409,18 +409,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.devfileMetadata.componentType = componentType
 		co.devfileMetadata.componentName = strings.ToLower(componentName)
 		co.devfileMetadata.componentNamespace = strings.ToLower(componentNamespace)
-
-		// If devfile.yaml is present, we don't need to download the devfile.yaml later
-		if util.CheckPathExists(DevfilePath) {
-			co.devfileMetadata.devfileSupport = true
-
-			err = co.InitEnvInfoFromContext()
-			if err != nil {
-				return err
-			}
-
-			return nil
-		}
 
 		co.devfileAppName = genericclioptions.ResolveApp(cmd, true, co.EnvSpecificInfo)
 
@@ -656,6 +644,7 @@ func (co *CreateOptions) Validate() (err error) {
 			spinner := log.Spinner("Validating devfile component")
 			defer spinner.End(false)
 
+			// This checks for the presence of s2i style component
 			if util.CheckPathExists(ConfigFilePath) {
 				return errors.New("This directory already contains a component")
 			}
@@ -781,23 +770,21 @@ func (co *CreateOptions) downloadProject() error {
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run() (err error) {
 	if experimental.IsExperimentalModeEnabled() {
-		// Download devfile.yaml file and create env.yaml file
+		// Download devfile.yaml file and create env.yaml file only if its not already present
 		if co.devfileMetadata.devfileSupport {
-			if !util.CheckPathExists(DevfilePath) {
-				err := util.DownloadFile(co.devfileMetadata.devfileRegistry.URL+co.devfileMetadata.devfileLink, DevfilePath)
-				if err != nil {
-					return errors.Wrap(err, "Faile to download devfile.yaml for devfile component")
-				}
+			err := util.DownloadFile(co.devfileMetadata.devfileRegistry.URL+co.devfileMetadata.devfileLink, DevfilePath)
+			if err != nil {
+				return errors.Wrap(err, "Faile to download devfile.yaml for devfile component")
 			}
 
-			if util.CheckPathExists(DevfilePath) && co.devfileMetadata.downloadSource {
+			if co.devfileMetadata.downloadSource {
 				err = co.downloadProject()
 				if err != nil {
 					return errors.Wrap(err, "Failed to download project for devfile component")
 				}
 			}
 
-			err := co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{Name: co.devfileMetadata.componentName,
+			err = co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{Name: co.devfileMetadata.componentName,
 				Namespace: co.devfileMetadata.componentNamespace,
 				AppName:   co.devfileAppName})
 			if err != nil {

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -196,7 +196,7 @@ func (do *DeleteOptions) Run() (err error) {
 	return
 }
 
-// Run has the logic to perform the required actions as part of command for devfiles
+// DevFileRun has the logic to perform the required actions as part of command for devfiles
 func (do *DeleteOptions) DevFileRun() (err error) {
 	// devfile delete
 	if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the devfile component: %s?", do.EnvSpecificInfo.GetName())) {

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 
@@ -45,14 +44,13 @@ type DeleteOptions struct {
 	*ComponentOptions
 
 	// devfile path
-	devfilePath     string
-	namespace       string
-	EnvSpecificInfo *envinfo.EnvSpecificInfo
+	devfilePath string
+	namespace   string
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, false, "", false, &ComponentOptions{}, "", "", nil}
+	return &DeleteOptions{false, false, false, "", false, &ComponentOptions{}, "", ""}
 }
 
 // Complete completes log args
@@ -61,10 +59,6 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
-		do.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(do.componentContext)
-		if err != nil {
-			return err
-		}
 
 		do.Context = genericclioptions.NewDevfileContext(cmd)
 		if !pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -40,11 +40,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 		return err
 	}
 
-	componentName, err := getComponentName(po.componentContext)
-	if err != nil {
-		return errors.Wrap(err, "unable to get component name")
-	}
-
+	componentName := po.EnvSpecificInfo.GetName()
 	// Set the source path to either the context or current working directory (if context not set)
 	po.sourcePath, err = util.GetAbsPath(po.componentContext)
 	if err != nil {
@@ -67,7 +63,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 		platformContext = kc
 	}
 
-	devfileHandler, err := adapters.NewPlatformAdapter(componentName, po.componentContext, devObj, platformContext)
+	devfileHandler, err := adapters.NewPlatformAdapter(componentName, po.Application, po.componentContext, devObj, platformContext)
 
 	if err != nil {
 		return err
@@ -101,27 +97,6 @@ func (po *PushOptions) DevfilePush() (err error) {
 	return
 }
 
-// Get component name from env.yaml file
-func getComponentName(context string) (string, error) {
-	var dir string
-	var err error
-	if context == "" {
-		dir, err = os.Getwd()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		dir = context
-	}
-
-	envInfo, err := envinfo.NewEnvSpecificInfo(dir)
-	if err != nil {
-		return "", err
-	}
-	componentName := envInfo.GetName()
-	return componentName, nil
-}
-
 // DevfileComponentDelete deletes the devfile component
 func (do *DeleteOptions) DevfileComponentDelete() error {
 	// Parse devfile
@@ -130,10 +105,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		return err
 	}
 
-	componentName, err := getComponentName(do.componentContext)
-	if err != nil {
-		return err
-	}
+	componentName := do.EnvSpecificInfo.GetName()
 
 	kc := kubernetes.KubernetesContext{
 		Namespace: do.namespace,
@@ -142,7 +114,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 	labels := map[string]string{
 		"component": componentName,
 	}
-	devfileHandler, err := adapters.NewPlatformAdapter(componentName, do.componentContext, devObj, kc)
+	devfileHandler, err := adapters.NewPlatformAdapter(componentName, do.Application, do.componentContext, devObj, kc)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -37,6 +37,7 @@ type ListOptions struct {
 	pathFlag         string
 	allAppsFlag      bool
 	componentContext string
+	IsOpenshift      bool
 	*genericclioptions.Context
 }
 
@@ -51,6 +52,8 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	if experimental.IsExperimentalModeEnabled() {
 		// Add a disclaimer that we are in *experimental mode*
 		log.Experimental("Experimental mode is enabled, use at your own risk")
+
+		lo.Context = genericclioptions.NewDevfileContext(cmd)
 
 	} else {
 		if util.CheckKubeConfigExist() {
@@ -70,6 +73,12 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 // Validate validates the list parameters
 func (lo *ListOptions) Validate() (err error) {
 
+	if experimental.IsExperimentalModeEnabled() {
+		if lo.Context.Application == "" && lo.Context.Project == "" {
+			return odoutil.ThrowContextError()
+		}
+		return nil
+	}
 	var project, app string
 
 	if !util.CheckKubeConfigExist() {
@@ -85,6 +94,7 @@ func (lo *ListOptions) Validate() (err error) {
 		return odoutil.ThrowContextError()
 	}
 	return nil
+
 }
 
 // Run has the logic to perform the required actions as part of command

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -6,12 +6,17 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
+
+	applabels "github.com/openshift/odo/pkg/application/labels"
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
 
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
@@ -34,10 +39,12 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
-	pathFlag         string
-	allAppsFlag      bool
-	componentContext string
-	IsOpenshift      bool
+	pathFlag             string
+	allAppsFlag          bool
+	componentContext     string
+	hasDCSupport         bool
+	hasDevfileComponents bool
+	hasS2IComponents     bool
 	*genericclioptions.Context
 }
 
@@ -65,6 +72,15 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 		}
 	}
+
+	lo.Client = genericclioptions.Client(cmd)
+
+	dcSupport, err := lo.Client.IsDeploymentConfigSupported()
+	if err != nil {
+		return err
+	}
+
+	lo.hasDCSupport = dcSupport
 
 	return
 
@@ -100,7 +116,13 @@ func (lo *ListOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (lo *ListOptions) Run() (err error) {
 
+	// --path workflow
+
 	if len(lo.pathFlag) != 0 {
+
+		if experimental.IsExperimentalModeEnabled() {
+			log.Experimental("--path flag is not supported for devfile components")
+		}
 		components, err := component.ListIfPathGiven(lo.Context.Client, filepath.SplitList(lo.pathFlag))
 		if err != nil {
 			return err
@@ -118,57 +140,120 @@ func (lo *ListOptions) Run() (err error) {
 		}
 		return nil
 	}
-	var components component.ComponentList
 
-	if lo.allAppsFlag {
-		// retrieve list of application
-		apps, err := application.List(lo.Client)
+	// non --path workflow below
+	// read the code like
+	// -> experimental
+	//	or	|-> --all-apps
+	//		|-> the current app
+	// -> non-experimental
+	//	or	|-> --all-apps
+	//		|-> the current app
+
+	// experimental workflow
+
+	if experimental.IsExperimentalModeEnabled() {
+
+		var dpl *appsv1.DeploymentList
+		var err error
+
+		// TODO: wrap this into a component list for docker support
+		if lo.allAppsFlag {
+			dpl, err = lo.KClient.ListAllDeployments()
+
+		} else {
+			dpl, err = lo.KClient.ListDeployments(lo.Application)
+		}
+
 		if err != nil {
 			return err
 		}
 
-		var componentList []component.Component
-
-		if len(apps) == 0 && lo.LocalConfigInfo.ConfigFileExists() {
-			comps, err := component.List(lo.Client, lo.LocalConfigInfo.GetApplication(), lo.LocalConfigInfo)
-			if err != nil {
-				return err
+		if len(dpl.Items) != 0 {
+			lo.hasDevfileComponents = true
+			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+			fmt.Fprintln(w, "Devfile Components: ")
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "REVISION")
+			for _, comp := range dpl.Items {
+				app := comp.Labels[applabels.ApplicationLabel]
+				cmpType := comp.Labels[componentlabels.ComponentTypeLabel]
+				revision := comp.Annotations["deployment.kubernetes.io/revision"]
+				fmt.Fprintln(w, app, "\t", comp.Name, "\t", comp.Namespace, "\t", cmpType, "\t", revision)
 			}
-			componentList = append(componentList, comps.Items...)
+			w.Flush()
+
 		}
 
-		// interating over list of application and get list of all components
-		for _, app := range apps {
-			comps, err := component.List(lo.Client, app, lo.LocalConfigInfo)
-			if err != nil {
-				return err
-			}
-			componentList = append(componentList, comps.Items...)
-		}
-		// Get machine readable component list format
-		components = component.GetMachineReadableFormatForList(componentList)
-	} else {
-
-		components, err = component.List(lo.Client, lo.Application, lo.LocalConfigInfo)
-		if err != nil {
-			return errors.Wrapf(err, "failed to fetch components list")
-		}
 	}
-	klog.V(4).Infof("the components are %+v", components)
 
-	if log.IsJSON() {
-		machineoutput.OutputSuccess(components)
-	} else {
-		if len(components.Items) == 0 {
-			log.Errorf("There are no components deployed.")
+	// non-experimental workflow
+
+	// we now check if DC is supported
+	if lo.hasDCSupport {
+
+		var components component.ComponentList
+
+		if lo.allAppsFlag {
+			// retrieve list of application
+			apps, err := application.List(lo.Client)
+			if err != nil {
+				return err
+			}
+
+			var componentList []component.Component
+
+			if len(apps) == 0 && lo.LocalConfigInfo.ConfigFileExists() {
+				comps, err := component.List(lo.Client, lo.LocalConfigInfo.GetApplication(), lo.LocalConfigInfo)
+				if err != nil {
+					return err
+				}
+				componentList = append(componentList, comps.Items...)
+			}
+
+			// interating over list of application and get list of all components
+			for _, app := range apps {
+				comps, err := component.List(lo.Client, app, lo.LocalConfigInfo)
+				if err != nil {
+					return err
+				}
+				componentList = append(componentList, comps.Items...)
+			}
+			// Get machine readable component list format
+			components = component.GetMachineReadableFormatForList(componentList)
+		} else {
+
+			components, err = component.List(lo.Client, lo.Application, lo.LocalConfigInfo)
+			if err != nil {
+				return errors.Wrapf(err, "failed to fetch components list")
+			}
+		}
+
+		klog.V(4).Infof("the components are %+v", components)
+
+		if log.IsJSON() {
+			machineoutput.OutputSuccess(components)
+		} else {
+			if len(components.Items) != 0 {
+				if lo.hasDevfileComponents {
+					fmt.Println()
+				}
+				lo.hasS2IComponents = true
+				w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+				fmt.Fprintln(w, "Openshift Components: ")
+				fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
+				for _, comp := range components.Items {
+					fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
+				}
+				w.Flush()
+			}
+		}
+
+		// if we dont have any of the components
+		if !lo.hasDevfileComponents && !lo.hasS2IComponents {
+			log.Error("There are no components deployed.")
 			return
 		}
-		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
-		for _, comp := range components.Items {
-			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
-		}
-		w.Flush()
+
 	}
 	return
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -74,8 +74,8 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	}
 
 	lo.Client = genericclioptions.Client(cmd)
-
 	dcSupport, err := lo.Client.IsDeploymentConfigSupported()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/odo/util/experimental"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -47,14 +48,21 @@ func NewListOptions() *ListOptions {
 // Complete completes log args
 func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 
-	if util.CheckKubeConfigExist() {
-		klog.V(4).Infof("New Context")
-		lo.Context = genericclioptions.NewContext(cmd)
-	} else {
-		klog.V(4).Infof("New Config Context")
-		lo.Context = genericclioptions.NewConfigContext(cmd)
+	if experimental.IsExperimentalModeEnabled() {
+		// Add a disclaimer that we are in *experimental mode*
+		log.Experimental("Experimental mode is enabled, use at your own risk")
 
+	} else {
+		if util.CheckKubeConfigExist() {
+			klog.V(4).Infof("New Context")
+			lo.Context = genericclioptions.NewContext(cmd)
+		} else {
+			klog.V(4).Infof("New Config Context")
+			lo.Context = genericclioptions.NewConfigContext(cmd)
+
+		}
 	}
+
 	return
 
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 
 	"github.com/openshift/odo/pkg/component"
@@ -63,11 +62,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
-		envinfo, err := envinfo.NewEnvSpecificInfo(po.componentContext)
-		if err != nil {
-			return errors.Wrap(err, "unable to retrieve configuration information")
-		}
-		po.EnvSpecificInfo = envinfo
+
 		po.Context = genericclioptions.NewDevfileContext(cmd)
 
 		if !pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -141,10 +141,9 @@ func (po *PushOptions) Run() (err error) {
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
 		return po.DevfilePush()
-	} else {
-		// Legacy odo push
-		return po.Push()
 	}
+	// Legacy odo push
+	return po.Push()
 }
 
 // NewCmdPush implements the push odo command

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/odo/pkg/devfile/adapters"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/occlient"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -59,8 +58,6 @@ type WatchOptions struct {
 	devfilePath    string
 	namespace      string
 	devfileHandler adapters.PlatformAdapter
-
-	EnvSpecificInfo *envinfo.EnvSpecificInfo
 
 	*genericclioptions.Context
 }

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -107,7 +107,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		} else {
 			platformContext = nil
 		}
-		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.Application, wo.componentName, wo.componentContext, devObj, platformContext)
+		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.componentName, wo.Application, wo.componentContext, devObj, platformContext)
 
 		return err
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -76,11 +76,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
-		envinfo, err := envinfo.NewEnvSpecificInfo(wo.componentContext)
-		if err != nil {
-			return errors.Wrap(err, "unable to retrieve configuration information")
-		}
-		wo.EnvSpecificInfo = envinfo
+
 		wo.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// Set the source path to either the context or current working directory (if context not set)
@@ -96,10 +92,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		}
 
 		// Get the component name
-		wo.componentName, err = getComponentName(wo.componentContext)
-		if err != nil {
-			return err
-		}
+		wo.componentName = wo.EnvSpecificInfo.GetName()
 
 		// Parse devfile
 		devObj, err := devfileParser.Parse(wo.devfilePath)
@@ -117,7 +110,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		} else {
 			platformContext = nil
 		}
-		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.componentName, wo.componentContext, devObj, platformContext)
+		wo.devfileHandler, err = adapters.NewPlatformAdapter(wo.Application, wo.componentName, wo.componentContext, devObj, platformContext)
 
 		return err
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -370,8 +370,8 @@ func resolveNamespace(command *cobra.Command, client *kclient.Client, envSpecifi
 	return namespace
 }
 
-// resolveApp resolves the app
-func resolveApp(command *cobra.Command, createAppIfNeeded bool, localConfiguration *config.LocalConfigInfo) string {
+// resolveApp resolves the app, the order of precedence being flag > local config > default.
+func resolveApp(command *cobra.Command, createAppIfNeeded bool, localConfiguration envinfo.LocalConfigProvider) string {
 	var app string
 	appFlag := FlagValueIfSet(command, ApplicationFlagName)
 	if len(appFlag) > 0 {
@@ -478,6 +478,9 @@ func newDevfileContext(command *cobra.Command) *Context {
 
 		internalCxt.EnvSpecificInfo = envInfo
 		resolveNamespace(command, kClient, envInfo)
+
+		// ignore the "true" for now
+		internalCxt.Application = resolveApp(command, true, envInfo)
 	}
 	// create a context from the internal representation
 	context := &Context{

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -481,7 +481,6 @@ func newDevfileContext(command *cobra.Command) *Context {
 
 		internalCxt.Project = resolveNamespace(command, kClient, envInfo)
 
-		// ignore the "true" for now
 	}
 	// create a context from the internal representation
 	context := &Context{

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -477,7 +477,7 @@ func newDevfileContext(command *cobra.Command) *Context {
 		internalCxt.KClient = kClient
 
 		internalCxt.EnvSpecificInfo = envInfo
-		resolveNamespace(command, kClient, envInfo)
+		internalCxt.Project = resolveNamespace(command, kClient, envInfo)
 
 		// ignore the "true" for now
 		internalCxt.Application = ResolveApp(command, true, envInfo)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -370,8 +370,8 @@ func resolveNamespace(command *cobra.Command, client *kclient.Client, envSpecifi
 	return namespace
 }
 
-// resolveApp resolves the app, the order of precedence being flag > local config > default.
-func resolveApp(command *cobra.Command, createAppIfNeeded bool, localConfiguration envinfo.LocalConfigProvider) string {
+// ResolveApp resolves the app, the order of precedence being flag > local config > default.
+func ResolveApp(command *cobra.Command, createAppIfNeeded bool, localConfiguration envinfo.LocalConfigProvider) string {
 	var app string
 	appFlag := FlagValueIfSet(command, ApplicationFlagName)
 	if len(appFlag) > 0 {
@@ -429,7 +429,7 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 	namespace := resolveProject(command, client, localConfiguration)
 
 	// resolve application
-	app := resolveApp(command, createAppIfNeeded, localConfiguration)
+	app := ResolveApp(command, createAppIfNeeded, localConfiguration)
 
 	// resolve output flag
 	outputFlag := FlagValueIfSet(command, OutputFlagName)
@@ -480,7 +480,7 @@ func newDevfileContext(command *cobra.Command) *Context {
 		resolveNamespace(command, kClient, envInfo)
 
 		// ignore the "true" for now
-		internalCxt.Application = resolveApp(command, true, envInfo)
+		internalCxt.Application = ResolveApp(command, true, envInfo)
 	}
 	// create a context from the internal representation
 	context := &Context{

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -468,7 +468,7 @@ func newDevfileContext(command *cobra.Command) *Context {
 
 	envInfo, err := getValidEnvinfo(command)
 	if err != nil {
-		util.LogErrorAndExit(err, "")
+		util.LogErrorAndExit(err, "unable to retrieve configuration information")
 	}
 
 	if !pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -471,16 +471,17 @@ func newDevfileContext(command *cobra.Command) *Context {
 		util.LogErrorAndExit(err, "unable to retrieve configuration information")
 	}
 
+	internalCxt.EnvSpecificInfo = envInfo
+	internalCxt.Application = ResolveApp(command, true, envInfo)
+
 	if !pushtarget.IsPushTargetDocker() {
 		// create a new kclient
 		kClient := kClient(command)
 		internalCxt.KClient = kClient
 
-		internalCxt.EnvSpecificInfo = envInfo
 		internalCxt.Project = resolveNamespace(command, kClient, envInfo)
 
 		// ignore the "true" for now
-		internalCxt.Application = ResolveApp(command, true, envInfo)
 	}
 	// create a context from the internal representation
 	context := &Context{

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -464,6 +464,8 @@ func newDevfileContext(command *cobra.Command) *Context {
 	internalCxt := internalCxt{
 		OutputFlag: outputFlag,
 		command:    command,
+		// this is only so we can make devfile and s2i work together for certain cases
+		LocalConfigInfo: &config.LocalConfigInfo{},
 	}
 
 	envInfo, err := getValidEnvinfo(command)

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -6,6 +6,7 @@ import (
 
 // TestDevfileData is a convenience data type used to mock up a devfile configuration
 type TestDevfileData struct {
+	Metadata            versionsCommon.DevfileMetadata
 	ComponentType       versionsCommon.DevfileComponentType
 	CommandActions      []versionsCommon.DevfileCommandAction
 	MissingInitCommand  bool
@@ -15,6 +16,10 @@ type TestDevfileData struct {
 // GetComponents is a mock function to get the components from a devfile
 func (d TestDevfileData) GetComponents() []versionsCommon.DevfileComponent {
 	return d.GetAliasedComponents()
+}
+
+func (d *TestDevfileData) GetMetadata() versionsCommon.DevfileMetadata {
+	return d.Metadata
 }
 
 // GetAliasedComponents is a mock function to get the components that have an alias from a devfile

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -18,7 +18,7 @@ func (d TestDevfileData) GetComponents() []versionsCommon.DevfileComponent {
 	return d.GetAliasedComponents()
 }
 
-func (d *TestDevfileData) GetMetadata() versionsCommon.DevfileMetadata {
+func (d TestDevfileData) GetMetadata() versionsCommon.DevfileMetadata {
 	return d.Metadata
 }
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -332,4 +332,66 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
+	Context("push with listing the devfile component", func() {
+
+		It("checks components of default app", func() {
+			helper.Chdir(currentWorkingDirectory)
+
+			// component created in "app" application
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", context)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// component created in different application
+			context2 := helper.CreateNewContext()
+			cmpName2 := cmpName + "2"
+			appName := helper.RandString(6)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--app", appName, "--context", context2, cmpName2)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+
+			output2 := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", context2)
+			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
+
+			output = helper.CmdShouldPass("odo", "list", "--project", namespace)
+			Expect(output).To(ContainSubstring(cmpName))
+			Expect(output).ToNot(ContainSubstring(cmpName2))
+
+		})
+
+		It("checks components of all app", func() {
+			// component created in "app" application
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", context)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// component created in different application
+			context2 := helper.CreateNewContext()
+			cmpName2 := cmpName + "2"
+			appName := helper.RandString(6)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--app", appName, "--context", context2, cmpName2)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+
+			output2 := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--context", context2)
+			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
+
+			output = helper.CmdShouldPass("odo", "list", "--all-apps", "--project", namespace)
+			Expect(output).To(ContainSubstring(cmpName))
+			Expect(output).To(ContainSubstring(cmpName2))
+		})
+
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What does does this PR do / why we need it**:
Adding support for `odo list` showing created devfile components. 
Currently the scope of this PR is not to support `--path` and docker runtime. Support for those flags will be provided as a follow up PR.

This PR contains some major cleanup that 
- removes duplicate env.yaml reads
- optimisations like not listing the devfile catalog when there is a devfile.yaml already present
- redundant checks
- general cleanup

**Which issue(s) this PR fixes**:

partly https://github.com/openshift/odo/issues/2835
fixes https://github.com/openshift/odo/issues/2959

**How to test changes / Special notes to the reviewer**:
Create some devfile components
```
odo list --project <project>
```
for all apps
```
odo list --project <project> --all-apps
```

Then create some s2i components, do
```
odo list --project <project>
```
confirm that both s2i and devfile components are displayed
