### PR TITLE
Don't show imagestreams error on experimental mode

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/util"
 
@@ -374,6 +375,9 @@ func (c *Client) GetPortsFromBuilderImage(componentType string) ([]string, error
 	}
 	imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
 	if err != nil {
+		if experimental.IsExperimentalModeEnabled() {
+			return []string{}, fmt.Errorf("component \"%s\" not found", componentType)
+		}
 		return []string{}, err
 	}
 	imageStreamImage, err := c.GetImageStreamImage(imageStream, imageTag)

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -375,9 +375,6 @@ func (c *Client) GetPortsFromBuilderImage(componentType string) ([]string, error
 	}
 	imageStream, err := c.GetImageStream(imageNS, imageName, imageTag)
 	if err != nil {
-		if experimental.IsExperimentalModeEnabled() {
-			return []string{}, fmt.Errorf("component \"%s\" not found", componentType)
-		}
 		return []string{}, err
 	}
 	imageStreamImage, err := c.GetImageStreamImage(imageStream, imageTag)
@@ -757,6 +754,9 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 		}
 		if e != nil && err != nil {
 			// Imagestream not found in openshift and current namespaces
+			if experimental.IsExperimentalModeEnabled() {
+				return nil, fmt.Errorf("component \"%s\" not found", imageName)
+			}
 			return nil, err
 		}
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -755,7 +755,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 		if e != nil && err != nil {
 			// Imagestream not found in openshift and current namespaces
 			if experimental.IsExperimentalModeEnabled() {
-				return nil, fmt.Errorf("component \"%s\" not found", imageName)
+				return nil, fmt.Errorf("component %q not found", imageName)
 			}
 			return nil, err
 		}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -474,9 +474,15 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		return errors.Wrap(err, "failed intiating local config")
 	}
 
-	// Do not execute S2I specific code on Kubernetes Cluster
+	// Do not execute S2I specific code on Kubernetes Cluster or Docker
 	// return from here, if it is not an openshift cluster.
-	openshiftCluster, _ := co.Client.IsImageStreamSupported()
+	var openshiftCluster bool
+	if !pushtarget.IsPushTargetDocker() {
+		openshiftCluster, _ = co.Client.IsImageStreamSupported()
+	} else {
+		openshiftCluster = false
+	}
+	openshiftCluster, _ = co.Client.IsImageStreamSupported()
 	if !openshiftCluster {
 		return errors.New("component not found")
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -482,7 +482,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	} else {
 		openshiftCluster = false
 	}
-	openshiftCluster, _ = co.Client.IsImageStreamSupported()
 	if !openshiftCluster {
 		return errors.New("component not found")
 	}


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup

**What does does this PR do / why we need it**:
When a user enters an invalid component name to `odo create` when experimental mode is enabled on OpenShift, they see this error:
```
 ✗  imagestreams.image.openshift.io "dsfdsfd" not found
```

This happens because on OpenShift (with odo's experimental mode enabled), if no valid devfile component with the given name is found, we drop down to checking for s2i/imagestream components instead, rather than erroring out.

This error can be confusing if the user doesn't know what imagestreams are / was only intending to create from a devfile component. So instead, I modified the error message that's returned when an image stream can't be found to display the following when experimental mode is enabled:
```
 ✗  component "dsfdsfd" not found
```

This PR does not affect odo without experimental mode enabled, so the regular imagestreams error message is shown.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3128

**How to test changes / Special notes to the reviewer**:
1. Log in to an OpenShift cluster and enable odo's experimental mode
2. Run `odo create <some-fake-component>`
3. Error message should say `component "<some-fake-component>" not found`