### PR TITLE
Don't prompt for namespace if pushtarget is Docker

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -368,7 +368,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			// Component namespace: User needs to specify component namespace,
 			// by default it is the current active namespace if it can't get from --project flag or --namespace flag
-			if len(co.devfileMetadata.componentNamespace) == 0 {
+			if len(co.devfileMetadata.componentNamespace) == 0 && !pushtarget.IsPushTargetDocker() {
 				if cmd.Flags().Changed("project") {
 					componentNamespace, err = cmd.Flags().GetString("project")
 					if err != nil {
@@ -399,7 +399,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			}
 
 			// Component namespace: Get from --project flag or --namespace flag, by default it is the current active namespace
-			if len(co.devfileMetadata.componentNamespace) == 0 {
+			if len(co.devfileMetadata.componentNamespace) == 0 && !pushtarget.IsPushTargetDocker() {
 				if cmd.Flags().Changed("project") {
 					componentNamespace, err = cmd.Flags().GetString("project")
 					if err != nil {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
This PR removes the prompt for the user to enter a namespace when running `odo create` with the pushtarget set to Docker. Since no namespaces are used in odo's Docker support, we don't need to prompt for it.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2978

**How to test changes / Special notes to the reviewer**:
1. Set pushtarget to Docker
2. `odo create`
You should not be prompted to enter a namespace