### PR TITLE
Add "Understanding odo" Documentation

### DIFF
--- a/docs/public/understanding-odo.adoc
+++ b/docs/public/understanding-odo.adoc
@@ -1,0 +1,92 @@
+= Understanding `odo`
+
+`odo` is a CLI tool for creating applications on OpenShift and Kubernetes. `odo` allows developers to concentrate on creating applications without the need to administer a cluster itself.
+Creating deployment configurations, build configurations, service routes and other OpenShift or Kubernetes elements are all automated by `odo`.
+
+Existing tools such as `oc` are more operations-focused and require a deep understanding of Kubernetes and OpenShift concepts. `odo` abstracts away complex Kubernetes and OpenShift concepts allowing developers to focus on what is most important to them: code.
+
+[id="odo-key-features"]
+== Key features
+
+`odo` is designed to be simple and concise with the following key features:
+
+* Simple syntax and design centered around concepts familiar to developers, such as projects, applications, and components.
+* Completely client based. No additional server other than OpenShift is required for deployment.
+* Official support for Node.js and Java components.
+* Detects changes to local code and deploys it to the cluster automatically, giving instant feedback to validate changes in real time.
+* Lists all the available components and services from the cluster.
+
+== Core concepts
+
+Project::
+A project is your source code, tests, and libraries organized in a separate single unit.
+Application::
+An application is a program designed for end users. An application consists of multiple microservices or components that work individually to build the entire application.
+Examples of applications: a video game, a media player, a web browser.
+Component::
+A component is a set of Kubernetes resources which host code or data. Each component can be run and deployed separately.
+Examples of components: Node.js, Perl, PHP, Python, Ruby.
+Service::
+A service is software that your component links to or depends on.
+Examples of services: MariaDB, Jenkins, MySQL.
+Devfile::
+A portable file responsible for your entire reproducable development environment.
+
+[id="odo-supported-devfiles"]
+=== Official Devfiles
+
+Devfiles describe your development environment link. link:https://odo.dev/docs/deploying-a-devfile-using-odo/[Click here for more information on Devfile.]
+
+All official example Devfiles are hosted on the link:https://github.com/odo-devfiles/registry[registry].
+
+.List of Devfiles which are officially supported by odo
+[options="header"]
+|===
+|Language | Devfile Name | Description | Devfile Source
+
+| Java
+| java-maven
+| Upstream Maven and OpenJDK 11
+| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-maven/devfile.yaml[java-maven/devfile.yaml]
+
+| Java
+| java-openliberty
+| Open Liberty microservice in Java      
+| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-openliberty/devfile.yaml[java-openliberty/devfile.yaml]
+
+| Java
+| java-quarkus
+| Upstream Quarkus with Java+GraalVM
+| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-quarkus/devfile.yaml[java-quarkus/devfile.yaml]
+
+| Java
+| java-springboot
+| Spring Boot® using Java 
+| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-springboot/devfile.yaml[java-springboot/devfile.yaml]
+
+| Node.JS
+| nodejs
+| Stack with NodeJS 12
+| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/nodejs/devfile.yaml[nodejs/devfile.yaml]
+
+|===
+[id="odo-listing-available-images"]
+==== Listing available Devfiles
+
+[NOTE]
+====
+The list of available Devfiles is sourced from the official link:https://github.com/odo-devfiles/registry[odo registry] as well as any other registies added via `odo registry add`.
+====
+
+To list the available Devfiles:
+
+----------------------------------------------------
+$ odo catalog list components
+Odo Devfile Components:
+NAME                 DESCRIPTION                            REGISTRY
+java-maven           Upstream Maven and OpenJDK 11          DefaultDevfileRegistry
+java-openliberty     Open Liberty microservice in Java      DefaultDevfileRegistry
+java-quarkus         Upstream Quarkus with Java+GraalVM     DefaultDevfileRegistry
+java-springboot      Spring Boot® using Java                DefaultDevfileRegistry
+nodejs               Stack with NodeJS 12                   DefaultDevfileRegistry
+----------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Since we are doing a future Devfile release of odo that uses Devfile, we
require our "Understanding odo" guide to be located upstream rather than
downstream (from github.com/openshift/openshift-docs).

This adds that documentation.

**Which issue(s) this PR fixes**:

Closes https://github.com/openshift/odo/issues/3517

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>