### PR TITLE
Remove additional / unneeded logging flags

### DIFF
--- a/docs/dev/logging.adoc
+++ b/docs/dev/logging.adoc
@@ -1,6 +1,6 @@
 = Logging in `odo`
 
-https://godoc.org/k8s.io/klog[Glog] is used for V style logging in `odo`.
+https://github.com/kubernetes/klog[Klog] is used for V style logging in `odo`.
 
 == Working
 
@@ -10,9 +10,11 @@ Alternatively, enviroment variable `ODO_LOG_LEVEL` can be used to set the verbos
 
 All ERROR severity level log messages will always be logged regardless of the values of `v` or `ODO_LOG_LEVEL`.
 
+In order to list multiple log levels, you can provide `--vmodule` to odo. For example: `--vmodule 1,2,3` to list log levels 1, 2 and 3.
+
 == Usage
 
-Every source file that requires logging will need to import glog:
+Every source file that requires logging will need to import klog:
 
 ----
 $ import "k8s.io/klog"
@@ -42,11 +44,14 @@ $ klog.Warningf(msg, args...)
 In addition to the above logging, the following hidden flags are available for debugging:
 
 ----
-      --alsologtostderr                  log to standard error as well as files
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --add_dir_header                   If true, adds the file directory to the header
+      --alsologtostderr                  Log to standard error as well as files
+      --log_backtrace_at traceLocation   When logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                   If non-empty, write log files in this directory
-      --logtostderr                      log to standard error instead of files (default false)
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          log level for V logs. Level varies from 0 to 9 (default 0).
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --log_file string                  If non-empty, use this log file
+      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      Log to standard error instead of files (default true)
+      --skip_headers                     If true, avoid header prefixes in the log messages
+      --skip_log_headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         Logs at or above this threshold go to stderr (default 2)
 ----

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -158,6 +158,11 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 	_ = pflag.CommandLine.MarkHidden("log_dir")
 	_ = pflag.CommandLine.MarkHidden("logtostderr")
 	_ = pflag.CommandLine.MarkHidden("stderrthreshold")
+	_ = pflag.CommandLine.MarkHidden("add_dir_header")
+	_ = pflag.CommandLine.MarkHidden("log_file")
+	_ = pflag.CommandLine.MarkHidden("log_file_max_size")
+	_ = pflag.CommandLine.MarkHidden("skip_headers")
+	_ = pflag.CommandLine.MarkHidden("skip_log_headers")
 
 	// We will mark the command as hidden and then re-enable if the command
 	// supports json output


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup

**What does does this PR do / why we need it**:

This PR removes additional logging flags that are not needed as well as
unused by odo.

So `odo --help` now looks like this:

```sh
Flags:
      --complete             Install completion for odo command
      --uncomplete           Uninstall completion for odo command
  -v, --v Level              Number for the log level verbosity. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging
  -y, --y                    Don't prompt user for typing 'yes' when installing completion
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3446

**How to test changes / Special notes to the reviewer**:

Run:

```sh
odo --help
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>