### PR TITLE
implement machine readable output for odo preference view

### DIFF
--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"text/tabwriter"
 
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/preference"
@@ -49,6 +51,13 @@ func (o *ViewOptions) Run() (err error) {
 	if err != nil {
 		util.LogErrorAndExit(err, "")
 	}
+
+	if log.IsJSON() {
+		prefDef := preference.NewPreferenceList(*cfg)
+		machineoutput.OutputSuccess(prefDef)
+
+		return
+	}
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 2, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "PARAMETER", "\t", "CURRENT_VALUE")
 	fmt.Fprintln(w, "UpdateNotification", "\t", showBlankIfNil(cfg.OdoSettings.UpdateNotification))
@@ -81,11 +90,13 @@ func showBlankIfNil(intf interface{}) interface{} {
 func NewCmdView(name, fullName string) *cobra.Command {
 	o := NewViewOptions()
 	preferenceViewCmd := &cobra.Command{
-		Use:     name,
-		Short:   "View current preference values",
-		Long:    "View current preference values",
-		Example: fmt.Sprintf(fmt.Sprint("\n", viewExample), fullName),
-		Args:    cobra.ExactArgs(0),
+		Use:         name,
+		Short:       "View current preference values",
+		Long:        "View current preference values",
+		Example:     fmt.Sprintf(fmt.Sprint("\n", viewExample), fullName),
+		Annotations: map[string]string{"machineoutput": "json"},
+
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/preference/machine_output.go
+++ b/pkg/preference/machine_output.go
@@ -1,0 +1,94 @@
+package preference
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	prefAPIVersion = "odo.dev/v1alpha1"
+	prefKind       = "PreferenceList"
+)
+
+type PreferenceList struct {
+	metav1.TypeMeta `json:",inline"`
+	Items           []PreferenceItem `json:"items,omitempty"`
+}
+
+type PreferenceItem struct {
+	Name        string
+	Value       interface{} // The value set by the user, this will be nil if the user hasn't set it
+	Default     interface{} // default value of the preference if the user hasn't set the value
+	Type        string      // the type of the preference, possible values int, string, bool
+	Description string      // The description of the preference
+}
+
+func NewPreferenceList(prefInfo PreferenceInfo) PreferenceList {
+	return PreferenceList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: prefAPIVersion,
+			Kind:       prefKind,
+		},
+		Items: toPreferenceItems(prefInfo),
+	}
+}
+
+func toPreferenceItems(prefInfo PreferenceInfo) []PreferenceItem {
+	odoSettings := prefInfo.OdoSettings
+	return []PreferenceItem{
+		{
+			Name:        UpdateNotificationSetting,
+			Value:       odoSettings.UpdateNotification,
+			Default:     true,
+			Type:        getType(prefInfo.GetUpdateNotification()), // use the Getter here to determine type
+			Description: UpdateNotificationSettingDescription,
+		},
+		{
+			Name:        NamePrefixSetting,
+			Value:       odoSettings.NamePrefix,
+			Default:     "",
+			Type:        getType(prefInfo.GetNamePrefix()),
+			Description: NamePrefixSettingDescription,
+		},
+		{
+			Name:        TimeoutSetting,
+			Value:       odoSettings.Timeout,
+			Default:     DefaultTimeout,
+			Type:        getType(prefInfo.GetTimeout()),
+			Description: TimeoutSettingDescription,
+		},
+		{
+			Name:        PushTimeoutSetting,
+			Value:       odoSettings.PushTimeout,
+			Default:     DefaultPushTimeout,
+			Type:        getType(prefInfo.GetPushTimeout()),
+			Description: PushTimeoutSettingDescription,
+		},
+		{
+			Name:        ExperimentalSetting,
+			Value:       odoSettings.Experimental,
+			Default:     false,
+			Type:        getType(prefInfo.GetExperimental()),
+			Description: ExperimentalDescription,
+		},
+		{
+			Name:        PushTargetSetting,
+			Value:       odoSettings.PushTarget,
+			Default:     KubePushTarget,
+			Type:        getType(prefInfo.GetPushTarget()),
+			Description: PushTargetDescription,
+		},
+	}
+}
+
+func getType(v interface{}) string {
+
+	rv := reflect.ValueOf(v)
+
+	if rv.Kind() == reflect.Ptr {
+		return rv.Elem().Kind().String()
+	}
+
+	return rv.Kind().String()
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


 /kind feature

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3094
**How to test changes / Special notes to the reviewer**:
```
odo preference view -o json
```

Output - 
```
{
        "kind": "PreferenceList",
        "apiVersion": "odo.dev/v1alpha1",
        "items": [
                {
                        "Name": "UpdateNotification",
                        "Value": null,
                        "Default": true,
                        "Type": "bool",
                        "Description": "Flag to control if an update notification is shown or not (Default: true)"
                },
                {
                        "Name": "NamePrefix",
                        "Value": null,
                        "Default": "",
                        "Type": "string",
                        "Description": "Use this value to set a default name prefix (Default: current directory name)"
                },
                {
                        "Name": "Timeout",
                        "Value": null,
                        "Default": 1,
                        "Type": "int",
                        "Description": "Timeout (in seconds) for OpenShift server connection check (Default: 1)"
                },
                {
                        "Name": "PushTimeout",
                        "Value": null,
                        "Default": 240,
                        "Type": "int",
                        "Description": "PushTimeout (in seconds) for waiting for a Pod to come up (Default: 240)"
                },
                {
                        "Name": "Experimental",
                        "Value": true,
                        "Default": false,
                        "Type": "bool",
                        "Description": "Set this value to true to expose features in development/experimental mode"
                },
                {
                        "Name": "PushTarget",
                        "Value": null,
                        "Default": "kube",
                        "Type": "string",
                        "Description": "Set this value to 'kube' or 'docker' to tell odo where to push applications to. (Default: kube)"
                }
        ]
}
```
