### PR TITLE
Replace multiple expect statement with MatchAllInOutput and DontMatchAllInOutput

### DIFF
--- a/tests/e2escenarios/e2e_beta_test.go
+++ b/tests/e2escenarios/e2e_beta_test.go
@@ -75,7 +75,13 @@ var _ = Describe("odo core beta flow", func() {
 		helper.CmdShouldPass(odo, append([]string{"push"}, extraArgs...)...)
 
 		dcSession := oc.GetComponentDC("mycomponent", "myapp", project)
-		helper.MatchAllInOutput(dcSession, []string{"app.kubernetes.io/instance: mycomponent", "app.kubernetes.io/component-source-type: local", "app.kubernetes.io/name: java", "app.kubernetes.io/part-of: myapp", "name: mycomponent-myapp"})
+		helper.MatchAllInOutput(dcSession, []string{
+			"app.kubernetes.io/instance: mycomponent",
+			"app.kubernetes.io/component-source-type: local",
+			"app.kubernetes.io/name: java",
+			"app.kubernetes.io/part-of: myapp",
+			"name: mycomponent-myapp",
+		})
 
 		// DC should have env variable
 		helper.MatchAllInOutput(dcSession, []string{"name: FOO", "value: bar"})

--- a/tests/e2escenarios/e2e_beta_test.go
+++ b/tests/e2escenarios/e2e_beta_test.go
@@ -75,19 +75,14 @@ var _ = Describe("odo core beta flow", func() {
 		helper.CmdShouldPass(odo, append([]string{"push"}, extraArgs...)...)
 
 		dcSession := oc.GetComponentDC("mycomponent", "myapp", project)
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/instance: mycomponent"))
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/component-source-type: local"))
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/name: java"))
-		Expect(dcSession).Should(ContainSubstring("app.kubernetes.io/part-of: myapp"))
-		Expect(dcSession).Should(ContainSubstring("name: mycomponent-myapp"))
+		helper.MatchAllInOutput(dcSession, []string{"app.kubernetes.io/instance: mycomponent", "app.kubernetes.io/component-source-type: local", "app.kubernetes.io/name: java", "app.kubernetes.io/part-of: myapp", "name: mycomponent-myapp"})
+
 		// DC should have env variable
-		Expect(dcSession).Should(ContainSubstring("name: FOO"))
-		Expect(dcSession).Should(ContainSubstring("value: bar"))
+		helper.MatchAllInOutput(dcSession, []string{"name: FOO", "value: bar"})
 
 		routeSession := oc.GetComponentRoutes("mycomponent", "myapp", project)
 		// check that route is pointing gto right port and component
-		Expect(routeSession).Should(ContainSubstring("targetPort: 8080"))
-		Expect(routeSession).Should(ContainSubstring("name: mycomponent-myapp"))
+		helper.MatchAllInOutput(routeSession, []string{"targetPort: 8080", "name: mycomponent-myapp"})
 		url := oc.GetFirstURL("mycomponent", "myapp", project)
 		helper.HttpWaitFor("http://"+url, "Hello World from Javalin!", 10, 5)
 	}

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -65,10 +65,7 @@ var _ = Describe("odo preference and config command tests", func() {
 		})
 		It("should get the default global config keys", func() {
 			configOutput := helper.CmdShouldPass("odo", "preference", "view")
-			Expect(configOutput).To(ContainSubstring("UpdateNotification"))
-			Expect(configOutput).To(ContainSubstring("NamePrefix"))
-			Expect(configOutput).To(ContainSubstring("Timeout"))
-			Expect(configOutput).To(ContainSubstring("PushTarget"))
+			helper.MatchAllInOutput(configOutput, []string{"UpdateNotification", "NamePrefix", "Timeout", "PushTarget"})
 			updateNotificationValue := helper.GetPreferenceValue("UpdateNotification")
 			Expect(updateNotificationValue).To(BeEmpty())
 			namePrefixValue := helper.GetPreferenceValue("NamePrefix")
@@ -289,8 +286,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.CmdShouldPass("odo", "config", "unset", "--env", "PORT", "--context", context)
 			helper.CmdShouldPass("odo", "config", "unset", "--env", "SECRET_KEY", "--context", context)
 			configValue := helper.CmdShouldPass("odo", "config", "view", "--context", context)
-			Expect(configValue).To(Not(ContainSubstring(("PORT"))))
-			Expect(configValue).To(Not(ContainSubstring(("SECRET_KEY"))))
+			helper.DontMatchAllInOutput(configValue, []string{"PORT", "SECRET_KEY"})
 		})
 		It("should check for existence of environment variable in config before unsetting it", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
@@ -322,8 +318,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			kubeconfigOld := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
 			configValue := helper.CmdShouldPass("odo", "config", "view", "--context", context)
-			Expect(configValue).To(ContainSubstring("hello"))
-			Expect(configValue).To(ContainSubstring("world"))
+			helper.MatchAllInOutput(configValue, []string{"hello", "world"})
 			os.Setenv("KUBECONFIG", kubeconfigOld)
 		})
 

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -150,8 +150,7 @@ var _ = Describe("odo push command tests", func() {
 			dir := envs["ODO_S2I_DEPLOYMENT_DIR"]
 
 			stdOut := oc.ExecListDir(podName, project, dir)
-			Expect(stdOut).To(ContainSubstring(("foobar.txt")))
-			Expect(stdOut).To(ContainSubstring(("testdir")))
+			helper.MatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 
 			// Now we delete the file and dir and push
 			helper.DeleteDir(newFilePath)
@@ -160,8 +159,7 @@ var _ = Describe("odo push command tests", func() {
 
 			// Then check to see if it's truly been deleted
 			stdOut = oc.ExecListDir(podName, project, dir)
-			Expect(stdOut).To(Not(ContainSubstring(("foobar.txt"))))
-			Expect(stdOut).To(Not(ContainSubstring(("testdir"))))
+			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 		})
 
 		It("should build when a new file and a new folder is added in the directory", func() {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -237,7 +237,14 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "URL,0,Name,url-1")
 			cmpDescribe := helper.CmdShouldPass("odo", append(args, "describe", "--context", context)...)
-			helper.MatchAllInOutput(cmpDescribe, []string{"cmp-git", "nodejs", "url-1", "url-2", "https://github.com/openshift/nodejs-ex", "storage-1"})
+			helper.MatchAllInOutput(cmpDescribe, []string{
+				"cmp-git",
+				"nodejs",
+				"url-1",
+				"url-2",
+				"https://github.com/openshift/nodejs-ex",
+				"storage-1",
+			})
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -210,8 +210,7 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "MinCPU,100m")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context)...)
-			Expect(cmpList).To(ContainSubstring("cmp-git"))
-			Expect(cmpList).To(ContainSubstring("Not Pushed"))
+			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "Not Pushed"})
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 		It("should list the state as unknown for disconnected cluster", func() {
@@ -220,8 +219,7 @@ func componentTests(args ...string) {
 			kubeconfigOrig := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context, "--v", "9")...)
-			Expect(cmpList).To(ContainSubstring("cmp-git"))
-			Expect(cmpList).To(ContainSubstring("Unknown"))
+			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "Unknown"})
 			// KUBECONFIG defaults to ~/.kube/config so it can be empty in some cases.
 			if kubeconfigOrig != "" {
 				os.Setenv("KUBECONFIG", kubeconfigOrig)
@@ -239,13 +237,7 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "URL,0,Name,url-1")
 			cmpDescribe := helper.CmdShouldPass("odo", append(args, "describe", "--context", context)...)
