### PR TITLE
Ignore .odo/env folder for devfile

### DIFF
--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -155,10 +155,6 @@ func newProxyEnvInfo() proxyEnvInfo {
 func (esi *EnvSpecificInfo) SetConfiguration(parameter string, value interface{}) (err error) {
 	if parameter, ok := asLocallySupportedParameter(parameter); ok {
 		switch parameter {
-		case "create":
-			createValue := value.(ComponentSettings)
-			esi.componentSettings.Name = createValue.Name
-			esi.componentSettings.Namespace = createValue.Namespace
 		case "url":
 			urlValue := value.(EnvInfoURL)
 			if esi.componentSettings.URL != nil {
@@ -284,25 +280,15 @@ func (ei *EnvInfo) GetPushCommand() EnvInfoPushCommand {
 
 // GetName returns the component name
 func (ei *EnvInfo) GetName() string {
-	if ei.componentSettings.Name == "" {
-		return ""
-	}
 	return ei.componentSettings.Name
 }
 
 // GetNamespace returns component namespace
 func (ei *EnvInfo) GetNamespace() string {
-	if ei.componentSettings.Namespace == "" {
-		return ""
-	}
 	return ei.componentSettings.Namespace
 }
 
 const (
-	// Create parameter
-	Create = "CREATE"
-	// CreateDescription is the description of Create parameter
-	CreateDescription = "Create parameter is the action to write devfile metadata to env.yaml"
 	// URL parameter
 	URL = "URL"
 	// URLDescription is the description of URL
@@ -315,9 +301,8 @@ const (
 
 var (
 	supportedLocalParameterDescriptions = map[string]string{
-		Create: CreateDescription,
-		URL:    URLDescription,
-		Push:   PushDescription,
+		URL:  URLDescription,
+		Push: PushDescription,
 	}
 
 	lowerCaseLocalParameters = util.GetLowerCaseParameters(GetLocallySupportedParameters())

--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -23,7 +23,6 @@ func TestSetEnvInfo(t *testing.T) {
 	os.Setenv(envInfoEnvName, tempEnvFile.Name())
 	testURL := EnvInfoURL{Name: "testURL", Host: "1.2.3.4.nip.io", TLSSecret: "testTLSSecret"}
 	invalidParam := "invalidParameter"
-	testCreate := ComponentSettings{Name: "componentName", Namespace: "namespace"}
 	testPush := EnvInfoPushCommand{Init: "myinit", Build: "myBuild", Run: "myRun"}
 
 	tests := []struct {
@@ -53,16 +52,6 @@ func TestSetEnvInfo(t *testing.T) {
 			},
 			checkConfigSetting: []string{"URL"},
 			expectError:        true,
-		},
-		{
-			name:      "Case 3: Test fields setup from create parameter",
-			parameter: Create,
-			value:     testCreate,
-			existingEnvInfo: EnvInfo{
-				componentSettings: ComponentSettings{},
-			},
-			checkConfigSetting: []string{"Name", "Namespace"},
-			expectError:        false,
 		},
 		{
 			name:      "Case 4: Test fields setup from push parameter",
@@ -377,7 +366,7 @@ func TestGetPushCommand(t *testing.T) {
 }
 
 func TestLowerCaseParameterForLocalParameters(t *testing.T) {
-	expected := map[string]bool{"create": true, "push": true, "url": true}
+	expected := map[string]bool{"push": true, "url": true}
 	actual := util.GetLowerCaseParameters(GetLocallySupportedParameters())
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected '%v', got '%v'", expected, actual)

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -88,6 +88,7 @@ const devFile = "devfile.yaml"
 var (
 	envFile    = filepath.Join(".odo", "env", "env.yaml")
 	configFile = filepath.Join(".odo", "config.yaml")
+	envDir     = filepath.Join(".odo", "env")
 )
 
 // DevfilePath is the devfile path that is used by odo,

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -84,8 +84,11 @@ const LocalDirectoryDefaultLocation = "./"
 
 // Constants for devfile component
 const devFile = "devfile.yaml"
-const envFile = ".odo/env/env.yaml"
-const configFile = ".odo/config.yaml"
+
+var (
+	envFile    = filepath.Join(".odo", "env", "env.yaml")
+	configFile = filepath.Join(".odo", "config.yaml")
+)
 
 // DevfilePath is the devfile path that is used by odo,
 // which means odo can:

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -926,9 +926,24 @@ func (co *CreateOptions) Run() (err error) {
 			}
 
 			// Generate env file
-			err = co.EnvSpecificInfo.SetConfiguration("create", envinfo.ComponentSettings{Name: co.devfileMetadata.componentName, Namespace: co.devfileMetadata.componentNamespace})
+			err = co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{Name: co.devfileMetadata.componentName, Namespace: co.devfileMetadata.componentNamespace})
 			if err != nil {
 				return errors.Wrap(err, "failed to create env file for devfile component")
+			}
+
+			sourcePath, err := util.GetAbsPath(co.componentContext)
+			if err != nil {
+				return errors.Wrap(err, "unable to get source path")
+			}
+
+			ignoreFile, err := util.CheckGitIgnoreFile(sourcePath)
+			if err != nil {
+				return err
+			}
+
+			err = util.AddFileToIgnoreFile(ignoreFile, filepath.Join(co.componentContext, envDir))
+			if err != nil {
+				return err
 			}
 
 			log.Italic("\nPlease use `odo push` command to create the component with source deployed")

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -54,16 +54,6 @@ func (po *PushOptions) DevfilePush() (err error) {
 		return errors.Wrap(err, "unable to get source path")
 	}
 
-	ignoreFile, err := util.CheckGitIgnoreFile(po.sourcePath)
-	if err != nil {
-		return err
-	}
-
-	err = util.AddFileToIgnoreFile(ignoreFile, filepath.Join(po.sourcePath, envDir))
-	if err != nil {
-		return err
-	}
-
 	// Apply ignore information
 	err = genericclioptions.ApplyIgnore(&po.ignores, po.sourcePath)
 	if err != nil {

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openshift/odo/pkg/envinfo"
@@ -17,6 +18,8 @@ import (
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/log"
 )
+
+var envDir = filepath.Join(".odo", "env")
 
 /*
 Devfile support is an experimental feature which extends the support for the
@@ -49,6 +52,16 @@ func (po *PushOptions) DevfilePush() (err error) {
 	po.sourcePath, err = util.GetAbsPath(po.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source path")
+	}
+
+	ignoreFile, err := util.CheckGitIgnoreFile(po.sourcePath)
+	if err != nil {
+		return err
+	}
+
+	err = util.AddFileToIgnoreFile(ignoreFile, filepath.Join(po.sourcePath, envDir))
+	if err != nil {
+		return err
 	}
 
 	// Apply ignore information

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/openshift/odo/pkg/envinfo"
@@ -18,8 +17,6 @@ import (
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/log"
 )
-
-var envDir = filepath.Join(".odo", "env")
 
 /*
 Devfile support is an experimental feature which extends the support for the

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/openshift/odo/pkg/testingutil/filesystem"
@@ -92,23 +91,7 @@ func AddOdoFileIndex(gitIgnoreFile string) error {
 }
 
 func addOdoFileIndex(gitIgnoreFile string, fs filesystem.Filesystem) error {
-	var data []byte
-	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, 0600)
-	if err != nil {
-		return errors.Wrap(err, "failed to open .gitignore file")
-	}
-	defer file.Close()
-
-	if data, err = fs.ReadFile(gitIgnoreFile); err != nil {
-		return errors.Wrap(err, "failed reading data from .gitignore file")
-	}
-	// check whether .odo/odo-file-index.json is already in the .gitignore file
-	if !strings.Contains(string(data), filepath.Join(fileIndexDirectory, fileIndexName)) {
-		if _, err := file.WriteString("\n" + filepath.Join(fileIndexDirectory, fileIndexName)); err != nil {
-			return errors.Wrapf(err, "failed to Add %v to .gitignore file", fileIndexName)
-		}
-	}
-	return nil
+	return addFileToIgnoreFile(gitIgnoreFile, filepath.Join(fileIndexDirectory, fileIndexName), fs)
 }
 
 // CheckGitIgnoreFile checks .gitignore file exists or not, if not then create it

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,6 +38,7 @@ import (
 const (
 	HTTPRequestTimeout    = 20 * time.Second // HTTPRequestTimeout configures timeout of all HTTP requests
 	ResponseHeaderTimeout = 10 * time.Second // ResponseHeaderTimeout is the timeout to retrieve the server's response headers
+	ModeReadWriteFile     = 0600             // default Permission for a file
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
@@ -938,7 +939,7 @@ func Unzip(src, dest, pathToUnzip string) ([]string, error) {
 			return filenames, err
 		}
 
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, ModeReadWriteFile)
 		if err != nil {
 			return filenames, err
 		}
@@ -1126,19 +1127,19 @@ func AddFileToIgnoreFile(gitIgnoreFile, filename string) error {
 
 func addFileToIgnoreFile(gitIgnoreFile, filename string, fs filesystem.Filesystem) error {
 	var data []byte
-	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, 0600)
+	file, err := fs.OpenFile(gitIgnoreFile, os.O_APPEND|os.O_RDWR, ModeReadWriteFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to open .gitignore file")
 	}
 	defer file.Close()
 
 	if data, err = fs.ReadFile(gitIgnoreFile); err != nil {
-		return errors.Wrap(err, "failed reading data from .gitignore file")
+		return errors.Wrap(err, fmt.Sprintf("failed reading data from %v file", gitIgnoreFile))
 	}
 	// check whether .odo/odo-file-index.json is already in the .gitignore file
 	if !strings.Contains(string(data), filename) {
 		if _, err := file.WriteString("\n" + filename); err != nil {
-			return errors.Wrapf(err, "failed to Add %v to .gitignore file", filepath.Base(filename))
+			return errors.Wrapf(err, "failed to add %v to %v file", filepath.Base(filename), gitIgnoreFile)
 		}
 	}
 	return nil

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -330,4 +330,21 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
+	FContext("when .gitignore file exists", func() {
+		It("checks that odo push works with a devfile", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+			ignoreFilePath := filepath.Join(context, ".gitignore")
+
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "odo-file-index.json"))
+			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "env"))
+
+		})
+	})
+
 })

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -334,13 +334,8 @@ var _ = Describe("odo devfile push command tests", func() {
 		It("checks that .odo/env and .odo/odo-file-index.json", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
 			ignoreFilePath := filepath.Join(context, ".gitignore")
 
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "odo-file-index.json"))
 			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "env"))
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -331,12 +331,11 @@ var _ = Describe("odo devfile push command tests", func() {
 	})
 
 	Context("when .gitignore file exists", func() {
-		It("checks that .odo/env and .odo/odo-file-index.json", func() {
+		It("checks that .odo/env exists in gitignore", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			ignoreFilePath := filepath.Join(context, ".gitignore")
 
-			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "odo-file-index.json"))
 			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "env"))
 
 		})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -330,8 +330,8 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
-	FContext("when .gitignore file exists", func() {
-		It("checks that odo push works with a devfile", func() {
+	Context("when .gitignore file exists", func() {
+		It("checks that .odo/env and .odo/odo-file-index.json", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


/kind bug

**What does does this PR do / why we need it**:
Add .odo/env in the .gitignore file for devfile push

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3386

**How to test changes / Special notes to the reviewer**:
Do odo create..odo push component creation 
and then check `.gitignore` for `.odo/env`