### PR TITLE
Adds a error message for creation of routes with host flag

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -206,6 +206,10 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 func (o *URLCreateOptions) Validate() (err error) {
 	// Check if exist
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+		// check if a host is provided for route based URLs
+		if o.isRouteSupported && !o.wantIngress && len(o.host) > 0 {
+			return fmt.Errorf("host is not supported for URLs of Route Kind")
+		}
 		// if experimental mode is enabled, and devfile is provided.
 		// check if valid host is provided
 		if !pushtarget.IsPushTargetDocker() && len(o.host) <= 0 && (!o.isRouteSupported || o.wantIngress) {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -229,6 +229,23 @@ var _ = Describe("odo devfile url command tests", func() {
 			Expect(output).ShouldNot(ContainSubstring(url1))
 		})
 
+		It("should error out when a host is provided with a route on a openShift cluster", func() {
+
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			url1 := helper.RandString(5)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldFail("odo", "url", "create", url1, "--host", "com")
+			Expect(output).To(ContainSubstring("host is not supported"))
+		})
+
 		It("should create a url for a unsupported devfile component", func() {
 			url1 := helper.RandString(5)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Adds a error message which is displayed when creation of routes is triggered using a host flag.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3354

**How to test changes / Special notes to the reviewer**:

On a openshift cluster, try to create a route based URL with a host flag
`odo url create example --host`
It should error out with a appropriate message.
