### PR TITLE
Fix multiple registry related issues

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -73,7 +73,7 @@ func convertURL(URL string) (string, error) {
 	if strings.Contains(url.Host, "github") && !strings.Contains(url.Host, "raw") {
 		// Convert path part of the URL
 		URLSlice := strings.Split(URL, "/")
-		if URLSlice[len(URLSlice)-2] == "tree" {
+		if len(URLSlice) > 2 && URLSlice[len(URLSlice)-2] == "tree" {
 			// GitHub raw URL doesn't have "tree" structure in the URL, need to remove it
 			URL = strings.Replace(URL, "/tree", "", 1)
 		} else {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -25,12 +25,6 @@ const (
 	apiVersion = "odo.dev/v1alpha1"
 )
 
-// DevfileRegistries contains the links of all devfile registries
-var DevfileRegistries = []string{
-	"https://raw.githubusercontent.com/elsony/devfile-registry/master",
-	"https://che-devfile-registry.openshift.io/",
-}
-
 // GetDevfileRegistries gets devfile registries from preference file,
 // if registry name is specified return the specific registry, otherwise return all registries
 func GetDevfileRegistries(registryName string) (map[string]Registry, error) {
@@ -76,7 +70,7 @@ func convertURL(URL string) (string, error) {
 		return "", err
 	}
 
-	if strings.Contains(url.Host, "github") {
+	if strings.Contains(url.Host, "github") && !strings.Contains(url.Host, "raw") {
 		// Convert path part of the URL
 		URLSlice := strings.Split(URL, "/")
 		if URLSlice[len(URLSlice)-2] == "tree" {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -3,10 +3,11 @@ package catalog
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/odo/pkg/preference"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/openshift/odo/pkg/preference"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
@@ -171,10 +172,9 @@ func ListDevfileComponents(registryName string) (DevfileComponentTypeList, error
 		// Load the devfile registry index.json
 		registry := reg // needed to prevent the lambda from capturing the value
 		retrieveRegistryIndices.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-			indexEntries, e := getDevfileIndexEntries(registry)
-			if e != nil {
-				log.Warningf("Registry %s is not set up properly with error: %v", registryName, err)
-				errChannel <- e
+			indexEntries, err := getDevfileIndexEntries(registry)
+			if err != nil {
+				log.Warningf("Registry %s is not set up properly with error: %v", registry.Name, err)
 				return
 			}
 
@@ -203,7 +203,6 @@ func ListDevfileComponents(registryName string) (DevfileComponentTypeList, error
 			devfile, err := GetDevfile(link)
 			if err != nil {
 				log.Warningf("Registry %s is not set up properly with error: %v", devfileIndex.Registry.Name, err)
-				errChannel <- err
 				return
 			}
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -187,7 +187,7 @@ OdoSettings:
   - Name: CheDevfileRegistry
     URL: https://che-devfile-registry.openshift.io/
   - Name: DefaultDevfileRegistry
-    URL: https://raw.githubusercontent.com/elsony/devfile-registry/master`,
+    URL: https://github.com/elsony/devfile-registry`,
 	))
 	if err != nil {
 		t.Error(err)
@@ -211,7 +211,7 @@ OdoSettings:
 				},
 				"DefaultDevfileRegistry": {
 					Name: "DefaultDevfileRegistry",
-					URL:  "https://raw.githubusercontent.com/elsony/devfile-registry/master",
+					URL:  "https://github.com/elsony/devfile-registry",
 				},
 			},
 		},

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -576,3 +576,40 @@ func MockImageStream() *imagev1.ImageStream {
 
 	return imageStream
 }
+
+func TestConvertURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		URL     string
+		wantURL string
+	}{
+		{
+			name:    "Case 1: GitHub regular URL without specifying branch",
+			URL:     "https://github.com/GeekArthur/registry",
+			wantURL: "https://raw.githubusercontent.com/GeekArthur/registry/master",
+		},
+		{
+			name:    "Case 2: GitHub regular URL with master branch specified",
+			URL:     "https://github.ibm.com/Jingfu-J-Wang/registry/tree/master",
+			wantURL: "https://raw.github.ibm.com/Jingfu-J-Wang/registry/master",
+		},
+		{
+			name:    "Case 3: GitHub regular URL with non-master branch specified",
+			URL:     "https://github.com/elsony/devfile-registry/tree/johnmcollier-crw",
+			wantURL: "https://raw.githubusercontent.com/elsony/devfile-registry/johnmcollier-crw",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, err := convertURL(tt.URL)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if !reflect.DeepEqual(gotURL, tt.wantURL) {
+				t.Errorf("Got url: %s, want URL: %s", gotURL, tt.wantURL)
+			}
+		})
+	}
+}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -359,9 +359,16 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		// Validate user specify registry
 		if co.devfileMetadata.devfileRegistry.Name != "" {
-			// TODO: We should add more validations here to validate registry existence and correctness
 			if co.devfileMetadata.devfilePath.value != "" {
-				return errors.New("You can specify registry via --registry if you want to use the devfile that is specified via --devfile")
+				return errors.New("You can't download devfile from registry by specifying --registry if you want to use the devfile that is specified via --devfile")
+			}
+
+			registryList, err := catalog.GetDevfileRegistries(co.devfileMetadata.devfileRegistry.Name)
+			if err != nil {
+				return err
+			}
+			if len(registryList) == 0 {
+				return errors.Errorf("Registry %s doesn't exist, please specify the valid registry via --registry", co.devfileMetadata.devfileRegistry.Name)
 			}
 		}
 
@@ -513,16 +520,29 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			// Since we need to support both devfile and s2i, so we have to check if the component type is
 			// supported by devfile, if it is supported we return and will download the corresponding devfile later,
 			// if it is not supported we still need to run all the codes related with s2i after devfile compatibility check
-			spinner := log.Spinner("Checking devfile compatibility")
+
+			hasComponent := false
 
 			for _, devfileComponent := range catalogDevfileList.Items {
-				if co.devfileMetadata.componentType == devfileComponent.Name && devfileComponent.Support {
-					co.devfileMetadata.devfileSupport = true
-					co.devfileMetadata.devfileLink = devfileComponent.Link
-					co.devfileMetadata.devfileRegistry = devfileComponent.Registry
+				if co.devfileMetadata.componentType == devfileComponent.Name {
+					hasComponent = true
+					if devfileComponent.Support {
+						co.devfileMetadata.devfileSupport = true
+						co.devfileMetadata.devfileLink = devfileComponent.Link
+						co.devfileMetadata.devfileRegistry = devfileComponent.Registry
+						break
+					}
 				}
 			}
 
+			existSpinner := log.Spinner("Checking devfile existence")
+			if hasComponent {
+				existSpinner.End(true)
+			} else {
+				existSpinner.End(false)
+			}
+
+			supportSpinner := log.Spinner("Checking devfile compatibility")
 			if co.devfileMetadata.devfileSupport {
 				registrySpinner := log.Spinnerf("Creating a devfile component from registry: %s", co.devfileMetadata.devfileRegistry.Name)
 
@@ -532,13 +552,19 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					return err
 				}
 
-				spinner.End(true)
+				supportSpinner.End(true)
 				registrySpinner.End(true)
 				return nil
 			}
+			supportSpinner.End(false)
 
-			spinner.End(false)
-			log.Warning("\nDevfile component type is not supported, please run `odo catalog list components` for a list of supported devfile component types")
+			// Currently only devfile component supports --registry flag, so if user specifies --registry when creating devfile component,
+			// we should error out instead of running s2i componet code and throw warning message
+			if co.devfileMetadata.devfileRegistry.Name != "" {
+				return errors.Errorf("Devfile component type %s is not supported, please run `odo catalog list components` for a list of supported devfile component types", co.devfileMetadata.componentType)
+			} else {
+				log.Warningf("Devfile component type %s is not supported, please run `odo catalog list components` for a list of supported devfile component types", co.devfileMetadata.componentType)
+			}
 		}
 	}
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -360,15 +360,15 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// Validate user specify registry
 		if co.devfileMetadata.devfileRegistry.Name != "" {
 			if co.devfileMetadata.devfilePath.value != "" {
-				return errors.New("You can't download devfile from registry by specifying --registry if you want to use the devfile that is specified via --devfile")
+				return errors.New("You can't specify registry via --registry if you want to use the devfile that is specified via --devfile")
 			}
 
 			registryList, err := catalog.GetDevfileRegistries(co.devfileMetadata.devfileRegistry.Name)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "Failed to get registry")
 			}
 			if len(registryList) == 0 {
-				return errors.Errorf("Registry %s doesn't exist, please specify the valid registry via --registry", co.devfileMetadata.devfileRegistry.Name)
+				return errors.Errorf("Registry %s doesn't exist, please specify a valid registry via --registry", co.devfileMetadata.devfileRegistry.Name)
 			}
 		}
 

