### PR TITLE
use a more specific error message for when image is not found

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -755,7 +755,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 		if e != nil && err != nil {
 			// Imagestream not found in openshift and current namespaces
 			if experimental.IsExperimentalModeEnabled() {
-				return nil, fmt.Errorf("component %q not found", imageName)
+				return nil, fmt.Errorf("component type %q not found", imageName)
 			}
 			return nil, err
 		}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -561,7 +561,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		openshiftCluster = false
 	}
 	if !openshiftCluster {
-		return errors.New("component not found")
+		return errors.New("component type not found")
 	}
 
 	// check to see if config file exists or not, if it does that

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -67,7 +67,7 @@ var _ = Describe("odo devfile create command tests", func() {
 		It("should fail to create the devfile componet with invalid component type", func() {
 			fakeComponentName := "fake-component"
 			output := helper.CmdShouldFail("odo", "create", fakeComponentName)
-			expectedString := "\"" + fakeComponentName + "\" not found"
+			expectedString := "component type \"" + fakeComponentName + "\" not found"
 			helper.MatchAllInOutput(output, []string{expectedString})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind cleanup

**What does does this PR do / why we need it**:
see $SUBJECT
**Which issue(s) this PR fixes**:

**How to test changes / Special notes to the reviewer**:
experimental mode on

```
$ odo create fake-s
Experimental mode is enabled, use at your own risk

Validation
 ✗  Checking devfile compatibility [97069ns]
 ✗  Creating a devfile component from registry:  [92999ns]

Please run `odo catalog list components` for a list of supported devfile component types
 ✗  component type "fake-s" not found <------ this was just "component before"
```
