### PR TITLE
Fixing kubeconfig path and login session for 4.x cluster

### DIFF
--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -14,7 +14,8 @@ KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_D
 OC_STABLE_LOGIN="false"
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
 # Exported to current env
-export KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
+ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
+export KUBECONFIG=$ORIGINAL_KUBECONFIG
 
 # List of users to create
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
@@ -133,3 +134,9 @@ fi
 oc new-project myproject
 sleep 4
 oc version
+
+# KUBECONFIG cleanup only if CI is set
+if [ ! -f $CI ]; then
+    rm -rf $KUBECONFIG
+    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+fi

--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -14,6 +14,19 @@ export PATH="$PATH:$(pwd):$GOPATH/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
+# Copy kubeconfig to temporary kubeconfig file
+# Read and Write permission to temporary kubeconfig file
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
+
+# Login as developer
+odo login -u developer -p developer
+
+# Check login user name for debugging purpose
+oc whoami
+
 # Integration tests
 make test-integration
 make test-integration-devfile

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -14,6 +14,19 @@ export PATH="$PATH:$(pwd):$GOPATH/bin"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
 
+# Copy kubeconfig to temporary kubeconfig file
+# Read and Write permission to temporary kubeconfig file
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
+
+# Login as developer
+odo login -u developer -p developer
+
+# Check login user name for debugging purpose
+oc whoami
+
 # Integration tests
 make test-integration
 make test-integration-devfile

--- a/tests/integration/loginlogout/cmd_login_logout_test.go
+++ b/tests/integration/loginlogout/cmd_login_logout_test.go
@@ -38,10 +38,6 @@ var _ = Describe("odo login and logout command tests", func() {
 	})
 
 	Context("when running login tests", func() {
-		JustBeforeEach(func() {
-			// To make sure that the script is using the developer login session
-			helper.CmdShouldPass("odo", "login", "-u", "developer", "-p", "developer")
-		})
 		It("should successful with correct credentials and fails with incorrect token", func() {
 			// Current user login token
 			currentUserToken = oc.GetToken()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind feature

**What does does this PR do / why we need it**:

Configuring kubeconfig path and login session for test script running against 4.x cluster

**Which issue(s) this PR fixes**:

Fixes #3501 

**How to test changes / Special notes to the reviewer**:

Test script should use the developer login session and pr https://github.com/openshift/release/pull/9431 should not fail.