### PR TITLE
Setting golang version uniformly accross repo and updating docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     - &base-test
       stage: test
       go_import_path: github.com/openshift/odo
-      go: "1.13.1"
+      go: "1.12.x"
       install:
         - make goget-tools
       script:
@@ -38,7 +38,7 @@ jobs:
       init:
       - git config --system core.longpaths true
       go_import_path: github.com/openshift/odo
-      go: "1.13.1"
+      go: "1.12.x"
       install:
         - systeminfo.exe | grep '^OS'
         - choco install make
@@ -57,7 +57,7 @@ jobs:
       os:
         - osx
       go_import_path: github.com/openshift/odo
-      go: "1.13.1"
+      go: "1.12.x"
       install:
         - make goget-tools
       script:

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing the Linux, Mac and Windows version of odo
 # layered on top of the ubi7/ubi image.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
 COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -7,14 +7,14 @@ toc::[]
 
 == Setting up
 
-[Golang Version]
-====
-
 Requires *Go 1.12*
 
 Testing and release builds happen with the above version. Developers are advised to stick to this version if they can but it is not compulsory.
 
-WARNING: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
+
+[WARNING]
+====
+If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
 
 .List of files to update for golang version
  * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -14,7 +14,7 @@ Testing and release builds happen with the above version. Developers are advised
 
 [WARNING]
 ====
-If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
+If you are adding any features that require a higher version of golang, than the one mentioned above, please contact the maintainers in order to check if the releasing systems can handle the newer version. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
 
 .List of files to update for golang version
  * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -16,7 +16,7 @@ Testing and release builds happen with the above version. Developers are advised
 
 WARNING: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
 
- .List of files to update for golang version
+.List of files to update for golang version
  * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]
  * link:/.travis.yml[`.travis.yml`]
  * link:/Dockerfile.rhel[`Dockerfile.rhel`]

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -7,9 +7,14 @@ toc::[]
 
 == Setting up
 
+[Golang Version]
+====
+
 Requires *Go 1.12*
 
-**WARNING**: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions.
+Testing and release builds happen with the above version. Developers are advised to stick to this version if they can but it is not compulsory.
+
+If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions.
 
 If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
 
@@ -17,6 +22,7 @@ If that is ok, please ensure you update the required golang version, both here a
  * link:/.travis.yml[`.travis.yml`]
  * link:/Dockerfile.rhel[`Dockerfile.rhel`]
  * link:/openshift-ci/build-root/Dockerfile[`openshift-ci/build-root/Dockerfile`]
+====
 
  First setup your fork of the odo project, following the steps below
 

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -9,10 +9,16 @@ toc::[]
 
 Requires *Go 1.12*
 
-**WARNING**: If you are adding any features that require a higher version of golang, such as golang 1.13
-for example, please contact maintainers to check of the releasing systems can handle the newer versions.
+**WARNING**: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions.
 
-If that is ok, please ensure you update the required golang version, both here and in the file link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]
+If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
+
+ * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]
+ * link:/.travis.yml[`.travis.yml`]
+ * link:/Dockerfile.rhel[`Dockerfile.rhel`]
+ * link:/openshift-ci/build-root/Dockerfile[`openshift-ci/build-root/Dockerfile`]
+
+ First setup your fork of the odo project, following the steps below
 
  . link:https://help.github.com/en/articles/fork-a-repo[Fork] the link:https://github.com/openshift/odo[`odo`] repository.
 

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -14,10 +14,7 @@ Requires *Go 1.12*
 
 Testing and release builds happen with the above version. Developers are advised to stick to this version if they can but it is not compulsory.
 
-If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions.
-
-If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
-
+NOTE: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
  * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]
  * link:/.travis.yml[`.travis.yml`]
  * link:/Dockerfile.rhel[`Dockerfile.rhel`]

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -14,7 +14,9 @@ Requires *Go 1.12*
 
 Testing and release builds happen with the above version. Developers are advised to stick to this version if they can but it is not compulsory.
 
-NOTE: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
+WARNING: If you are adding any features that require a higher version of golang, that the one mentioned above, please contact maintainers to check of the releasing systems can handle the newer versions. If that is ok, please ensure you update the required golang version, both here and in the files below, in your PR.
+
+ .List of files to update for golang version
  * link:/scripts/rpm-prepare.sh[`scripts/rpm-prepare.sh`]
  * link:/.travis.yml[`.travis.yml`]
  * link:/Dockerfile.rhel[`Dockerfile.rhel`]

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -24,7 +24,7 @@ If that is ok, please ensure you update the required golang version, both here a
  * link:/openshift-ci/build-root/Dockerfile[`openshift-ci/build-root/Dockerfile`]
 ====
 
- First setup your fork of the odo project, following the steps below
+First setup your fork of the odo project, following the steps below
 
  . link:https://help.github.com/en/articles/fork-a-repo[Fork] the link:https://github.com/openshift/odo[`odo`] repository.
 

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
 
 RUN yum -y install make wget gcc git httpd-tools
 


### PR DESCRIPTION
 - All golang version references now uniformly updated to 1.12
 - Adding all golang version references to development.adoc

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>
/kind code-refactoring
/kind documentation

**Which issue(s) this PR fixes**:

Fixes #3023 
