### PR TITLE
Add unsupported component info in watch help UX

### DIFF
--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -2,10 +2,11 @@ package component
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/adapters"
@@ -32,8 +33,8 @@ import (
 // WatchRecommendedCommandName is the recommended watch command name
 const WatchRecommendedCommandName = "watch"
 
-var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on change.`)
-var watchExampleWithDevfile = ktemplates.Examples(`  # Watch for changes in directory for current component
+var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on change. Watch doesn't provide support for git component.`)
+var watchExampleWithComponentName = ktemplates.Examples(`  # Watch for changes in directory for current component
 %[1]s
 
 # Watch source code changes with custom devfile commands using --build-command and --run-command for experimental mode
@@ -250,12 +251,12 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	usage := name
 
 	if experimental.IsExperimentalModeEnabled() {
-		example = fmt.Sprintf(watchExampleWithDevfile, fullName)
+		example = fmt.Sprintf(watchExampleWithComponentName, fullName)
 	}
 
 	var watchCmd = &cobra.Command{
 		Use:         usage,
-		Short:       "Watch for changes, update component on change",
+		Short:       "Watch for changes, update component on change. Watch doesn't provide support for git component.",
 		Long:        watchLongDesc,
 		Example:     example,
 		Args:        cobra.NoArgs,

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo/pkg/devfile/adapters/common"
-
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/adapters"
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes"
 	"github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/occlient"
@@ -33,8 +32,8 @@ import (
 // WatchRecommendedCommandName is the recommended watch command name
 const WatchRecommendedCommandName = "watch"
 
-var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on change. Watch doesn't provide support for git component.`)
-var watchExampleWithComponentName = ktemplates.Examples(`  # Watch for changes in directory for current component
+var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on change. Watch doesn't support git components.`)
+var watchExampleWithDevfile = ktemplates.Examples(`  # Watch for changes in directory for current component
 %[1]s
 
 # Watch source code changes with custom devfile commands using --build-command and --run-command for experimental mode
@@ -251,12 +250,12 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	usage := name
 
 	if experimental.IsExperimentalModeEnabled() {
-		example = fmt.Sprintf(watchExampleWithComponentName, fullName)
+		example = fmt.Sprintf(watchExampleWithDevfile, fullName)
 	}
 
 	var watchCmd = &cobra.Command{
 		Use:         usage,
-		Short:       "Watch for changes, update component on change. Watch doesn't provide support for git component.",
+		Short:       "Watch for changes, update component on change. Watch doesn't support git components.",
 		Long:        watchLongDesc,
 		Example:     example,
 		Args:        cobra.NoArgs,

--- a/tests/integration/cmd_watch_test.go
+++ b/tests/integration/cmd_watch_test.go
@@ -38,7 +38,7 @@ var _ = Describe("odo watch command tests", func() {
 	Context("when running help for watch command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "watch", "-h")
-			Expect(appHelp).To(ContainSubstring("Watch for changes"))
+			helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -50,7 +50,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 	Context("when running help for watch command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "watch", "-h")
-			Expect(appHelp).To(ContainSubstring("Watch for changes"))
+			helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Informative watch UX
**Which issue(s) this PR fixes**:

Fixes #3447 

**How to test changes / Special notes to the reviewer**:
```
$ odo watch -h
Watch for changes, update component on change. Watch doesn't provide support for git component.

Usage:
  odo watch [flags]

Examples:
  # Watch for changes in directory for current component
  odo watch

Flags:
      [...]
```