### PR TITLE
Push odo without an .odo directory

### DIFF
--- a/pkg/devfile/parser/data/1.0.0/components.go
+++ b/pkg/devfile/parser/data/1.0.0/components.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 )
 
+// GetMetadata returns the struct of DevfileMetadata objects parsed from the Devfile
 func (d *Devfile100) GetMetadata() common.DevfileMetadata {
 	// No GenerateName field in V2
 	return common.DevfileMetadata{

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -10,7 +10,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/envinfo"
+	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
@@ -329,4 +331,71 @@ func filterIgnores(filesChanged, filesDeleted, absIgnoreRules []string) (filesCh
 		}
 	}
 	return filesChangedFiltered, filesDeletedFiltered
+}
+
+// retrieveKubernetesDefaultNamespace tries to retrieve the current active namespace
+// to set as a default namespace
+func retrieveKubernetesDefaultNamespace() (string, error) {
+	// Get current active namespace
+	client, err := kclient.New()
+	if err != nil {
+		return "", err
+	}
+	return client.Namespace, nil
+}
+
+// retrieveCmdNamespace retrieves the namespace from project or namespace, if neither of those are available
+// we revert to the default namespace available from Kubernetes
+func retrieveCmdNamespace(cmd *cobra.Command) (string, error) {
+	var componentNamespace string
+	var err error
+
+	// For "odo create" check to see if --project has been passed.
+	if cmd.Flags().Changed("project") {
+		componentNamespace, err = cmd.Flags().GetString("project")
+		if err != nil {
+			return "", err
+		}
+	} else if cmd.Flags().Changed("namespace") {
+		// For "odo push" check to see if project has been passed
+		componentNamespace, err = cmd.Flags().GetString("namespace")
+		if err != nil {
+			return "", err
+		}
+	} else {
+		componentNamespace, err = retrieveKubernetesDefaultNamespace()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return componentNamespace, nil
+}
+
+// gatherName parses the Devfile retrieves an appropriate name in two ways.
+// 1. If metadata.name exists, we use it
+// 2. If metadata.name does NOT exist, we use the folder name where the devfile.yaml is located
+func gatherName(devObj parser.DevfileObj, devfilePath string) (string, error) {
+
+	metadata := devObj.Data.GetMetadata()
+
+	klog.V(4).Infof("metadata.Name: %s", metadata.Name)
+
+	// 1. Use metadata.name if it exists
+	if metadata.Name != "" {
+
+		// Remove any suffix's that end with `-`. This is because many Devfile's use the original v1 Devfile pattern of
+		// having names such as "foo-bar-" in order to prepend container names such as "foo-bar-container1"
+		return strings.TrimSuffix(metadata.Name, "-"), nil
+	}
+
+	// 2. Use the folder name as a last resort if nothing else exists
+	sourcePath, err := util.GetAbsPath(devfilePath)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get source path")
+	}
+	klog.V(4).Infof("Source path: %s", sourcePath)
+	klog.V(4).Infof("devfile dir: %s", filepath.Dir(sourcePath))
+
+	return filepath.Base(filepath.Dir(sourcePath)), nil
 }

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -54,6 +54,7 @@ func (po *PushOptions) DevfilePush() error {
 }
 
 func (po *PushOptions) devfilePushInner() (err error) {
+
 	// Parse devfile and validate
 	devObj, err := parser.ParseAndValidate(po.DevfilePath)
 	if err != nil {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -126,7 +126,9 @@ func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
 	return nil
 }
 
-func getValidEnvinfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
+// getValidEnvInfo accesses the environment file
+func getValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
+
 	// Get details from the env file
 	componentContext := FlagValueIfSet(command, ContextFlagName)
 
@@ -143,72 +145,21 @@ func getValidEnvinfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
 		return nil, err
 	}
 
-	// Here we will check for parent commands, if the match a certain criteria, we will skip
-	// using the configuration.
-	//
-	// For example, `odo create` should NOT check to see if there is actually a configuration yet.
-	if command.HasParent() {
-
-		// Gather necessary preliminary information
-		parentCommand := command.Parent()
-		rootCommand := command.Root()
-		flagValue := FlagValueIfSet(command, ApplicationFlagName)
-
-		// Find the first child of the command, as some groups are allowed even with non existent configuration
-		firstChildCommand := getFirstChildOfCommand(command)
-
-		// This should not happen but just to be safe
-		if firstChildCommand == nil {
-			return nil, fmt.Errorf("Unable to get first child of command")
-		}
-		// Case 1 : if command is create operation just allow it
-		if command.Name() == "create" && (parentCommand.Name() == "component" || parentCommand.Name() == rootCommand.Name()) {
-			return envInfo, nil
-		}
-		// Case 2 : if command is describe or delete and app flag is used just allow it
-		if (firstChildCommand.Name() == "describe" || firstChildCommand.Name() == "delete") && len(flagValue) > 0 {
-			return envInfo, nil
-		}
-		// Case 2 : if command is list, just allow it
-		if firstChildCommand.Name() == "list" {
-			return envInfo, nil
-		}
-		// Case 3 : Check if firstChildCommand is project. If so, skip validation of context
-		if firstChildCommand.Name() == "project" {
-			return envInfo, nil
-		}
-		// Case 4 : Check if specific flags are set for specific first child commands
-		if firstChildCommand.Name() == "app" {
-			return envInfo, nil
-		}
-		// Case 5 : Check if firstChildCommand is catalog and request is to list or search
-		if firstChildCommand.Name() == "catalog" && (parentCommand.Name() == "list" || parentCommand.Name() == "search") {
-			return envInfo, nil
-		}
-		// Check if firstChildCommand is component and  request is list
-		if (firstChildCommand.Name() == "component" || firstChildCommand.Name() == "service") && command.Name() == "list" {
-			return envInfo, nil
-		}
-		// Case 6 : Check if firstChildCommand is component and app flag is used
-		if firstChildCommand.Name() == "component" && len(flagValue) > 0 {
-			return envInfo, nil
-		}
-		// Case 7 : Check if firstChildCommand is logout and app flag is used
-		if firstChildCommand.Name() == "logout" {
-			return envInfo, nil
-		}
-		// Case 8: Check if firstChildCommand is service and command is create or delete. Allow it if that's the case
-		if firstChildCommand.Name() == "service" && (command.Name() == "create" || command.Name() == "delete") {
-			return envInfo, nil
-		}
-
-	} else {
+	// Now we check to see if we can skip gathering the information.
+	// Return if we can skip gathering configuration information
+	canWeSkip, err := checkIfConfigurationNeeded(command)
+	if err != nil {
+		return nil, err
+	}
+	if canWeSkip {
 		return envInfo, nil
 	}
 
+	// Check to see if the environment file exists
 	if !envInfo.EnvInfoFileExists() {
 		return nil, fmt.Errorf("The current directory does not represent an odo component. Use 'odo create' to create component here or switch to directory with a component")
 	}
+
 	return envInfo, nil
 }
 
@@ -229,70 +180,15 @@ func getValidConfig(command *cobra.Command, ignoreMissingConfiguration bool) (*c
 		return nil, err
 	}
 
