### PR TITLE
Fixing location field for odo catalog describe component jave-openliberty

### DIFF
--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -91,7 +91,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog describe component with a component name with a single project", func() {
 		It("should only give information about one project", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java-openliberty")
-			helper.MatchAllInOutput(output, []string{"location: https://github.com/odo-devfiles/openliberty-ex.git"})
+			helper.MatchAllInOutput(output, []string{"location: https://github.com/OpenLiberty/application-stack.git"})
 		})
 	})
 	Context("When executing catalog describe component with a component name with no starter projects", func() {

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -91,7 +91,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog describe component with a component name with a single project", func() {
 		It("should only give information about one project", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java-openliberty")
-			helper.MatchAllInOutput(output, []string{"location: https://github.com/OpenLiberty/application-stack.git"})
+			Expect(output).To(MatchRegexp("location: .+"))
 		})
 	})
 	Context("When executing catalog describe component with a component name with no starter projects", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

$SUBJECT which is breaking CI https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_odo/3523/pull-ci-openshift-odo-master-v4.5-integration-e2e/1281448634201673728#1:build-log.txt%3A567

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:

It should solve the CI break issue for `odo catalog describe component jave-openliberty`