### PR TITLE
Fix empty devfile overriding issue for `odo create --devfile ./devfile.yaml`

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1129,6 +1129,10 @@ func ValidateFile(filePath string) error {
 
 // CopyFile copies file from source path to destination path
 func CopyFile(srcPath string, dstPath string, info os.FileInfo) error {
+	// In order to avoid file overriding issue, do nothing if source path is equal to destination path
+	if PathEqual(srcPath, dstPath) {
+		return nil
+	}
 	// Check if the source file path exists
 	err := ValidateFile(srcPath)
 	if err != nil {

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -225,3 +225,17 @@ func ReplaceDevfileField(devfileLocation, field, newValue string) error {
 	}
 	return nil
 }
+
+// FileIsEmpty checks if the file is empty
+func FileIsEmpty(filename string) (bool, error) {
+	file, err := os.Stat(filename)
+	if err != nil {
+		return false, err
+	}
+
+	if file.Size() > 0 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -161,6 +161,9 @@ var _ = Describe("odo devfile create command tests", func() {
 
 			It("should successfully create the devfile component with --devfile points to the same devfile", func() {
 				helper.CmdShouldPass("odo", "create", "nodejs", "--devfile", "./devfile.yaml")
+				fileIsEmpty, err := helper.FileIsEmpty("./devfile.yaml")
+				Expect(err).Should(BeNil())
+				Expect(fileIsEmpty).Should(BeFalse())
 			})
 
 			It("should fail to create the devfile component with more than 1 arguments are passed in", func() {


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug
/area devfile

**What does does this PR do / why we need it**:

This PR fixes the empty devfile overriding issue when user run `odo create --devfile ./devfile.yaml` successfully.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3542
Fixes https://github.com/openshift/odo/issues/3452

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
1. Copy existing devfile to your current directory.
2. In you current directory, run `odo create --devfile ./devfile.yaml`
