### PR TITLE
Fix `odo create` interactive mode

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -398,7 +398,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			// Interactive mode
 
 			// Component type: We provide supported devfile component list to let user choose
-			catalogDevfileList, err := catalog.ListDevfileComponents(co.devfileMetadata.devfileRegistry.Name)
+			catalogDevfileList, err = catalog.ListDevfileComponents(co.devfileMetadata.devfileRegistry.Name)
 			if err != nil {
 				return err
 			}
@@ -523,8 +523,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			hasComponent := false
 
+			fmt.Println(catalogDevfileList.Items)
 			for _, devfileComponent := range catalogDevfileList.Items {
+				fmt.Println(devfileComponent.Name)
+				fmt.Println(co.devfileMetadata.componentType)
 				if co.devfileMetadata.componentType == devfileComponent.Name {
+					fmt.Println("HERE")
 					hasComponent = true
 					if devfileComponent.Support {
 						co.devfileMetadata.devfileSupport = true

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -523,12 +523,8 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 			hasComponent := false
 
-			fmt.Println(catalogDevfileList.Items)
 			for _, devfileComponent := range catalogDevfileList.Items {
-				fmt.Println(devfileComponent.Name)
-				fmt.Println(co.devfileMetadata.componentType)
 				if co.devfileMetadata.componentType == devfileComponent.Name {
-					fmt.Println("HERE")
 					hasComponent = true
 					if devfileComponent.Support {
 						co.devfileMetadata.devfileSupport = true


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR fixes interactive mode for devfiles. It seems a recent change that was delivered used a short assignment operator (:=) to assign a value to the `catalogDevfileList` variable, which caused a local-scoped version of it to get created in the if-block. This meant the value of `catalogDevfileList` couldn't be seen outside of the if-statement (despite the variable being declared outside it)

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3436

**How to test changes / Special notes to the reviewer**:
`odo create`