### PR TITLE
JSON output for service list in experimental mode

### DIFF
--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -74,9 +74,16 @@ func (o *ServiceListOptions) Run() (err error) {
 			return err
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		if len(list) == 0 {
+			return fmt.Errorf("No operator backed services found in the namesapce")
+		}
 
-		if len(list) > 0 {
+		if log.IsJSON() {
+			machineoutput.OutputSuccess(list)
+			return
+		} else {
+			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+
 			fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "AGE")
 
 			for _, item := range list {
@@ -84,11 +91,9 @@ func (o *ServiceListOptions) Run() (err error) {
 				fmt.Fprintln(w, item.GetName(), "\t", item.GetKind(), "\t", duration)
 			}
 
-		} else {
-			fmt.Fprintln(w, "No operator backed services found in the namesapce")
-		}
+			w.Flush()
 
-		w.Flush()
+		}
 
 		return err
 	}

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -209,9 +209,7 @@ spec:
 
 			// now check for json output
 			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-			Expect(jsonOut).To(ContainSubstring("\"apiVersion\": \"etcd.database.coreos.com/v1beta2\""))
-			Expect(jsonOut).To(ContainSubstring("\"kind\": \"EtcdCluster\""))
-			Expect(jsonOut).To(ContainSubstring("\"name\": \"example3\""))
+			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example3\""})
 
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
@@ -222,8 +220,7 @@ spec:
 			stdOut = helper.CmdShouldFail("odo", "service", "list")
 			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
 			Expect(stdOut).To(ContainSubstring("No operator backed services found in the namesapce"))
-			Expect(jsonOut).To(ContainSubstring("No operator backed services found in the namesapce"))
-			Expect(jsonOut).To(ContainSubstring("\"message\": \"No operator backed services found in the namesapce\""))
+			helper.MatchAllInOutput(jsonOut, []string{"No operator backed services found in the namesapce", "\"message\": \"No operator backed services found in the namesapce\""})
 		})
 	})
 })

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -207,14 +207,23 @@ spec:
 			Expect(stdOut).To(ContainSubstring("example"))
 			Expect(stdOut).To(ContainSubstring("EtcdCluster"))
 
+			// now check for json output
+			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+			Expect(jsonOut).To(ContainSubstring("\"apiVersion\": \"etcd.database.coreos.com/v1beta2\""))
+			Expect(jsonOut).To(ContainSubstring("\"kind\": \"EtcdCluster\""))
+			Expect(jsonOut).To(ContainSubstring("\"name\": \"example3\""))
+
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
 			// services yet.
 			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example3")
 
 			// Now let's check the output again to ensure expected behaviour
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
+			stdOut = helper.CmdShouldFail("odo", "service", "list")
+			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
 			Expect(stdOut).To(ContainSubstring("No operator backed services found in the namesapce"))
+			Expect(jsonOut).To(ContainSubstring("No operator backed services found in the namesapce"))
+			Expect(jsonOut).To(ContainSubstring("\"message\": \"No operator backed services found in the namesapce\""))
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
Adds support for `odo service list -o json` in experimental mode.
Need it because it is required by odo consumers like IDE plugin folks.

**Which issue(s) this PR fixes**:

Fixes #2790 (2nd acceptance criteria)

**How to test changes / Special notes to the reviewer**:
- In experimental mode, [start an operator backed service](https://github.com/openshift/odo/blob/master/docs/public/operator-hub.adoc#deploying-etcd-to-a-cluster).
- Execute `odo service list -o json`.