### PR TITLE
WIP: experiment code should use genericclioptions.NewDevfileContext

### DIFF
--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -37,7 +37,7 @@ func NewListServicesOptions() *ListServicesOptions {
 func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	if experimental.IsExperimentalModeEnabled() {
 		var noCsvs, noServices bool
-		o.Context = genericclioptions.NewContext(cmd)
+		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.csvs, err = o.KClient.GetClusterServiceVersionList()
 		if err != nil {
 			// Error only occurs when OperatorHub is not installed/enabled on the


### PR DESCRIPTION
**What type of PR is this?**




**What does does this PR do / why we need it**:
this comes from review of #3355 
experiment code should use genericclioptions.NewDevfileContext(cmd)
not genericclioptions.NewContext(cmd

**Which issue(s) this PR fixes**:



**How to test changes / Special notes to the reviewer**:
