### PR TITLE
Fix checkForImageStream to return correct result.

### DIFF
--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -264,8 +264,8 @@ func (oc OcRunner) SourceLocationBC(componentName string, appName string, projec
 // checkForImageStream checks if there is a ImageStram with name and tag in openshift namespace
 func (oc OcRunner) checkForImageStream(name string, tag string) bool {
 	// first check if there is ImageStream with given name
-	names := CmdShouldPass(oc.path, "get", "is", "-n", "openshift",
-		"-o", "jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'")
+	names := strings.Trim(CmdShouldPass(oc.path, "get", "is", "-n", "openshift",
+		"-o", "jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'"), "'")
 	scanner := bufio.NewScanner(strings.NewReader(names))
 	namePresent := false
 	for scanner.Scan() {
@@ -276,8 +276,8 @@ func (oc OcRunner) checkForImageStream(name string, tag string) bool {
 	tagPresent := false
 	// if there is a ImageStream check if there is a given tag
 	if namePresent {
-		tags := CmdShouldPass(oc.path, "get", "is", name, "-n", "openshift",
-			"-o", "jsonpath='{range .spec.tags[*]}{.name}{\"\\n\"}{end}'")
+		tags := strings.Trim(CmdShouldPass(oc.path, "get", "is", name, "-n", "openshift",
+			"-o", "jsonpath='{range .spec.tags[*]}{.name}{\"\\n\"}{end}'"), "'")
 		scanner := bufio.NewScanner(strings.NewReader(tags))
 		for scanner.Scan() {
 			if scanner.Text() == tag {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
The strings returned from 'CmdShouldPass' contain the char "'" which cause the comparison with target name or tag failed. Then the 'oc.checkForImageStream' returned false all the time. 

**Which issue(s) this PR fixes**:

Fixes #3051 

**How to test changes / Special notes to the reviewer**:
With this PR, If there is the target imagestream, the oc.checkForImageStream should return true. 