### PR TITLE
Updating url delete to apply `--now` on devfile

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -60,6 +60,7 @@ func NewPushOptions() *PushOptions {
 	}
 }
 
+// CompleteDevfilePath completes the devfile path from context
 func (po *PushOptions) CompleteDevfilePath() {
 	if len(po.DevfilePath) > 0 {
 		po.DevfilePath = filepath.Join(po.componentContext, po.DevfilePath)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -60,9 +60,19 @@ func NewPushOptions() *PushOptions {
 	}
 }
 
+func (po *PushOptions) CompleteDevfilePath() {
+	if len(po.DevfilePath) > 0 {
+		po.DevfilePath = filepath.Join(po.componentContext, po.DevfilePath)
+	} else {
+		po.DevfilePath = filepath.Join(po.componentContext, "devfile.yaml")
+	}
+}
+
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.DevfilePath = filepath.Join(po.componentContext, DevfilePath)
+	po.CompleteDevfilePath()
+
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		envInfo, err := envinfo.NewEnvSpecificInfo(po.componentContext)

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -71,7 +71,6 @@ func (po *PushOptions) CompleteDevfilePath() {
 
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	po.DevfilePath = filepath.Join(po.componentContext, DevfilePath)
 	po.CompleteDevfilePath()
 
 	// if experimental mode is enabled and devfile is present

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -48,9 +48,7 @@ func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []stri
 		if err != nil {
 			return err
 		}
-		if o.now {
-			o.CompleteDevfilePath()
-		}
+		o.CompleteDevfilePath()
 	} else {
 		if o.now {
 			o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -164,6 +164,7 @@ func NewCmdURLDelete(name, fullName string) *cobra.Command {
 	}
 	urlDeleteCmd.Flags().BoolVarP(&o.urlForceDeleteFlag, "force", "f", false, "Delete url without prompting")
 	o.AddContextFlag(urlDeleteCmd)
+	urlDeleteCmd.Flags().StringVar(&o.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
 	genericclioptions.AddNowFlag(urlDeleteCmd, &o.now)
 	completion.RegisterCommandHandler(urlDeleteCmd, completion.URLCompletionHandler)
 	completion.RegisterCommandFlagHandler(urlDeleteCmd, "context", completion.FileCompletionHandler)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -171,7 +171,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--ingress", "--devfile", "devfile.yaml")
 			helper.CmdShouldPass("odo", "push")
-			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now")
+			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})
 		})
 

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -165,9 +165,8 @@ var _ = Describe("odo devfile url command tests", func() {
 			var stdout string
 			url1 := helper.RandString(5)
 			host := helper.RandString(5) + ".com"
-
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--ingress", "--devfile", "devfile.yaml")
 			helper.CmdShouldPass("odo", "push")

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -161,6 +161,20 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
 		})
 
+		It("delete with now flag should pass", func() {
+			var stdout string
+			url1 := helper.RandString(5)
+			host := helper.RandString(5) + ".com"
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--ingress", "--devfile", "devfile.yaml")
+			helper.CmdShouldPass("odo", "push")
+			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now")
+			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})
+		})
+
 		It("should create a automatically route on a openShift cluster", func() {
 
 			if os.Getenv("KUBERNETES") == "true" {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -147,7 +147,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			Expect(stdout).To(ContainSubstring("no URLs found"))
 		})
 
-		It("create with now flag should pass", func() {
+		It("create and delete with now flag should pass", func() {
 			var stdout string
 			url1 := helper.RandString(5)
 			host := helper.RandString(5) + ".com"
@@ -159,17 +159,6 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
-		})
-
-		It("delete with now flag should pass", func() {
-			var stdout string
-			url1 := helper.RandString(5)
-			host := helper.RandString(5) + ".com"
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--ingress", "--devfile", "devfile.yaml")
-			helper.CmdShouldPass("odo", "push")
 			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does this PR do / why we need it**:
`--now` flag is being implemented for `odo url delete`

**Which issue(s) this PR fixes**:

Fixes #2804 

**How to test changes / Special notes to the reviewer**:
1. Have a kubernetes cluster
2. export ODO_EXPERIMENTAL=true 
3. Create a devfile component with a url. Make sure it is pushed
4. odo url delete myurl --now

```
❯ odo url delete nodejs-3000 --now --context <redacted>/nodejs-ex-2
I0511 16:34:33.774340   44748 cert_rotation.go:137] Starting client certificate rotation controller
? Are you sure you want to delete the url nodejs-3000 Yes

Validation
 ✓  Validating the devfile [62110ns]

Creating Kubernetes resources for component nodejs
 ✓  Waiting for component to start [1ms]

Applying URL changes
 ✓  URL nodejs-3000 successfully deleted

Syncing to component nodejs
 ✓  Checking file changes for pushing [294793ns]
 ✓  No file changes detected, skipping build. Use the '-f' flag to force the build.

Pushing devfile component nodejs
 ✓  Changes successfully pushed to component


```

TODO: add tests and address any comments