-
-			Expect(cmpDescribe).To(ContainSubstring("cmp-git"))
-			Expect(cmpDescribe).To(ContainSubstring("nodejs"))
-			Expect(cmpDescribe).To(ContainSubstring("url-1"))
-			Expect(cmpDescribe).To(ContainSubstring("url-2"))
-			Expect(cmpDescribe).To(ContainSubstring("https://github.com/openshift/nodejs-ex"))
-			Expect(cmpDescribe).To(ContainSubstring("storage-1"))
+			helper.MatchAllInOutput(cmpDescribe, []string{"cmp-git", "nodejs", "url-1", "url-2", "https://github.com/openshift/nodejs-ex", "storage-1"})
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "describe", "-o", "json", "--context", context)...))
 			Expect(err).Should(BeNil())
@@ -290,11 +282,7 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git-2", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context2, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context2, "Type,nodejs", "Name,cmp-git-2", "Application,testing")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context2)...)
-
-			Expect(cmpList).To(ContainSubstring("cmp-git"))
-			Expect(cmpList).To(ContainSubstring("cmp-git-2"))
-			Expect(cmpList).To(ContainSubstring("Not Pushed"))
-			Expect(cmpList).To(ContainSubstring("Pushed"))
+			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "cmp-git-2", "Not Pushed", "Pushed"})
 
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context2)...)
@@ -305,8 +293,7 @@ func componentTests(args ...string) {
 
 			// Since components catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			Expect(output).To(ContainSubstring("List"))
-			Expect(output).To(ContainSubstring("supportedTags"))
+			helper.MatchAllInOutput(output, []string{"List", "supportedTags"})
 		})
 
 		It("binary component should not fail when --context is not set", func() {
@@ -668,9 +655,7 @@ func componentTests(args ...string) {
 			cmpListOutput := helper.CmdShouldPass("odo", append(args, "list")...)
 			Expect(cmpListOutput).To(ContainSubstring(cmpName))
 			cmpDescribe := helper.CmdShouldPass("odo", append(args, "describe")...)
-
-			Expect(cmpDescribe).To(ContainSubstring(cmpName))
-			Expect(cmpDescribe).To(ContainSubstring("nodejs"))
+			helper.MatchAllInOutput(cmpDescribe, []string{cmpName, "nodejs"})
 
 			url := helper.DetermineRouteURL(context)
 			Expect(cmpDescribe).To(ContainSubstring(url))

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -192,7 +192,11 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command \"echo hello",
+				"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 		})
 
 		It("should execute devinit and devrun commands if present", func() {
@@ -202,7 +206,10 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init-without-build.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command \"echo hello",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 		})
 
 		It("should only execute devinit command once if component is already created", func() {
@@ -212,12 +219,19 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command \"echo hello",
+				"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 
 			// Need to force so build and run get triggered again with the component already created.
 			output = helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace, "-f")
 			Expect(output).NotTo(ContainSubstring("Executing devinit command \"echo hello"))
-			helper.MatchAllInOutput(output, []string{"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 		})
 
 		It("should be able to handle a missing devinit command", func() {
@@ -228,7 +242,10 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
 			Expect(output).NotTo(ContainSubstring("Executing devinit command"))
-			helper.MatchAllInOutput(output, []string{"Executing devbuild command \"npm install\"", "Executing devrun command \"nodemon app.js\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devbuild command \"npm install\"",
+				"Executing devrun command \"nodemon app.js\"",
+			})
 		})
 
 		It("should be able to handle a missing devbuild command", func() {
@@ -258,7 +275,11 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volumes.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"Executing devinit command", "Executing devbuild command", "Executing devrun command"})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command",
+				"Executing devbuild command",
+				"Executing devrun command",
+			})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			podName := oc.GetRunningPodNameByComponent(cmpName, namespace)

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -106,8 +106,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			podName := oc.GetRunningPodNameByComponent(cmpName, namespace)
 
 			stdOut := oc.ExecListDir(podName, namespace, sourcePath)
-			Expect(stdOut).To(ContainSubstring(("foobar.txt")))
-			Expect(stdOut).To(ContainSubstring(("testdir")))
+			helper.MatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 
 			// Now we delete the file and dir and push
 			helper.DeleteDir(newFilePath)
@@ -116,8 +115,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			// Then check to see if it's truly been deleted
 			stdOut = oc.ExecListDir(podName, namespace, sourcePath)
-			Expect(stdOut).To(Not(ContainSubstring(("foobar.txt"))))
-			Expect(stdOut).To(Not(ContainSubstring(("testdir"))))
+			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 		})
 
 		It("should delete the files from the container if its removed locally", func() {
@@ -194,9 +192,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(output).To(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devbuild command \"/artifacts/bin/build-container-full.sh\""))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 		})
 
 		It("should execute devinit and devrun commands if present", func() {
@@ -206,8 +202,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init-without-build.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(output).To(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 		})
 
 		It("should only execute devinit command once if component is already created", func() {
@@ -217,15 +212,12 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(output).To(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devbuild command \"/artifacts/bin/build-container-full.sh\""))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 
 			// Need to force so build and run get triggered again with the component already created.
 			output = helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace, "-f")
 			Expect(output).NotTo(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devbuild command \"/artifacts/bin/build-container-full.sh\""))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 		})
 
 		It("should be able to handle a missing devinit command", func() {
@@ -236,8 +228,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
 			Expect(output).NotTo(ContainSubstring("Executing devinit command"))
-			Expect(output).To(ContainSubstring("Executing devbuild command \"npm install\""))
-			Expect(output).To(ContainSubstring("Executing devrun command \"nodemon app.js\""))
+			helper.MatchAllInOutput(output, []string{"Executing devbuild command \"npm install\"", "Executing devrun command \"nodemon app.js\""})
 		})
 
 		It("should be able to handle a missing devbuild command", func() {
@@ -267,9 +258,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volumes.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(output).To(ContainSubstring("Executing devinit command"))
-			Expect(output).To(ContainSubstring("Executing devbuild command"))
-			Expect(output).To(ContainSubstring("Executing devrun command"))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command", "Executing devbuild command", "Executing devrun command"})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			podName := oc.GetRunningPodNameByComponent(cmpName, namespace)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -157,8 +157,7 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
 			pushStdOut := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(pushStdOut).NotTo(ContainSubstring("successfully deleted"))
-			Expect(pushStdOut).NotTo(ContainSubstring("created"))
+			helper.DontMatchAllInOutput(pushStdOut, []string{"successfully deleted", "created"})
 			Expect(pushStdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 
 			output := helper.CmdShouldPass("oc", "get", "routes", "--namespace", namespace)
@@ -167,8 +166,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f")
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
 			pushStdOut = helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--namespace", namespace)
-			Expect(pushStdOut).NotTo(ContainSubstring("successfully deleted"))
-			Expect(pushStdOut).NotTo(ContainSubstring("created"))
+			helper.DontMatchAllInOutput(pushStdOut, []string{"successfully deleted", "created"})
 			Expect(pushStdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 
 			output = helper.CmdShouldPass("oc", "get", "routes", "--namespace", namespace)
@@ -205,16 +203,14 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace)
 			stdOut = helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace)
-			Expect(stdOut).NotTo(ContainSubstring("successfully deleted"))
-			Expect(stdOut).NotTo(ContainSubstring("created"))
+			helper.DontMatchAllInOutput(stdOut, []string{"successfully deleted", "created"})
 			Expect(stdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f")
 
 			helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace)
 			stdOut = helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml", "--project", namespace)
-			Expect(stdOut).NotTo(ContainSubstring("successfully deleted"))
-			Expect(stdOut).NotTo(ContainSubstring("created"))
+			helper.DontMatchAllInOutput(stdOut, []string{"successfully deleted", "created"})
 			Expect(stdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 		})
 	})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -120,8 +120,7 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			Expect(len(containers)).To(Equal(1))
 
 			stdOut := dockerClient.ExecContainer(containers[0], "ls -la "+sourcePath)
