### PR TITLE
Add .gitignore files for jekyll / site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ tags
 
 # Finder Desktop Service
 .DS_Store
+
+# Jekyll / site specific
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind code-refactoring

**What does does this PR do / why we need it**:

Updates the `.gitignore` for html and jekyll information. As I kept
having to `git clean` the dir.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>