### PR TITLE
resolved the gosec issue failing unit tests

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -85,8 +85,8 @@ func GenerateRandomString(n int) string {
 	b := make([]rune, n)
 
 	for i := range b {
-		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0.
-		// which wont happend
+		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0
+		// which wont happen
 		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterRunes))))
 		b[i] = letterRunes[n.Int64()]
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,10 +4,11 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -81,10 +82,13 @@ func ConvertLabelsToSelector(labels map[string]string) string {
 // GenerateRandomString generates a random string of lower case characters of
 // the given size
 func GenerateRandomString(n int) string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]rune, n)
+
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0.
+		// which wont happend
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterRunes))))
+		b[i] = letterRunes[n.Int64()]
 	}
 	return string(b)
 }

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -2,9 +2,10 @@ package helper
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,16 +17,15 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
-
 // RandString returns a random string of given length
 func RandString(n int) string {
 	const letterBytes = "abcdefghijklmnopqrstuvwxyz"
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0.
+		// which wont happen
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		b[i] = letterBytes[n.Int64()]
 	}
 	return string(b)
 }

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -2,10 +2,8 @@ package helper
 
 import (
 	"bytes"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,19 +13,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/openshift/odo/pkg/util"
 )
 
 // RandString returns a random string of given length
 func RandString(n int) string {
-	const letterBytes = "abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, n)
-	for i := range b {
-		// this error is ignored because it fails only when the 2nd arg of Int() is less then 0.
-		// which wont happen
-		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
-		b[i] = letterBytes[n.Int64()]
-	}
-	return string(b)
+	return util.GenerateRandomString(n)
 }
 
 // WaitForCmdOut runs a command until it gets


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`



 /kind failing-test

**What does does this PR do / why we need it**:
resolving gosec error

**Which issue(s) this PR fixes**:
```
gosec -severity medium -confidence medium -exclude G304,G204 -quiet  ./...
Results:
[�[97;41m/go/src/github.com/openshift/odo/pkg/util/util.go:87�[0m] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
  > rand.Intn(len(letterRunes))
[�[97;41m/go/src/github.com/openshift/odo/tests/helper/helper_generic.go:29�[0m] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
  > rand.Intn(len(letterBytes))
�[1;36mSummary:�[0m
   Files: 229
```

**How to test changes / Special notes to the reviewer**:

running gosec locally using `make sec` should pass

```
(base) [gramnani@girishpc odo]
$ make sec
/home/gramnani/GoProjects/bin/gosec
gosec -severity medium -confidence medium -exclude G304,G204 -quiet  ./...
(base) [gramnani@girishpc odo]
```
