### PR TITLE
Change service list output to make linking easier

### DIFF
--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -84,11 +85,11 @@ func (o *ServiceListOptions) Run() (err error) {
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 
-			fmt.Fprintln(w, "NAME", "\t", "TYPE", "\t", "AGE")
+			fmt.Fprintln(w, "NAME", "\t", "AGE")
 
 			for _, item := range list {
 				duration := time.Since(item.GetCreationTimestamp().Time).Truncate(time.Second).String()
-				fmt.Fprintln(w, item.GetName(), "\t", item.GetKind(), "\t", duration)
+				fmt.Fprintln(w, strings.Join([]string{item.GetKind(), item.GetName()}, "/"), "\t", duration)
 			}
 
 			w.Flush()


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring
/area UX

**What does does this PR do / why we need it**:
It changes the way `odo service list` prints the output.

**Which issue(s) this PR fixes**:

Fixes #3560

**How to test changes / Special notes to the reviewer**:
Start a few Operator backed services and execute `odo service list`. Output should be of the format:
```sh
$ odo service list
NAME                          AGE
Cockroachdb/example           3s
EtcdCluster/example           3m22s
EtcdCluster/myawesomeetcd     3s
```