### PR TITLE
Fix #2707 : `odo catalog list components -o json` does not have `imageStreamRef` in json output after update from v1.0.x to v1.1.0

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -443,7 +443,7 @@ func SliceSupportedTags(component ComponentType) ([]string, []string) {
 
 	// this makes sure that json marshal shows these lists as [] instead of null
 	supTag, unSupTag := []string{}, []string{}
-	tagMap := createImageTagMap(component.Spec.ImageStreamRef.Spec.Tags)
+	tagMap := createImageTagMap(component.Spec.ImageStreamTags)
 
 	for _, tag := range component.Spec.NonHiddenTags {
 		imageName := tagMap[tag]
@@ -586,9 +586,9 @@ func getBuildersFromImageStreams(imageStreams []imagev1.ImageStream, imageStream
 					Namespace: imageStream.Namespace,
 				},
 				Spec: ComponentSpec{
-					AllTags:        allTags,
-					NonHiddenTags:  getAllNonHiddenTags(allTags, hiddenTags),
-					ImageStreamRef: imageStream,
+					AllTags:         allTags,
+					NonHiddenTags:   getAllNonHiddenTags(allTags, hiddenTags),
+					ImageStreamTags: imageStream.Spec.Tags,
 				},
 			}
 			builderImages = append(builderImages, catalogImage)

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -159,7 +159,7 @@ func TestSliceSupportedTags(t *testing.T) {
 			NonHiddenTags: []string{
 				"12", "10", "8", "6", "latest",
 			},
-			ImageStreamRef: *imageStream,
+			ImageStreamTags: (*imageStream).Spec.Tags,
 		},
 	}
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -58,10 +58,10 @@ type Devfile struct {
 
 // ComponentSpec is the spec for ComponentType
 type ComponentSpec struct {
-	AllTags        []string            `json:"allTags"`
-	NonHiddenTags  []string            `json:"nonHiddenTags"`
-	SupportedTags  []string            `json:"supportedTags"`
-	ImageStreamRef imagev1.ImageStream `json:"-"`
+	AllTags         []string               `json:"allTags"`
+	NonHiddenTags   []string               `json:"nonHiddenTags"`
+	SupportedTags   []string               `json:"supportedTags"`
+	ImageStreamTags []imagev1.TagReference `json:"imageStreamTags"`
 }
 
 // ComponentTypeList lists all the ComponentType's


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**: 
Undoes the change made/bug added in PR  #2451

**Which issue(s) this PR fixes**:
 Fixes #2707