### PR TITLE
Removing unused secret directory

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -4,4 +4,3 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
 
 RUN yum -y install make wget gcc git httpd-tools
 
-RUN mkdir -p /tmp/secret


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What does does this PR do / why we need it**:

Due to new workflow in [pr](https://github.com/openshift/release/pull/9431) `/tmp` dir has encountered permission issue while copying the unnecessary secret to it. So removing the unused secret directory from docker file.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:
