### PR TITLE
Fixed wrong expected registry input from odo catalog describe component nodejs

### DIFF
--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -106,7 +106,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 			output := helper.CmdShouldPass("odo", "registry", "list")
 			helper.MatchAllInOutput(output, []string{registryName, addRegistryURL})
 			output = helper.CmdShouldPass("odo", "catalog", "describe", "component", "nodejs")
-			helper.MatchAllInOutput(output, []string{"name: nodejs-web-app", "Registry: DefaultDevfileRegistry", "Registry: " + registryName})
+			helper.MatchAllInOutput(output, []string{"name: nodejs-starter", "Registry: DefaultDevfileRegistry", "Registry: " + registryName})
 		})
 	})
 	Context("When executing catalog describe component with a component name that does not have a devfile component", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Pass expected registry input as `name: nodejs-starter` from `odo catalog describe component nodejs`

**Which issue(s) this PR fixes**:

Fixes #3465 

**How to test changes / Special notes to the reviewer**:

`odo catalog describe component nodejs` should contain nodejs-starter