### PR TITLE
Fix unsafe data race in ExecuteCommand

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"k8s.io/klog"
 
@@ -12,16 +13,21 @@ import (
 	"github.com/openshift/odo/pkg/log"
 )
 
+// ExecClient  is a wrapper around ExecCMDInContainer which executes a command in a specific container of a pod.
 type ExecClient interface {
 	ExecCMDInContainer(common.ComponentInfo, []string, io.Writer, io.Writer, io.Reader, bool) error
 }
 
 // ExecuteCommand executes the given command in the pod's container
 func ExecuteCommand(client ExecClient, compInfo common.ComponentInfo, command []string, show bool) (err error) {
+
+	// Create a mutex so we don't run into the issue of go routines trying to write to stdout
+	var mu sync.Mutex
+
 	reader, writer := io.Pipe()
 	var cmdOutput string
 
-	klog.V(3).Infof("Executing command %v for pod: %v in container: %v", command, compInfo.PodName, compInfo.ContainerName)
+	klog.V(4).Infof("Executing command %v for pod: %v in container: %v", command, compInfo.PodName, compInfo.ContainerName)
 
 	// This Go routine will automatically pipe the output from ExecCMDInContainer to
 	// our logger.
@@ -37,13 +43,17 @@ func ExecuteCommand(client ExecClient, compInfo common.ComponentInfo, command []
 				}
 			}
 
+			mu.Lock()
 			cmdOutput += fmt.Sprintln(line)
+			mu.Unlock()
 		}
 	}()
 
 	err = client.ExecCMDInContainer(compInfo, command, writer, writer, nil, false)
 	if err != nil {
+		mu.Lock()
 		log.Errorf("\nUnable to exec command %v: \n%v", command, cmdOutput)
+		mu.Unlock()
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Fixes a potential flake with regards to when writing to cmdOutput at the
same time that log.ErrorF(...) is reading from it.

**Which issue(s) this PR fixes**:

Closes https://github.com/openshift/odo/issues/2828

**How to test changes / Special notes to the reviewer**:

N/A, honestly not too sure