### PR TITLE
Update odo delete for no component and devfile.yaml

### DIFF
--- a/pkg/devfile/adapters/common/interface.go
+++ b/pkg/devfile/adapters/common/interface.go
@@ -5,7 +5,7 @@ import "io"
 // ComponentAdapter defines the functions that platform-specific adapters must implement
 type ComponentAdapter interface {
 	Push(parameters PushParameters) error
-	DoesComponentExist(cmpName string) bool
+	DoesComponentExist(cmpName string) (bool, error)
 	Delete(labels map[string]string) error
 	Log(follow, debug bool) (io.ReadCloser, error)
 }

--- a/pkg/devfile/adapters/docker/adapter.go
+++ b/pkg/devfile/adapters/docker/adapter.go
@@ -36,7 +36,7 @@ func (d Adapter) Push(parameters common.PushParameters) error {
 }
 
 // DoesComponentExist returns true if a component with the specified name exists
-func (d Adapter) DoesComponentExist(cmpName string) bool {
+func (d Adapter) DoesComponentExist(cmpName string) (bool, error) {
 	return d.componentAdapter.DoesComponentExist(cmpName)
 }
 

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -203,8 +203,8 @@ func (a Adapter) Delete(labels map[string]string) error {
 	componentContainer := a.Client.GetContainersByComponent(componentName, containers)
 
 	if len(componentContainer) == 0 {
-		log.Infof("Component %s does not exist", componentName)
-		spinner.End(true)
+		spinner.End(false)
+		log.Warningf("Component %s does not exist", componentName)
 		return nil
 	}
 

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -200,7 +200,8 @@ func (a Adapter) Delete(labels map[string]string) error {
 	componentContainer := a.Client.GetContainersByComponent(componentName, containers)
 
 	if len(componentContainer) == 0 {
-		return errors.Errorf("the component %s doesn't exist", a.ComponentName)
+		log.Italicf("Component %s does not exist", componentName)
+		return nil
 	}
 
 	allVolumes, err := a.Client.GetVolumes()
@@ -223,6 +224,9 @@ func (a Adapter) Delete(labels map[string]string) error {
 			}
 		}
 	}
+
+	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
+	defer spinner.End(false)
 
 	// A unique list of volumes to delete; map key is volume name.
 	volumesToDelete := map[string]string{}
@@ -272,6 +276,9 @@ func (a Adapter) Delete(labels map[string]string) error {
 			return errors.Wrapf(err, "Unable to remove volume %s of component %s", name, componentName)
 		}
 	}
+
+	spinner.End(true)
+	log.Successf("Successfully deleted component")
 
 	return nil
 

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -146,9 +146,9 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 }
 
 // DoesComponentExist returns true if a component with the specified name exists, false otherwise
-func (a Adapter) DoesComponentExist(cmpName string) bool {
-	componentExists, _ := utils.ComponentExists(a.Client, a.Devfile.Data, cmpName)
-	return componentExists
+func (a Adapter) DoesComponentExist(cmpName string) (bool, error) {
+	componentExists, err := utils.ComponentExists(a.Client, a.Devfile.Data, cmpName)
+	return componentExists, err
 }
 
 // getFirstContainerWithSourceVolume returns the first container that set mountSources: true

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -175,6 +175,9 @@ func (a Adapter) Delete(labels map[string]string) error {
 		return errors.New("unable to delete component without a component label")
 	}
 
+	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
+	defer spinner.End(false)
+
 	containers, err := a.Client.GetContainerList()
 	if err != nil {
 		return errors.Wrap(err, "unable to retrieve container list for delete operation")
@@ -200,7 +203,8 @@ func (a Adapter) Delete(labels map[string]string) error {
 	componentContainer := a.Client.GetContainersByComponent(componentName, containers)
 
 	if len(componentContainer) == 0 {
-		log.Italicf("Component %s does not exist", componentName)
+		log.Infof("Component %s does not exist", componentName)
+		spinner.End(true)
 		return nil
 	}
 
@@ -224,9 +228,6 @@ func (a Adapter) Delete(labels map[string]string) error {
 			}
 		}
 	}
-
-	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
-	defer spinner.End(false)
 
 	// A unique list of volumes to delete; map key is volume name.
 	volumesToDelete := map[string]string{}

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -175,7 +175,7 @@ func (a Adapter) Delete(labels map[string]string) error {
 		return errors.New("unable to delete component without a component label")
 	}
 
-	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
+	spinner := log.Spinnerf("Deleting devfile component %s", componentName)
 	defer spinner.End(false)
 
 	containers, err := a.Client.GetContainerList()

--- a/pkg/devfile/adapters/docker/component/adapter_test.go
+++ b/pkg/devfile/adapters/docker/component/adapter_test.go
@@ -244,7 +244,7 @@ func TestAdapterDelete(t *testing.T) {
 			}},
 			componentName:   "component",
 			componentExists: false,
-			wantErr:         true,
+			wantErr:         false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/devfile/adapters/docker/component/adapter_test.go
+++ b/pkg/devfile/adapters/docker/component/adapter_test.go
@@ -132,6 +132,7 @@ func TestDoesComponentExist(t *testing.T) {
 		componentName    string
 		getComponentName string
 		want             bool
+		wantErr          bool
 	}{
 		{
 			name:   "Case 1: Valid component name",
@@ -143,6 +144,7 @@ func TestDoesComponentExist(t *testing.T) {
 			componentName:    "golang",
 			getComponentName: "golang",
 			want:             true,
+			wantErr:          false,
 		},
 		{
 			name:   "Case 2: Non-existent component name",
@@ -153,9 +155,19 @@ func TestDoesComponentExist(t *testing.T) {
 			componentName:    "test",
 			getComponentName: "fake-component",
 			want:             false,
+			wantErr:          false,
 		},
 		{
-			name:   "Case 3: Docker client error",
+			name:             "Case 3: Container and devfile component mismatch",
+			componentName:    "test",
+			getComponentName: "golang",
+			client:           fakeClient,
+			components:       []common.DevfileComponent{},
+			want:             true,
+			wantErr:          true,
+		},
+		{
+			name:   "Case 4: Docker client error",
 			client: fakeErrorClient,
 			components: []common.DevfileComponent{
 				testingutil.GetFakeComponent("alias1"),
@@ -163,6 +175,7 @@ func TestDoesComponentExist(t *testing.T) {
 			componentName:    "test",
 			getComponentName: "fake-component",
 			want:             false,
+			wantErr:          true,
 		},
 	}
 	for _, tt := range tests {
@@ -181,9 +194,13 @@ func TestDoesComponentExist(t *testing.T) {
 			componentAdapter := New(adapterCtx, *tt.client)
 
 			// Verify that a component with the specified name exists
-			componentExists := componentAdapter.DoesComponentExist(tt.getComponentName)
-			if componentExists != tt.want {
+			componentExists, err := componentAdapter.DoesComponentExist(tt.getComponentName)
+			if !tt.wantErr && err != nil {
+				t.Errorf("TestDoesComponentExist error, unexpected error - %v", err)
+			} else if !tt.wantErr && componentExists != tt.want {
 				t.Errorf("expected %v, actual %v", tt.want, componentExists)
+			} else if tt.wantErr && tt.want != componentExists {
+				t.Errorf("expected %v, wanted %v, err %v", componentExists, tt.want, err)
 			}
 
 		})

--- a/pkg/devfile/adapters/docker/utils/utils.go
+++ b/pkg/devfile/adapters/docker/utils/utils.go
@@ -45,7 +45,7 @@ func ComponentExists(client lclient.Client, data data.DevfileData, name string) 
 	} else if len(containers) == len(supportedComponents) {
 		componentExists = true
 	} else if len(containers) > 0 && len(containers) != len(supportedComponents) {
-		return false, errors.New(fmt.Sprintf("component %s is in an invalid state, please execute odo delete and retry odo push", name))
+		return true, errors.New(fmt.Sprintf("component %s is in an invalid state, please execute odo delete and retry odo push", name))
 	}
 
 	return componentExists, nil

--- a/pkg/devfile/adapters/docker/utils/utils_test.go
+++ b/pkg/devfile/adapters/docker/utils/utils_test.go
@@ -66,12 +66,12 @@ func TestComponentExists(t *testing.T) {
 			componentName: "test",
 			client:        fakeClient,
 			components:    []common.DevfileComponent{},
-			want:          false,
+			want:          true,
 			wantErr:       true,
 		},
 		{
 			name:          "Case 5: Devfile does not have supported components",
-			componentName: "golang",
+			componentName: "abc",
 			client:        fakeClient,
 			components: []common.DevfileComponent{
 				{
@@ -95,6 +95,8 @@ func TestComponentExists(t *testing.T) {
 				t.Errorf("TestComponentExists error, unexpected error - %v", err)
 			} else if !tt.wantErr && tt.want != cmpExists {
 				t.Errorf("expected %v, wanted %v", cmpExists, tt.want)
+			} else if tt.wantErr && tt.want != cmpExists {
+				t.Errorf("expected %v, wanted %v, err %v", cmpExists, tt.want, err)
 			}
 		})
 	}

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -40,7 +40,7 @@ func (k Adapter) Push(parameters common.PushParameters) error {
 }
 
 // DoesComponentExist returns true if a component with the specified name exists
-func (k Adapter) DoesComponentExist(cmpName string) bool {
+func (k Adapter) DoesComponentExist(cmpName string) (bool, error) {
 	return k.componentAdapter.DoesComponentExist(cmpName)
 }
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -458,16 +458,16 @@ func (a Adapter) Delete(labels map[string]string) error {
 	if kerrors.IsForbidden(err) {
 		klog.V(4).Infof("Resource for %s forbidden", a.ComponentName)
 		// log the error if it failed to determine if the component exists due to insufficient RBACs
-		log.Infof("%s: %v", errorMsg, err)
-		spinner.End(true)
+		spinner.End(false)
+		log.Warningf("%s: %v", errorMsg, err)
 		return nil
 	} else if err != nil {
 		return errors.Wrapf(err, "unable to determine if component %s exists", a.ComponentName)
 	}
 
 	if !componentExists {
-		log.Infof(errorMsg)
-		spinner.End(true)
+		spinner.End(false)
+		log.Warningf(errorMsg)
 		return nil
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -164,8 +164,8 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 }
 
 // DoesComponentExist returns true if a component with the specified name exists, false otherwise
-func (a Adapter) DoesComponentExist(cmpName string) bool {
-	return utils.ComponentExists(a.Client, cmpName)
+func (a Adapter) DoesComponentExist(cmpName string) (bool, error) {
+	return utils.ComponentExists(a.Client, cmpName), nil
 }
 
 func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
@@ -252,7 +252,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	klog.V(4).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
 	klog.V(4).Infof("The component name is %v", componentName)
 
-	if utils.ComponentExists(a.Client, componentName) {
+	if componentExists {
 		// If the component already exists, get the resource version of the deploy before updating
 		klog.V(4).Info("The component already exists, attempting to update it")
 		deployment, err := a.Client.UpdateDeployment(*deploymentSpec)

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -449,17 +449,15 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 
 // Delete deletes the component
 func (a Adapter) Delete(labels map[string]string) error {
-	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", a.ComponentName))
+	spinner := log.Spinnerf("Deleting devfile component %s", a.ComponentName)
 	defer spinner.End(false)
-
-	errorMsg := fmt.Sprintf("Component %s does not exist", a.ComponentName)
 
 	componentExists, err := utils.ComponentExists(a.Client, a.ComponentName)
 	if kerrors.IsForbidden(err) {
 		klog.V(4).Infof("Resource for %s forbidden", a.ComponentName)
 		// log the error if it failed to determine if the component exists due to insufficient RBACs
 		spinner.End(false)
-		log.Warningf("%s: %v", errorMsg, err)
+		log.Warningf("%v", err)
 		return nil
 	} else if err != nil {
 		return errors.Wrapf(err, "unable to determine if component %s exists", a.ComponentName)
@@ -467,7 +465,7 @@ func (a Adapter) Delete(labels map[string]string) error {
 
 	if !componentExists {
 		spinner.End(false)
-		log.Warningf(errorMsg)
+		log.Warningf("Component %s does not exist", a.ComponentName)
 		return nil
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -448,17 +448,18 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 
 // Delete deletes the component
 func (a Adapter) Delete(labels map[string]string) error {
+	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", a.ComponentName))
+	defer spinner.End(false)
+
 	componentExists, err := utils.ComponentExists(a.Client, a.ComponentName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to determine if component %s exists", a.ComponentName)
 	}
 	if !componentExists {
-		log.Italicf("Component %s does not exist", a.ComponentName)
+		log.Infof("Component %s does not exist", a.ComponentName)
+		spinner.End(true)
 		return nil
 	}
-
-	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", a.ComponentName))
-	defer spinner.End(false)
 
 	err = a.Client.DeleteDeployment(labels)
 	if err != nil {

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -452,11 +452,16 @@ func (a Adapter) Delete(labels map[string]string) error {
 	defer spinner.End(false)
 
 	componentExists, err := utils.ComponentExists(a.Client, a.ComponentName)
-	if err != nil {
-		return errors.Wrapf(err, "unable to determine if component %s exists", a.ComponentName)
-	}
-	if !componentExists {
-		log.Infof("Component %s does not exist", a.ComponentName)
+	if !componentExists || err != nil {
+		msg := fmt.Sprintf("Component %s does not exist", a.ComponentName)
+
+		// log the error if it failed to determine if the component exists
+		if err != nil {
+			msg = fmt.Sprintf("%s: %v", msg, err)
+		}
+
+		log.Infof(msg)
+
 		spinner.End(true)
 		return nil
 	}

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -302,7 +302,7 @@ func TestDoesComponentExist(t *testing.T) {
 			}
 
 			// Verify that a component with the specified name exists
-			componentExists := componentAdapter.DoesComponentExist(tt.getComponentName)
+			componentExists, _ := componentAdapter.DoesComponentExist(tt.getComponentName)
 			if componentExists != tt.want {
 				t.Errorf("expected %v, actual %v", tt.want, componentExists)
 			}

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -454,7 +454,7 @@ func TestAdapterDelete(t *testing.T) {
 			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
 			componentName:      "component",
 			componentExists:    false,
-			wantErr:            true,
+			wantErr:            false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -15,8 +15,10 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	ktesting "k8s.io/client-go/testing"
 )
@@ -332,7 +334,7 @@ func TestDoesComponentExist(t *testing.T) {
 					return true, deployment, nil
 				}
 
-				return true, emptyDeployment, nil
+				return true, emptyDeployment, kerrors.NewNotFound(schema.GroupResource{}, "")
 			})
 
 			// Verify that a component with the specified name exists

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/odo/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog"
 )
@@ -19,7 +20,11 @@ import (
 // ComponentExists checks whether a deployment by the given name exists
 func ComponentExists(client kclient.Client, name string) (bool, error) {
 	deployment, err := client.GetDeploymentByName(name)
-	return len(deployment.GetName()) != 0, err
+	if kerrors.IsNotFound(err) {
+		klog.V(4).Infof("Deployment %s not found", name)
+		return false, nil
+	}
+	return deployment != nil, err
 }
 
 // ConvertEnvs converts environment variables from the devfile structure to kubernetes structure

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -17,9 +17,9 @@ import (
 )
 
 // ComponentExists checks whether a deployment by the given name exists
-func ComponentExists(client kclient.Client, name string) bool {
-	_, err := client.GetDeploymentByName(name)
-	return err == nil
+func ComponentExists(client kclient.Client, name string) (bool, error) {
+	deployment, err := client.GetDeploymentByName(name)
+	return len(deployment.GetName()) != 0, err
 }
 
 // ConvertEnvs converts environment variables from the devfile structure to kubernetes structure

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -64,7 +66,7 @@ func TestComponentExists(t *testing.T) {
 					return true, deployment, nil
 				}
 
-				return true, emptyDeployment, nil
+				return true, emptyDeployment, kerrors.NewNotFound(schema.GroupResource{}, "")
 			})
 
 			// Verify that a component with the specified name exists

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,10 +27,6 @@ const (
 // GetDeploymentByName gets a deployment by querying by name
 func (c *Client) GetDeploymentByName(name string) (*appsv1.Deployment, error) {
 	deployment, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(name, metav1.GetOptions{})
-	if kerrors.IsNotFound(err) {
-		klog.V(4).Infof("Deployment %s not found", name)
-		return deployment, nil
-	}
 	return deployment, err
 }
 

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,10 @@ const (
 // GetDeploymentByName gets a deployment by querying by name
 func (c *Client) GetDeploymentByName(name string) (*appsv1.Deployment, error) {
 	deployment, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Get(name, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		klog.V(4).Infof("Deployment %s not found", name)
+		return deployment, nil
+	}
 	return deployment, err
 }
 

--- a/pkg/kclient/deployments_test.go
+++ b/pkg/kclient/deployments_test.go
@@ -1,8 +1,10 @@
 package kclient
 
 import (
-	"github.com/openshift/odo/pkg/util"
 	"testing"
+
+	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/util"
 
 	"github.com/pkg/errors"
 
@@ -92,6 +94,62 @@ func TestCreateDeployment(t *testing.T) {
 					}
 				}
 
+			}
+
+		})
+	}
+}
+
+func TestGetDeploymentByName(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		deploymentName     string
+		wantDeploymentName string
+		wantErr            bool
+	}{
+		{
+			name:               "Case 1: Valid deployment name",
+			deploymentName:     "mydeploy1",
+			wantDeploymentName: "mydeploy1",
+			wantErr:            false,
+		},
+		{
+			name:               "Case 2: Invalid deployment name",
+			deploymentName:     "mydeploy2",
+			wantDeploymentName: "",
+			wantErr:            false,
+		},
+		{
+			name:           "Case 3: Error condition",
+			deploymentName: "mydeploy1",
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// initialising the fakeclient
+			fkclient, fkclientset := FakeNew()
+			fkclient.Namespace = "default"
+
+			fkclientset.Kubernetes.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+				if tt.deploymentName == "mydeploy2" {
+					emptyDeployment := testingutil.CreateFakeDeployment("")
+					return true, emptyDeployment, nil
+				} else if tt.deploymentName == "mydeploy1" {
+					deployment := testingutil.CreateFakeDeployment(tt.deploymentName)
+					return true, deployment, nil
+				} else {
+					return true, nil, errors.Errorf("deployment get error")
+				}
+
+			})
+
+			deployment, err := fkclient.GetDeploymentByName(tt.deploymentName)
+			if !tt.wantErr && err != nil {
+				t.Errorf("TestGetDeploymentByName unexpected error: %v", err)
+			} else if !tt.wantErr && deployment.GetName() != tt.wantDeploymentName {
+				t.Errorf("TestGetDeploymentByName error: expected %v, got %v", tt.wantDeploymentName, deployment.GetName())
 			}
 
 		})

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -209,6 +209,7 @@ func (do *DeleteOptions) DevFileRun() (err error) {
 	}
 
 	if do.componentDeleteAllFlag {
+		// Prompt and delete env folder
 		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete env folder?")) {
 			if !do.EnvSpecificInfo.EnvInfoFileExists() {
 				return fmt.Errorf("env folder doesn't exist for the component")
@@ -237,6 +238,22 @@ func (do *DeleteOptions) DevFileRun() (err error) {
 			log.Successf("Successfully deleted env file")
 		} else {
 			log.Error("Aborting deletion of env folder")
+		}
+
+		// Prompt and delete devfile.yaml
+		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete devfile.yaml?")) {
+			if !util.CheckPathExists(DevfilePath) {
+				return fmt.Errorf("devfile.yaml does not exist in the current directory")
+			}
+
+			err = util.DeletePath(DevfilePath)
+			if err != nil {
+				return err
+			}
+
+			log.Successf("Successfully deleted devfile.yaml file")
+		} else {
+			log.Error("Aborting deletion of devfile.yaml file")
 		}
 	}
 

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -1,7 +1,6 @@
 package component
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -213,22 +212,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		return err
 	}
 
-	componentExists, _ := devfileHandler.DoesComponentExist(componentName)
-	if !componentExists {
-		log.Italicf("Component %s does not exist", componentName)
-		return nil
-	}
-
-	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
-	defer spinner.End(false)
-
-	err = devfileHandler.Delete(labels)
-	if err != nil {
-		return err
-	}
-	spinner.End(true)
-	log.Successf("Successfully deleted component")
-	return nil
+	return devfileHandler.Delete(labels)
 }
 
 func warnIfURLSInvalid(url []envinfo.EnvInfoURL) {

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -213,6 +213,12 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		return err
 	}
 
+	componentExists, _ := devfileHandler.DoesComponentExist(componentName)
+	if !componentExists {
+		log.Italicf("Component %s does not exist", componentName)
+		return nil
+	}
+
 	spinner := log.Spinner(fmt.Sprintf("Deleting devfile component %s", componentName))
 	defer spinner.End(false)
 

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -158,7 +158,10 @@ func (wo *WatchOptions) Validate() (err error) {
 
 	// if experimental mode is enabled and devfile is present, return. The rest of the validation is for non-devfile components
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
-		exists := wo.devfileHandler.DoesComponentExist(wo.componentName)
+		exists, err := wo.devfileHandler.DoesComponentExist(wo.componentName)
+		if err != nil {
+			return err
+		}
 		if !exists {
 			return fmt.Errorf("component does not exist. Please use `odo push` to create your component")
 		}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -99,7 +99,7 @@ func kClient(command *cobra.Command) *kclient.Client {
 // checkProjectCreateOrDeleteOnlyOnInvalidNamespace errors out if user is trying to create or delete something other than project
 // errFormatforCommand must contain one %s
 func checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command *cobra.Command, errFormatForCommand string) {
-	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || command.Name() == "delete") {
+	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || (command.Name() == "delete" && !command.Flags().Changed("all"))) {
 		err := fmt.Errorf(errFormatForCommand, command.Root().Name())
 		util.LogErrorAndExit(err, "")
 	}

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -65,6 +66,21 @@ var _ = Describe("odo devfile delete command tests", func() {
 		})
 	})
 
+	Context("when no component exists", func() {
+
+		It("should print the information and not throw an error", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "delete", "--project", namespace, "-f")
+
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprintf("Component %s does not exist", componentName),
+			})
+		})
+	})
+
 	Context("when devfile delete command is executed with all flag", func() {
 
 		It("should delete the component created from the devfile and also the env and odo folders and the odo-index-file.json file", func() {
@@ -83,6 +99,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 
 			files := helper.ListFilesInDir(context)
 			Expect(files).To(Not(ContainElement(".odo")))
+			Expect(files).To(Not(ContainElement("devfile.yaml")))
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -115,11 +115,12 @@ var _ = Describe("odo devfile delete command tests", func() {
 			})
 
 			output = helper.CmdShouldPass("odo", "delete", "-af")
-			helper.MatchAllInOutput(output, []string{
-				fmt.Sprintf("Component %s does not exist", componentName),
+			expectedOutput := []string{
 				"Successfully deleted env file",
 				"Successfully deleted devfile.yaml file",
-			})
+				fmt.Sprintf("Component %s does not exist", componentName),
+			}
+			helper.MatchAllInOutput(output, expectedOutput)
 		})
 
 		It("should let the user delete the local config files with -a and -project flags", func() {
@@ -129,11 +130,12 @@ var _ = Describe("odo devfile delete command tests", func() {
 			helper.CmdShouldFail("odo", "delete", "--project", invalidNamespace)
 
 			output := helper.CmdShouldPass("odo", "delete", "--project", invalidNamespace, "-af")
-			helper.MatchAllInOutput(output, []string{
-				fmt.Sprintf("Component %s does not exist", componentName),
+			expectedOutput := []string{
 				"Successfully deleted env file",
 				"Successfully deleted devfile.yaml file",
-			})
+				fmt.Sprintf("Component %s does not exist", componentName),
+			}
+			helper.MatchAllInOutput(output, expectedOutput)
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -106,9 +106,9 @@ var _ = Describe("odo devfile delete command tests", func() {
 	Context("when the project doesn't exist", func() {
 
 		It("should let the user delete the local config files with -a flag", func() {
-			newNamespace := cliRunner.CreateRandNamespaceProject()
+			newNamespace := "garbage"
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
-			cliRunner.DeleteNamespaceProject(newNamespace)
+			// cliRunner.DeleteNamespaceProject(newNamespace)
 
 			output := helper.CmdShouldFail("odo", "delete")
 			helper.MatchAllInOutput(output, []string{
@@ -124,9 +124,9 @@ var _ = Describe("odo devfile delete command tests", func() {
 		})
 
 		It("should let the user delete the local config files with -a and -project flags", func() {
-			newNamespace := cliRunner.CreateRandNamespaceProject()
+			newNamespace := "garbage"
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
-			cliRunner.DeleteNamespaceProject(newNamespace)
+			// cliRunner.DeleteNamespaceProject(newNamespace)
 
 			output := helper.CmdShouldFail("odo", "delete", "--project", newNamespace)
 			helper.MatchAllInOutput(output, []string{

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -102,4 +102,43 @@ var _ = Describe("odo devfile delete command tests", func() {
 			Expect(files).To(Not(ContainElement("devfile.yaml")))
 		})
 	})
+
+	Context("when the project doesn't exist", func() {
+
+		It("should let the user delete the local config files with -a flag", func() {
+			newNamespace := cliRunner.CreateRandNamespaceProject()
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
+			cliRunner.DeleteNamespaceProject(newNamespace)
+
+			output := helper.CmdShouldFail("odo", "delete")
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprint("the namespace doesn't exist"),
+			})
+
+			output = helper.CmdShouldPass("odo", "delete", "-af")
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprintf("Component %s does not exist", componentName),
+				"Successfully deleted env file",
+				"Successfully deleted devfile.yaml file",
+			})
+		})
+
+		It("should let the user delete the local config files with -a and -project flags", func() {
+			newNamespace := cliRunner.CreateRandNamespaceProject()
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
+			cliRunner.DeleteNamespaceProject(newNamespace)
+
+			output := helper.CmdShouldFail("odo", "delete", "--project", newNamespace)
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprintf("namespaces \"%s\" not found", newNamespace),
+			})
+
+			output = helper.CmdShouldPass("odo", "delete", "--project", newNamespace, "-af")
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprintf("Component %s does not exist", componentName),
+				"Successfully deleted env file",
+				"Successfully deleted devfile.yaml file",
+			})
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -106,9 +106,8 @@ var _ = Describe("odo devfile delete command tests", func() {
 	Context("when the project doesn't exist", func() {
 
 		It("should let the user delete the local config files with -a flag", func() {
-			newNamespace := "garbage"
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
-			// cliRunner.DeleteNamespaceProject(newNamespace)
+			invalidNamespace := "garbage"
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", invalidNamespace, componentName)
 
 			output := helper.CmdShouldFail("odo", "delete")
 			helper.MatchAllInOutput(output, []string{
@@ -124,16 +123,12 @@ var _ = Describe("odo devfile delete command tests", func() {
 		})
 
 		It("should let the user delete the local config files with -a and -project flags", func() {
-			newNamespace := "garbage"
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", newNamespace, componentName)
-			// cliRunner.DeleteNamespaceProject(newNamespace)
+			invalidNamespace := "garbage"
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", invalidNamespace, componentName)
 
-			output := helper.CmdShouldFail("odo", "delete", "--project", newNamespace)
-			helper.MatchAllInOutput(output, []string{
-				fmt.Sprintf("namespaces \"%s\" not found", newNamespace),
-			})
+			helper.CmdShouldFail("odo", "delete", "--project", invalidNamespace)
 
-			output = helper.CmdShouldPass("odo", "delete", "--project", newNamespace, "-af")
+			output := helper.CmdShouldPass("odo", "delete", "--project", invalidNamespace, "-af")
 			helper.MatchAllInOutput(output, []string{
 				fmt.Sprintf("Component %s does not exist", componentName),
 				"Successfully deleted env file",

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -73,11 +73,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "delete", "--project", namespace, "-f")
-
-			helper.MatchAllInOutput(output, []string{
-				fmt.Sprintf("Component %s does not exist", componentName),
-			})
+			helper.CmdShouldPass("odo", "delete", "--project", namespace, "-f")
 		})
 	})
 
@@ -118,7 +114,6 @@ var _ = Describe("odo devfile delete command tests", func() {
 			expectedOutput := []string{
 				"Successfully deleted env file",
 				"Successfully deleted devfile.yaml file",
-				fmt.Sprintf("Component %s does not exist", componentName),
 			}
 			helper.MatchAllInOutput(output, expectedOutput)
 		})
@@ -133,7 +128,6 @@ var _ = Describe("odo devfile delete command tests", func() {
 			expectedOutput := []string{
 				"Successfully deleted env file",
 				"Successfully deleted devfile.yaml file",
-				fmt.Sprintf("Component %s does not exist", componentName),
 			}
 			helper.MatchAllInOutput(output, expectedOutput)
 		})

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -68,7 +68,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 
 	Context("when no component exists", func() {
 
-		It("should print the information and not throw an error", func() {
+		It("should not throw an error with an existing namespace", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))

--- a/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -129,6 +130,21 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 
 	})
 
+	Context("when no component exists", func() {
+
+		It("should print the information and not throw an error", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "delete", "-f")
+
+			helper.MatchAllInOutput(output, []string{
+				fmt.Sprintf("Component %s does not exist", cmpName),
+			})
+		})
+	})
+
 	Context("when docker devfile delete command is executed with all flag", func() {
 
 		It("should delete the component created from the devfile and also the env folder", func() {
@@ -151,7 +167,7 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 
 			files := helper.ListFilesInDir(context)
 			Expect(files).To(Not(ContainElement(".odo")))
-
+			Expect(files).To(Not(ContainElement("devfile.yaml")))
 		})
 	})
 })

--- a/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
@@ -131,7 +131,7 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 
 	Context("when no component exists", func() {
 
-		It("should print the information and not throw an error", func() {
+		It("should not throw an error", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))

--- a/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_delete_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -137,11 +136,7 @@ var _ = Describe("odo docker devfile delete command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "delete", "-f")
-
-			helper.MatchAllInOutput(output, []string{
-				fmt.Sprintf("Component %s does not exist", cmpName),
-			})
+			helper.CmdShouldPass("odo", "delete", "-f")
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
- `odo delete`/`odo delete -a` does not err out when there is no component to delete. Just shows a message saying there is no component present
- `odo delete -a` now also prompts if user wants to delete the devfile.yaml

**Which issue(s) this PR fixes**:

Fixes #3104 

**How to test changes / Special notes to the reviewer**:
See https://github.com/openshift/odo/pull/3405#issuecomment-651913789 for detailed case scenarios