### PR TITLE
Use volume components from the devfile

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -156,8 +156,8 @@ func validateCommand(data data.DevfileData, command common.DevfileCommand) (err 
 		return fmt.Errorf("exec commands must have a command")
 	}
 
-	// must map to a supported component
-	components := GetSupportedComponents(data)
+	// must map to a container component
+	components := GetDevfileContainerComponents(data)
 
 	isComponentValid := false
 	for _, component := range components {

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -1286,7 +1286,7 @@ func TestGetTestCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 					ExecCommands: tt.execCommands,
 				},
 			}
@@ -1950,7 +1950,7 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 					ExecCommands: execCommands,
 				},
 			}

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -175,9 +175,9 @@ func TestGetCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			components := []common.DevfileComponent{testingutil.GetFakeComponent(tt.execCommands[0].Component)}
+			components := []common.DevfileComponent{testingutil.GetFakeContainerComponent(tt.execCommands[0].Component)}
 			if tt.execCommands[0].Component == invalidComponent {
-				components = []common.DevfileComponent{testingutil.GetFakeComponent("randomComponent")}
+				components = []common.DevfileComponent{testingutil.GetFakeContainerComponent("randomComponent")}
 			}
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
@@ -408,9 +408,9 @@ func TestGetCommandFromDevfile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			components := []common.DevfileComponent{testingutil.GetFakeComponent(tt.execCommands[0].Component)}
+			components := []common.DevfileComponent{testingutil.GetFakeContainerComponent(tt.execCommands[0].Component)}
 			if tt.execCommands[0].Component == invalidComponent {
-				components = []common.DevfileComponent{testingutil.GetFakeComponent("randomComponent")}
+				components = []common.DevfileComponent{testingutil.GetFakeContainerComponent("randomComponent")}
 			}
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
@@ -645,9 +645,9 @@ func TestGetCommandFromFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			components := []common.DevfileComponent{testingutil.GetFakeComponent(tt.execCommands[0].Component)}
+			components := []common.DevfileComponent{testingutil.GetFakeContainerComponent(tt.execCommands[0].Component)}
 			if tt.execCommands[0].Component == invalidComponent {
-				components = []common.DevfileComponent{testingutil.GetFakeComponent("randomComponent")}
+				components = []common.DevfileComponent{testingutil.GetFakeContainerComponent("randomComponent")}
 			}
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
@@ -933,7 +933,7 @@ func TestValidateCommand(t *testing.T) {
 			Data: testingutil.TestDevfileData{
 				ExecCommands:      tt.exec,
 				CompositeCommands: tt.comp,
-				Components:        []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+				Components:        []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {
@@ -1022,7 +1022,7 @@ func TestGetInitCommand(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					ExecCommands: tt.execCommands,
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 				},
 			}
 
@@ -1109,7 +1109,7 @@ func TestGetBuildCommand(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					ExecCommands: tt.execCommands,
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 				},
 			}
 
@@ -1196,7 +1196,7 @@ func TestGetDebugCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 					ExecCommands: tt.execCommands,
 				},
 			}
@@ -1375,7 +1375,7 @@ func TestGetRunCommand(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					ExecCommands: tt.execCommands,
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 				},
 			}
 
@@ -1450,7 +1450,7 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 					ExecCommands: execCommands,
 				},
 			}
@@ -1661,7 +1661,7 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					ExecCommands: tt.execCommands,
-					Components:   []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+					Components:   []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 				},
 			}
 

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -801,7 +801,7 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					Components: []versionsCommon.DevfileComponent{
-						testingutil.GetFakeComponent("alias1"),
+						testingutil.GetFakeContainerComponent("alias1"),
 					},
 					ExecCommands:      tt.execCommands,
 					CompositeCommands: tt.compCommands,
