### PR TITLE
use linux path separator for commands executed on pod

### DIFF
--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -375,7 +375,7 @@ var _ = Describe("odo push command tests", func() {
 			)
 
 			Expect(statErr).To(HaveOccurred())
-			path := filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java")
+			path := filepath.ToSlash(filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java"))
 			Expect(statErr.Error()).To(ContainSubstring("cannot stat '" + path + "': No such file or directory"))
 		})
 

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -328,7 +328,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/"), "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					modifiedCatServerFile = cmdOp
 					return true

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"time"
 
+	"strings"
+
 	"github.com/openshift/odo/tests/helper"
 
 	. "github.com/onsi/ginkgo"
@@ -286,7 +288,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "server.js")},
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					earlierCatServerFile = cmdOp
 					return true
@@ -298,7 +300,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "views", "index.html")},
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/views/index.html"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					earlierCatViewFile = cmdOp
 					return true
@@ -314,7 +316,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "views", "index.html")},
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/views/index.html"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					modifiedCatViewFile = cmdOp
 					return true
@@ -326,7 +328,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "server.js")},
+				[]string{"stat", strings.TrimSuffix(dir, "/"), "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					modifiedCatServerFile = cmdOp
 					return true
@@ -353,7 +355,7 @@ var _ = Describe("odo push command tests", func() {
 				"backend",
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java")},
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/src/main/java/AnotherMessageProducer.java"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					statErr = err
 					return true
@@ -367,7 +369,7 @@ var _ = Describe("odo push command tests", func() {
 				"backend",
 				appName,
 				project,
-				[]string{"stat", filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java")},
+				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/src/main/java/AnotherMessageProducer.java"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
 				func(cmdOp string, err error) bool {
 					statErr = err
 					return true

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"time"
 
-	"strings"
-
 	"github.com/openshift/odo/tests/helper"
 
 	. "github.com/onsi/ginkgo"
@@ -288,7 +286,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "server.js"))},
 				func(cmdOp string, err error) bool {
 					earlierCatServerFile = cmdOp
 					return true
@@ -300,7 +298,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/views/index.html"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "views", "index.html"))},
 				func(cmdOp string, err error) bool {
 					earlierCatViewFile = cmdOp
 					return true
@@ -316,7 +314,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/views/index.html"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "views", "index.html"))},
 				func(cmdOp string, err error) bool {
 					modifiedCatViewFile = cmdOp
 					return true
@@ -328,7 +326,7 @@ var _ = Describe("odo push command tests", func() {
 				cmpName,
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/server.js"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "server.js"))},
 				func(cmdOp string, err error) bool {
 					modifiedCatServerFile = cmdOp
 					return true
@@ -355,7 +353,7 @@ var _ = Describe("odo push command tests", func() {
 				"backend",
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/src/main/java/AnotherMessageProducer.java"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java"))},
 				func(cmdOp string, err error) bool {
 					statErr = err
 					return true
@@ -369,7 +367,7 @@ var _ = Describe("odo push command tests", func() {
 				"backend",
 				appName,
 				project,
-				[]string{"stat", strings.TrimSuffix(dir, "/") + "/src/src/main/java/AnotherMessageProducer.java"}, // this doesn't use filepath.Join for a reason as this commands needs to run on linux, but the host machine can be windows
+				[]string{"stat", filepath.ToSlash(filepath.Join(dir, "src", "src", "main", "java", "AnotherMessageProducer.java"))},
 				func(cmdOp string, err error) bool {
 					statErr = err
 					return true


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`



**What does does this PR do / why we need it**:
use linux path separator for commands executed on pod instead of platform independent `filepath.Join` as the pod will always be linux but host machine can be windows. Would would join the paths in the commands incorrectly for linux.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3328

**How to test changes / Special notes to the reviewer**:
failing tests mentioned in the above issue should pass on windows