--- a/pkg/odo/cli/registry/add.go
+++ b/pkg/odo/cli/registry/add.go
@@ -25,7 +25,7 @@ var (
 	addExample = ktemplates.Examples(`# Add devfile registry
 	%[1]s CheRegistry https://che-devfile-registry.openshift.io
 
-	%[1]s CheRegistryFromGitHub https://raw.githubusercontent.com/eclipse/che-devfile-registry/master
+	%[1]s RegistryFromGitHub https://github.com/elsony/devfile-registry
 	`)
 )
 

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -77,7 +77,7 @@ const (
 	DefaultDevfileRegistryName = "DefaultDevfileRegistry"
 
 	// DefaultDevfileRegistryURL is the URL of default devfile registry
-	DefaultDevfileRegistryURL = "https://raw.githubusercontent.com/elsony/devfile-registry/master"
+	DefaultDevfileRegistryURL = "https://github.com/elsony/devfile-registry"
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -74,4 +74,18 @@ var _ = Describe("odo devfile catalog command tests", func() {
 			helper.MatchAllInOutput(output, wantOutput)
 		})
 	})
+
+	Context("When executing catalog list components with registry that is not set up properly", func() {
+		It("should list components from valid registry", func() {
+			helper.CmdShouldPass("odo", "registry", "add", "fake", "http://fake")
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
+			wantOutput := []string{
+				"Odo Devfile Components",
+				"java-spring-boot",
+				"quarkus",
+			}
+			helper.MatchAllInOutput(output, wantOutput)
+			helper.CmdShouldPass("odo", "registry", "delete", "fake", "-f")
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -97,12 +97,11 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		It("should list components from valid registry", func() {
 			helper.CmdShouldPass("odo", "registry", "add", "fake", "http://fake")
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
-			wantOutput := []string{
+			helper.MatchAllInOutput(output, []string{
 				"Odo Devfile Components",
 				"java-spring-boot",
 				"quarkus",
-			}
-			helper.MatchAllInOutput(output, wantOutput)
+			})
 			helper.CmdShouldPass("odo", "registry", "delete", "fake", "-f")
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -128,7 +128,8 @@ var _ = Describe("odo devfile create command tests", func() {
 
 		It("should fail to create the devfile component if specified registry is invalid", func() {
 			componentRegistry := "fake"
-			helper.CmdShouldFail("odo", "create", "java-openliberty", "--registry", componentRegistry)
+			output := helper.CmdShouldFail("odo", "create", "java-openliberty", "--registry", componentRegistry)
+			helper.MatchAllInOutput(output, []string{"Registry fake doesn't exist, please specify a valid registry via --registry"})
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -105,9 +105,14 @@ var _ = Describe("odo devfile create command tests", func() {
 	})
 
 	Context("When executing odo create with devfile component type argument and --registry flag", func() {
-		It("should successfully create the devfile component", func() {
+		It("should successfully create the devfile component if specified registry is valid", func() {
 			componentRegistry := "DefaultDevfileRegistry"
 			helper.CmdShouldPass("odo", "create", "java-openliberty", "--registry", componentRegistry)
+		})
+
+		It("should fail to create the devfile component if specified registry is invalid", func() {
+			componentRegistry := "fake"
+			helper.CmdShouldFail("odo", "create", "java-openliberty", "--registry", componentRegistry)
 		})
 	})
 

--- a/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
@@ -69,12 +69,11 @@ var _ = Describe("odo docker devfile catalog command tests", func() {
 		It("should list components from valid registry", func() {
 			helper.CmdShouldPass("odo", "registry", "add", "fake", "http://fake")
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
-			wantOutput := []string{
+			helper.MatchAllInOutput(output, []string{
 				"Odo Devfile Components",
 				"java-spring-boot",
 				"quarkus",
-			}
-			helper.MatchAllInOutput(output, wantOutput)
+			})
 			helper.CmdShouldPass("odo", "registry", "delete", "fake", "-f")
 		})
 	})

--- a/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
@@ -46,4 +46,18 @@ var _ = Describe("odo docker devfile catalog command tests", func() {
 			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-spring-boot", "java-maven", "php-mysql"})
 		})
 	})
+
+	Context("When executing catalog list components with registry that is not set up properly", func() {
+		It("should list components from valid registry", func() {
+			helper.CmdShouldPass("odo", "registry", "add", "fake", "http://fake")
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
+			wantOutput := []string{
+				"Odo Devfile Components",
+				"java-spring-boot",
+				"quarkus",
+			}
+			helper.MatchAllInOutput(output, wantOutput)
+			helper.CmdShouldPass("odo", "registry", "delete", "fake", "-f")
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug
/area devfile

**What does does this PR do / why we need it**:
This PR fixes the following issues related with registry
1. Only throw warning for invalid registry and display registry name properly
2. Improve `--registry` flag validation
3. Improve component type existence validation when creating devfile component from registry
4. Add GitHub raw URL conversion support so that user can directly add GirHub regular URL (can be reachable) instead of GitHub raw URL as registry URL
5. Update corresponding help and usage

**Which issue(s) this PR fixes**:
Fixes https://github.com/openshift/odo/issues/3297
Fixes https://github.com/openshift/odo/issues/3167
Fixes https://github.com/openshift/odo/issues/3382

**How to test changes / Special notes to the reviewer**:
1. Only throw warning for invalid registry and display registry name properly
   1. Run `odo registry add fake http://fake`
   2. Run `odo catalog list components` can list valid registry and throw warning for invalid registry
2. Improve `--registry` flag validation
   1. Run `odo create nodejs --registry fake` can throw proper error directly
3. Improve component type existence validation when creating devfile component from registry
   1. Run `odo create nodejs` can validate if the component type exists in the registry