### PR TITLE
Modify operator hub tests to run in separate namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,4 +339,4 @@ openshiftci-presubmit-unittests:
 # Run OperatorHub tests
 .PHONY: test-operator-hub
 test-operator-hub:
-	ginkgo $(GINKGO_FLAGS) -focus="odo service command tests" tests/integration/operatorhub/
+	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo service command tests" tests/integration/operatorhub/

--- a/scripts/setup-operators.sh
+++ b/scripts/setup-operators.sh
@@ -28,9 +28,9 @@ install_etcd_operator(){
   kind: Subscription
   metadata:
     name: etcd
-    namespace: ${OPERATOR_HUB_PROJECT}
+    namespace: openshift-operators
   spec:
-    channel: singlenamespace-alpha
+    channel: clusterwide-alpha
     installPlanApproval: Automatic
     name: etcd
     source: community-operators
@@ -51,25 +51,11 @@ do
     fi
 done
 
-# Now onto namespace bound operator
-# Create OperatorGroup
-oc create -f - <<EOF
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  generateName: ${CI_OPERATOR_HUB_PROJECT}-
-  generation: 1
-  namespace: ${CI_OPERATOR_HUB_PROJECT}
-spec:
-  targetNamespaces:
-  - ${CI_OPERATOR_HUB_PROJECT}
-EOF
-
 # install etcd operator
 count=0
 while [ "$count" -lt "5" ];
 do
-    if oc get csv -n ${CI_OPERATOR_HUB_PROJECT} | grep etcd; then
+    if oc get csv -n openshift-operators | grep etcd; then
         break
     else
         install_etcd_operator

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -32,18 +32,12 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		// wait till oc can see the all operators installed by setup script in the namespace
 		ocArgs := []string{"get", "csv"}
 		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-			return strings.Contains(output, "NAME")
-		}, true)
-
-		ocArgs = []string{"get", "csv"}
-		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 			return strings.Contains(output, "etcd")
-		}, true)
+		})
 
-		ocArgs = []string{"get", "csv"}
 		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 			return strings.Contains(output, "mongo")
-		}, true)
+		})
 	}
 
 	cleanPreSetup := func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -14,21 +14,68 @@ import (
 	"github.com/openshift/odo/tests/helper"
 )
 
-const (
-	CI_OPERATOR_HUB_PROJECT = "ci-operator-hub-project"
-)
-
 var _ = Describe("odo service command tests for OperatorHub", func() {
+
+	var project string
 
 	BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		SetDefaultConsistentlyDuration(30 * time.Second)
-		helper.CmdShouldPass("odo", "project", "set", CI_OPERATOR_HUB_PROJECT)
 		// TODO: remove this when OperatorHub integration is fully baked into odo
 		os.Setenv("ODO_EXPERIMENTAL", "true")
 	})
 
