### PR TITLE
Invalid ANSI colouring on Windows when doing devfile push

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -303,7 +303,7 @@ func Spinnerf(format string, a ...interface{}) *Status {
 
 // SpinnerNoSpin is the same as the "Spinner" function but forces no spinning
 func SpinnerNoSpin(status string) *Status {
-	s := NewStatus(os.Stdout)
+	s := NewStatus(GetStdout())
 	s.Start(status, true)
 	return s
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR updates `SpinnerNoSpin` to use the same Windows stdout code as other `Get*` methods in `log/status.go`.

**Which issue(s) this PR fixes**:
https://github.com/openshift/odo/issues/2851

**How to test changes / Special notes to the reviewer**:

You MUST use the Windows 'Command Prompt' application, rather than 'Windows Terminal' (including the 'Command Prompt' shell in Windows Terminal) or Powershell (both which handle ANSI escape codes better).