-			Expect(stdOut).To(ContainSubstring(("foobar.txt")))
-			Expect(stdOut).To(ContainSubstring(("testdir")))
+			helper.MatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 
 			// Now we delete the file and dir and push
 			helper.DeleteDir(newFilePath)
@@ -130,8 +129,7 @@ var _ = Describe("odo docker devfile push command tests", func() {
 
 			// Then check to see if it's truly been deleted
 			stdOut = dockerClient.ExecContainer(containers[0], "ls -la "+sourcePath)
-			Expect(stdOut).To(Not(ContainSubstring(("foobar.txt"))))
-			Expect(stdOut).To(Not(ContainSubstring(("testdir"))))
+			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 		})
 
 		It("should build when no changes are detected in the directory and force flag is enabled", func() {
@@ -156,9 +154,7 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
-			Expect(output).To(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devbuild command \"/artifacts/bin/build-container-full.sh\""))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")
@@ -175,8 +171,7 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init-without-build.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
-			Expect(output).To(ContainSubstring("Executing devinit command \"echo hello"))
-			Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -154,7 +154,11 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
-			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command \"echo hello",
+				"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")
@@ -171,7 +175,10 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-init-without-build.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--devfile", "devfile.yaml")
-			helper.MatchAllInOutput(output, []string{"Executing devinit command \"echo hello", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+			helper.MatchAllInOutput(output, []string{
+				"Executing devinit command \"echo hello",
+				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+			})
 
 			// Check to see if it's been pushed (foobar.txt abd directory testdir)
 			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -29,7 +29,10 @@ func ExecDefaultDevfileCommands(projectDirPath, cmpName, namespace string) {
 	args = []string{"push", "--devfile", "devfile.yaml"}
 	args = useProjectIfAvailable(args, namespace)
 	output := helper.CmdShouldPass("odo", args...)
-	helper.MatchAllInOutput(output, []string{"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
+	helper.MatchAllInOutput(output, []string{
+		"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
+		"Executing devrun command \"/artifacts/bin/start-server.sh\"",
+	})
 }
 
 // ExecWithMissingBuildCommand executes odo push with a missing build command
@@ -79,7 +82,10 @@ func ExecWithCustomCommand(projectDirPath, cmpName, namespace string) {
 	args = []string{"push", "--devfile", "devfile.yaml", "--build-command", "build", "--run-command", "run"}
 	args = useProjectIfAvailable(args, namespace)
 	output := helper.CmdShouldPass("odo", args...)
-	helper.MatchAllInOutput(output, []string{"Executing build command \"npm install\"", "Executing run command \"nodemon app.js\""})
+	helper.MatchAllInOutput(output, []string{
+		"Executing build command \"npm install\"",
+		"Executing run command \"nodemon app.js\"",
+	})
 }
 
 // ExecWithWrongCustomCommand executes odo push with a wrong custom command

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -29,8 +29,7 @@ func ExecDefaultDevfileCommands(projectDirPath, cmpName, namespace string) {
 	args = []string{"push", "--devfile", "devfile.yaml"}
 	args = useProjectIfAvailable(args, namespace)
 	output := helper.CmdShouldPass("odo", args...)
-	Expect(output).To(ContainSubstring("Executing devbuild command \"/artifacts/bin/build-container-full.sh\""))
-	Expect(output).To(ContainSubstring("Executing devrun command \"/artifacts/bin/start-server.sh\""))
+	helper.MatchAllInOutput(output, []string{"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"", "Executing devrun command \"/artifacts/bin/start-server.sh\""})
 }
 
 // ExecWithMissingBuildCommand executes odo push with a missing build command
@@ -80,8 +79,7 @@ func ExecWithCustomCommand(projectDirPath, cmpName, namespace string) {
 	args = []string{"push", "--devfile", "devfile.yaml", "--build-command", "build", "--run-command", "run"}
 	args = useProjectIfAvailable(args, namespace)
 	output := helper.CmdShouldPass("odo", args...)
-	Expect(output).To(ContainSubstring("Executing build command \"npm install\""))
-	Expect(output).To(ContainSubstring("Executing run command \"nodemon app.js\""))
+	helper.MatchAllInOutput(output, []string{"Executing build command \"npm install\"", "Executing run command \"nodemon app.js\""})
 }
 
 // ExecWithWrongCustomCommand executes odo push with a wrong custom command

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -50,11 +50,7 @@ var _ = Describe("odo generic", func() {
 	Context("When executing catalog list without component directory", func() {
 		It("should list all component catalogs", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "components")
-			Expect(stdOut).To(ContainSubstring("dotnet"))
-			Expect(stdOut).To(ContainSubstring("nginx"))
-			Expect(stdOut).To(ContainSubstring("php"))
-			Expect(stdOut).To(ContainSubstring("ruby"))
-			Expect(stdOut).To(ContainSubstring("wildfly"))
+			helper.MatchAllInOutput(stdOut, []string{"dotnet", "nginx", "php", "ruby", "wildfly"})
 		})
 
 	})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -247,7 +247,7 @@ spec:
 				return strings.Contains(output, "Running")
 			})
 
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
 			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
 
 			// now check for json output

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -54,9 +54,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			Expect(stdOut).To(ContainSubstring("Operators available in the cluster"))
-			Expect(stdOut).To(ContainSubstring("mongodb-enterprise"))
-			Expect(stdOut).To(ContainSubstring("etcdoperator"))
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "mongodb-enterprise", "etcdoperator"})
 		})
 	})
 
