### PR TITLE
Run devfile docker url tests without kube config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ jobs:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
-        - travis_wait make test-cmd-docker-devfile-url
+        - travis_wait test-cmd-docker-devfile-url-pushtarget
         # These tests need cluster login as they will be interacting with a Kube environment
         - odo login -u developer
         - travis_wait make test-cmd-devfile-catalog
@@ -169,6 +169,7 @@ jobs:
         - travis_wait make test-cmd-docker-devfile-push
         - travis_wait make test-cmd-docker-devfile-catalog
         - travis_wait make test-cmd-docker-devfile-delete
+        - travis_wait make test-cmd-docker-devfile-url
 
     # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ jobs:
         - ./scripts/oc-cluster.sh
         - make bin
         - sudo cp odo /usr/bin
-        - travis_wait test-cmd-docker-devfile-url-pushtarget
+        - travis_wait make test-cmd-docker-devfile-url-pushtarget
         # These tests need cluster login as they will be interacting with a Kube environment
         - odo login -u developer
         - travis_wait make test-cmd-devfile-catalog

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ test-cmd-docker-devfile-catalog:
 
 # Run odo url docker devfile command tests
 .PHONY: test-cmd-docker-devfile-url-pushtarget
-test-cmd-docker-devfile-url:
+test-cmd-docker-devfile-url-pushtarget:
 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url pushtarget command tests" tests/integration/devfile/docker/
 
 # Run odo watch command tests

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,11 @@ test-cmd-docker-devfile-delete:
 test-cmd-docker-devfile-catalog:
 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile catalog command tests" tests/integration/devfile/docker/
 
+# Run odo url docker devfile command tests
+.PHONY: test-cmd-docker-devfile-url-pushtarget
+test-cmd-docker-devfile-url:
+	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url pushtarget command tests" tests/integration/devfile/docker/
+
 # Run odo watch command tests
 .PHONY: test-cmd-watch
 test-cmd-watch:

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_pushtarget_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_pushtarget_test.go
@@ -1,0 +1,82 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/openshift/odo/tests/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo docker devfile url pushtarget command tests", func() {
+	var context, currentWorkingDirectory, cmpName string
+	dockerClient := helper.NewDockerRunner("docker")
+
+	// This is run after every Spec (It)
+	var _ = BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Minute)
+		context = helper.CreateNewContext()
+		currentWorkingDirectory = helper.Getwd()
+		cmpName = helper.RandString(6)
+		helper.Chdir(context)
+		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
+		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+		helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker")
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		// Stop all containers labeled with the component name
+		label := "component=" + cmpName
+		dockerClient.StopContainers(label)
+
+		helper.Chdir(currentWorkingDirectory)
+		helper.DeleteDir(context)
+		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	// These tests require an active kube context *and* Docker daemon, so keeping them separate
+	// from the other Docker URL tests which only require Docker.
+	Context("Switching pushtarget", func() {
+		It("switch from docker to kube, odo push should display warning", func() {
+			var stdout string
+
+			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "url", "create")
+
+			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
+			session := helper.CmdRunner("odo", "push", "--devfile", "devfile.yaml")
+			stdout = string(session.Wait().Out.Contents())
+			stderr := string(session.Wait().Err.Contents())
+			Expect(stderr).To(ContainSubstring("Found a URL defined for Docker, but no valid URLs for Kubernetes."))
+			Expect(stdout).To(ContainSubstring("Changes successfully pushed to component"))
+		})
+
+		It("switch from kube to docker, odo push should display warning", func() {
+			var stdout string
+			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
+			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "url", "create", "--host", "1.2.3.4.com", "--ingress")
+
+			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker", "-f")
+			session := helper.CmdRunner("odo", "push", "--devfile", "devfile.yaml")
+			stdout = string(session.Wait().Out.Contents())
+			stderr := string(session.Wait().Err.Contents())
+			Expect(stderr).To(ContainSubstring("Found a URL defined for Kubernetes, but no valid URLs for Docker."))
+			Expect(stdout).To(ContainSubstring("Changes successfully pushed to component"))
+		})
+	})
+
+})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
@@ -103,44 +103,6 @@ var _ = Describe("odo docker devfile url command tests", func() {
 		})
 	})
 
-	Context("Switching pushtarget", func() {
-		It("switch from docker to kube, odo push should display warning", func() {
-			var stdout string
-
-			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			helper.CmdShouldPass("odo", "url", "create")
-
-			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
-			session := helper.CmdRunner("odo", "push", "--devfile", "devfile.yaml")
-			stdout = string(session.Wait().Out.Contents())
-			stderr := string(session.Wait().Err.Contents())
-			Expect(stderr).To(ContainSubstring("Found a URL defined for Docker, but no valid URLs for Kubernetes."))
-			Expect(stdout).To(ContainSubstring("Changes successfully pushed to component"))
-		})
-
-		It("switch from kube to docker, odo push should display warning", func() {
-			var stdout string
-			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "kube", "-f")
-			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			helper.CmdShouldPass("odo", "url", "create", "--host", "1.2.3.4.com", "--ingress")
-
-			helper.CmdShouldPass("odo", "preference", "set", "pushtarget", "docker", "-f")
-			session := helper.CmdRunner("odo", "push", "--devfile", "devfile.yaml")
-			stdout = string(session.Wait().Out.Contents())
-			stderr := string(session.Wait().Err.Contents())
-			Expect(stderr).To(ContainSubstring("Found a URL defined for Kubernetes, but no valid URLs for Docker."))
-			Expect(stdout).To(ContainSubstring("Changes successfully pushed to component"))
-		})
-	})
-
 	Context("Listing urls", func() {
 		It("should list url with appropriate state", func() {
 			var stdout string


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup
/area devfile

**What does does this PR do / why we need it**:
Currently, the Docker `odo url` tests require both a Docker daemon **and** a Kube config to run, because of a couple tests that test switching back and forth from a Kube pushtarget and a Docker pushtarget. This means that [bugs that occur when there's no Kube config, go unnoticed](https://github.com/openshift/odo/issues/3074). 

To fix this, I've separated out those test cases to their own test file (`cmd_docker_devfile_url_pushtarget_test.go`) that will run alongside the devfile Kube tests on Travis (where Docker and a Kube config is available). Then I moved the remaining `odo url` Docker tests to run in a kube-less environment (where the rest of the Docker tests currently run)

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3148

**How to test changes / Special notes to the reviewer**:
- `make test-cmd-docker-devfile-url`
- `make test-cmd-docker-devfile-url-pushtarget`