### PR TITLE
Copy kubeconfig to temporary file and add permissions

### DIFF
--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -14,10 +14,10 @@ KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_D
 OC_STABLE_LOGIN="false"
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
 # Copy kubeconfig to temporary kubeconfig file
-# Read, Write and Execute permission to temporary kubeconfig file
-mkdir -p ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
+# Read and Write permission to temporary kubeconfig file
+mkdir -p ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp
 cp ${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
-chmod 764 ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
+chmod 644 ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
 # Exported to current env
 export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig"}
 

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -13,18 +13,13 @@ KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_D
 # Default values
 OC_STABLE_LOGIN="false"
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
-# Copy kubeconfig to temporary kubeconfig file
-# Read and Write permission to temporary kubeconfig file
-mkdir -p ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp
-cp ${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
-chmod 644 ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
 # Exported to current env
-export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig"}
+export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
 
 # List of users to create
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
-# Attempt resolution of kubeadmin, only if a CI is set
+# Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then
     # Check if nessasary files exist
     if [ ! -f $KUBEADMIN_PASSWORD_FILE ]; then
@@ -42,6 +37,13 @@ if [ -z $CI ]; then
 
     # Login as admin user
     oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
+else
+    # Copy kubeconfig to temporary kubeconfig file
+    # Read and Write permission to temporary kubeconfig file
+    TMP_DIR=$(mktemp -d)
+    cp $KUBECONFIG $TMP_DIR/kubeconfig
+    chmod 640 $TMP_DIR/kubeconfig
+    export KUBECONFIG=$TMP_DIR/kubeconfig
 fi
 
 # Setup the cluster for Operator tests

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -13,8 +13,13 @@ KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_D
 # Default values
 OC_STABLE_LOGIN="false"
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
+# Copy kubeconfig to temporary kubeconfig file
+# Read, Write and Execute permission to temporary kubeconfig file
+mkdir -p ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
+cp ${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
+chmod 764 ${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig
 # Exported to current env
-export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
+export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/tmp/kubeconfig"}
 
 # List of users to create
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -38,6 +38,10 @@ var _ = Describe("odo login and logout command tests", func() {
 	})
 
 	Context("when running login tests", func() {
+		JustBeforeEach(func() {
+			// To make sure that the script is using the developer login session
+			helper.CmdShouldPass("odo", "login", "-u", "developer", "-p", "developer")
+		})
 		It("should successful with correct credentials and fails with incorrect token", func() {
 			// Current user login token
 			currentUserToken = oc.GetToken()


### PR DESCRIPTION
**What type of PR is this?**


/kind feature

**What does does this PR do / why we need it**:

This pr gives read write permission for kubeconfig file which is blocking us for multi-stage testing. Detailed explanation in [comment](https://github.com/openshift/odo/issues/3270#issuecomment-651838728)

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:

Copying kubeconfig to tmp file and accessing it should work with template based test too.