### PR TITLE
WIP: honor --now flag when create component when using devfile

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -59,7 +59,7 @@ type CreateOptions struct {
 	cpu         string
 	interactive bool
 	now         bool
-	*CommonPushOptions
+	*PushOptions
 	devfileMetadata DevfileMetadata
 }
 
@@ -153,7 +153,7 @@ const defaultProjectName = "devfile-project-name"
 // NewCreateOptions returns new instance of CreateOptions
 func NewCreateOptions() *CreateOptions {
 	return &CreateOptions{
-		CommonPushOptions: NewCommonPushOptions(),
+		PushOptions: NewPushOptions(),
 	}
 }
 
@@ -1029,7 +1029,14 @@ func (co *CreateOptions) Run() (err error) {
 				return err
 			}
 
-			log.Italic("\nPlease use `odo push` command to create the component with source deployed")
+			if co.now {
+				err = co.DevfilePush()
+				if err != nil {
+					return errors.Wrapf(err, "failed to push the changes")
+				}
+			} else {
+				log.Italic("\nPlease use `odo push` command to create the component with source deployed")
+			}
 			return nil
 		}
 	}

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -107,6 +107,17 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "push", "--project", namespace)
 		})
 
+		It("checks that odo push works with a devfile with now flag", func() {
+			originalDir := helper.Getwd()
+			context2 := helper.CreateNewContext()
+			helper.Chdir(context2)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+			output := helper.CmdShouldPass("odo", "create", "--starter", "nodejs", "--now")
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			helper.Chdir(originalDir)
+			helper.DeleteDir(context2)
+		})
+
 		It("checks that odo push works with a devfile with sourcemapping set", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does does this PR do / why we need it**:
honor --now flag when create component when using devfile

**Which issue(s) this PR fixes**:

Fixes #3469

**How to test changes / Special notes to the reviewer**:
`odo create  --starter nodejs   --env VariableName=Value --env app=nodejstest --now --port 3000`