@@ -108,8 +106,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
 			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
-			Expect(stdOut).To(ContainSubstring("apiVersion"))
-			Expect(stdOut).To(ContainSubstring("kind"))
+			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
 		})
 	})
 
@@ -221,8 +218,7 @@ spec:
 
 		It("listing catalog of services", func() {
 			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			Expect(jsonOut).To(ContainSubstring("mongodb-enterprise"))
-			Expect(jsonOut).To(ContainSubstring("etcdoperator"))
+			helper.MatchAllInOutput(jsonOut, []string{"mongodb-enterprise", "etcdoperator"})
 		})
 	})
 
@@ -251,9 +247,8 @@ spec:
 				return strings.Contains(output, "Running")
 			})
 
-			stdOut := helper.CmdShouldPass("odo", "service", "list")
-			Expect(stdOut).To(ContainSubstring("example"))
-			Expect(stdOut).To(ContainSubstring("EtcdCluster"))
+			stdOut = helper.CmdShouldPass("odo", "service", "list")
+			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
 
 			// now check for json output
 			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")

--- a/tests/integration/servicecatalog/cmd_link_unlink_test.go
+++ b/tests/integration/servicecatalog/cmd_link_unlink_test.go
@@ -210,15 +210,11 @@ var _ = Describe("odo link and unlink command tests", func() {
 
 			// tests for linking a component to a component
 			stdOut := helper.CmdShouldPass("odo", "link", "component2", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were added"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were added", "COMPONENT_COMPONENT2_HOST", "COMPONENT_COMPONENT2_PORT"})
 
 			// tests for unlinking a component from a component
 			stdOut = helper.CmdShouldPass("odo", "unlink", "component2", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were removed"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were removed", "COMPONENT_COMPONENT2_HOST", "COMPONENT_COMPONENT2_PORT"})
 
 			// first create a service
 			helper.CmdShouldPass("odo", "service", "create", "-w", "dh-postgresql-apb", "--project", project, "--plan", "dev",
@@ -231,15 +227,11 @@ var _ = Describe("odo link and unlink command tests", func() {
 
 			// tests for linking a service to a component
 			stdOut = helper.CmdShouldPass("odo", "link", "dh-postgresql-apb", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were added"))
-			Expect(stdOut).To(ContainSubstring("DB_PORT"))
-			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were added", "DB_PORT", "DB_HOST"})
 
 			// tests for unlinking a service to a component
 			stdOut = helper.CmdShouldPass("odo", "unlink", "dh-postgresql-apb", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were removed"))
-			Expect(stdOut).To(ContainSubstring("DB_PORT"))
-			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were removed", "DB_PORT", "DB_HOST"})
 		})
 	})
 })

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -257,8 +257,7 @@ var _ = Describe("odo service command tests", func() {
 
 			// Check json output
 			stdOut = helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
-			Expect(stdOut).To(ContainSubstring("ServiceList"))
+			helper.MatchAllInOutput(stdOut, []string{"dh-prometheus-apb", "ServiceList"})
 
 			// cd to a non-component directory and list services
 			helper.Chdir(originalDir)
@@ -268,8 +267,7 @@ var _ = Describe("odo service command tests", func() {
 			// Check json output
 			helper.Chdir(originalDir)
 			stdOut = helper.CmdShouldPass("odo", "service", "list", "--app", app, "--project", project, "-o", "json")
-			Expect(stdOut).To(ContainSubstring("dh-prometheus-apb"))
-			Expect(stdOut).To(ContainSubstring("ServiceList"))
+			helper.MatchAllInOutput(stdOut, []string{"dh-prometheus-apb", "ServiceList"})
 
 		})
 
@@ -384,15 +382,11 @@ var _ = Describe("odo service command tests", func() {
 
 			// tests for linking a component to a component
 			stdOut := helper.CmdShouldPass("odo", "link", "component2", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were added"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were added", "COMPONENT_COMPONENT2_HOST", "COMPONENT_COMPONENT2_PORT"})
 
 			// tests for unlinking a component from a component
 			stdOut = helper.CmdShouldPass("odo", "unlink", "component2", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were removed"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_HOST"))
-			Expect(stdOut).To(ContainSubstring("COMPONENT_COMPONENT2_PORT"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were removed", "COMPONENT_COMPONENT2_HOST", "COMPONENT_COMPONENT2_PORT"})
 
 			// first create a service
 			helper.CmdShouldPass("odo", "service", "create", "-w", "dh-postgresql-apb", "--project", project, "--plan", "dev",
@@ -405,15 +399,11 @@ var _ = Describe("odo service command tests", func() {
 
 			// tests for linking a service to a component
 			stdOut = helper.CmdShouldPass("odo", "link", "dh-postgresql-apb", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were added"))
-			Expect(stdOut).To(ContainSubstring("DB_PORT"))
-			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were added", "DB_PORT", "DB_HOST"})
 
 			// tests for unlinking a service to a component
 			stdOut = helper.CmdShouldPass("odo", "unlink", "dh-postgresql-apb", "--context", context1)
-			Expect(stdOut).To(ContainSubstring("The below secret environment variables were removed"))
-			Expect(stdOut).To(ContainSubstring("DB_PORT"))
-			Expect(stdOut).To(ContainSubstring("DB_HOST"))
+			helper.MatchAllInOutput(stdOut, []string{"The below secret environment variables were removed", "DB_PORT", "DB_HOST"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind code-refactoring

**What does does this PR do / why we need it**:

Removes multiple `expect` assert statements throughout the test.

**Which issue(s) this PR fixes**:

Fixes #3245 

**How to test changes / Special notes to the reviewer**:

It should check for the parameter passed in `MatchAllInOutput` and `DontMatchAllInOutput`