+	preSetup := func() {
+		project = helper.CreateRandProject()
+		helper.CmdShouldPass("odo", "project", "set", project)
+
+		// wait till oc can see the all operators installed by setup script in the namespace
+		ocArgs := []string{"get", "csv"}
+		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+			return strings.Contains(output, "NAME")
+		}, true)
+
+		ocArgs = []string{"get", "csv"}
+		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+			return strings.Contains(output, "etcd")
+		}, true)
+
+		ocArgs = []string{"get", "csv"}
+		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+			return strings.Contains(output, "mongo")
+		}, true)
+	}
+
+	cleanPreSetup := func() {
+		helper.DeleteProject(project)
+	}
+
+	createEtcdClusterService := func() {
+		operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+		etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+		helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
+
+		// now verify if the pods for the operator have started
+		pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+		// Look for pod with example name because that's the name etcd will give to the pods.
+		etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+		ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+			return strings.Contains(output, "Running")
+		})
+	}
+
 	Context("When experimental mode is enabled", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			Expect(stdOut).To(ContainSubstring("Operators available in the cluster"))
@@ -38,21 +85,17 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 	})
 
 	Context("When creating an operator backed service", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("should be able to create EtcdCluster from its alm example", func() {
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
-
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
-
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", CI_OPERATOR_HUB_PROJECT}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
-			})
+			createEtcdClusterService()
 
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
@@ -62,10 +105,19 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 	})
 
 	Context("When using dry-run option to create operator backed service", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("should only output the definition of the CR that will be used to start service", func() {
 			// First let's grab the etcd operator's name from "odo catalog list services" output
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
 			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
 			Expect(stdOut).To(ContainSubstring("apiVersion"))
@@ -74,21 +126,21 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 	})
 
 	Context("When using from-file option", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("should be able to create a service", func() {
 			// First let's grab the etcd operator's name from "odo catalog list services" output
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
 			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
-
-			// change the metadata.name from example to example2 so that we can run tests parallely
-			lines := strings.Split(stdOut, "\n")
-			for i, line := range lines {
-				if strings.Contains(line, "name: example") {
-					lines[i] = strings.Replace(lines[i], "example", "example2", 1)
-				}
-			}
-			stdOut = strings.Join(lines, "\n")
 
 			// stdOut contains the yaml specification. Store it to a file
 			randomFileName := helper.RandString(6) + ".yaml"
@@ -101,11 +153,11 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
 
 			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
 			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example2-.[a-z0-9]*`).FindString(pods)
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
 
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", CI_OPERATOR_HUB_PROJECT}
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "Running")
 			})
@@ -113,7 +165,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
 			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example2")
+			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
 		})
 
 		It("should fail to create service if metadata doesn't exist or is invalid", func() {
@@ -159,6 +211,15 @@ spec:
 	})
 
 	Context("JSON output", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("listing catalog of services", func() {
 			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
 			Expect(jsonOut).To(ContainSubstring("mongodb-enterprise"))
@@ -167,58 +228,34 @@ spec:
 	})
 
 	Context("When operator backed services are created", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
 		It("should list the services if they exist", func() {
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]`).FindString(operators)
+			createEtcdClusterService()
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
-
-			// change the metadata.name from example to example3 so that we can run tests parallely
-			lines := strings.Split(stdOut, "\n")
-			for i, line := range lines {
-				if strings.Contains(line, "name: example") {
-					lines[i] = strings.Replace(lines[i], "example", "example3", 1)
-				}
-			}
-			stdOut = strings.Join(lines, "\n")
-
-			// stdOut contains the yaml specification. Store it to a file
-			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join("/tmp", randomFileName)
-			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", CI_OPERATOR_HUB_PROJECT)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example3-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", CI_OPERATOR_HUB_PROJECT}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
-			})
-
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
 			Expect(stdOut).To(ContainSubstring("example"))
 			Expect(stdOut).To(ContainSubstring("EtcdCluster"))
 
 			// now check for json output
 			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example3\""})
+			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
 
 			// Delete the pods created. This should idealy be done by `odo
 			// service delete` but that's not implemented for operator backed
 			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example3")
+			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
 
 			// Now let's check the output again to ensure expected behaviour
-			stdOut = helper.CmdShouldFail("odo", "service", "list")
-			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
+			stdOut = helper.CmdShouldFail("odo", "service", "list", "--project", project)
+			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json", "--project", project)
 			Expect(stdOut).To(ContainSubstring("No operator backed services found in the namesapce"))
 			helper.MatchAllInOutput(jsonOut, []string{"No operator backed services found in the namesapce", "\"message\": \"No operator backed services found in the namesapce\""})
 		})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -30,13 +30,12 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		// wait till oc can see the all operators installed by setup script in the namespace
 		ocArgs := []string{"get", "csv"}
-		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-			return strings.Contains(output, "etcd")
-		})
-
-		helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-			return strings.Contains(output, "mongo")
-		})
+		operators := []string{"etcd", "mongodb"}
+		for _, operator := range operators {
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, operator)
+			})
+		}
 	}
 
 	cleanPreSetup := func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What does does this PR do / why we need it**:
This PR ensures that each test spec for operator hub is run in a
separate namespace. This is needed because these tests were written in a
stringent fashion which tied the hands while writing additional tests
for the feature.

This PR should help take the tests out of the "odo test statistics"
dashboard.

**Which issue(s) this PR fixes**:

Fixes #3193

**How to test changes / Special notes to the reviewer**:
* CI should pass. Specially for Operator Hub tests under
`tests/integration/operatorhub`.
* Looks at the review comments I've made for clarification