### PR TITLE
Build progress does not show correctly when the command line is too long

### DIFF
--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -154,8 +154,9 @@ func trimSuffixIfNeeded(suffix string, w io.Writer, padding int) string {
 
 	// Otherwise trim down to the desired length and append '...'
 	abbrevSuffix := "..."
-	maxWidth -= len(abbrevSuffix)
+	maxWidth -= len(abbrevSuffix) // maxWidth is necessarily >20 at this point
 
+	// len(suffix) is necessarily >= maxWidth at this point
 	suffix = suffix[:maxWidth] + abbrevSuffix
 
 	return suffix

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -88,12 +88,14 @@ func (s *Status) updateStatus() {
 	if s.warningStatus != "" {
 		yellow := color.New(color.FgYellow).SprintFunc()
 
+		// Determine the warning size, so that we can calculate its length and use that length as padding parameter
 		warningSubstring := fmt.Sprintf(" [%s %s]", yellow(getWarningString()), yellow(s.warningStatus))
 
+		// Combine suffix and spacing, then resize them
 		newSuffix := fmt.Sprintf(suffixSpacing+"%s", s.status)
-
 		newSuffix = trimSuffixIfNeeded(newSuffix, s.writer, len(warningSubstring))
 
+		// Combine the warning and non-warning text (since we don't want to trim the warning text)
 		s.spinner.SetSuffix(fmt.Sprintf("%s%s", newSuffix, warningSubstring))
 	} else {
 		newSuffix := fmt.Sprintf(suffixSpacing+"%s", s.status)

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -93,13 +93,13 @@ func (s *Status) updateStatus() {
 
 		// Combine suffix and spacing, then resize them
 		newSuffix := fmt.Sprintf(suffixSpacing+"%s", s.status)
-		newSuffix = trimSuffixIfNeeded(newSuffix, s.writer, len(warningSubstring))
+		newSuffix = truncateSuffixIfNeeded(newSuffix, s.writer, len(warningSubstring))
 
-		// Combine the warning and non-warning text (since we don't want to trim the warning text)
+		// Combine the warning and non-warning text (since we don't want to truncate the warning text)
 		s.spinner.SetSuffix(fmt.Sprintf("%s%s", newSuffix, warningSubstring))
 	} else {
 		newSuffix := fmt.Sprintf(suffixSpacing+"%s", s.status)
-		s.spinner.SetSuffix(trimSuffixIfNeeded(newSuffix, s.writer, 0))
+		s.spinner.SetSuffix(truncateSuffixIfNeeded(newSuffix, s.writer, 0))
 	}
 	mu.Unlock()
 }
@@ -122,15 +122,15 @@ func (s *Status) Start(status string, debug bool) {
 		} else {
 			s.spinner.SetPrefix(prefixSpacing)
 			newSuffix := fmt.Sprintf(suffixSpacing+"%s", s.status)
-			s.spinner.SetSuffix(trimSuffixIfNeeded(newSuffix, s.writer, 0))
+			s.spinner.SetSuffix(truncateSuffixIfNeeded(newSuffix, s.writer, 0))
 			s.spinner.Start()
 		}
 	}
 }
 
-// trimSuffixIfNeeded returns a represention of the 'suffix' parameter that fits within the terminal
+// truncateSuffixIfNeeded returns a represention of the 'suffix' parameter that fits within the terminal
 // (including the extra space occupied by the padding parameter).
-func trimSuffixIfNeeded(suffix string, w io.Writer, padding int) string {
+func truncateSuffixIfNeeded(suffix string, w io.Writer, padding int) string {
 
 	terminalWidth := getTerminalWidth(w)
 	if terminalWidth == nil {
@@ -152,7 +152,7 @@ func trimSuffixIfNeeded(suffix string, w io.Writer, padding int) string {
 		return suffix
 	}
 
-	// Otherwise trim down to the desired length and append '...'
+	// Otherwise truncate down to the desired length and append '...'
 	abbrevSuffix := "..."
 	maxWidth -= len(abbrevSuffix) // maxWidth is necessarily >20 at this point
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR truncates the spinner suffix based on the detected terminal width (in cases where the terminal width is available).

**Which issue(s) this PR fixes**:
https://github.com/openshift/odo/issues/3373

**How to test changes / Special notes to the reviewer**:
See issue for reproduction steps.