### PR TITLE
Fix failing CI tests due to Open Liberty devfile rename

### DIFF
--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -47,7 +47,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 				"Odo Devfile Components",
 				"NAME",
 				"java-spring-boot",
-				"openLiberty",
+				"java-openliberty",
 				"quarkus",
 				"DESCRIPTION",
 				"REGISTRY",

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -60,28 +60,28 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	Context("When executing odo create with devfile component type argument", func() {
 		It("should successfully create the devfile component", func() {
-			helper.CmdShouldPass("odo", "create", "openLiberty")
+			helper.CmdShouldPass("odo", "create", "java-openliberty")
 		})
 	})
 
 	Context("When executing odo create with devfile component type and component name arguments", func() {
 		It("should successfully create the devfile component", func() {
 			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "openLiberty", componentName)
+			helper.CmdShouldPass("odo", "create", "java-openliberty", componentName)
 		})
 	})
 
 	Context("When executing odo create with devfile component type argument and --project flag", func() {
 		It("should successfully create the devfile component", func() {
 			componentNamespace := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "openLiberty", "--project", componentNamespace)
+			helper.CmdShouldPass("odo", "create", "java-openliberty", "--project", componentNamespace)
 		})
 	})
 
 	Context("When executing odo create with devfile component type argument and --registry flag", func() {
 		It("should successfully create the devfile component", func() {
 			componentRegistry := "DefaultDevfileRegistry"
-			helper.CmdShouldPass("odo", "create", "openLiberty", "--registry", componentRegistry)
+			helper.CmdShouldPass("odo", "create", "java-openliberty", "--registry", componentRegistry)
 		})
 	})
 
@@ -92,7 +92,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			envFilePath := filepath.Join(newContext, envFile)
 			helper.MakeDir(newContext)
 
-			helper.CmdShouldPass("odo", "create", "openLiberty", "--context", newContext)
+			helper.CmdShouldPass("odo", "create", "java-openliberty", "--context", newContext)
 			output := util.CheckPathExists(devfilePath)
 			Expect(output).Should(BeTrue())
 			output = util.CheckPathExists(envFilePath)
@@ -104,7 +104,7 @@ var _ = Describe("odo devfile create command tests", func() {
 	Context("When executing odo create with devfile component name that contains unsupported character", func() {
 		It("should failed with devfile component name is not valid and prompt supported character", func() {
 			componentName := "BAD@123"
-			output := helper.CmdShouldFail("odo", "create", "openLiberty", componentName)
+			output := helper.CmdShouldFail("odo", "create", "java-openliberty", componentName)
 			helper.MatchAllInOutput(output, []string{"Contain only lowercase alphanumeric characters or ‘-’"})
 		})
 	})
@@ -112,7 +112,7 @@ var _ = Describe("odo devfile create command tests", func() {
 	Context("When executing odo create with devfile component name that contains all numeric values", func() {
 		It("should failed with devfile component name is not valid and prompt container name must not contain all numeric values", func() {
 			componentName := "123456"
-			output := helper.CmdShouldFail("odo", "create", "openLiberty", componentName)
+			output := helper.CmdShouldFail("odo", "create", "java-openliberty", componentName)
 			helper.MatchAllInOutput(output, []string{"Must not contain all numeric values"})
 		})
 	})
@@ -120,7 +120,7 @@ var _ = Describe("odo devfile create command tests", func() {
 	Context("When executing odo create with devfile component name that contains more than 63 characters", func() {
 		It("should failed with devfile component name is not valid and prompt container name contains at most 63 characters", func() {
 			componentName := helper.RandString(64)
-			output := helper.CmdShouldFail("odo", "create", "openLiberty", componentName)
+			output := helper.CmdShouldFail("odo", "create", "java-openliberty", componentName)
 			helper.MatchAllInOutput(output, []string{"Contain at most 63 characters"})
 		})
 	})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
@@ -36,7 +36,7 @@ var _ = Describe("odo docker devfile catalog command tests", func() {
 	Context("When executing catalog list components on Docker", func() {
 		It("should list all supported devfile components", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
-			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-spring-boot", "openLiberty"})
+			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-spring-boot", "java-openliberty"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area testing

**What does does this PR do / why we need it**:
Updates odo's devfile integration tests to use `java-openliberty` instead of `openLiberty`, as the name of the Open Liberty devfile stack was recently renamed.

I'm putting this change up so that our PRs are unblocked on CI failures. I'm not crazy about an external dependency (a devfile registry in this case) being able to completely break our tests, but given that we need to test `odo create` with devfiles in a registry, I'm not sure what's the best approach here.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3316

**How to test changes / Special notes to the reviewer**:
Run the integration tests that I updated.