### PR TITLE
Adds support for deletion of Operator backed service

### DIFF
--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -189,3 +189,10 @@ func (c *Client) ListDynamicResource(group, version, resource string) (*unstruct
 
 	return list, nil
 }
+
+// DeleteDynamicResource deletes an instance, specified by name, of a Custom Resource
+func (c *Client) DeleteDynamicResource(name, group, version, resource string) error {
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	return c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Delete(name, &metav1.DeleteOptions{})
+}

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -1,6 +1,7 @@
 package kclient
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
@@ -11,8 +12,7 @@ import (
 )
 
 var (
-	ErrNoSuchOperator        = errors.New("Could not find specified operator")
-	ErrNoOperatorWithGivenCR = errors.New("Could not find any Operator containing requested CR")
+	ErrNoSuchOperator = errors.New("Could not find specified operator")
 )
 
 const (
@@ -92,5 +92,5 @@ func (c *Client) GetCSVWithCR(name string) (*olm.ClusterServiceVersion, error) {
 			}
 		}
 	}
-	return &olm.ClusterServiceVersion{}, ErrNoOperatorWithGivenCR
+	return &olm.ClusterServiceVersion{}, fmt.Errorf("Could not find any Operator containing requested CR: %s", name)
 }

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -85,7 +85,8 @@ func (c *Client) GetCSVWithCR(name string) (*olm.ClusterServiceVersion, error) {
 	}
 
 	for _, csv := range csvs.Items {
-		for _, cr := range *c.GetCustomResourcesFromCSV(&csv) {
+		clusterServiceVersion := csv
+		for _, cr := range *c.GetCustomResourcesFromCSV(&clusterServiceVersion) {
 			if cr.Kind == name {
 				return &csv, nil
 			}

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -45,9 +45,9 @@ func (c *Client) GetClusterServiceVersion(name string) (olm.ClusterServiceVersio
 }
 
 // GetCustomResourcesFromCSV returns a list of CRs provided by an operator/CSV.
-func (c *Client) GetCustomResourcesFromCSV(csv olm.ClusterServiceVersion) []olm.CRDDescription {
+func (c *Client) GetCustomResourcesFromCSV(csv *olm.ClusterServiceVersion) *[]olm.CRDDescription {
 	// we will return a list of CRs owned by the csv
-	return csv.Spec.CustomResourceDefinitions.Owned
+	return &csv.Spec.CustomResourceDefinitions.Owned
 }
 
 // SearchClusterServiceVersionList searches for whether the operator/CSV contains
@@ -78,18 +78,18 @@ func (c *Client) SearchClusterServiceVersionList(name string) (*olm.ClusterServi
 }
 
 // GetCSVWithCR returns the CSV (Operator) that contains the CR (service)
-func (c *Client) GetCSVWithCR(name string) (olm.ClusterServiceVersion, error) {
+func (c *Client) GetCSVWithCR(name string) (*olm.ClusterServiceVersion, error) {
 	csvs, err := c.GetClusterServiceVersionList()
 	if err != nil {
-		return olm.ClusterServiceVersion{}, errors.Wrap(err, "unable to list services")
+		return &olm.ClusterServiceVersion{}, errors.Wrap(err, "unable to list services")
 	}
 
 	for _, csv := range csvs.Items {
-		for _, cr := range c.GetCustomResourcesFromCSV(csv) {
+		for _, cr := range *c.GetCustomResourcesFromCSV(&csv) {
 			if cr.Kind == name {
-				return csv, nil
+				return &csv, nil
 			}
 		}
 	}
-	return olm.ClusterServiceVersion{}, ErrNoOperatorWithGivenCR
+	return &olm.ClusterServiceVersion{}, ErrNoOperatorWithGivenCR
 }

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -77,10 +77,17 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 func (o *ServiceDeleteOptions) Run() (err error) {
 	if experimental.IsExperimentalModeEnabled() {
 		if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
+
+			s := log.Spinner("Waiting for service to be deleted")
+			defer s.End(false)
+
 			err = svc.DeleteOperatorService(o.KClient, o.serviceName)
 			if err != nil {
 				return err
 			}
+
+			s.End(true)
+
 			log.Infof("Service %q has been successfully deleted", o.serviceName)
 		}
 		return nil

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/odo/util/experimental"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -42,7 +43,11 @@ func NewServiceDeleteOptions() *ServiceDeleteOptions {
 
 // Complete completes ServiceDeleteOptions after they've been created
 func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
+	if experimental.IsExperimentalModeEnabled() {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+	} else {
+		o.Context = genericclioptions.NewContext(cmd)
+	}
 	o.serviceName = args[0]
 
 	return
@@ -50,6 +55,14 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
+	if experimental.IsExperimentalModeEnabled() {
+		_, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	exists, err := svc.SvcExists(o.Client, o.serviceName, o.Application)
 	if err != nil {
 		return fmt.Errorf("unable to delete service because Service Catalog is not enabled in your cluster:\n%v", err)
@@ -62,6 +75,17 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service delete command
 func (o *ServiceDeleteOptions) Run() (err error) {
+	if experimental.IsExperimentalModeEnabled() {
+		if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
+			err = svc.DeleteOperatorService(o.KClient, o.serviceName)
+			if err != nil {
+				return err
+			}
+			log.Infof("Service %q has been successfully deleted", o.serviceName)
+		}
+		return nil
+	}
+
 	if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v from %v", o.serviceName, o.Application)) {
 		err = svc.DeleteServiceAndUnlinkComponents(o.Client, o.serviceName, o.Application)
 		if err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -114,26 +114,14 @@ func DeleteServiceAndUnlinkComponents(client *occlient.Client, serviceName strin
 // TODO: make it unlink the service from component as a part of
 // https://github.com/openshift/odo/issues/3563
 func DeleteOperatorService(client *kclient.Client, serviceName string) error {
-	serviceList, err := ListOperatorServices(client)
-	if err != nil {
-		return errors.Wrap(err, "unable to get the service list")
-	}
-
 	kind, name, err := splitServiceKindName(serviceName)
 	if err != nil {
 		return err
 	}
 
-	var csv *olm.ClusterServiceVersion
-
-	for _, s := range serviceList {
-		if s.GetKind() == kind && s.GetName() == name {
-			csv, err = client.GetCSVWithCR(kind)
-			if err != nil {
-				return err
-			}
-			break
-		}
+	csv, err := client.GetCSVWithCR(kind)
+	if err != nil {
+		return err
 	}
 
 	if csv == nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -144,8 +144,9 @@ func DeleteOperatorService(client *kclient.Client, serviceName string) error {
 	var cr *olm.CRDDescription
 
 	for _, c := range *crs {
-		if c.Kind == kind {
-			cr = &c
+		customResource := c
+		if customResource.Kind == kind {
+			cr = &customResource
 			break
 		}
 	}
@@ -284,8 +285,9 @@ func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, 
 
 	// let's get the Services a.k.a Custom Resources (CR) defined by each operator, one by one
 	for _, csv := range csvs.Items {
-		klog.V(4).Infof("Getting services started from operator: %s\n", csv.Name)
-		customResources := client.GetCustomResourcesFromCSV(&csv)
+		clusterServiceVersion := csv
+		klog.V(4).Infof("Getting services started from operator: %s\n", clusterServiceVersion.Name)
+		customResources := client.GetCustomResourcesFromCSV(&clusterServiceVersion)
 
 		// list and write active instances of each service/CR
 		instances, err := getCRInstances(client, customResources)
@@ -322,8 +324,9 @@ func getCRInstances(client *kclient.Client, customResources *[]olm.CRDDescriptio
 	var instances []unstructured.Unstructured
 
 	for _, cr := range *customResources {
-		klog.V(4).Infof("Getting instances of: %s\n", cr.Name)
-		group, version, resource, err := getGVRFromCR(&cr)
+		customResource := cr
+		klog.V(4).Infof("Getting instances of: %s\n", customResource.Name)
+		group, version, resource, err := getGVRFromCR(&customResource)
 		if err != nil {
 			return []unstructured.Unstructured{}, err
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -399,6 +399,8 @@ func OperatorSvcExists(client *kclient.Client, serviceName string) (bool, error)
 	return false, fmt.Errorf("Couldn't find service named %q. Refer %q to see list of running services", serviceName, "odo service list")
 }
 
+// splitServiceKindName splits the service name provided for deletion by the
+// user. It has to be of the format <service-kind>/<service-name>. Example: EtcdCluster/myetcd
 func splitServiceKindName(serviceName string) (string, string, error) {
 	sn := strings.SplitN(serviceName, "/", 2)
 	if len(sn) != 2 || sn[0] == "" || sn[1] == "" {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -59,7 +59,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		})
 	})
 
-	Context("When creating an operator backed service", func() {
+	Context("When creating and deleting an operator backed service", func() {
 
 		JustBeforeEach(func() {
 			preSetup()
@@ -69,7 +69,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			cleanPreSetup()
 		})
 
-		It("should be able to create EtcdCluster from its alm example", func() {
+		It("should be able to create and then delete EtcdCluster from its alm example", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
@@ -84,7 +84,23 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				return strings.Contains(output, "Running")
 			})
 
+			// now test the deletion of the service using odo
 			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+			// now try deleting the same service again. It should fail with error message
+			stdOut := helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
+			Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
+		})
+	})
+
+	Context("When deleting an invalid operator backed service", func() {
+		It("should correctly detect invalid service names", func() {
+			names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+
+			for _, name := range names {
+				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
+				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			}
 		})
 	})
 
@@ -281,39 +297,6 @@ spec:
 			msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
 			Expect(stdOut).To(ContainSubstring(msg))
 			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
-		})
-	})
-
-	Context("When deleting Operator backed service", func() {
-		It("should be able to delete a service existing on the cluster and fail otherwise", func() {
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
-			})
-
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-			// now try deleting the same service again. It should fail with error message
-			stdOut := helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
-			Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
-		})
-
-		It("should correctly detect invalid service names", func() {
-			names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
-
-			for _, name := range names {
-				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
-			}
 		})
 	})
 })

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -84,10 +84,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				return strings.Contains(output, "Running")
 			})
 
-			// Delete the pods created. This should idealy be done by `odo
-			// service delete` but that's not implemented for operator backed
-			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
 		})
 	})
 
@@ -170,10 +167,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				return strings.Contains(output, "Running")
 			})
 
-			// Delete the pods created. This should idealy be done by `odo
-			// service delete` but that's not implemented for operator backed
-			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
 		})
 	})
 
@@ -277,10 +271,7 @@ spec:
 			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
 			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
 
-			// Delete the pods created. This should idealy be done by `odo
-			// service delete` but that's not implemented for operator backed
-			// services yet.
-			helper.CmdShouldPass("oc", "delete", "EtcdCluster", "example")
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
 
 			// Now let's check the output again to ensure expected behaviour
 			stdOut = helper.CmdShouldFail("odo", "service", "list")


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
Adds support for deletion of Operator backed service because it's essential to let users be able to delete a service.

**Which issue(s) this PR fixes**:

Fixes #2792

**How to test changes / Special notes to the reviewer**:
Create an Operator backed service. Try to delete it with `odo service delete <serviceType>/<serviceName>`. 

For example: `odo service delete EtcdCluster/example`.

**NOTE**: ~This PR is rebased on top of #3561.~ NVM, it's merged.