-	// Here we will check for parent commands, if the match a certain criteria, we will skip
-	// using the configuration.
-	//
-	// For example, `odo create` should NOT check to see if there is actually a configuration yet.
-	if command.HasParent() {
-
-		// Gather necessary preliminary information
-		parentCommand := command.Parent()
-		rootCommand := command.Root()
-		flagValue := FlagValueIfSet(command, ApplicationFlagName)
-
-		// Find the first child of the command, as some groups are allowed even with non existent configuration
-		firstChildCommand := getFirstChildOfCommand(command)
-
-		// This should not happen but just to be safe
-		if firstChildCommand == nil {
-			return nil, fmt.Errorf("Unable to get first child of command")
-		}
-		// Case 1 : if command is create operation just allow it
-		if command.Name() == "create" && (parentCommand.Name() == "component" || parentCommand.Name() == rootCommand.Name()) {
-			return localConfiguration, nil
-		}
-		// Case 2 : if command is describe or delete and app flag is used just allow it
-		if (firstChildCommand.Name() == "describe" || firstChildCommand.Name() == "delete") && len(flagValue) > 0 {
-			return localConfiguration, nil
-		}
-		// Case 2 : if command is list, just allow it
-		if firstChildCommand.Name() == "list" {
-			return localConfiguration, nil
-		}
-		// Case 3 : Check if firstChildCommand is project. If so, skip validation of context
-		if firstChildCommand.Name() == "project" {
-			return localConfiguration, nil
-		}
-		// Case 4 : Check if specific flags are set for specific first child commands
-		if firstChildCommand.Name() == "app" {
-			return localConfiguration, nil
-		}
-		// Case 5 : Check if firstChildCommand is catalog and request is to list or search
-		if firstChildCommand.Name() == "catalog" && (parentCommand.Name() == "list" || parentCommand.Name() == "search") {
-			return localConfiguration, nil
-		}
-		// Check if firstChildCommand is component and  request is list
-		if (firstChildCommand.Name() == "component" || firstChildCommand.Name() == "service") && command.Name() == "list" {
-			return localConfiguration, nil
-		}
-		// Case 6 : Check if firstChildCommand is component and app flag is used
-		if firstChildCommand.Name() == "component" && len(flagValue) > 0 {
-			return localConfiguration, nil
-		}
-		// Case 7 : Check if firstChildCommand is logout and app flag is used
-		if firstChildCommand.Name() == "logout" {
-			return localConfiguration, nil
-		}
-		// Case 8: Check if firstChildCommand is service and command is create or delete. Allow it if that's the case
-		if firstChildCommand.Name() == "service" && (command.Name() == "create" || command.Name() == "delete") {
-			return localConfiguration, nil
-		}
-
-	} else {
+	// Now we check to see if we can skip gathering the information.
+	// If true, we just return.
+	canWeSkip, err := checkIfConfigurationNeeded(command)
+	if err != nil {
+		return nil, err
+	}
+	if canWeSkip {
 		return localConfiguration, nil
 	}
-
-	// * Ignore error block ends
 
 	// If file does not exist at this point, raise an error
 	// HOWEVER..
@@ -410,10 +306,10 @@ func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error)
 
 // newContext creates a new context based on the command flags, creating missing app when requested
 func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingConfiguration bool) *Context {
-	// create a new occlient
+	// Create a new occlient
 	client := client(command)
 
-	// create a new kclient
+	// Create a new kclient
 	KClient, err := kclient.New()
 	if err != nil {
 		util.LogErrorAndExit(err, "")
@@ -425,16 +321,16 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 		util.LogErrorAndExit(err, "")
 	}
 
-	// resolve project
+	// Resolve project
 	namespace := resolveProject(command, client, localConfiguration)
 
-	// resolve application
+	// Resolve application
 	app := resolveApp(command, createAppIfNeeded, localConfiguration)
 
-	// resolve output flag
+	// Resolve output flag
 	outputFlag := FlagValueIfSet(command, OutputFlagName)
 
-	// create the internal context representation based on calculated values
+	// Create the internal context representation based on calculated values
 	internalCxt := internalCxt{
 		Client:          client,
 		Project:         namespace,
@@ -445,11 +341,11 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 		KClient:         KClient,
 	}
 
-	// create a context from the internal representation
+	// Create a context from the internal representation
 	context := &Context{
 		internalCxt: internalCxt,
 	}
-	// once the component is resolved, add it to the context
+	// Once the component is resolved, add it to the context
 	context.cmp = resolveComponent(command, localConfiguration, context)
 
 	return context
@@ -457,29 +353,37 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 
 // newDevfileContext creates a new context based on command flags for devfile components
 func newDevfileContext(command *cobra.Command) *Context {
-	// resolve output flag
+
+	// Resolve output flag
 	outputFlag := FlagValueIfSet(command, OutputFlagName)
 
-	// create the internal context representation based on calculated values
+	// Create the internal context representation based on calculated values
 	internalCxt := internalCxt{
 		OutputFlag: outputFlag,
 		command:    command,
 	}
 
-	envInfo, err := getValidEnvinfo(command)
+	// Get valid env information
+	envInfo, err := getValidEnvInfo(command)
 	if err != nil {
 		util.LogErrorAndExit(err, "")
 	}
 
 	internalCxt.EnvSpecificInfo = envInfo
 
+	// If the push target is NOT Docker we will set the client to Kubernetes.
 	if !pushtarget.IsPushTargetDocker() {
-		// create a new kclient
+
+		// Create a new kubernetes client
 		kClient := kClient(command)
 		internalCxt.KClient = kClient
+
+		// Gather the environment information
+		internalCxt.EnvSpecificInfo = envInfo
 		resolveNamespace(command, kClient, envInfo)
 	}
-	// create a context from the internal representation
+
+	// Create a context from the internal representation
 	context := &Context{
 		internalCxt: internalCxt,
 	}
@@ -562,4 +466,73 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 		*ignores = append(*ignores, rules...)
 	}
 	return nil
+}
+
+// checkIfConfigurationNeeded checks against a set of commands that do *NOT* need configuration.
+func checkIfConfigurationNeeded(command *cobra.Command) (bool, error) {
+
+	// Here we will check for parent commands, if the match a certain criteria, we will skip
+	// using the configuration.
+	//
+	// For example, `odo create` should NOT check to see if there is actually a configuration yet.
+	if command.HasParent() {
+
+		// Gather necessary preliminary information
+		parentCommand := command.Parent()
+		rootCommand := command.Root()
+		flagValue := FlagValueIfSet(command, ApplicationFlagName)
+
+		// Find the first child of the command, as some groups are allowed even with non existent configuration
+		firstChildCommand := getFirstChildOfCommand(command)
+
+		// This should *never* happen, but added just to be safe
+		if firstChildCommand == nil {
+			return false, fmt.Errorf("Unable to get first child of command")
+		}
+		// Case 1 : if command is create operation just allow it
+		if command.Name() == "create" && (parentCommand.Name() == "component" || parentCommand.Name() == rootCommand.Name()) {
+			return true, nil
+		}
+		// Case 2 : if command is describe or delete and app flag is used just allow it
+		if (firstChildCommand.Name() == "describe" || firstChildCommand.Name() == "delete") && len(flagValue) > 0 {
+			return true, nil
+		}
+		// Case 3 : if command is list, just allow it
+		if firstChildCommand.Name() == "list" {
+			return true, nil
+		}
+		// Case 4 : Check if firstChildCommand is project. If so, skip validation of context
+		if firstChildCommand.Name() == "project" {
+			return true, nil
+		}
+		// Case 5 : Check if specific flags are set for specific first child commands
+		if firstChildCommand.Name() == "app" {
+			return true, nil
+		}
+		// Case 6 : Check if firstChildCommand is catalog and request is to list or search
+		if firstChildCommand.Name() == "catalog" && (parentCommand.Name() == "list" || parentCommand.Name() == "search") {
+			return true, nil
+		}
+		// Case 7: Check if firstChildCommand is component and  request is list
+		if (firstChildCommand.Name() == "component" || firstChildCommand.Name() == "service") && command.Name() == "list" {
+			return true, nil
+		}
+		// Case 8 : Check if firstChildCommand is component and app flag is used
+		if firstChildCommand.Name() == "component" && len(flagValue) > 0 {
+			return true, nil
+		}
+		// Case 9 : Check if firstChildCommand is logout and app flag is used
+		if firstChildCommand.Name() == "logout" {
+			return true, nil
+		}
+		// Case 10: Check if firstChildCommand is service and command is create or delete. Allow it if that's the case
+		if firstChildCommand.Name() == "service" && (command.Name() == "create" || command.Name() == "delete") {
+			return true, nil
+		}
+
+	} else {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -16,14 +16,14 @@ func (d TestDevfileData) GetComponents() []versionsCommon.DevfileComponent {
 	return d.GetAliasedComponents()
 }
 
-// GetEvents is a mock function to get events from devfile
-func (d TestDevfileData) GetEvents() versionsCommon.DevfileEvents {
-	return versionsCommon.DevfileEvents{}
-}
-
 // GetMetadata is a mock function to get metadata from devfile
 func (d TestDevfileData) GetMetadata() versionsCommon.DevfileMetadata {
 	return versionsCommon.DevfileMetadata{}
+}
+
+// GetEvents is a mock function to get events from devfile
+func (d TestDevfileData) GetEvents() versionsCommon.DevfileEvents {
+	return versionsCommon.DevfileEvents{}
 }
 
 // GetParent is a mock function to get parent from devfile

--- a/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: foobar-
+  generateName: java-spring-boot
+projects:
+  -
+    name: springbootproject
+    source:
+      type: git
+      location: "https://github.com/maysunfaisal/springboot.git"
+components:
+  -
+    type: chePlugin
+    id: redhat/java/latest
+    memoryLimit: 1512Mi
+  -
+    type: dockerimage
+    image: maysunfaisal/springbootbuild
+    alias: tools
+    memoryLimit: 768Mi
+    command: ['tail']
+    args: [ '-f', '/dev/null']
+    mountSources: true
+    volumes:
+      - name: springbootpvc
+        containerPath: /data
+  -
+    type: dockerimage
+    image: maysunfaisal/springbootruntime
+    alias: runtime
+    memoryLimit: 768Mi
+    endpoints:
+      - name: '8080/tcp'
+        port: 8080
+    mountSources: false
+    volumes:
+      - name: springbootpvc
+        containerPath: /data
+commands:
+  -
+    name: devBuild
+    actions:
+      -
+        type: exec
+        component: tools
+        command: "/artifacts/bin/build-container-full.sh"
+        workdir: /projects/springbootproject
+  -
+    name: devRun
+    actions:
+      -
+        type: exec
+        component: runtime
+        command: "/artifacts/bin/start-server.sh"
+        workdir: /

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -48,6 +48,29 @@ var _ = Describe("odo devfile push command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
+	Context("Pushing devfile without an .odo folder", func() {
+
+		It("should be able to push based on metadata.name in devfile WITH a dash in the name", func() {
+			// This is the name that's contained within `devfile-with-metadataname-foobar.yaml`
+			name := "foobar"
+			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-with-metadataname-foobar.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace)
+			Expect(output).To(ContainSubstring("Executing devfile commands for component " + name))
+		})
+
+		It("should be able to push based on name passed", func() {
+			name := "springboot"
+			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace, name)
+			Expect(output).To(ContainSubstring("Executing devfile commands for component " + name))
+		})
+
+	})
+
 	Context("Verify devfile push works", func() {
 
 		It("should have no errors when no endpoints within the devfile, should create a service when devfile has endpoints", func() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature

**What does does this PR do / why we need it**:

This PR changes:
  - Being able to push without an `.odo` directory
  - Automatic creation of an `.odo/env/env.yaml` file when pushing
  - Safe determination of a devfile's name when pushing
  - Code refactoring in order to be able to implement the above features

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3144

**How to test changes / Special notes to the reviewer**:

```sh
odo create java-spring-boot # only to initially create it
rm -r .odo
odo push
```