### PR TITLE
Building redistributable only on x86_64 and updating golang version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
     - &base-test
       stage: test
       go_import_path: github.com/openshift/odo
-      go: "1.12.x"
+      go: "1.13.x"
       install:
         - make goget-tools
       script:
@@ -31,7 +31,7 @@ jobs:
       init:
       - git config --system core.longpaths true
       go_import_path: github.com/openshift/odo
-      go: "1.12.x"
+      go: "1.13.x"
       install:
         - systeminfo.exe | grep '^OS'
         - choco install make
@@ -50,7 +50,7 @@ jobs:
       os:
         - osx
       go_import_path: github.com/openshift/odo
-      go: "1.12.x"
+      go: "1.13.x"
       install:
         - make goget-tools
       script:

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing the Linux, Mac and Windows version of odo
 # layered on top of the ubi7/ubi image.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
 COPY . /go/src/github.com/openshift/odo
 WORKDIR /go/src/github.com/openshift/odo

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 == Setting up
 
-Requires *Go 1.12*
+Requires *Go 1.13*
 
 Testing and release builds happen with the above version. Developers are advised to stick to this version if they can but it is not compulsory.
 

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
 
 RUN yum -y install make wget gcc git httpd-tools
 

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -65,6 +65,7 @@ cp -avrf dist/release/SHA256_SUM %{buildroot}%{_datadir}/%{name}-redistributable
 %license LICENSE
 %{_bindir}/odo
 
+%ifarch x86_64
 %package redistributable
 Summary:        %{product_name} client CLI binaries for Linux, macOS and Windows
 BuildRequires:  gcc
@@ -91,4 +92,4 @@ Obsoletes:      %{package_name}-redistributable
 %{_datadir}/%{name}-redistributable/odo-windows-amd64.exe
 %{_datadir}/%{name}-redistributable/odo-windows-amd64.exe.tar.gz
 %{_datadir}/%{name}-redistributable/SHA256_SUM
-
+%endif

--- a/scripts/rpm-local-build.sh
+++ b/scripts/rpm-local-build.sh
@@ -6,6 +6,10 @@ if [[ ! -d dist/rpmbuild  ]]; then
 	exit 1
 fi
 
+echo "Cleaning up old rpmcontent"
+rm -f ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
 echo "Copying content to local rpmbuild"
 cp -avrf dist/rpmbuild/SOURCES/* $HOME/rpmbuild/SOURCES/
 cp -avrf dist/rpmbuild/SPECS/* $HOME/rpmbuild/SPECS/

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -13,8 +13,8 @@ export ODO_RPM_VERSION=${ODO_VERSION//-}
 
 # Golang version variables, if you are bumping this, please contact redhat maintainers to ensure that internal
 # build systems can handle these versions
-export GOLANG_VERSION=${GOLANG_VERSION:-1.12}
-export GOLANG_VERSION_NODOT=${GOLANG_VERSION_NODOT:-112}
+export GOLANG_VERSION=${GOLANG_VERSION:-1.13}
+export GOLANG_VERSION_NODOT=${GOLANG_VERSION_NODOT:-113}
 
 # Print env for verifcation
 echo "Printing envs for verification"


### PR DESCRIPTION
We dont need redistributable package building
on multiple architectures as it is happening right
now (case in point internal scratch build)

Eg:
  - openshift-odo-redistributable-1.2.3-1.el8.s390x.rpm
  - openshift-odo-redistributable-1.2.3-1.el8.ppc64le.rpm
  - openshift-odo-redistributable-1.2.3-1.el8.x86_64.rpm

We only need last one as individual rpms for specific architectures
is fine but not the redistributable ones.

Internal build system now supports golang 1.13

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup

**What does does this PR do / why we need it**:
See above

**Which issue(s) this PR fixes**:

None, this is cleanup in preparation of new build system

**How to test changes / Special notes to the reviewer**:

You can double check by building using golang 1.13 for any breakages