### PR TITLE
replace secured with secure

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -53,8 +53,8 @@ var (
 	# Create a URL of ingress kind for the current component with a host (using CRC as an example)
 	%[1]s --host apps-crc.testing --ingress
 
-	# Create a secured URL for the current component with a specific host (using CRC as an example)
-	%[1]s --host apps-crc.testing --secured
+	# Create a secure URL for the current component with a specific host (using CRC as an example)
+	%[1]s --host apps-crc.testing --secure
 	  `)
 
 	urlCreateExampleDocker = ktemplates.Examples(`  # Create a URL with a specific name by automatically detecting the port used by the component


### PR DESCRIPTION
A typo existing in sample file


/kind bug

[skip ci]
no need to CI as it's modify sample output and the real test cases for `secure` is correct using
no need to add additionl test
**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #3237 

**How to test changes / Special notes to the reviewer**:
