### PR TITLE
Support listing devfile components with no devBuild command

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -124,12 +124,9 @@ func IsDevfileComponentSupported(devfile Devfile) bool {
 			hasRunCommand = strings.Contains(command.Name, "devRun")
 		}
 
-		if !hasBuildCommand {
-			hasBuildCommand = strings.Contains(command.Name, "devBuild")
-		}
 	}
 
-	if hasDockerImage && hasAlias && hasBuildCommand && hasRunCommand {
+	if hasDockerImage && hasAlias && hasRunCommand {
 		return true
 	}
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/preference"
@@ -121,7 +122,7 @@ func IsDevfileComponentSupported(devfile Devfile) bool {
 		}
 
 		if !hasRunCommand {
-			hasRunCommand = strings.Contains(command.Name, "devRun")
+			hasRunCommand = strings.Contains(strings.ToLower(command.Name), string(common.DefaultDevfileRunCommand))
 		}
 
 	}

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -53,6 +53,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 				"NAME",
 				"java-spring-boot",
 				"openLiberty",
+				"quarkus",
 				"DESCRIPTION",
 				"REGISTRY",
 				"SUPPORTED",

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -70,6 +70,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 				"NAME",
 				"java-spring-boot",
 				"java-maven",
+				"quarkus",
 				"php-mysql",
 				"DESCRIPTION",
 				"REGISTRY",

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -152,7 +152,8 @@ var _ = Describe("odo devfile create command tests", func() {
 	Context("When executing odo create with component with no devBuild command", func() {
 		It("should successfully create the devfile component", func() {
 			// Quarkus devfile has no devBuild command
-			helper.CmdShouldPass("odo", "create", "quarkus")
+			output := helper.CmdShouldPass("odo", "create", "quarkus")
+			helper.MatchAllInOutput(output, []string{"Please use `odo push` command to create the component with source deployed"})
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -149,6 +149,13 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
+	Context("When executing odo create with component with no devBuild command", func() {
+		It("should successfully create the devfile component", func() {
+			// Quarkus devfile has no devBuild command
+			helper.CmdShouldPass("odo", "create", "quarkus")
+		})
+	})
+
 	// Currently these tests need interactive mode in order to set the name of the component.
 	// Once this feature is added we can change these tests.
 	//Context("When executing odo create with devfile component and --downloadSource flag with github type", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area devfile

**What does does this PR do / why we need it**:
This PR fixes a bug in the `odo catalog list` code, where devfile components with no `devBuild` command were being filtered out. Odo only requires a `devRun` command in the devfile, and so we shouldn't be filtering out devfiles that meet that criteria without having a `devBuild` command.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3170

**How to test changes / Special notes to the reviewer**:
The quarkus devfile that was recently added to https://github.com/elsony/devfile-registry has no `devBuild command, so the following should work with my changes:
- `odo catalog list components` should show the quarkus devfile
- `odo create quarkus` should succeed