### PR TITLE
Update odo docs directory in a docs sync script

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -9,7 +9,7 @@ set -e
 
 tmp_openshift_docs_dir=$(mktemp -d -t odo-upstream-docs-XXXXXXXXXX)
 tmp_public_docs_dir=$(mktemp -d -t odo-public-docs-XXXXXXXXXX)
-odo_doc_directory="/cli_reference/openshift_developer_cli"
+odo_doc_directory="/cli_reference/developer_cli_odo"
 odo_public_doc_dir="/docs/public"
 output_dir=$(mktemp -d -t odo-output-docs-XXXXXXXXXX)
 openshift_docs="chosen-docs/openshift-docs"


### PR DESCRIPTION
Signed-off-by: Yana Hontyk <yhontyk@redhat.com>

> /kind code-refactoring

**What does does this PR do / why we need it**:
Updates the upstream doc directory name.

While getting rid of "OpenShift Do", I also renamed the directory of the docs sources: https://github.com/openshift/openshift-docs/pull/21982

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
