### PR TITLE
cleanup #3403: removed --memory, --min-memory. --max-memory, --cpu, --min-cpu, --max-cpu flags from 'odo create' command

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -544,7 +544,7 @@ func ValidateComponentCreateRequest(client *occlient.Client, componentSettings c
 func ensureAndLogProperResourceUsage(resourceMin, resourceMax *string, resourceName string) error {
 	klog.V(4).Infof("Validating configured %v values", resourceName)
 
-	err := fmt.Errorf("`min%s` should accompany `max%s` or use `odo config set %s` to use same value for both min and max or try not passing any of them\n", resourceName, resourceName, resourceName)
+	err := fmt.Errorf("`min%s` should accompany `max%s` or use `odo config set %s` to use same value for both min and max", resourceName, resourceName, resourceName)
 
 	if (resourceMin == nil) != (resourceMax == nil) {
 		return err

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -530,7 +530,29 @@ func ValidateComponentCreateRequest(client *occlient.Client, componentSettings c
 		}
 	}
 
+	if err := ensureAndLogProperResourceUsage(componentSettings.MinMemory, componentSettings.MaxMemory, "memory"); err != nil {
+		return err
+	}
+
+	if err := ensureAndLogProperResourceUsage(componentSettings.MinCPU, componentSettings.MaxCPU, "cpu"); err != nil {
+		return err
+	}
+
 	return
+}
+
+func ensureAndLogProperResourceUsage(resourceMin, resourceMax *string, resourceName string) error {
+	klog.V(4).Infof("Validating configured %v values", resourceName)
+
+	err := fmt.Errorf("`min%s` should accompany `max%s` or use `odo config set %s` to use same value for both min and max or try not passing any of them\n", resourceName, resourceName, resourceName)
+
+	if (resourceMin == nil) != (resourceMax == nil) {
+		return err
+	}
+	if (resourceMin != nil && *resourceMin == "") != (resourceMax != nil && *resourceMax == "") {
+		return err
+	}
+	return nil
 }
 
 // ApplyConfig applies the component config onto component dc

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -170,6 +170,11 @@ func isValidArgumentList(args []string) error {
 	}
 
 	switch param {
+	case "memory", "minmemory", "maxmemory", "cpu", "mincpu", "maxcpu":
+		err = validation.NonNegativeValidator(args[1])
+		if err != nil {
+			err = errors.Errorf("%s is invalid %v", param, err)
+		}
 	case "ports", "debugport":
 		err = validation.PortsValidator(args[1])
 	}

--- a/pkg/odo/util/validation/validators.go
+++ b/pkg/odo/util/validation/validators.go
@@ -2,10 +2,11 @@ package validation
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/util"
-	"gopkg.in/AlecAivazis/survey.v1"
 	"strconv"
 	"strings"
+
+	"github.com/openshift/odo/pkg/util"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // NameValidator provides a Validator view of the ValidateName function.
@@ -38,6 +39,16 @@ func IntegerValidator(ans interface{}) error {
 	}
 
 	return fmt.Errorf("don't know how to convert %v into an integer", ans)
+}
+
+// NonNegativeValidator validates whether the given value is not negative or not
+func NonNegativeValidator(arg interface{}) error {
+	if s, ok := arg.(string); ok {
+		if strings.HasPrefix(s, "-") {
+			return fmt.Errorf("negative value is not acceptable")
+		}
+	}
+	return nil
 }
 
 // PathValidator validates whether the given path exists on the file system

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -43,6 +43,9 @@ var _ = Describe("odo supported images e2e tests", func() {
 		helper.CopyExample(filepath.Join("source", srcType), context)
 		helper.CmdShouldPass("odo", "create", cmpType, srcType+"-app", "--project", project, "--context", context, "--app", appName)
 
+		helper.CmdShouldPass("odo", "config", "set", "minmemory", "400Mi", "--context", context)
+		helper.CmdShouldPass("odo", "config", "set", "maxmemory", "700Mi", "--context", context)
+
 		// push component and validate
 		helper.CmdShouldPass("odo", "push", "--context", context)
 		cmpList := helper.CmdShouldPass("odo", "list", "--context", context)

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -41,7 +41,7 @@ var _ = Describe("odo supported images e2e tests", func() {
 
 		// create the component
 		helper.CopyExample(filepath.Join("source", srcType), context)
-		helper.CmdShouldPass("odo", "create", cmpType, srcType+"-app", "--project", project, "--context", context, "--app", appName, "--min-memory", "400Mi", "--max-memory", "700Mi")
+		helper.CmdShouldPass("odo", "create", cmpType, srcType+"-app", "--project", project, "--context", context, "--app", appName)
 
 		// push component and validate
 		helper.CmdShouldPass("odo", "push", "--context", context)

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -54,17 +54,6 @@ var _ = Describe("odo push command tests", func() {
 	})
 
 	Context("Check memory and cpu config before odo push", func() {
-		It("Should work when both minmemory and maxmemory is set..", func() {
-
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
-
-			helper.CmdShouldPass("odo", "config", "set", "minMemory", "100Mi", "--context", context)
-			helper.CmdShouldPass("odo", "config", "set", "maxmemory", "200Mi", "--context", context)
-			helper.CmdShouldPass("odo", "push", "--context", context)
-		})
-
 		It("Should work when memory is set..", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
@@ -83,7 +72,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CmdShouldPass("odo", "config", "set", "minmemory", "100Mi", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
-			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max or try not passing any of them"))
+			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max"))
 		})
 
 		It("should fail if maxmemory is set but minmemory is not set..", func() {
@@ -94,18 +83,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CmdShouldPass("odo", "config", "set", "maxmemory", "400Mi", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
-			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max or try not passing any of them"))
-		})
-
-		It("Should work when both mincpu and maxcpu is set..", func() {
-
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
-
-			helper.CmdShouldPass("odo", "config", "set", "mincpu", "0.2", "--context", context)
-			helper.CmdShouldPass("odo", "config", "set", "maxcpu", "0.5", "--context", context)
-			helper.CmdShouldPass("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max"))
 		})
 
 		It("Should work when cpu is set", func() {
@@ -126,7 +104,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CmdShouldPass("odo", "config", "set", "mincpu", "0.4", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
-			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max or try not passing any of them"))
+			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max"))
 		})
 
 		It("should fail if maxcpu is set but mincpu is not set..", func() {
@@ -137,7 +115,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CmdShouldPass("odo", "config", "set", "maxcpu", "0.5", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
-			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max or try not passing any of them"))
+			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max"))
 		})
 	})
 

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -53,6 +53,94 @@ var _ = Describe("odo push command tests", func() {
 
 	})
 
+	Context("Check memory and cpu config before odo push", func() {
+		It("Should work when both minmemory and maxmemory is set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "minMemory", "100Mi", "--context", context)
+			helper.CmdShouldPass("odo", "config", "set", "maxmemory", "200Mi", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+		})
+
+		It("Should work when memory is set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "Memory", "300Mi", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+		})
+
+		It("Should fail if minMemory is set but maxmemory is not set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "minmemory", "100Mi", "--context", context)
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max or try not passing any of them"))
+		})
+
+		It("should fail if maxmemory is set but minmemory is not set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "maxmemory", "400Mi", "--context", context)
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("`minmemory` should accompany `maxmemory` or use `odo config set memory` to use same value for both min and max or try not passing any of them"))
+		})
+
+		It("Should work when both mincpu and maxcpu is set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "mincpu", "0.2", "--context", context)
+			helper.CmdShouldPass("odo", "config", "set", "maxcpu", "0.5", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+		})
+
+		It("Should work when cpu is set", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "cpu", "0.4", "--context", context)
+			helper.CmdShouldPass("odo", "push", "--context", context)
+		})
+
+		It("Should fail if mincpu is set but maxcpu is not set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "mincpu", "0.4", "--context", context)
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max or try not passing any of them"))
+		})
+
+		It("should fail if maxcpu is set but mincpu is not set..", func() {
+
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+
+			helper.CmdShouldPass("odo", "config", "set", "maxcpu", "0.5", "--context", context)
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("`mincpu` should accompany `maxcpu` or use `odo config set cpu` to use same value for both min and max or try not passing any of them"))
+		})
+	})
+
 	Context("Check for label propagation after pushing", func() {
 
 		It("Check for labels", func() {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -192,8 +192,8 @@ func componentTests(args ...string) {
 		})
 
 		It("should list the component", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "MaxMemory,300Mi")
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--project", project)...)
@@ -207,15 +207,15 @@ func componentTests(args ...string) {
 		})
 
 		It("should list the component when it is not pushed", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "MinCPU,100m")
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context)...)
 			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "Not Pushed"})
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 		It("should list the state as unknown for disconnected cluster", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
-			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing", "MinCPU,100m")
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			kubeconfigOrig := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context, "--v", "9")...)
@@ -596,12 +596,8 @@ func componentTests(args ...string) {
 
 		It("should be able to create a git component and update it from local to git", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--min-cpu", "0.1", "--max-cpu", "2", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
-			getCPULimit := oc.MaxCPU("cmp-git", "testing", project)
-			Expect(getCPULimit).To(ContainSubstring("2"))
-			getCPURequest := oc.MinCPU("cmp-git", "testing", project)
-			Expect(getCPURequest).To(ContainSubstring("100m"))
 
 			helper.CmdShouldPass("odo", "update", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", context)
 			// check the source location and type in the deployment config
@@ -612,22 +608,13 @@ func componentTests(args ...string) {
 		})
 
 		It("should be able to update a component from git to local", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--min-memory", "100Mi", "--max-memory", "300Mi", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
-			getMemoryLimit := oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest := oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
 
 			// update the component config according to the git component
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
 			helper.CmdShouldPass("odo", "update", "--local", "./", "--context", context)
-
-			getMemoryLimit = oc.MaxMemory("cmp-git", "testing", project)
-			Expect(getMemoryLimit).To(ContainSubstring("300Mi"))
-			getMemoryRequest = oc.MinMemory("cmp-git", "testing", project)
-			Expect(getMemoryRequest).To(ContainSubstring("100Mi"))
 
 			// check the source location and type in the deployment config
 			getSourceLocation := oc.SourceLocationDC("cmp-git", "testing", project)
@@ -755,20 +742,6 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", contextNumeric, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(contextNumeric, "Type,nodejs", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", contextNumeric, "-v4")...)
-		})
-	})
-
-	Context("when creating component with improper memory quantities", func() {
-		JustBeforeEach(func() {
-			project = helper.CreateRandProject()
-		})
-		JustAfterEach(func() {
-			helper.DeleteProject(project)
-		})
-		It("should fail gracefully with proper error message", func() {
-			stdError := helper.CmdShouldFail("odo", append(args, "create", "java:8", "backend", "--memory", "1GB", "--project", project, "--context", context)...)
-			Expect(stdError).ToNot(ContainSubstring("panic: cannot parse"))
-			Expect(stdError).To(ContainSubstring("quantities must match the regular expression"))
 		})
 	})
 

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -360,6 +360,13 @@ func OdoWatch(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, project, context, fl
 	Expect(success).To(Equal(true))
 	Expect(err).To(BeNil())
 
+	if !isDevfileTest {
+		// Verify memory limits to be same as configured
+		getMemoryLimit := runner.(helper.OcRunner).MaxMemory(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
+		Expect(getMemoryLimit).To(ContainSubstring("700Mi"))
+		getMemoryRequest := runner.(helper.OcRunner).MinMemory(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
+		Expect(getMemoryRequest).To(ContainSubstring("400Mi"))
+	}
 }
 
 func validateContainerExecListDir(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, runner interface{}, platform, project string, isDevfileTest bool) error {

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -360,13 +360,6 @@ func OdoWatch(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, project, context, fl
 	Expect(success).To(Equal(true))
 	Expect(err).To(BeNil())
 
-	if !isDevfileTest {
-		// Verify memory limits to be same as configured
-		getMemoryLimit := runner.(helper.OcRunner).MaxMemory(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
-		Expect(getMemoryLimit).To(ContainSubstring("700Mi"))
-		getMemoryRequest := runner.(helper.OcRunner).MinMemory(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
-		Expect(getMemoryRequest).To(ContainSubstring("400Mi"))
-	}
 }
 
 func validateContainerExecListDir(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, runner interface{}, platform, project string, isDevfileTest bool) error {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What does does this PR do / why we need it**:

Cleans up and remove the memory and cpu flags from `odo create` command.
There parameters can be set using `odo config` command.

**Which issue(s) this PR fixes**:
 #3403 

**How to test changes / Special notes to the reviewer**:
