### PR TITLE
Remove unnecessary preference set

### DIFF
--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -40,7 +40,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	Context("Enabling experimental preference should show a disclaimer", func() {
 		It("checks that the experimental warning appears for create", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
 			// Check that it will contain the experimental mode output
@@ -137,7 +136,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	Context("When executing odo create with devfile component and --downloadSource flag", func() {
 		It("should succesfully create the compoment and download the source", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 			contextDevfile := helper.CreateNewContext()
 			helper.Chdir(contextDevfile)
 			devfile := "devfile.yaml"
@@ -159,7 +157,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	Context("When executing odo create with devfile component and --downloadSource flag with a valid project", func() {
 		It("should succesfully create the compoment specified and download the source", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 			contextDevfile := helper.CreateNewContext()
 			helper.Chdir(contextDevfile)
 			devfile := "devfile.yaml"
@@ -192,7 +189,6 @@ var _ = Describe("odo devfile create command tests", func() {
 	// Once this feature is added we can change these tests.
 	//Context("When executing odo create with devfile component and --downloadSource flag with github type", func() {
 	//	It("should succesfully create the compoment and download the source", func() {
-	//		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	//		contextDevfile := helper.CreateNewContext()
 	//		helper.Chdir(contextDevfile)
 	//		devfile := "devfile.yaml"
@@ -211,7 +207,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	//Context("When executing odo create with devfile component and --downloadSource flag with zip type", func() {
 	//	It("should create the compoment and download the source", func() {
-	//		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	//		contextDevfile := helper.CreateNewContext()
 	//		helper.Chdir(contextDevfile)
 	//		devfile := "devfile.yaml"
@@ -233,7 +228,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	// Context("When executing odo create with devfile component, --downloadSource flag and sparseContextDir has a valid value", func() {
 	// 	It("should only extract the specified path in the sparseContextDir field", func() {
-	// 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	// 		contextDevfile := helper.CreateNewContext()
 	// 		helper.Chdir(contextDevfile)
 	// 		devfile := "devfile.yaml"
@@ -248,7 +242,6 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	// Context("When executing odo create with devfile component, --downloadSource flag and sparseContextDir has an invalid value", func() {
 	// 	It("should fail and alert the user that the specified path in sparseContextDir does not exist", func() {
-	// 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	// 		contextDevfile := helper.CreateNewContext()
 	// 		helper.Chdir(contextDevfile)
 	// 		devfile := "devfile.yaml"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What does does this PR do / why we need it**:
It re moves the unnecessary experimental preference set in devfile create test script
**Which issue(s) this PR fixes**:

Fixes NA, I see the issue and directly sending the pr.

**How to test changes / Special notes to the reviewer**:
```make test-cmd-devfile-create``` should not print output like 
```
[odo] I0603 09:13:54.826617    4108 preference.go:188] The path for preference file is C:\Users\Admin\AppData\Local\Temp\132378982\config.yaml
[odo] ? Experimental is already set. Do you want to override it in the config (y/N) I0603 09:13:54.876372    4108 common.go:1
7] Encountered an error processing prompt: Incorrect function.
```