### PR TITLE
Fix windows incompatibility with /tmp

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -129,7 +130,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 			// stdOut contains the yaml specification. Store it to a file
 			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join("/tmp", randomFileName)
+			fileName := filepath.Join(os.TempDir(), randomFileName)
 			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
 				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
The purpose of the pr is to make `/tmp` compatible for All supported OS

**Which issue(s) this PR fixes**:

Fixes #3246 

**How to test changes / Special notes to the reviewer**:

The changes should work for all the platform.