@@ -1874,7 +1874,7 @@ func TestValidateCompositeCommand(t *testing.T) {
 			Data: testingutil.TestDevfileData{
 				ExecCommands:      tt.execCommands,
 				CompositeCommands: tt.compositeCommands,
-				Components:        []common.DevfileComponent{testingutil.GetFakeComponent(component)},
+				Components:        []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -92,10 +92,20 @@ type CommandNames struct {
 	AdapterName string
 }
 
-func isComponentSupported(component common.DevfileComponent) bool {
+// isComponentAContainer returns a bool if the component is a container
+func isComponentAContainer(component common.DevfileComponent) bool {
 	// Currently odo only uses devfile components of type container, since most of the Che registry devfiles use it
 	if component.Container != nil {
 		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.ContainerComponentType, component.Container.Name)
+		return true
+	}
+	return false
+}
+
+// isComponentAVolume returns a bool if the component is a volume
+func isComponentAVolume(component common.DevfileComponent) bool {
+	if component.Volume != nil {
+		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.VolumeComponentType, component.Volume.Name)
 		return true
 	}
 	return false
@@ -109,12 +119,24 @@ func GetBootstrapperImage() string {
 	return defaultBootstrapperImage
 }
 
-// GetSupportedComponents iterates through the components in the devfile and returns a list of odo supported components
-func GetSupportedComponents(data data.DevfileData) []common.DevfileComponent {
+// GetDevfileContainerComponents iterates through the components in the devfile and returns a list of devfile container components
+func GetDevfileContainerComponents(data data.DevfileData) []common.DevfileComponent {
 	var components []common.DevfileComponent
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetAliasedComponents() {
-		if isComponentSupported(comp) {
+		if isComponentAContainer(comp) {
+			components = append(components, comp)
+		}
+	}
+	return components
+}
+
+// GetDevfileVolumeComponents iterates through the components in the devfile and returns a list of devfile volume components
+func GetDevfileVolumeComponents(data data.DevfileData) []common.DevfileComponent {
+	var components []common.DevfileComponent
+	// Only components with aliases are considered because without an alias commands cannot reference them
+	for _, comp := range data.GetComponents() {
+		if isComponentAVolume(comp) {
 			components = append(components, comp)
 		}
 	}
@@ -135,24 +157,37 @@ func getCommandsByGroup(data data.DevfileData, groupType common.DevfileCommandGr
 	return commands
 }
 
-// GetVolumes iterates through the components in the devfile and returns a map of component alias to the devfile volumes
+// GetVolumes iterates through the components in the devfile and returns a map of container name to the devfile volumes
 func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume {
-	// componentAliasToVolumes is a map of the Devfile Component Alias to the Devfile Component Volumes
-	componentAliasToVolumes := make(map[string][]DevfileVolume)
-	size := volumeSize
-	for _, comp := range GetSupportedComponents(devfileObj.Data) {
-		if len(comp.Container.VolumeMounts) != 0 {
-			for _, volume := range comp.Container.VolumeMounts {
-				vol := DevfileVolume{
-					Name:          volume.Name,
-					ContainerPath: volume.Path,
-					Size:          size,
+	containerComponents := GetDevfileContainerComponents(devfileObj.Data)
+	volumeComponents := GetDevfileVolumeComponents(devfileObj.Data)
+
+	// containerNameToVolumes is a map of the Devfile container name to the Devfile container Volumes
+	containerNameToVolumes := make(map[string][]DevfileVolume)
+	for _, containerComp := range containerComponents {
+		for _, volumeMount := range containerComp.Container.VolumeMounts {
+			size := volumeSize
+
+			for _, volumeComp := range volumeComponents {
+				// compare volume component name against the container component volume mount name
+				if volumeComp.Volume.Name == volumeMount.Name {
+					// If there is a volume size mentioned in the devfile, use it
+					if len(volumeComp.Volume.Size) > 0 {
+						size = volumeComp.Volume.Size
+						break
+					}
 				}
-				componentAliasToVolumes[comp.Container.Name] = append(componentAliasToVolumes[comp.Container.Name], vol)
 			}
+
+			vol := DevfileVolume{
+				Name:          volumeMount.Name,
+				ContainerPath: volumeMount.Path,
+				Size:          size,
+			}
+			containerNameToVolumes[containerComp.Container.Name] = append(containerNameToVolumes[containerComp.Container.Name], vol)
 		}
 	}
-	return componentAliasToVolumes
+	return containerNameToVolumes
 }
 
 // IsEnvPresent checks if the env variable is present in an array of env variables

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -92,8 +92,8 @@ type CommandNames struct {
 	AdapterName string
 }
 
-// isComponentAContainer returns a bool if the component is a container
-func isComponentAContainer(component common.DevfileComponent) bool {
+// isContainer checks if the component is a container
+func isContainer(component common.DevfileComponent) bool {
 	// Currently odo only uses devfile components of type container, since most of the Che registry devfiles use it
 	if component.Container != nil {
 		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.ContainerComponentType, component.Container.Name)
@@ -102,8 +102,8 @@ func isComponentAContainer(component common.DevfileComponent) bool {
 	return false
 }
 
-// isComponentAVolume returns a bool if the component is a volume
-func isComponentAVolume(component common.DevfileComponent) bool {
+// isVolume checks if the component is a volume
+func isVolume(component common.DevfileComponent) bool {
 	if component.Volume != nil {
 		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.VolumeComponentType, component.Volume.Name)
 		return true
@@ -124,7 +124,7 @@ func GetDevfileContainerComponents(data data.DevfileData) []common.DevfileCompon
 	var components []common.DevfileComponent
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetAliasedComponents() {
-		if isComponentAContainer(comp) {
+		if isContainer(comp) {
 			components = append(components, comp)
 		}
 	}
@@ -136,7 +136,7 @@ func GetDevfileVolumeComponents(data data.DevfileData) []common.DevfileComponent
 	var components []common.DevfileComponent
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetComponents() {
-		if isComponentAVolume(comp) {
+		if isVolume(comp) {
 			components = append(components, comp)
 		}
 	}

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -505,7 +505,7 @@ func TestGetCommandsForGroup(t *testing.T) {
 func TestGetCommandsMap(t *testing.T) {
 
 	component := []versionsCommon.DevfileComponent{
-		testingutil.GetFakeComponent("alias1"),
+		testingutil.GetFakeContainerComponent("alias1"),
 	}
 
 	tests := []struct {

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
@@ -10,7 +11,7 @@ import (
 	"github.com/openshift/odo/pkg/testingutil"
 )
 
-func TestGetSupportedComponents(t *testing.T) {
+func TestGetDevfileContainerComponents(t *testing.T) {
 
 	tests := []struct {
 		name                 string
@@ -36,13 +37,13 @@ func TestGetSupportedComponents(t *testing.T) {
 
 		{
 			name:                 "Case 4 : Valid devfile with correct component type (Container)",
-			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("comp1"), testingutil.GetFakeComponent("comp2")},
+			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeContainerComponent("comp2")},
 			expectedMatchesCount: 2,
 		},
 
 		{
 			name:                 "Case 5: Valid devfile with correct component type (Container) without name",
-			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("comp1"), testingutil.GetFakeComponent("")},
+			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeContainerComponent("")},
 			expectedMatchesCount: 1,
 		},
 	}
@@ -54,10 +55,167 @@ func TestGetSupportedComponents(t *testing.T) {
 				},
 			}
 
-			devfileComponents := GetSupportedComponents(devObj.Data)
+			devfileComponents := GetDevfileContainerComponents(devObj.Data)
 
 			if len(devfileComponents) != tt.expectedMatchesCount {
-				t.Errorf("TestGetSupportedComponents error: wrong number of components matched: expected %v, actual %v", tt.expectedMatchesCount, len(devfileComponents))
+				t.Errorf("TestGetDevfileContainerComponents error: wrong number of components matched: expected %v, actual %v", tt.expectedMatchesCount, len(devfileComponents))
+			}
+		})
+	}
+
+}
+
+func TestGetDevfileVolumeComponents(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		component            []versionsCommon.DevfileComponent
+		alias                []string
+		expectedMatchesCount int
+	}{
+		{
+			name:                 "Case 1: Invalid devfile",
+			component:            []versionsCommon.DevfileComponent{},
+			expectedMatchesCount: 0,
+		},
+		{
+			name:                 "Case 2: Valid devfile with wrong component type (Openshift)",
+			component:            []versionsCommon.DevfileComponent{{Openshift: &versionsCommon.Openshift{}}},
+			expectedMatchesCount: 0,
+		},
+		{
+			name:                 "Case 3: Valid devfile with wrong component type (Kubernetes)",
+			component:            []versionsCommon.DevfileComponent{{Kubernetes: &versionsCommon.Kubernetes{}}},
+			expectedMatchesCount: 0,
+		},
+
+		{
+			name:                 "Case 4 : Valid devfile with wrong component type (Container)",
+			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeContainerComponent("comp2")},
+			expectedMatchesCount: 0,
+		},
+
+		{
+			name:                 "Case 5: Valid devfile with correct component type (Volume)",
+			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvol")},
+			expectedMatchesCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					Components: tt.component,
+				},
+			}
+
+			devfileComponents := GetDevfileVolumeComponents(devObj.Data)
+
+			if len(devfileComponents) != tt.expectedMatchesCount {
+				t.Errorf("TestGetDevfileVolumeComponents error: wrong number of components matched: expected %v, actual %v", tt.expectedMatchesCount, len(devfileComponents))
+			}
+		})
+	}
+
+}
+
+func TestGetVolumes(t *testing.T) {
+
+	tests := []struct {
+		name                       string
+		component                  []versionsCommon.DevfileComponent
+		wantContainerNameToVolumes map[string][]DevfileVolume
+	}{
+		{
+			name:      "Case 1: Valid devfile with container referencing a volume component",
+			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume1")},
+			wantContainerNameToVolumes: map[string][]DevfileVolume{
+				"comp1": {
+					{
+						Name:          "myvolume1",
+						Size:          "4Gi",
+						ContainerPath: "/my/volume/mount/path1",
+					},
+				},
+			},
+		},
+		{
+			name: "Case 2: Valid devfile with container referencing multiple volume components",
+			component: []versionsCommon.DevfileComponent{
+				testingutil.GetFakeVolumeComponent("myvolume1"),
+				testingutil.GetFakeVolumeComponent("myvolume2"),
+				testingutil.GetFakeVolumeComponent("myvolume3"),
+				{
+					Container: &versionsCommon.Container{
+						Name:  "mycontainer",
+						Image: "image",
+						VolumeMounts: []versionsCommon.VolumeMount{
+							{
+								Name: "myvolume1",
+								Path: "/myvolume1",
+							},
+							{
+								Name: "myvolume2",
+								Path: "/myvolume2",
+							},
+						},
+					},
+				},
+			},
+			wantContainerNameToVolumes: map[string][]DevfileVolume{
+				"mycontainer": {
+					{
+						Name:          "myvolume1",
+						Size:          "4Gi",
+						ContainerPath: "/myvolume1",
+					},
+					{
+						Name:          "myvolume2",
+						Size:          "4Gi",
+						ContainerPath: "/myvolume2",
+					},
+				},
+			},
+		},
+		{
+			name:      "Case 3: Valid devfile with container referencing no volume component",
+			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume2")},
+			wantContainerNameToVolumes: map[string][]DevfileVolume{
+				"comp1": {
+					{
+						Name:          "myvolume1",
+						Size:          "5Gi",
+						ContainerPath: "/my/volume/mount/path1",
+					},
+				},
+			},
+		},
+		{
+			name: "Case 4: Valid devfile with no container volume mounts",
+			component: []versionsCommon.DevfileComponent{
+				testingutil.GetFakeVolumeComponent("myvolume2"),
+				{
+					Container: &versionsCommon.Container{
+						Name:  "mycontainer",
+						Image: "image",
+					},
+				},
+			},
+			wantContainerNameToVolumes: map[string][]DevfileVolume{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					Components: tt.component,
+				},
+			}
+
+			containerNameToVolumes := GetVolumes(devObj)
+
+			if !reflect.DeepEqual(containerNameToVolumes, tt.wantContainerNameToVolumes) {
+				t.Errorf("TestGetVolumes error - got %v wanted %v", containerNameToVolumes, tt.wantContainerNameToVolumes)
 			}
 		})
 	}
@@ -177,7 +335,7 @@ func TestGetBootstrapperImage(t *testing.T) {
 
 }
 
-func TestIsComponentSupported(t *testing.T) {
+func TestIsComponentAContainer(t *testing.T) {
 
 	tests := []struct {
 		name            string
@@ -185,12 +343,12 @@ func TestIsComponentSupported(t *testing.T) {
 		wantIsSupported bool
 	}{
 		{
-			name:            "Case 1: Supported component",
-			component:       testingutil.GetFakeComponent("comp1"),
+			name:            "Case 1: Container component",
+			component:       testingutil.GetFakeContainerComponent("comp1"),
 			wantIsSupported: true,
 		},
 		{
-			name: "Case 2: Unsupported component",
+			name: "Case 2: Not a container component",
 			component: common.DevfileComponent{
 				Openshift: &versionsCommon.Openshift{},
 			},
@@ -199,9 +357,40 @@ func TestIsComponentSupported(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isSupported := isComponentSupported(tt.component)
+			isSupported := isComponentAContainer(tt.component)
 			if isSupported != tt.wantIsSupported {
-				t.Errorf("TestIsComponentSupported error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+				t.Errorf("TestIsComponentAContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+			}
+		})
+	}
+
+}
+
+func TestIsComponentAVolume(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		component       common.DevfileComponent
+		wantIsSupported bool
+	}{
+		{
+			name:            "Case 1: Volume component",
+			component:       testingutil.GetFakeVolumeComponent("myvol"),
+			wantIsSupported: true,
+		},
+		{
+			name: "Case 2: Not a volume component",
+			component: common.DevfileComponent{
+				Openshift: &versionsCommon.Openshift{},
+			},
+			wantIsSupported: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isSupported := isComponentAVolume(tt.component)
+			if isSupported != tt.wantIsSupported {
+				t.Errorf("TestIsComponentAVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
 			}
 		})
 	}
@@ -211,7 +400,7 @@ func TestIsComponentSupported(t *testing.T) {
 func TestGetCommandsForGroup(t *testing.T) {
 
 	component := []versionsCommon.DevfileComponent{
-		testingutil.GetFakeComponent("alias1"),
+		testingutil.GetFakeContainerComponent("alias1"),
 	}
 	componentName := "alias1"
 	command := "ls -la"

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -335,7 +335,7 @@ func TestGetBootstrapperImage(t *testing.T) {
 
 }
 
-func TestIsComponentAContainer(t *testing.T) {
+func TestIsContainer(t *testing.T) {
 
 	tests := []struct {
 		name            string
@@ -357,16 +357,16 @@ func TestIsComponentAContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isSupported := isComponentAContainer(tt.component)
+			isSupported := isContainer(tt.component)
 			if isSupported != tt.wantIsSupported {
-				t.Errorf("TestIsComponentAContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+				t.Errorf("TestIsContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
 			}
 		})
 	}
 
 }
 
-func TestIsComponentAVolume(t *testing.T) {
+func TestIsVolume(t *testing.T) {
 
 	tests := []struct {
 		name            string
@@ -388,9 +388,9 @@ func TestIsComponentAVolume(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isSupported := isComponentAVolume(tt.component)
+			isSupported := isVolume(tt.component)
 			if isSupported != tt.wantIsSupported {
-				t.Errorf("TestIsComponentAVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+				t.Errorf("TestIsVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
 			}
 		})
 	}

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -46,7 +46,7 @@ type Adapter struct {
 	Client lclient.Client
 	common.AdapterContext
 
-	componentAliasToVolumes   map[string][]common.DevfileVolume
+	containerNameToVolumes    map[string][]common.DevfileVolume
 	uniqueStorage             []common.Storage
 	volumeNameToDockerVolName map[string]string
 	devfileInitCmd            string
@@ -65,8 +65,8 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	}
 
 	// Process the volumes defined in the devfile
-	a.componentAliasToVolumes = common.GetVolumes(a.Devfile)
-	a.uniqueStorage, a.volumeNameToDockerVolName, err = storage.ProcessVolumes(&a.Client, a.ComponentName, a.componentAliasToVolumes)
+	a.containerNameToVolumes = common.GetVolumes(a.Devfile)
+	a.uniqueStorage, a.volumeNameToDockerVolName, err = storage.ProcessVolumes(&a.Client, a.ComponentName, a.containerNameToVolumes)
 	if err != nil {
 		return errors.Wrapf(err, "unable to process volumes for component %s", a.ComponentName)
 	}

--- a/pkg/devfile/adapters/docker/component/adapter_test.go
+++ b/pkg/devfile/adapters/docker/component/adapter_test.go
@@ -285,8 +285,8 @@ func TestDoesComponentExist(t *testing.T) {
 			name:   "Case 1: Valid component name",
 			client: fakeClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
-				testingutil.GetFakeComponent("alias2"),
+				testingutil.GetFakeContainerComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias2"),
 			},
 			componentName:    "golang",
 			getComponentName: "golang",
@@ -297,7 +297,7 @@ func TestDoesComponentExist(t *testing.T) {
 			name:   "Case 2: Non-existent component name",
 			client: fakeClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias1"),
 			},
 			componentName:    "test",
 			getComponentName: "fake-component",
@@ -317,7 +317,7 @@ func TestDoesComponentExist(t *testing.T) {
 			name:   "Case 4: Docker client error",
 			client: fakeErrorClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias1"),
 			},
 			componentName:    "test",
 			getComponentName: "fake-component",

--- a/pkg/devfile/adapters/docker/component/utils_test.go
+++ b/pkg/devfile/adapters/docker/component/utils_test.go
@@ -38,13 +38,13 @@ func TestCreateComponent(t *testing.T) {
 		},
 		{
 			name:       "Case 2: Valid devfile",
-			components: []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("alias1")},
+			components: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("alias1")},
 			client:     fakeClient,
 			wantErr:    false,
 		},
 		{
 			name:       "Case 3: Valid devfile, docker client error",
-			components: []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("alias1")},
+			components: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("alias1")},
 			client:     fakeErrorClient,
 			wantErr:    true,
 		},
@@ -96,14 +96,14 @@ func TestUpdateComponent(t *testing.T) {
 		},
 		{
 			name:          "Case 2: Valid devfile",
-			components:    []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("alias1")},
+			components:    []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("alias1")},
 			componentName: "test",
 			client:        fakeClient,
 			wantErr:       false,
 		},
 		{
 			name:          "Case 3: Valid devfile, docker client error",
-			components:    []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("alias1")},
+			components:    []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("alias1")},
 			componentName: "",
 			client:        fakeErrorClient,
 			wantErr:       true,
@@ -212,7 +212,7 @@ func TestPullAndStartContainer(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					Components: []versionsCommon.DevfileComponent{
-						testingutil.GetFakeComponent("alias1"),
+						testingutil.GetFakeContainerComponent("alias1"),
 					},
 					ExecCommands: testingutil.GetFakeExecRunCommands(),
 				},
@@ -294,7 +294,7 @@ func TestStartContainer(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
 					Components: []versionsCommon.DevfileComponent{
-						testingutil.GetFakeComponent("alias1"),
+						testingutil.GetFakeContainerComponent("alias1"),
 					},
 					ExecCommands: testingutil.GetFakeExecRunCommands(),
 				},

--- a/pkg/devfile/adapters/docker/storage/utils.go
+++ b/pkg/devfile/adapters/docker/storage/utils.go
@@ -101,13 +101,16 @@ func GetExistingVolume(Client *lclient.Client, volumeName, componentName string)
 
 // ProcessVolumes takes in a list of component volumes and for each unique volume in the devfile, creates a Docker volume name for it
 // It returns a list of unique volumes, a mapping of devfile volume names to docker volume names, and an error if applicable
-func ProcessVolumes(client *lclient.Client, componentName string, componentAliasToVolumes map[string][]common.DevfileVolume) ([]common.Storage, map[string]string, error) {
+func ProcessVolumes(client *lclient.Client, componentName string, containerNameToVolumes map[string][]common.DevfileVolume) ([]common.Storage, map[string]string, error) {
 	var uniqueStorages []common.Storage
 	volumeNameToDockerVolName := make(map[string]string)
 	processedVolumes := make(map[string]bool)
 
 	// Get a list of all the unique volume names and generate their Docker volume names
-	for _, volumes := range componentAliasToVolumes {
+	// we do not use the volume components which are unique here because
+	// not all volume components maybe referenced by a container component.
+	// We only want to create volumes which are going to be used by a container
+	for _, volumes := range containerNameToVolumes {
 		for _, vol := range volumes {
 			if _, ok := processedVolumes[vol.Name]; !ok {
 				processedVolumes[vol.Name] = true

--- a/pkg/devfile/adapters/docker/utils/utils.go
+++ b/pkg/devfile/adapters/docker/utils/utils.go
@@ -28,23 +28,23 @@ const (
 )
 
 // ComponentExists checks if a component exist
-// returns true, if the number of containers equals the number of unique devfile components
+// returns true, if the number of containers equals the number of unique devfile container components
 // returns false, if number of containers is zero
-// returns an error, if number of containers is more than zero but does not equal the number of unique devfile components
+// returns an error, if number of containers is more than zero but does not equal the number of unique devfile container components
 func ComponentExists(client lclient.Client, data data.DevfileData, name string) (bool, error) {
 	containers, err := GetComponentContainers(client, name)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to get the containers for component %s", name)
 	}
 
-	supportedComponents := adaptersCommon.GetSupportedComponents(data)
+	containerComponents := adaptersCommon.GetDevfileContainerComponents(data)
 
 	var componentExists bool
 	if len(containers) == 0 {
 		componentExists = false
-	} else if len(containers) == len(supportedComponents) {
+	} else if len(containers) == len(containerComponents) {
 		componentExists = true
-	} else if len(containers) > 0 && len(containers) != len(supportedComponents) {
+	} else if len(containers) > 0 && len(containers) != len(containerComponents) {
 		return true, errors.New(fmt.Sprintf("component %s is in an invalid state, please execute odo delete and retry odo push", name))
 	}
 

--- a/pkg/devfile/adapters/docker/utils/utils_test.go
+++ b/pkg/devfile/adapters/docker/utils/utils_test.go
@@ -35,8 +35,8 @@ func TestComponentExists(t *testing.T) {
 			componentName: "golang",
 			client:        fakeClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
-				testingutil.GetFakeComponent("alias2"),
+				testingutil.GetFakeContainerComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias2"),
 			},
 			want:    true,
 			wantErr: false,
@@ -46,7 +46,7 @@ func TestComponentExists(t *testing.T) {
 			componentName: "fakecomponent",
 			client:        fakeClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias1"),
 			},
 			want:    false,
 			wantErr: false,
@@ -56,7 +56,7 @@ func TestComponentExists(t *testing.T) {
 			componentName: "golang",
 			client:        fakeErrorClient,
 			components: []common.DevfileComponent{
-				testingutil.GetFakeComponent("alias1"),
+				testingutil.GetFakeContainerComponent("alias1"),
 			},
 			want:    false,
 			wantErr: true,

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -77,7 +77,7 @@ func TestCreateOrUpdateComponent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var comp versionsCommon.DevfileComponent
 			if tt.componentType != "" {
-				comp = testingutil.GetFakeComponent("component")
+				comp = testingutil.GetFakeContainerComponent("component")
 			}
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
@@ -308,7 +308,7 @@ func TestDoesComponentExist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components:   []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("component")},
+					Components:   []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("component")},
 					ExecCommands: []versionsCommon.Exec{getExecCommand("run", versionsCommon.RunCommandGroupType)},
 				},
 			}
@@ -390,7 +390,7 @@ func TestWaitAndGetComponentPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: testingutil.TestDevfileData{
-					Components: []versionsCommon.DevfileComponent{testingutil.GetFakeComponent("component")},
+					Components: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("component")},
 				},
 			}
 

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -62,7 +62,7 @@ func ConvertPorts(endpoints []common.Endpoint) ([]corev1.ContainerPort, error) {
 // GetContainers iterates through the components in the devfile and returns a slice of the corresponding containers
 func GetContainers(devfileObj devfileParser.DevfileObj) ([]corev1.Container, error) {
 	var containers []corev1.Container
-	for _, comp := range adaptersCommon.GetSupportedComponents(devfileObj.Data) {
+	for _, comp := range adaptersCommon.GetDevfileContainerComponents(devfileObj.Data) {
 		envVars := ConvertEnvs(comp.Container.Env)
 		resourceReqs := GetResourceReqs(comp)
 		ports, err := ConvertPorts(comp.Container.Endpoints)

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -332,7 +332,7 @@ type Volume struct {
 // VolumeMount describes a path where a volume should be mounted to a component container
 type VolumeMount struct {
 
-	// The volume mount name is the name of an existing `Volume` component. If no corresponding `Volume` component exist it is implicitly added. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.
+	// The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.
 	Name string `json:"name"`
 
 	// The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -8,8 +8,9 @@ import (
 
 // Errors
 var (
-	ErrorNoComponents         = "no components present"
-	ErrorNoContainerComponent = fmt.Sprintf("odo requires atleast one component of type '%s' in devfile", common.ContainerComponentType)
+	ErrorNoComponents              = "no components present"
+	ErrorNoContainerComponent      = fmt.Sprintf("odo requires atleast one component of type '%s' in devfile", common.ContainerComponentType)
+	ErrorDuplicateVolumeComponents = "duplicate volume components present in devfile"
 )
 
 // validateComponents validates all the devfile components
@@ -20,12 +21,23 @@ func validateComponents(components []common.DevfileComponent) error {
 		return fmt.Errorf(ErrorNoComponents)
 	}
 
-	// Check if component of type container  is present
+	processedVolumes := make(map[string]bool)
+	// var containerVolumeMountNames []string
+
+	// Check if component of type container is present
+	// and if volume components are unique
 	isContainerComponentPresent := false
 	for _, component := range components {
 		if component.Container != nil {
 			isContainerComponentPresent = true
-			break
+		}
+
+		if component.Volume != nil {
+			if _, ok := processedVolumes[component.Volume.Name]; !ok {
+				processedVolumes[component.Volume.Name] = true
+			} else {
+				return fmt.Errorf(ErrorDuplicateVolumeComponents)
+			}
 		}
 	}
 

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/openshift/odo/pkg/odo/util/pushtarget"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Errors
@@ -11,6 +13,7 @@ var (
 	ErrorNoComponents              = "no components present"
 	ErrorNoContainerComponent      = fmt.Sprintf("odo requires atleast one component of type '%s' in devfile", common.ContainerComponentType)
 	ErrorDuplicateVolumeComponents = "duplicate volume components present in devfile"
+	ErrorInvalidVolumeSize         = "size %s for volume component %s is invalid: %v. Example - 2Gi, 1024Mi"
 )
 
 // validateComponents validates all the devfile components
@@ -34,6 +37,15 @@ func validateComponents(components []common.DevfileComponent) error {
 		if component.Volume != nil {
 			if _, ok := processedVolumes[component.Volume.Name]; !ok {
 				processedVolumes[component.Volume.Name] = true
+				if !pushtarget.IsPushTargetDocker() && len(component.Volume.Size) > 0 {
+					// Only validate on Kubernetes since Docker volumes do not use sizes
+					// We use the Kube API for validation because there are so many ways to
+					// express storage in Kubernetes. For reference, you may check doc
+					// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+					if _, err := resource.ParseQuantity(component.Volume.Size); err != nil {
+						return fmt.Errorf(ErrorInvalidVolumeSize, component.Volume.Size, component.Volume.Name, err)
+					}
+				}
 			} else {
 				return fmt.Errorf(ErrorDuplicateVolumeComponents)
 			}

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -22,7 +22,6 @@ func validateComponents(components []common.DevfileComponent) error {
 	}
 
 	processedVolumes := make(map[string]bool)
-	// var containerVolumeMountNames []string
 
 	// Check if component of type container is present
 	// and if volume components are unique

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -130,4 +130,36 @@ func TestValidateComponents(t *testing.T) {
 			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
 		}
 	})
+
+	t.Run("Invalid volume mount", func(t *testing.T) {
+
+		components := []common.DevfileComponent{
+			{
+				Volume: &common.Volume{
+					Name: "myvol",
+					Size: "2Gi",
+				},
+			},
+			{
+				Container: &common.Container{
+					Name: "container",
+					VolumeMounts: []common.VolumeMount{
+						{
+							Name: "myinvalidvol",
+						},
+						{
+							Name: "myinvalidvol2",
+						},
+					},
+				},
+			},
+		}
+
+		got := ValidateComponents(components)
+		want := &MissingVolumeMountError{volumeName: "myinvalidvol2,myinvalidvol"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
+		}
+	})
 }

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -17,7 +16,7 @@ func TestValidateComponents(t *testing.T) {
 		components := []common.DevfileComponent{}
 
 		got := validateComponents(components)
-		want := fmt.Errorf(ErrorNoComponents)
+		want := &NoComponentsError{}
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
@@ -56,8 +55,8 @@ func TestValidateComponents(t *testing.T) {
 			},
 		}
 
-		got := ValidateComponents(components)
-		want := fmt.Errorf(ErrorDuplicateVolumeComponents)
+		got := validateComponents(components)
+		want := &DuplicateVolumeComponentsError{}
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
@@ -95,7 +94,7 @@ func TestValidateComponents(t *testing.T) {
 			},
 		}
 
-		got := ValidateComponents(components)
+		got := validateComponents(components)
 
 		if got != nil {
 			t.Errorf("TestValidateComponents error - got: '%v'", got)
@@ -124,7 +123,7 @@ func TestValidateComponents(t *testing.T) {
 			},
 		}
 
-		got := ValidateComponents(components)
+		got := validateComponents(components)
 		want := "size randomgarbage for volume component myvol is invalid"
 
 		if !strings.Contains(got.Error(), want) {

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -19,7 +19,7 @@ func TestValidateComponents(t *testing.T) {
 		want := fmt.Errorf(ErrorNoComponents)
 
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got: '%v', want: '%v'", got, want)
+			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
 		}
 	})
 
@@ -36,7 +36,68 @@ func TestValidateComponents(t *testing.T) {
 		got := validateComponents(components)
 
 		if got != nil {
-			t.Errorf("Not expecting an error: '%v'", got)
+			t.Errorf("TestValidateComponents error - Not expecting an error: '%v'", got)
+		}
+	})
+
+	t.Run("Duplicate volume components present", func(t *testing.T) {
+
+		components := []common.DevfileComponent{
+			{
+				Volume: &common.Volume{
+					Name: "myvol",
+				},
+			},
+			{
+				Volume: &common.Volume{
+					Name: "myvol",
+				},
+			},
+		}
+
+		got := ValidateComponents(components)
+		want := fmt.Errorf(ErrorDuplicateVolumeComponents)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
+		}
+	})
+
+	t.Run("Valid container and volume component", func(t *testing.T) {
+
+		components := []common.DevfileComponent{
+			{
+				Volume: &common.Volume{
+					Name: "myvol",
+				},
+			},
+			{
+				Container: &common.Container{
+					Name: "container",
+					VolumeMounts: []common.VolumeMount{
+						{
+							Name: "myvol",
+							Path: "/some/path/",
+						},
+					},
+				},
+			},
+			{
+				Container: &common.Container{
+					Name: "container2",
+					VolumeMounts: []common.VolumeMount{
+						{
+							Name: "myvol",
+						},
+					},
+				},
+			},
+		}
+
+		got := ValidateComponents(components)
+
+		if got != nil {
+			t.Errorf("TestValidateComponents error - got: '%v'", got)
 		}
 	})
 }

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -155,11 +155,11 @@ func TestValidateComponents(t *testing.T) {
 			},
 		}
 
-		got := ValidateComponents(components)
-		want := &MissingVolumeMountError{volumeName: "myinvalidvol2,myinvalidvol"}
+		got := validateComponents(components)
+		want := "unable to find volume mount"
 
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("TestValidateComponents error - got: '%v', want: '%v'", got, want)
+		if !strings.Contains(got.Error(), want) {
+			t.Errorf("TestValidateComponents error - got: '%v', want substr: '%v'", got.Error(), want)
 		}
 	})
 }

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
@@ -98,6 +99,36 @@ func TestValidateComponents(t *testing.T) {
 
 		if got != nil {
 			t.Errorf("TestValidateComponents error - got: '%v'", got)
+		}
+	})
+
+	t.Run("Invalid volume component size", func(t *testing.T) {
+
+		components := []common.DevfileComponent{
+			{
+				Volume: &common.Volume{
+					Name: "myvol",
+					Size: "randomgarbage",
+				},
+			},
+			{
+				Container: &common.Container{
+					Name: "container",
+					VolumeMounts: []common.VolumeMount{
+						{
+							Name: "myvol",
+							Path: "/some/path/",
+						},
+					},
+				},
+			},
+		}
+
+		got := ValidateComponents(components)
+		want := "size randomgarbage for volume component myvol is invalid"
+
+		if !strings.Contains(got.Error(), want) {
+			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
 		}
 	})
 }

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -1,0 +1,42 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+)
+
+// NoComponentsError returns an error if no component is found
+type NoComponentsError struct {
+}
+
+func (e *NoComponentsError) Error() string {
+	return "no components present"
+}
+
+// NoContainerComponentError returns an error if no container component is found
+type NoContainerComponentError struct {
+}
+
+func (e *NoContainerComponentError) Error() string {
+	return fmt.Sprintf("odo requires atleast one component of type '%s' in devfile", common.ContainerComponentType)
+}
+
+// DuplicateVolumeComponentsError returns an error if duplicate volume components are found
+type DuplicateVolumeComponentsError struct {
+}
+
+func (e *DuplicateVolumeComponentsError) Error() string {
+	return "duplicate volume components present in devfile"
+}
+
+// InvalidVolumeSizeError returns an error if volume component has an invalid size
+type InvalidVolumeSizeError struct {
+	size            string
+	componentName   string
+	validationError error
+}
+
+func (e *InvalidVolumeSizeError) Error() string {
+	return fmt.Sprintf("size %s for volume component %s is invalid: %v. Example - 2Gi, 1024Mi", e.size, e.componentName, e.validationError)
+}

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -40,3 +40,12 @@ type InvalidVolumeSizeError struct {
 func (e *InvalidVolumeSizeError) Error() string {
 	return fmt.Sprintf("size %s for volume component %s is invalid: %v. Example - 2Gi, 1024Mi", e.size, e.componentName, e.validationError)
 }
+
+// MissingVolumeMountError returns an error if the container volume mount does not reference a valid volume component
+type MissingVolumeMountError struct {
+	volumeName string
+}
+
+func (e *MissingVolumeMountError) Error() string {
+	return fmt.Sprintf("unable to find volume mount %s in devfile volume components", e.volumeName)
+}

--- a/pkg/kclient/volumes_test.go
+++ b/pkg/kclient/volumes_test.go
@@ -30,7 +30,7 @@ func TestCreatePVC(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "Case: Valid pvc name",
+			name:      "Case 1: Valid pvc name",
 			pvcName:   "mypvc",
 			size:      "1Gi",
 			namespace: "default",
@@ -40,9 +40,19 @@ func TestCreatePVC(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "Case: Invalid pvc name",
+			name:      "Case 2: Invalid pvc name",
 			pvcName:   "",
 			size:      "1Gi",
+			namespace: "default",
+			labels: map[string]string{
+				"testpvc": "testpvc",
+			},
+			wantErr: true,
+		},
+		{
+			name:      "Case 3: Invalid pvc size",
+			pvcName:   "mypvc",
+			size:      "garbage",
 			namespace: "default",
 			labels: map[string]string{
 				"testpvc": "testpvc",
@@ -58,8 +68,10 @@ func TestCreatePVC(t *testing.T) {
 			fkclient.Namespace = tt.namespace
 
 			quantity, err := resource.ParseQuantity(tt.size)
-			if err != nil {
+			if err != nil && tt.size != "garbage" {
 				t.Errorf("resource.ParseQuantity unexpected error %v", err)
+			} else if err != nil && tt.size == "garbage" {
+				return
 			}
 			pvcSpec := GeneratePVCSpec(quantity)
 

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -14,7 +14,7 @@ type TestDevfileData struct {
 
 // GetComponents is a mock function to get the components from a devfile
 func (d TestDevfileData) GetComponents() []versionsCommon.DevfileComponent {
-	return d.GetAliasedComponents()
+	return d.Components
 }
 
 // GetMetadata is a mock function to get metadata from devfile
@@ -114,8 +114,8 @@ func (d TestDevfileData) UpdateEvents(postStart, postStop, preStart, preStop []s
 
 func (d TestDevfileData) SetParent(parent common.DevfileParent) {}
 
-// GetFakeComponent returns fake component for testing
-func GetFakeComponent(name string) versionsCommon.DevfileComponent {
+// GetFakeContainerComponent returns a fake container component for testing
+func GetFakeContainerComponent(name string) versionsCommon.DevfileComponent {
 	image := "docker.io/maven:latest"
 	memoryLimit := "128Mi"
 	volumeName := "myvolume1"
@@ -132,6 +132,18 @@ func GetFakeComponent(name string) versionsCommon.DevfileComponent {
 				Path: volumePath,
 			}},
 			MountSources: true,
+		}}
+
+}
+
+// GetFakeVolumeComponent returns a fake volume component for testing
+func GetFakeVolumeComponent(name string) versionsCommon.DevfileComponent {
+	size := "4Gi"
+
+	return versionsCommon.DevfileComponent{
+		Volume: &versionsCommon.Volume{
+			Name: name,
+			Size: size,
 		}}
 
 }

--- a/tests/examples/source/devfiles/nodejs/devfile-with-invalid-volmount.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-invalid-volmount.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.0.0
 metadata:
-  name: nodejs
+  name: test-devfile
 projects:
   - name: nodejs-starter
     git:
@@ -9,10 +9,6 @@ components:
   - container:
       name: runtime
       image: quay.io/eclipse/che-nodejs10-ubi:nightly
-      memoryLimit: 1024Mi
-      env:
-        - name: FOO
-          value: "bar"
       endpoints:
         - name: "3000/tcp"
           configuration:
@@ -21,23 +17,22 @@ components:
           targetPort: 3000
       mountSources: true
       volumeMounts:
-        - name: myvol
+        - name: invalidvol1
           path: /data
   - container:
       name: runtime2
       image: quay.io/eclipse/che-nodejs10-ubi:nightly
-      memoryLimit: 1024Mi
       mountSources: false
       volumeMounts:
-        - name: myvol
+        - name: invalidvol2
           path: /data
-        - name: myvol2
+        - name: secondvol
           path: /data2
   - volume:
-      name: myvol
-      size: 3Gi
+      name: firstvol
   - volume:
-      name: myvol2
+      name: secondvol
+      size: 3Gi
 commands:
   - exec:
       id: devbuild

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 2.0.0
+metadata:
+  name: test-devfile
+projects:
+  - name: nodejs-starter
+    git:
+      location: "https://github.com/che-samples/web-nodejs-sample.git"
+components:
+  - container:
+      name: runtime
+      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      memoryLimit: 1024Mi
+      env:
+        - name: FOO
+          value: "bar"
+      endpoints:
+        - name: "3000/tcp"
+          configuration:
+            protocol: tcp
+            scheme: http
+          targetPort: 3000
+      mountSources: true
+      volumeMounts:
+        - name: firstvol
+          path: /data
+  - container:
+      name: runtime2
+      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      memoryLimit: 1024Mi
+      mountSources: false
+      volumeMounts:
+        - name: firstvol
+          path: /data
+        - name: secondvol
+          path: /data2
+  - volume:
+      name: firstvol
+  - volume:
+      name: secondvol
+      size: 3Gi
+commands:
+  - exec:
+      id: devbuild
+      component: runtime
+      commandLine: "echo hello >> myfile.log"
+      workingDir: /data
+      group:
+        kind: build
+        isDefault: true
+  - exec:
+      id: devrun
+      component: runtime2
+      commandLine: "cat myfile.log"
+      workingDir: /data
+      group:
+        kind: run
+        isDefault: true

--- a/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
@@ -1,56 +1,54 @@
 ---
-apiVersion: 1.0.0
+schemaVersion: 2.0.0
 metadata:
   name: foobar-
-  generateName: java-spring-boot
 projects:
-  -
-    name: springbootproject
-    source:
-      type: git
+  - name: springbootproject
+    git:
       location: "https://github.com/maysunfaisal/springboot.git"
 components:
-  -
-    type: chePlugin
-    id: redhat/java/latest
-    memoryLimit: 1512Mi
-  -
-    type: dockerimage
-    image: maysunfaisal/springbootbuild
-    alias: tools
-    memoryLimit: 768Mi
-    command: ['tail']
-    args: [ '-f', '/dev/null']
-    mountSources: true
-    volumes:
-      - name: springbootpvc
-        containerPath: /data
-  -
-    type: dockerimage
-    image: maysunfaisal/springbootruntime
-    alias: runtime
-    memoryLimit: 768Mi
-    endpoints:
-      - name: '8080/tcp'
-        port: 8080
-    mountSources: false
-    volumes:
-      - name: springbootpvc
-        containerPath: /data
+  - container:
+      name: tools
+      image: maysunfaisal/springbootbuild
+      memoryLimit: 768Mi
+      command: ['tail']
+      args: [ '-f', '/dev/null']
+      volumeMounts:
+        - name: springbootpvc
+          path: /data
+      mountSources: true
+  - container:
+      name: runtime
+      image: maysunfaisal/springbootruntime
+      memoryLimit: 768Mi
+      command: ['tail']
+      args: [ '-f', '/dev/null']
+      endpoints:
+        - name: "8080/tcp"
+          configuration:
+            protocol: tcp
+            scheme: http
+          targetPort: 8080
+      volumeMounts:
+        - name: springbootpvc
+          path: /data
+      mountSources: false
+  - volume:
+      name: springbootpvc
 commands:
-  -
-    name: devBuild
-    actions:
-      -
-        type: exec
-        component: tools
-        command: "/artifacts/bin/build-container-full.sh"
-        workdir: /projects/springbootproject
-  -
-    name: devRun
-    actions:
-      -
-        type: exec
-        component: runtime
-        command: "/artifacts/bin/start-server.sh"
-        workdir: /
+  - exec:
+      id: defaultBuild
+      component: tools
+      commandLine: "/artifacts/bin/build-container-full.sh"
+      workingDir: /projects/springbootproject
+      group:
+        kind: build
+        isDefault: true
+  - exec:
+      id: defaultRun
+      component: runtime
+      commandLine: "/artifacts/bin/start-server.sh"
+      workingDir: /
+      group:
+        kind: run
+        isDefault: true

--- a/tests/examples/source/devfiles/springboot/devfile.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile.yaml
@@ -33,6 +33,8 @@ components:
         - name: springbootpvc
           path: /data
       mountSources: false
+  - volume:
+      name: springbootpvc
 commands:
   - exec:
       id: defaultBuild

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -15,4 +15,5 @@ type CliRunner interface {
 	CreateRandNamespaceProject() string
 	DeleteNamespaceProject(projectName string)
 	GetEnvsDevFileDeployment(componentName string, projectName string) map[string]string
+	GetPVCSize(compName, storageName, namespace string) string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -63,6 +63,14 @@ func (kubectl KubectlRunner) GetRunningPodNameByComponent(compName string, names
 	return strings.TrimSpace(podName)
 }
 
+// GetPVCSize executes kubectl command and returns the bound storage size
+func (kubectl KubectlRunner) GetPVCSize(compName, storageName, namespace string) string {
+	stdOut := CmdShouldPass(kubectl.path, "get", "pvc", "--namespace", namespace, "--show-labels")
+	re := regexp.MustCompile(storageName + `-\S+\s+Bound\s+\S+\s+(\S+).*component=` + compName + `,storage-name=` + storageName)
+	storageSize := re.FindStringSubmatch(stdOut)[1]
+	return strings.TrimSpace(storageSize)
+}
+
 // GetVolumeMountNamesandPathsFromContainer returns the volume name and mount path in the format name:path\n
 func (kubectl KubectlRunner) GetVolumeMountNamesandPathsFromContainer(deployName string, containerName, namespace string) string {
 	volumeName := CmdShouldPass(kubectl.path, "get", "deploy", deployName, "--namespace", namespace,

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -379,6 +379,14 @@ func (oc OcRunner) GetRunningPodNameByComponent(compName string, namespace strin
 	return strings.TrimSpace(podName)
 }
 
+// GetPVCSize executes oc command and returns the bound storage size
+func (oc OcRunner) GetPVCSize(compName, storageName, namespace string) string {
+	stdOut := CmdShouldPass(oc.path, "get", "pvc", "--namespace", namespace, "--show-labels")
+	re := regexp.MustCompile(storageName + `-\S+\s+Bound\s+\S+\s+(\S+).*component=` + compName + `,storage-name=` + storageName)
+	storageSize := re.FindStringSubmatch(stdOut)[1]
+	return strings.TrimSpace(storageSize)
+}
+
 // GetRoute returns route URL
 func (oc OcRunner) GetRoute(urlName string, appName string) string {
 	session := CmdRunner(oc.path, "get", "routes", urlName+"-"+appName,

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -548,6 +548,17 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(output).To(ContainSubstring("quantities must match the regular expression"))
 		})
 
+		It("should error out if a container component has volume mount that does not refer a valid volume component", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-invalid-volmount.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldFail("odo", "push", "--project", namespace)
+			Expect(output).To(ContainSubstring("unable to find volume mount"))
+		})
+
 		It("should successfully use the volume components in container components", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -55,17 +55,6 @@ var _ = Describe("odo devfile test command tests", func() {
 			Expect(output).To(ContainSubstring("error occurred while getting the pod: no Pod was found for the selector"))
 		})
 
-		It("should show error for devfile v1", func() {
-			helper.CmdShouldPass("odo", "create", "java-springboot", "--context", context, cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			output := helper.CmdShouldFail("odo", "test", "--context", context)
-
-			Expect(output).To(ContainSubstring("'odo test' is not supported in devfile 1.0.0"))
-		})
-
 		It("should show error if no test group is defined", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
 

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -183,49 +183,6 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			Expect(stdOut).To(ContainSubstring(("/myproject/app.jar")))
 		})
 
-		// v1 devfile test
-		It("should execute the optional devinit, and devrun commands if present", func() {
-			helper.CmdShouldPass("odo", "create", "java-springboot", cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			output := helper.CmdShouldPass("odo", "push")
-			helper.MatchAllInOutput(output, []string{
-				"Executing devinit command \"echo hello",
-				"Executing devbuild command \"/artifacts/bin/build-container-full.sh\"",
-				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
-			})
-
-			// Check to see if it's been pushed (foobar.txt abd directory testdir)
-			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")
-			Expect(len(containers)).To(Equal(1))
-
-			stdOut := dockerClient.ExecContainer(containers[0], "ps -ef")
-			Expect(stdOut).To(ContainSubstring(("/myproject/app.jar")))
-		})
-
-		// v1 devfile test
-		It("should execute devinit and devrun commands if present", func() {
-			helper.CmdShouldPass("odo", "create", "java-springboot", cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init-without-build.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			output := helper.CmdShouldPass("odo", "push")
-			helper.MatchAllInOutput(output, []string{
-				"Executing devinit command \"echo hello",
-				"Executing devrun command \"/artifacts/bin/start-server.sh\"",
-			})
-
-			// Check to see if it's been pushed (foobar.txt abd directory testdir)
-			containers := dockerClient.GetRunningContainersByCompAlias(cmpName, "runtime")
-			Expect(len(containers)).To(Equal(1))
-
-			stdOut := dockerClient.ExecContainer(containers[0], "ls /data")
-			Expect(stdOut).To(ContainSubstring(("afile.txt")))
-		})
-
 		It("should execute PostStart commands if present", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
 

--- a/tests/integration/devfile/docker/cmd_docker_devfile_test_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_test_test.go
@@ -58,17 +58,6 @@ var _ = Describe("odo docker devfile test command tests", func() {
 			Expect(output).To(ContainSubstring("component does not exist, a valid component is required to run 'odo test'"))
 		})
 
-		It("should show error for devfile v1", func() {
-			helper.CmdShouldPass("odo", "create", "java-springboot", "--context", context, cmpName)
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
-
-			output := helper.CmdShouldFail("odo", "test", "--context", context)
-
-			Expect(output).To(ContainSubstring("'odo test' is not supported in devfile 1.0.0"))
-		})
-
 		It("should show error if no test group is defined", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, cmpName)
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
- utilizes the `Volume` components from the devfile - refer the [devfile v2 schema](https://devfile.github.io/devfile/_attachments/api-reference.html) 
- can now customize volume size using the devfile volume component
- updates func and variable names to differentiate between container components and volume components from the devfile for better readability 
- unit & integration tests

**Which issue(s) this PR fixes**:

Fixes #3407

**PR acceptance criteria**:

- [x] Unit test  993253746dd16a4cc54e99c2e763ffedb7c30b0b

- [x] Integration test TODO a3eeee997f6ee76347a65fcccad98c5bdd9e500e

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
- confirm that there can not be duplicate volume components in a devfile:
```
components:
  - container:
      name: tools
      image: maysunfaisal/springbootbuild
      memoryLimit: 768Mi
      command: ['tail']
      args: [ '-f', '/dev/null']
      mountSources: true
      volumeMounts:
        - name: first
          path: /data
  - container:
      name: runtime
      image: maysunfaisal/springbootruntime
      memoryLimit: 768Mi
      command: ['tail']
      args: [ '-f', '/dev/null']
      endpoints:
        - name: '8080/tcp'
          configuration:
            public: true
          targetPort: 8080
      mountSources: false
      volumeMounts:
        - name: first
          path: /data
  - volume:
      name: secondvol
  - volume:
      name: secondvol
      size: 10Gi
```

- use this spring devfile components and change the container volume mounts to either `firstvol`, `secondvol`, `thirdvol` and `odo push`.  When using
1. `firstvol` though not defined in volume components, will be implicitly added with a default size of `5Gi`
2. `secondvol` will use a default size of `5Gi` since its size is not mentioend
3. `thirdvol` will use the mentioned size of `10Gi`
```
components:
  - container:
      name: tools
      image: maysunfaisal/springbootbuild
      memoryLimit: 768Mi
      command: ['tail']
      args: [ '-f', '/dev/null']
      mountSources: true
      volumeMounts:
        - name: firstvol
          path: /data
  - container:
      name: runtime
      image: maysunfaisal/springbootruntime
      memoryLimit: 768Mi
      command: ['tail']
      args: [ '-f', '/dev/null']
      endpoints:
        - name: '8080/tcp'
          configuration:
            public: true
          targetPort: 8080
      mountSources: false
      volumeMounts:
        - name: firstvol
          path: /data
  - volume:
      name: secondvol
  - volume:
      name: thirdvol
      size: 10Gi
``` 