### PR TITLE
Fix namespace issue for url create --now

### DIFF
--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -62,7 +62,7 @@ func (po *PushOptions) DevfilePush() (err error) {
 		platformContext = nil
 	} else {
 		kc := kubernetes.KubernetesContext{
-			Namespace: po.namespace,
+			Namespace: po.KClient.Namespace,
 		}
 		platformContext = kc
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test
/kind flake

**What does does this PR do / why we need it**:
fixes use of wrong namespace  while pushing a component via `odo url create --now`

Run 
```
$ odo create nodejs mynodejs --project project1`
$ oc project
Using project "project2" on server "https://api.crc.testing:6443".
$ `odo url create url1  --host "myhost.com" --ingress --now`
```
url create --now, pushes the component and create the url, but it pushes the component in current namespace not in the namespace saved in env.yaml or namespace used while creation.
This causes failure in CI if the current set namespace gets terminated before component deployment.


**Which issue(s) this PR fixes**:

Fixes #3122

**How to test changes / Special notes to the reviewer**:
Component should be pushed into the correct namespace while `odo url create --now`
