### PR TITLE
removed deprecated and nodejs 8 images from e2e tests and README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,8 +36,6 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 |===
 |Language |Container Image |Supported Package Manager
 |*Node.js*
-
-|
 |https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-10-rhel7[rhscl/nodejs-10-rhel7]
 |NPM
 

--- a/README.adoc
+++ b/README.adoc
@@ -36,19 +36,6 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 |===
 |Language |Container Image |Supported Package Manager
 |*Node.js*
-|https://github.com/sclorg/s2i-nodejs-container[centos/nodejs-8-centos7]
-|NPM
-
-| |https://access.redhat.com/articles/3376841[rhoar-nodejs/nodejs-8]
-|NPM
-
-|
-|https://www.github.com/bucharest-gold/centos7-s2i-nodejs[bucharestgold/centos7-s2i-nodejs]
-|NPM
-
-|
-|https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-8-rhel7[rhscl/nodejs-8-rhel7]
-|NPM
 
 |
 |https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-10-rhel7[rhscl/nodejs-10-rhel7]

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -98,16 +98,6 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 
-		It("Should be able to verify the centos7-s2i-nodejs image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
-		It("Should be able to verify the centos7-s2i-nodejs:10.x image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
 			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-10-centos7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("centos", "nodejs-10-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -93,16 +93,6 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel7:latest"), "openjdk", "java:8", project, appName, context)
 		})
 
-		It("Should be able to verify the nodejs-8-rhel7 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("rhscl", "nodejs-8-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
-		It("Should be able to verify the nodejs-8 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-8:latest"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
 		It("Should be able to verify the nodejs-10 image", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("rhoar-nodejs", "nodejs-10:latest"), "nodejs", "nodejs:latest", project, appName, context)
@@ -118,11 +108,6 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("bucharestgold", "centos7-s2i-nodejs:10.x"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 
-		It("Should be able to verify the nodejs-8-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("centos", "nodejs-8-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
 			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-10-centos7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("centos", "nodejs-10-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)
@@ -136,11 +121,6 @@ var _ = Describe("odo supported images e2e tests", func() {
 		It("Should be able to verify the nodejs-10-rhel7 image", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
-		})
-
-		It("Should be able to verify the centos7-s2i-nodejs image", func() {
-			oc.ImportImageFromRegistry("docker.io", filepath.Join("nodeshift", "centos7-s2i-nodejs:latest"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("nodeshift", "centos7-s2i-nodejs:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


 /kind failing-test

**What does does this PR do / why we need it**:
Removes deprecated and nodejs 8 images from e2e tests

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/2641

**How to test changes / Special notes to the reviewer**:
CI shouldn't fail
