### PR TITLE
Fix bug that triggers redeploy even if there are no changes in the file

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -20,6 +20,22 @@ type DevfileVolume struct {
 	Size          string
 }
 
+// ComponentVolumesPair is a struct to hold the relationship between components and their volumes
+// Use splices of this struct instead of a map because it is important to maintain order since iteration order of maps is not guaranteed.
+// When maps were used the ordering of the volumes could change in the pod spec causing an unnecessary rollout of the deployment which can be slow.
+type ComponentVolumesPair struct {
+	ComponentAlias string
+	Volumes        []DevfileVolume
+}
+
+// VolumePVCPair is a struct to hold the relationship between volumes and their PVCs
+// Use splices of this struct instead of a map because it is important to maintain order since iteration order of maps is not guaranteed.
+// When maps were used the ordering of the volumes could change in the pod spec causing an unnecessary rollout of the deployment which can be slow.
+type VolumePVCPair struct {
+	Volume string
+	PVC    string
+}
+
 // Storage is a struct that is common to all the adapters
 type Storage struct {
 	Name   string

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -45,7 +45,7 @@ type Adapter struct {
 	Client lclient.Client
 	common.AdapterContext
 
-	componentAliasToVolumes   map[string][]common.DevfileVolume
+	componentAliasToVolumes   []common.ComponentVolumesPair
 	uniqueStorage             []common.Storage
 	volumeNameToDockerVolName map[string]string
 	devfileInitCmd            string

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -49,14 +49,24 @@ func (a Adapter) createComponent() (err error) {
 	// Loop over each component and start a container for it
 	for _, comp := range supportedComponents {
 		var dockerVolumeMounts []mount.Mount
-		for _, vol := range a.componentAliasToVolumes[comp.Container.Name] {
 
-			volMount := mount.Mount{
-				Type:   mount.TypeVolume,
-				Source: a.volumeNameToDockerVolName[vol.Name],
-				Target: vol.ContainerPath,
+		// Let's find the container / component alias!
+		for _, vol := range a.componentAliasToVolumes {
+
+			// If we find the container, we add all the volumes we'll be mounting.
+			if vol.ComponentAlias == comp.Container.Name {
+
+				// Iterate through each volume and add it to the list to mount.
+				for _, volToMount := range vol.Volumes {
+					volMount := mount.Mount{
+						Type:   mount.TypeVolume,
+						Source: a.volumeNameToDockerVolName[vol.ComponentAlias],
+						Target: volToMount.ContainerPath,
+					}
+					dockerVolumeMounts = append(dockerVolumeMounts, volMount)
+				}
+
 			}
-			dockerVolumeMounts = append(dockerVolumeMounts, volMount)
 		}
 		err = a.pullAndStartContainer(dockerVolumeMounts, comp)
 		if err != nil {
@@ -91,14 +101,26 @@ func (a Adapter) updateComponent() (componentExists bool, err error) {
 		}
 
 		var dockerVolumeMounts []mount.Mount
-		for _, vol := range a.componentAliasToVolumes[comp.Container.Name] {
-			volMount := mount.Mount{
-				Type:   mount.TypeVolume,
-				Source: a.volumeNameToDockerVolName[vol.Name],
-				Target: vol.ContainerPath,
+
+		// Let's find the container / component alias!
+		for _, vol := range a.componentAliasToVolumes {
+
+			// If we find the container, we add all the volumes we'll be mounting.
+			if vol.ComponentAlias == comp.Container.Name {
+
+				// Iterate through each volume and add it to the list to mount.
+				for _, volToMount := range vol.Volumes {
+					volMount := mount.Mount{
+						Type:   mount.TypeVolume,
+						Source: a.volumeNameToDockerVolName[vol.ComponentAlias],
+						Target: volToMount.ContainerPath,
+					}
+					dockerVolumeMounts = append(dockerVolumeMounts, volMount)
+				}
+
 			}
-			dockerVolumeMounts = append(dockerVolumeMounts, volMount)
 		}
+
 		if len(containers) == 0 {
 			log.Infof("\nCreating Docker resources for component %s", a.ComponentName)
 

--- a/pkg/devfile/adapters/docker/storage/utils.go
+++ b/pkg/devfile/adapters/docker/storage/utils.go
@@ -101,14 +101,15 @@ func GetExistingVolume(Client *lclient.Client, volumeName, componentName string)
 
 // ProcessVolumes takes in a list of component volumes and for each unique volume in the devfile, creates a Docker volume name for it
 // It returns a list of unique volumes, a mapping of devfile volume names to docker volume names, and an error if applicable
-func ProcessVolumes(client *lclient.Client, componentName string, componentAliasToVolumes map[string][]common.DevfileVolume) ([]common.Storage, map[string]string, error) {
+// we return a map since it does not matter if the volumes are out-of-order for Docker.
+func ProcessVolumes(client *lclient.Client, componentName string, componentAliasToVolumes []common.ComponentVolumesPair) ([]common.Storage, map[string]string, error) {
 	var uniqueStorages []common.Storage
 	volumeNameToDockerVolName := make(map[string]string)
 	processedVolumes := make(map[string]bool)
 
 	// Get a list of all the unique volume names and generate their Docker volume names
 	for _, volumes := range componentAliasToVolumes {
-		for _, vol := range volumes {
+		for _, vol := range volumes.Volumes {
 			if _, ok := processedVolumes[vol.Name]; !ok {
 				processedVolumes[vol.Name] = true
 

--- a/pkg/devfile/adapters/docker/storage/utils_test.go
+++ b/pkg/devfile/adapters/docker/storage/utils_test.go
@@ -140,7 +140,7 @@ func TestProcessVolumes(t *testing.T) {
 	tests := []struct {
 		name               string
 		client             *lclient.Client
-		aliasVolumeMapping map[string][]common.DevfileVolume
+		aliasVolumeMapping []common.ComponentVolumesPair
 		wantErr            bool
 		wantStorage        []common.Storage
 	}{
@@ -153,12 +153,15 @@ func TestProcessVolumes(t *testing.T) {
 		},
 		{
 			name: "Case 2: One volume defined, one component",
-			aliasVolumeMapping: map[string][]common.DevfileVolume{
-				"some-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[0],
-						ContainerPath: volumePaths[0],
-						Size:          volumeSizes[0],
+			aliasVolumeMapping: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "some-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[0],
+							ContainerPath: volumePaths[0],
+							Size:          volumeSizes[0],
+						},
 					},
 				},
 			},
@@ -176,22 +179,25 @@ func TestProcessVolumes(t *testing.T) {
 		},
 		{
 			name: "Case 3: Multiple volumes defined, one component",
-			aliasVolumeMapping: map[string][]common.DevfileVolume{
-				"some-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[0],
-						ContainerPath: volumePaths[0],
-						Size:          volumeSizes[0],
-					},
-					{
-						Name:          volumeNames[1],
-						ContainerPath: volumePaths[1],
-						Size:          volumeSizes[1],
-					},
-					{
-						Name:          volumeNames[2],
-						ContainerPath: volumePaths[2],
-						Size:          volumeSizes[2],
+			aliasVolumeMapping: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "some-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[0],
+							ContainerPath: volumePaths[0],
+							Size:          volumeSizes[0],
+						},
+						{
+							Name:          volumeNames[1],
+							ContainerPath: volumePaths[1],
+							Size:          volumeSizes[1],
+						},
+						{
+							Name:          volumeNames[2],
+							ContainerPath: volumePaths[2],
+							Size:          volumeSizes[2],
+						},
 					},
 				},
 			},
@@ -223,36 +229,45 @@ func TestProcessVolumes(t *testing.T) {
 		},
 		{
 			name: "Case 4: Multiple volumes defined, multiple components",
-			aliasVolumeMapping: map[string][]common.DevfileVolume{
-				"some-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[0],
-						ContainerPath: volumePaths[0],
-						Size:          volumeSizes[0],
-					},
-					{
-						Name:          volumeNames[1],
-						ContainerPath: volumePaths[1],
-						Size:          volumeSizes[1],
-					},
-				},
-				"second-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[0],
-						ContainerPath: volumePaths[0],
-						Size:          volumeSizes[0],
+			aliasVolumeMapping: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "some-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[0],
+							ContainerPath: volumePaths[0],
+							Size:          volumeSizes[0],
+						},
+						{
+							Name:          volumeNames[1],
+							ContainerPath: volumePaths[1],
+							Size:          volumeSizes[1],
+						},
 					},
 				},
-				"third-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[1],
-						ContainerPath: volumePaths[1],
-						Size:          volumeSizes[1],
+				common.ComponentVolumesPair{
+					ComponentAlias: "second-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[0],
+							ContainerPath: volumePaths[0],
+							Size:          volumeSizes[0],
+						},
 					},
-					{
-						Name:          volumeNames[2],
-						ContainerPath: volumePaths[2],
-						Size:          volumeSizes[2],
+				},
+				common.ComponentVolumesPair{
+					ComponentAlias: "third-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[1],
+							ContainerPath: volumePaths[1],
+							Size:          volumeSizes[1],
+						},
+						{
+							Name:          volumeNames[2],
+							ContainerPath: volumePaths[2],
+							Size:          volumeSizes[2],
+						},
 					},
 				},
 			},
@@ -284,12 +299,15 @@ func TestProcessVolumes(t *testing.T) {
 		},
 		{
 			name: "Case 5: Docker client error",
-			aliasVolumeMapping: map[string][]common.DevfileVolume{
-				"some-component": []common.DevfileVolume{
-					{
-						Name:          volumeNames[0],
-						ContainerPath: volumePaths[0],
-						Size:          volumeSizes[0],
+			aliasVolumeMapping: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "some-component",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volumeNames[0],
+							ContainerPath: volumePaths[0],
+							Size:          volumeSizes[0],
+						},
 					},
 				},
 			},

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -197,12 +197,12 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 	componentAliasToVolumes := common.GetVolumes(a.Devfile)
 
 	var uniqueStorages []common.Storage
-	volumeNameToPVCName := make(map[string]string)
+	volumeNameToPVCName := []common.VolumePVCPair{}
 	processedVolumes := make(map[string]bool)
 
 	// Get a list of all the unique volume names and generate their PVC names
 	for _, volumes := range componentAliasToVolumes {
-		for _, vol := range volumes {
+		for _, vol := range volumes.Volumes {
 			if _, ok := processedVolumes[vol.Name]; !ok {
 				processedVolumes[vol.Name] = true
 
@@ -228,7 +228,11 @@ func (a Adapter) createOrUpdateComponent(componentExists bool) (err error) {
 					Volume: vol,
 				}
 				uniqueStorages = append(uniqueStorages, pvc)
-				volumeNameToPVCName[vol.Name] = generatedPVCName
+				pairData := common.VolumePVCPair{
+					Volume: vol.Name,
+					PVC:    generatedPVCName,
+				}
+				volumeNameToPVCName = append(volumeNameToPVCName, pairData)
 			}
 		}
 	}

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -76,20 +76,20 @@ func AddVolumeMountToPodTemplateSpec(podTemplateSpec *corev1.PodTemplateSpec, vo
 // AddPVCAndVolumeMount adds PVC and volume mount to the pod template spec
 // volumeNameToPVCName is a map of volume name to the PVC created
 // componentAliasToVolumes is a map of the Devfile component alias to the Devfile Volumes
-func AddPVCAndVolumeMount(podTemplateSpec *corev1.PodTemplateSpec, volumeNameToPVCName map[string]string, componentAliasToVolumes map[string][]common.DevfileVolume) error {
-	for volName, pvcName := range volumeNameToPVCName {
-		generatedVolumeName, err := generateVolumeNameFromPVC(pvcName)
+func AddPVCAndVolumeMount(podTemplateSpec *corev1.PodTemplateSpec, volumeNameToPVCName []common.VolumePVCPair, componentAliasToVolumes []common.ComponentVolumesPair) error {
+	for _, pair := range volumeNameToPVCName {
+		generatedVolumeName, err := generateVolumeNameFromPVC(pair.PVC)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to generate volume name from pvc name")
 		}
-		AddPVCToPodTemplateSpec(podTemplateSpec, generatedVolumeName, pvcName)
+		AddPVCToPodTemplateSpec(podTemplateSpec, generatedVolumeName, pair.PVC)
 
 		// componentAliasToMountPaths is a map of the Devfile container alias to their Devfile Volume Mount Paths for a given Volume Name
 		componentAliasToMountPaths := make(map[string][]string)
-		for containerName, volumes := range componentAliasToVolumes {
-			for _, volume := range volumes {
-				if volName == volume.Name {
-					componentAliasToMountPaths[containerName] = append(componentAliasToMountPaths[containerName], volume.ContainerPath)
+		for _, volumeData := range componentAliasToVolumes {
+			for _, volume := range volumeData.Volumes {
+				if pair.Volume == volume.Name {
+					componentAliasToMountPaths[volumeData.ComponentAlias] = append(componentAliasToMountPaths[volumeData.ComponentAlias], volume.ContainerPath)
 				}
 			}
 		}

--- a/pkg/kclient/volumes_test.go
+++ b/pkg/kclient/volumes_test.go
@@ -340,8 +340,8 @@ func TestAddPVCAndVolumeMount(t *testing.T) {
 		namespace               string
 		labels                  map[string]string
 		containers              []corev1.Container
-		volumeNameToPVCName     map[string]string
-		componentAliasToVolumes map[string][]common.DevfileVolume
+		volumeNameToPVCName     []common.VolumePVCPair
+		componentAliasToVolumes []common.ComponentVolumesPair
 		wantErr                 bool
 	}{
 		{
@@ -372,34 +372,49 @@ func TestAddPVCAndVolumeMount(t *testing.T) {
 					Env:     []corev1.EnvVar{},
 				},
 			},
-			volumeNameToPVCName: map[string]string{
-				"volume1": "volume1-pvc",
-				"volume2": "volume2-pvc",
-				"volume3": "volume3-pvc",
+			volumeNameToPVCName: []common.VolumePVCPair{
+				common.VolumePVCPair{
+					Volume: "volume1",
+					PVC:    "volume1-pvc",
+				},
+				common.VolumePVCPair{
+					Volume: "volume2",
+					PVC:    "volume2-pvc",
+				},
+				common.VolumePVCPair{
+					Volume: "volume3",
+					PVC:    "volume3-pvc",
+				},
 			},
-			componentAliasToVolumes: map[string][]common.DevfileVolume{
-				"container1": []common.DevfileVolume{
-					{
-						Name:          volNames[0],
-						ContainerPath: volContainerPath[0],
-					},
-					{
-						Name:          volNames[0],
-						ContainerPath: volContainerPath[1],
-					},
-					{
-						Name:          volNames[1],
-						ContainerPath: volContainerPath[2],
+			componentAliasToVolumes: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "container1",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volNames[0],
+							ContainerPath: volContainerPath[0],
+						},
+						{
+							Name:          volNames[0],
+							ContainerPath: volContainerPath[1],
+						},
+						{
+							Name:          volNames[1],
+							ContainerPath: volContainerPath[2],
+						},
 					},
 				},
-				"container2": []common.DevfileVolume{
-					{
-						Name:          volNames[1],
-						ContainerPath: volContainerPath[1],
-					},
-					{
-						Name:          volNames[2],
-						ContainerPath: volContainerPath[2],
+				common.ComponentVolumesPair{
+					ComponentAlias: "container2",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volNames[1],
+							ContainerPath: volContainerPath[1],
+						},
+						{
+							Name:          volNames[2],
+							ContainerPath: volContainerPath[2],
+						},
 					},
 				},
 			},
@@ -414,19 +429,28 @@ func TestAddPVCAndVolumeMount(t *testing.T) {
 				"component": "frontend",
 			},
 			containers: []corev1.Container{},
-			volumeNameToPVCName: map[string]string{
-				"volume2": "volume2-pvc",
-				"volume3": "volume3-pvc",
+			volumeNameToPVCName: []common.VolumePVCPair{
+				common.VolumePVCPair{
+					Volume: "volume2",
+					PVC:    "volume2-pvc",
+				},
+				common.VolumePVCPair{
+					Volume: "volume3",
+					PVC:    "volume3-pvc",
+				},
 			},
-			componentAliasToVolumes: map[string][]common.DevfileVolume{
-				"container2": []common.DevfileVolume{
-					{
-						Name:          volNames[1],
-						ContainerPath: volContainerPath[1],
-					},
-					{
-						Name:          volNames[2],
-						ContainerPath: volContainerPath[2],
+			componentAliasToVolumes: []common.ComponentVolumesPair{
+				common.ComponentVolumesPair{
+					ComponentAlias: "container2",
+					Volumes: []common.DevfileVolume{
+						{
+							Name:          volNames[1],
+							ContainerPath: volContainerPath[1],
+						},
+						{
+							Name:          volNames[2],
+							ContainerPath: volContainerPath[2],
+						},
 					},
 				},
 			},
@@ -463,17 +487,17 @@ func TestAddPVCAndVolumeMount(t *testing.T) {
 
 			// check the volume mounts of the pod template spec containers
 			for _, container := range podTemplateSpec.Spec.Containers {
-				for testcontainerAlias, testContainerVolumes := range tt.componentAliasToVolumes {
-					if container.Name == testcontainerAlias {
+				for _, pair := range tt.componentAliasToVolumes {
+					if container.Name == pair.ComponentAlias {
 						// check if container has the correct number of volume mounts
-						if len(container.VolumeMounts) != len(testContainerVolumes) {
-							t.Errorf("Incorrect number of Volume Mounts found in the pod template spec container %v, expected: %v found: %v", container.Name, len(testContainerVolumes), len(container.VolumeMounts))
+						if len(container.VolumeMounts) != len(pair.Volumes) {
+							t.Errorf("Incorrect number of Volume Mounts found in the pod template spec container %v, expected: %v found: %v", container.Name, len(pair.Volumes), len(container.VolumeMounts))
 						}
 
 						// check if container has the specified volume
 						volumeMatched := 0
 						for _, volumeMount := range container.VolumeMounts {
-							for _, testVolume := range testContainerVolumes {
+							for _, testVolume := range pair.Volumes {
 								testVolumeName := testVolume.Name
 								testVolumePath := testVolume.ContainerPath
 								if strings.Contains(volumeMount.Name, testVolumeName) && volumeMount.MountPath == testVolumePath {
@@ -481,8 +505,8 @@ func TestAddPVCAndVolumeMount(t *testing.T) {
 								}
 							}
 						}
-						if volumeMatched != len(testContainerVolumes) {
-							t.Errorf("Failed to match Volume Mounts for pod template spec container %v, expected: %v found: %v", container.Name, len(testContainerVolumes), volumeMatched)
+						if volumeMatched != len(pair.Volumes) {
+							t.Errorf("Failed to match Volume Mounts for pod template spec container %v, expected: %v found: %v", container.Name, len(pair.Volumes), volumeMatched)
 						}
 					}
 				}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:

If there are no changes to your code, we shouldn't have to redeploy.
There was an issue with maps being passed back in the volumes functionss
which was causing different orders of volumes.

When the volumes were passed back, they were causing unexpected redeploys
when deploying to Kubernetes / OpenShift.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2662

**How to test changes / Special notes to the reviewer**:

```sh
odo preference set experimental true
odo create java-spring-boot --downloadSource
odo push
odo push # try again and make sure that it does not redeploy with no
changes
```