### PR TITLE
Use the name provided on CLI to create an Operator backed service

### DIFF
--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -164,9 +164,12 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 	if experimental.IsExperimentalModeEnabled() {
 		// let's validate if the service exists
 		svcFullName := strings.Join([]string{o.serviceType, o.serviceName}, "/")
-		_, err := svc.OperatorSvcExists(o.KClient, svcFullName)
+		svcExists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
 		if err != nil {
 			return err
+		}
+		if !svcExists {
+			return fmt.Errorf("Couldn't find service named %q. Refer %q to see list of running services", svcFullName, "odo service list")
 		}
 
 		// since the service exists, let's get more info to populate service binding request

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -474,7 +474,7 @@ func setServiceName(crd interface{}, name string) (map[string]interface{}, error
 		if k == "metadata" {
 			n := v.(map[string]interface{})
 
-			for k1, _ := range n {
+			for k1 := range n {
 				if k1 == "name" {
 					n[k1] = name
 					return m, nil

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
@@ -97,8 +96,7 @@ type ServiceCreateOptions struct {
 	// Location of the file in which yaml specification of CR is stored.
 	// TODO: remove this after service create's interactive mode supports creating operator backed services
 	fromFile string
-	// For accessing information from Devfile
-	EnvSpecificInfo *envinfo.EnvSpecificInfo
+}
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -113,12 +111,6 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 	}
 
 	if experimental.IsExperimentalModeEnabled() {
-		envInfo, err := envinfo.NewEnvSpecificInfo(o.componentContext)
-		if err != nil {
-			return errors.Wrap(err, "unable to retrieve configuration information")
-		}
-
-		o.EnvSpecificInfo = envInfo
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.componentContext != "" {
 		o.Context = genericclioptions.NewContext(cmd)

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -309,8 +309,12 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			}
 
 			if o.ServiceName != "" {
-				exists, err := svc.OperatorSvcExists(o.KClient, o.CustomResource, o.ServiceName)
-				fmt.Println(exists, err)
+				// First check if service with provided name already exists
+				svcFullName := strings.Join([]string{o.CustomResource, o.ServiceName}, "/")
+				exists, _ := svc.OperatorSvcExists(o.KClient, svcFullName)
+				if exists {
+					return fmt.Errorf("Service %q already exists. Please provide a different name or delete the existing service first.", svcFullName)
+				}
 
 				err = d.setServiceName(o.ServiceName)
 				if err != nil {

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -262,7 +262,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 
 			// Check if the operator and the CR exist on cluster
 			var csv olm.ClusterServiceVersion
-			o.CustomResource, csv, err = svc.CheckCRExists(o.KClient, d.OriginalCRD)
+			o.CustomResource, csv, err = svc.GetCSV(o.KClient, d.OriginalCRD)
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -109,8 +109,6 @@ func NewServiceCreateOptions() *ServiceCreateOptions {
 type DynamicCRD struct {
 	// contains the CR as obtained from CSV or user
 	OriginalCRD map[string]interface{}
-	// contains the metadata of the provided CR
-	metadata map[string]interface{}
 }
 
 func NewDynamicCRD() *DynamicCRD {

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -24,6 +24,7 @@ import (
 
 	scv1beta1 "github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -300,7 +301,10 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			if o.ServiceName != "" && !o.DryRun {
 				// First check if service with provided name already exists
 				svcFullName := strings.Join([]string{o.CustomResource, o.ServiceName}, "/")
-				exists, _ := svc.OperatorSvcExists(o.KClient, svcFullName)
+				exists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
+				if kerrors.IsNotFound(err) {
+					return err
+				}
 				if exists {
 					return fmt.Errorf("Service %q already exists. Please provide a different name or delete the existing service first.", svcFullName)
 				}
@@ -341,7 +345,10 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			if o.ServiceName != "" && !o.DryRun {
 				// First check if service with provided name already exists
 				svcFullName := strings.Join([]string{o.CustomResource, o.ServiceName}, "/")
-				exists, _ := svc.OperatorSvcExists(o.KClient, svcFullName)
+				exists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
+				if kerrors.IsNotFound(err) {
+					return err
+				}
 				if exists {
 					return fmt.Errorf("Service %q already exists. Please provide a different name or delete the existing service first.", svcFullName)
 				}

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -24,7 +24,6 @@ import (
 
 	scv1beta1 "github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -302,7 +301,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 				// First check if service with provided name already exists
 				svcFullName := strings.Join([]string{o.CustomResource, o.ServiceName}, "/")
 				exists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
-				if kerrors.IsNotFound(err) {
+				if err != nil {
 					return err
 				}
 				if exists {
@@ -346,7 +345,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 				// First check if service with provided name already exists
 				svcFullName := strings.Join([]string{o.CustomResource, o.ServiceName}, "/")
 				exists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
-				if kerrors.IsNotFound(err) {
+				if err != nil {
 					return err
 				}
 				if exists {

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -306,7 +306,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 					return err
 				}
 				if exists {
-					return fmt.Errorf("Service %q already exists. Please provide a different name or delete the existing service first.", svcFullName)
+					return fmt.Errorf("service %q already exists; please provide a different name or delete the existing service first.", svcFullName)
 				}
 
 				d.setServiceName(o.ServiceName)
@@ -350,7 +350,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 					return err
 				}
 				if exists {
-					return fmt.Errorf("Service %q already exists. Please provide a different name or delete the existing service first.", svcFullName)
+					return fmt.Errorf("service %q already exists; please provide a different name or delete the existing service first.", svcFullName)
 				}
 
 				d.setServiceName(o.ServiceName)
@@ -372,7 +372,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			// correct way is to execute:
 			// `odo service create <operator-name> --crd <crd-name>`
 
-			return fmt.Errorf("Please use a valid command to start an Operator backed service. Desired format: %q", "odo service create <operator-name> --crd <crd-name>")
+			return fmt.Errorf("please use a valid command to start an Operator backed service; desired format: %q", "odo service create <operator-name> --crd <crd-name>")
 		}
 	}
 	// make sure the service type exists
@@ -518,14 +518,14 @@ func (d *DynamicCRD) validateMetadataInCRD() error {
 	metadata, ok := d.OriginalCRD["metadata"].(map[string]interface{})
 	if !ok {
 		// this condition is satisfied if there's no metadata at all in the provided CRD
-		return fmt.Errorf("Couldn't find \"metadata\" in the yaml. Need metadata start the service")
+		return fmt.Errorf("couldn't find \"metadata\" in the yaml; need metadata start the service")
 	}
 
 	if _, ok := metadata["name"].(string); ok {
 		// found the metadata.name; no error
 		return nil
 	}
-	return fmt.Errorf("Couldn't find metadata.name in the yaml. Provide a name for the service")
+	return fmt.Errorf("couldn't find metadata.name in the yaml; provide a name for the service")
 }
 
 // setServiceName modifies the CRD to contain user provided name on the CLI
@@ -548,12 +548,12 @@ func (d *DynamicCRD) getServiceNameFromCRD() (string, error) {
 	metadata, ok := d.OriginalCRD["metadata"].(map[string]interface{})
 	if !ok {
 		// this condition is satisfied if there's no metadata at all in the provided CRD
-		return "", fmt.Errorf("Couldn't find \"metadata\" in the yaml. Need metadata.name to start the service")
+		return "", fmt.Errorf("couldn't find \"metadata\" in the yaml; need metadata.name to start the service")
 	}
 
 	if name, ok := metadata["name"].(string); ok {
 		// found the metadata.name; no error
 		return name, nil
 	}
-	return "", fmt.Errorf("Couldn't find metadata.name in the yaml. Provide a name for the service")
+	return "", fmt.Errorf("couldn't find metadata.name in the yaml; provide a name for the service")
 }

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -56,9 +56,13 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
 	if experimental.IsExperimentalModeEnabled() {
-		_, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
+		svcExists, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
 		if err != nil {
 			return err
+		}
+
+		if !svcExists {
+			return fmt.Errorf("Couldn't find service named %q. Refer %q to see list of running services", o.serviceName, "odo service list")
 		}
 		return nil
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -66,10 +66,10 @@ func CreateService(client *occlient.Client, serviceName string, serviceType stri
 	return nil
 }
 
-// CheckCRExists checks if the CR provided by the user in the YAML file exists in the namesapce
+// GetCSV checks if the CR provided by the user in the YAML file exists in the namesapce
 // It returns a CR (string representation) and CSV (Operator) upon successfully
 // able to find them, an error otherwise.
-func CheckCRExists(client *kclient.Client, crd map[string]interface{}) (string, olm.ClusterServiceVersion, error) {
+func GetCSV(client *kclient.Client, crd map[string]interface{}) (string, olm.ClusterServiceVersion, error) {
 	cr := crd["kind"].(string)
 	csvs, err := client.GetClusterServiceVersionList()
 	if err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -415,6 +415,7 @@ func GetAlmExample(csv olm.ClusterServiceVersion, cr, serviceType string) (almEx
 	return almExample, nil
 }
 
+// getAlmExample returns the alm-example for exact service of an Operator
 func getAlmExample(almExamples []map[string]interface{}, crd, operator string) (map[string]interface{}, error) {
 	for _, example := range almExamples {
 		if example["kind"].(string) == crd {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -97,40 +97,6 @@ func doesCRExist(kind string, csvs *olm.ClusterServiceVersionList) (olm.ClusterS
 
 }
 
-func serviceNameFromCRD(crd map[string]interface{}, serviceName string) (string, error) {
-	metadata, ok := crd["metadata"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("Couldn't find \"metadata\" in the yaml. Need metadata.name to start the service")
-	}
-
-	if name, ok := metadata["name"].(string); ok {
-		return name, nil
-	}
-	return "", fmt.Errorf("Couldn't find metadata.name in the yaml. Provide a name for the service")
-}
-
-// Parses group and version values from the alm-example
-func groupVersionALMExample(example map[string]interface{}) (group, version string) {
-	apiVersion := example["apiVersion"].(string)
-	// use SplitN so that if apiVersion field's value is something like
-	// etcd.coreos.com/v1/beta1 then group's value ends up being etcd.cores.com
-	// and version ends up being v1/beta1
-	gv := strings.SplitN(apiVersion, "/", 2)
-
-	group, version = gv[0], gv[1]
-	return
-}
-
-func resourceFromCSV(csv olm.ClusterServiceVersion, crdName string) (resource string) {
-	for _, crd := range csv.Spec.CustomResourceDefinitions.Owned {
-		if crd.Kind == crdName {
-			resource = strings.Split(crd.Name, ".")[0]
-			return
-		}
-	}
-	return
-}
-
 // CreateOperatorService creates new service (actually a Deployment) from OperatorHub
 func CreateOperatorService(client *kclient.Client, group, version, resource string, CustomResourceDefinition map[string]interface{}) error {
 	err := client.CreateDynamicResource(CustomResourceDefinition, group, version, resource)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -345,8 +345,9 @@ func getGVKRFromCR(cr olm.CRDDescription) (group, version, kind, resource string
 
 func GetGVRFromOperator(csv olm.ClusterServiceVersion, cr string) (group, version, resource string, err error) {
 	for _, customresource := range csv.Spec.CustomResourceDefinitions.Owned {
-		if customresource.Kind == cr {
-			return GetGVRFromCR(&customresource)
+		custRes := customresource
+		if custRes.Kind == cr {
+			return GetGVRFromCR(&custRes)
 		}
 	}
 	return "", "", "", fmt.Errorf("Couldn't parse group, version, resource from Operator %q\n", csv.Name)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -25,7 +25,6 @@ import (
 const provisionedAndBoundStatus = "ProvisionedAndBound"
 const provisionedAndLinkedStatus = "ProvisionedAndLinked"
 const apiVersion = "odo.dev/v1alpha1"
-const serviceListCmd = "odo service list"
 
 // NewServicePlanParameter creates a new ServicePlanParameter instance with the specified state
 func NewServicePlanParameter(name, typeName, defaultValue string, required bool) ServicePlanParameter {
@@ -550,7 +549,7 @@ func OperatorSvcExists(client *kclient.Client, serviceName string) (bool, error)
 		}
 	}
 
-	return false, fmt.Errorf("Couldn't find service named %q. Refer %q to see list of running services", serviceName, serviceListCmd)
+	return false, nil
 }
 
 // splitServiceKindName splits the service name provided for deletion by the
@@ -558,7 +557,7 @@ func OperatorSvcExists(client *kclient.Client, serviceName string) (bool, error)
 func splitServiceKindName(serviceName string) (string, string, error) {
 	sn := strings.SplitN(serviceName, "/", 2)
 	if len(sn) != 2 || sn[0] == "" || sn[1] == "" {
-		return "", "", fmt.Errorf("Invalid service name. Refer %q to see list of running services", serviceListCmd)
+		return "", "", fmt.Errorf("Invalid service name. Refer %q to see list of running services", "odo service list")
 	}
 
 	kind := sn[0]

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -79,7 +79,7 @@ func GetCSV(client *kclient.Client, crd map[string]interface{}) (string, olm.Clu
 	csv, err := doesCRExist(cr, csvs)
 	if err != nil {
 		return cr, olm.ClusterServiceVersion{},
-			fmt.Errorf("Could not find specified service/custom resource: %s\nPlease check the \"kind\" field in the yaml (it's case-sensitive)", cr)
+			fmt.Errorf("could not find specified service/custom resource: %s; please check the \"kind\" field in the yaml (it's case-sensitive)", cr)
 	}
 	return cr, csv, nil
 }
@@ -93,7 +93,7 @@ func doesCRExist(kind string, csvs *olm.ClusterServiceVersionList) (olm.ClusterS
 			}
 		}
 	}
-	return olm.ClusterServiceVersion{}, errors.New("Could not find the requested cluster resource")
+	return olm.ClusterServiceVersion{}, errors.New("could not find the requested cluster resource")
 
 }
 
@@ -101,7 +101,7 @@ func doesCRExist(kind string, csvs *olm.ClusterServiceVersionList) (olm.ClusterS
 func CreateOperatorService(client *kclient.Client, group, version, resource string, CustomResourceDefinition map[string]interface{}) error {
 	err := client.CreateDynamicResource(CustomResourceDefinition, group, version, resource)
 	if err != nil {
-		return errors.Wrap(err, "Unable to create operator backed service")
+		return errors.Wrap(err, "unable to create operator backed service")
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, 
 	// let's get the Services a.k.a Custom Resources (CR) defined by each operator, one by one
 	for _, csv := range csvs.Items {
 		clusterServiceVersion := csv
-		klog.V(4).Infof("Getting services started from operator: %s\n", clusterServiceVersion.Name)
+		klog.V(4).Infof("Getting services started from operator: %s", clusterServiceVersion.Name)
 		customResources := client.GetCustomResourcesFromCSV(&clusterServiceVersion)
 
 		// list and write active instances of each service/CR
@@ -334,7 +334,7 @@ func getGVKRFromCR(cr olm.CRDDescription) (group, version, kind, resource string
 
 	gr := strings.SplitN(cr.Name, ".", 2)
 	if len(gr) != 2 {
-		err = fmt.Errorf("Couldn't split Custom Resource's name into two: %s\n", cr.Name)
+		err = fmt.Errorf("Couldn't split Custom Resource's name into two: %s", cr.Name)
 		return
 	}
 	resource = gr[0]
@@ -350,7 +350,7 @@ func GetGVRFromOperator(csv olm.ClusterServiceVersion, cr string) (group, versio
 			return GetGVRFromCR(&custRes)
 		}
 	}
-	return "", "", "", fmt.Errorf("Couldn't parse group, version, resource from Operator %q\n", csv.Name)
+	return "", "", "", fmt.Errorf("couldn't parse group, version, resource from Operator %q", csv.Name)
 }
 
 // GetGVRFromCR parses and returns the values for group, version and resource
@@ -360,7 +360,7 @@ func GetGVRFromCR(cr *olm.CRDDescription) (group, version, resource string, err 
 
 	gr := strings.SplitN(cr.Name, ".", 2)
 	if len(gr) != 2 {
-		err = fmt.Errorf("Couldn't split Custom Resource's name into two: %s\n", cr.Name)
+		err = fmt.Errorf("couldn't split Custom Resource's name into two: %s", cr.Name)
 		return
 	}
 	resource = gr[0]
@@ -381,7 +381,7 @@ func getGVKFromCR(cr *olm.CRDDescription) (group, version, kind string, err erro
 
 	gr := strings.SplitN(cr.Name, ".", 2)
 	if len(gr) != 2 {
-		err = fmt.Errorf("Couldn't split Custom Resource's name into two: %s\n", cr.Name)
+		err = fmt.Errorf("Couldn't split Custom Resource's name into two: %s", cr.Name)
 		return
 	}
 	group = gr[1]
@@ -404,7 +404,7 @@ func GetAlmExample(csv olm.ClusterServiceVersion, cr, serviceType string) (almEx
 	} else {
 		// There's no alm examples in the CSV's definition
 		return nil,
-			fmt.Errorf("Could not find alm-examples in %q Operator's definition.", cr)
+			fmt.Errorf("could not find alm-examples in %q Operator's definition.", cr)
 	}
 
 	almExample, err = getAlmExample(almExamples, cr, serviceType)
@@ -422,7 +422,7 @@ func getAlmExample(almExamples []map[string]interface{}, crd, operator string) (
 			return example, nil
 		}
 	}
-	return nil, errors.Errorf("Could not find example yaml definition for %q service in %q Operator's definition.\n", crd, operator)
+	return nil, errors.Errorf("could not find example yaml definition for %q service in %q Operator's definition.", crd, operator)
 }
 
 // GetInstancesOfCustomResources returns active instances of given Custom Resource (service in

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -112,7 +112,8 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
 			// Look for pod with custom name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(name).FindString(pods)
+			compileString := name + `-.[a-z0-9]*`
+			etcdPod := regexp.MustCompile(compileString).FindString(pods)
 
 			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -60,7 +60,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should now allow interactive mode command to be executed", func() {
 			stdOut := helper.CmdShouldFail("odo", "service", "create")
-			Expect(stdOut).To(ContainSubstring("Please use a valid command to start an Operator backed service"))
+			Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
 		})
 	})
 
@@ -121,7 +121,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 			// now try creating service with same name again. it should fail
 			stdOut := helper.CmdShouldFail("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", name)
-			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("Service %q already exists", svcFullName)))
+			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
 
 			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
 		})
@@ -240,7 +240,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 			// Attempting to create service with same name should fail
 			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
-			Expect(stdOut).To(ContainSubstring("Please provide a different name or delete the existing service first"))
+			Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
 		})
 	})
 
@@ -281,7 +281,7 @@ spec:
 
 			// now create operator backed service
 			stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-			Expect(stdOut).To(ContainSubstring("Couldn't find \"metadata\" in the yaml"))
+			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
 
 			invalidMetaFile := helper.RandString(6) + ".yaml"
 			fileName = filepath.Join("/tmp", invalidMetaFile)
@@ -291,7 +291,7 @@ spec:
 
 			// now create operator backed service
 			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-			Expect(stdOut).To(ContainSubstring("Couldn't find metadata.name in the yaml"))
+			Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
 
 		})
 	})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -58,7 +58,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "mongodb-enterprise", "etcdoperator"})
 		})
 
-		It("should now allow interactive mode command to be executed", func() {
+		It("should not allow interactive mode command to be executed", func() {
 			stdOut := helper.CmdShouldFail("odo", "service", "create")
 			Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind code-refactoring

**What does does this PR do / why we need it**:
This PR lets the user create a service named `myservice` when they do something like `odo service create etcdoperator.v0.9.4-clusterwide --crd EtcdCluster myservice`. This wasn't working earlier for Operator Hub backed services

It also does some refactoring of the code in `pkg/odo/cli/service/create.go`. Part of the business logic is moved to `service` package.
**Which issue(s) this PR fixes**:

Fixes #3180

**How to test changes / Special notes to the reviewer**:
```sh
$ odo service create etcdoperator.v0.9.4-clusterwide --crd EtcdCluster myservice

$ odo service list
NAME                TYPE                      AGE
myservice            EtcdCluster               4s
```