### PR TITLE
Watch command should better handle file synchronization/error reporting when push command is invoked before/after the watch

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -39,7 +39,7 @@ type PushParameters struct {
 	DevfileBuildCmd          string                  // DevfileBuildCmd takes the build command through the command line and overwrites devfile build command
 	DevfileRunCmd            string                  // DevfileRunCmd takes the run command through the command line and overwrites devfile run command
 	DevfileDebugCmd          string                  // DevfileDebugCmd takes the debug command through the command line and overwrites the devfile debug command
-	DevfileScanIndexForWatch bool                    // DevfileScanIndexForWatch is true if watch's push should regenerate the index file during SyncFiles, false otherwise. See pkg/sync/adapter.go for details
+	DevfileScanIndexForWatch bool                    // DevfileScanIndexForWatch is true if watch's push should regenerate the index file during SyncFiles, false otherwise. See 'pkg/sync/adapter.go' for details
 	EnvSpecificInfo          envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
 	Debug                    bool                    // Runs the component in debug mode
 	DebugPort                int                     // Port used for remote debugging

--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -29,19 +29,20 @@ type Storage struct {
 
 // PushParameters is a struct containing the parameters to be used when pushing to a devfile component
 type PushParameters struct {
-	Path              string                  // Path refers to the parent folder containing the source code to push up to a component
-	WatchFiles        []string                // Optional: WatchFiles is the list of changed files detected by odo watch. If empty or nil, odo will check .odo/odo-file-index.json to determine changed files
-	WatchDeletedFiles []string                // Optional: WatchDeletedFiles is the list of deleted files detected by odo watch. If empty or nil, odo will check .odo/odo-file-index.json to determine deleted files
-	IgnoredFiles      []string                // IgnoredFiles is the list of files to not push up to a component
-	ForceBuild        bool                    // ForceBuild determines whether or not to push all of the files up to a component or just files that have changed, added or removed.
-	Show              bool                    // Show tells whether the devfile command output should be shown on stdout
-	DevfileInitCmd    string                  // DevfileInitCmd takes the init command through the command line and overwrites devfile init command
-	DevfileBuildCmd   string                  // DevfileBuildCmd takes the build command through the command line and overwrites devfile build command
-	DevfileRunCmd     string                  // DevfileRunCmd takes the run command through the command line and overwrites devfile run command
-	DevfileDebugCmd   string                  // DevfileDebugCmd takes the debug command through the command line and overwrites the devfile debug command
-	EnvSpecificInfo   envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
-	Debug             bool                    // Runs the component in debug mode
-	DebugPort         int                     // Port used for remote debugging
+	Path                     string                  // Path refers to the parent folder containing the source code to push up to a component
+	WatchFiles               []string                // Optional: WatchFiles is the list of changed files detected by odo watch. If empty or nil, odo will check .odo/odo-file-index.json to determine changed files
+	WatchDeletedFiles        []string                // Optional: WatchDeletedFiles is the list of deleted files detected by odo watch. If empty or nil, odo will check .odo/odo-file-index.json to determine deleted files
+	IgnoredFiles             []string                // IgnoredFiles is the list of files to not push up to a component
+	ForceBuild               bool                    // ForceBuild determines whether or not to push all of the files up to a component or just files that have changed, added or removed.
+	Show                     bool                    // Show tells whether the devfile command output should be shown on stdout
+	DevfileInitCmd           string                  // DevfileInitCmd takes the init command through the command line and overwrites devfile init command
+	DevfileBuildCmd          string                  // DevfileBuildCmd takes the build command through the command line and overwrites devfile build command
+	DevfileRunCmd            string                  // DevfileRunCmd takes the run command through the command line and overwrites devfile run command
+	DevfileDebugCmd          string                  // DevfileDebugCmd takes the debug command through the command line and overwrites the devfile debug command
+	DevfileScanIndexForWatch bool                    // DevfileScanIndexForWatch is true if watch's push should regenerate the index file during SyncFiles, false otherwise. See pkg/sync/adapter.go for details
+	EnvSpecificInfo          envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
+	Debug                    bool                    // Runs the component in debug mode
+	DebugPort                int                     // Port used for remote debugging
 }
 
 // SyncParameters is a struct containing the parameters to be used when syncing a devfile component

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -326,6 +326,6 @@ func regenerateComponentAdapterFromWatchParams(parameters watch.WatchParameters)
 		platformContext = nil
 	}
 
-	return adapters.NewComponentAdapter(parameters.ComponentName, parameters.Path, devObj, platformContext)
+	return adapters.NewComponentAdapter(parameters.ComponentName, parameters.Path, parameters.ApplicationName, devObj, platformContext)
 
 }

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -299,6 +299,9 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 	return watchCmd
 }
 
+// regenerateAdapterAndPush is used as a DevfileWatchHandler in WatchParameters; it is a wrapper around adapter.Push()
+// that first regenerates the component adapter before calling push. This ensures that it has picked up the latest
+// devfile.yaml changes
 func regenerateAdapterAndPush(pushParams common.PushParameters, watchParams watch.WatchParameters) error {
 	var adapter common.ComponentAdapter
 	adapter, err := regenerateComponentAdapterFromWatchParams(watchParams)
@@ -309,6 +312,7 @@ func regenerateAdapterAndPush(pushParams common.PushParameters, watchParams watc
 	return err
 }
 
+// regenerateComponentAdapterFromWatchParams (re)generates a component adapter from the given watch parameters.
 func regenerateComponentAdapterFromWatchParams(parameters watch.WatchParameters) (common.ComponentAdapter, error) {
 
 	// Parse devfile and validate

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -55,9 +55,12 @@ type WatchOptions struct {
 	componentContext string
 	client           *occlient.Client
 
-	componentName         string
-	devfilePath           string
-	namespace             string
+	componentName string
+	devfilePath   string
+	namespace     string
+
+	// initialDevfileHandler is only use to initial validation on the devfile.
+	// All subsequent uses of the devfile adapter are generated in regenerateAdapterAndPush.
 	initialDevfileHandler common.ComponentAdapter
 
 	// devfile commands

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -310,8 +310,9 @@ func regenerateAdapterAndPush(pushParams common.PushParameters, watchParams watc
 }
 
 func regenerateComponentAdapterFromWatchParams(parameters watch.WatchParameters) (common.ComponentAdapter, error) {
+
 	// Parse devfile and validate
-	devObj, err := parser.ParseAndValidate(parameters.DevfilePath)
+	devObj, err := devfile.ParseAndValidate(parameters.DevfilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -59,7 +59,7 @@ type WatchOptions struct {
 	devfilePath   string
 	namespace     string
 
-	// initialDevfileHandler is only use to initial validation on the devfile.
+	// initialDevfileHandler is only used to do initial validation on the devfile.
 	// All subsequent uses of the devfile adapter are generated in regenerateAdapterAndPush.
 	initialDevfileHandler common.ComponentAdapter
 

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -206,7 +206,6 @@ func (wo *WatchOptions) Run() (err error) {
 
 		err = watch.DevfileWatchAndPush(
 			os.Stdout,
-			// watchParams,
 			watch.WatchParameters{
 				ComponentName:       wo.componentName,
 				Path:                wo.sourcePath,

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -201,28 +201,6 @@ func (wo *WatchOptions) Run() (err error) {
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
 
-		// watchParams := watch.WatchParameters{
-		// 	ComponentName:    wo.componentName,
-		// 	Path:             wo.sourcePath,
-		// 	FileIgnores:      util.GetAbsGlobExps(wo.sourcePath, wo.ignores),
-		// 	PushDiffDelay:    wo.delay,
-		// 	StartChan:        nil,
-		// 	ExtChan:          make(chan bool),
-		// 	DevfileNamespace: wo.namespace,
-		// 	DevfilePath:      wo.devfilePath,
-		// 	// DevfileWatchHandler:   doPush, /*wo.initialDevfileHandler.Push,*/
-		// 	Show:                  wo.show,
-		// 	DevfileInitCmd:        strings.ToLower(wo.devfileInitCommand),
-		// 	DevfileBuildCmd:       strings.ToLower(wo.devfileBuildCommand),
-		// 	DevfileRunCmd:         strings.ToLower(wo.devfileRunCommand),
-		// 	EnvSpecificInfo:       wo.EnvSpecificInfo,
-		// 	IsDevfileWatchHandler: true,
-		// }
-
-		// thing := JGW{parameters: watchParams}
-
-		// watchParams.DevfileWatchHandler = thing.doPush
-
 		err = watch.DevfileWatchAndPush(
 			os.Stdout,
 			// watchParams,
@@ -235,13 +213,12 @@ func (wo *WatchOptions) Run() (err error) {
 				ExtChan:             make(chan bool),
 				DevfileNamespace:    wo.namespace,
 				DevfilePath:         wo.devfilePath,
-				DevfileWatchHandler: regenerateAdapterAndPush, /*wo.initialDevfileHandler.Push,*/
+				DevfileWatchHandler: regenerateAdapterAndPush,
 				Show:                wo.show,
 				DevfileInitCmd:      strings.ToLower(wo.devfileInitCommand),
 				DevfileBuildCmd:     strings.ToLower(wo.devfileBuildCommand),
 				DevfileRunCmd:       strings.ToLower(wo.devfileRunCommand),
 				EnvSpecificInfo:     wo.EnvSpecificInfo,
-				// IsDevfileWatchHandler: true,
 			},
 		)
 		if err != nil {
@@ -261,10 +238,9 @@ func (wo *WatchOptions) Run() (err error) {
 			PushDiffDelay:       wo.delay,
 			StartChan:           nil,
 			ExtChan:             make(chan bool),
-			DevfileWatchHandler: nil, /*wo.initialDevfileHandler.Push,*/
+			DevfileWatchHandler: nil,
 			WatchHandler:        component.PushLocal,
 			Show:                wo.show,
-			// IsDevfileWatchHandler: false,
 		},
 	)
 	if err != nil {

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -122,8 +122,6 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 		}
 	}
 
-	fmt.Println("isForcePush", isForcePush)
-
 	err = a.pushLocal(pushParameters.Path,
 		changedFiles,
 		deletedFiles,

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -53,7 +53,6 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 	// Sync source code to the component
 	// If syncing for the first time, sync the entire source directory
 	// If syncing to an already running component, sync the deltas
-	// If syncing from an odo watch process, skip this step, as we already have the list of changed and deleted files.
 	if !syncParameters.PodChanged && !pushParameters.ForceBuild {
 		absIgnoreRules := util.GetAbsGlobExps(pushParameters.Path, pushParameters.IgnoredFiles)
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -49,6 +49,9 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 	globExps := util.GetAbsGlobExps(pushParameters.Path, pushParameters.IgnoredFiles)
 	isWatch := len(pushParameters.WatchFiles) > 0 || len(pushParameters.WatchDeletedFiles) > 0
 
+	// Sync source code to the component
+	// If syncing for the first time, sync the entire source directory
+	// If syncing to an already running component, sync the deltas
 	// If syncing from an odo watch process, skip this step, as we already have the list of changed and deleted files.
 	if isWatch && !isForcePush {
 		changedFiles = pushParameters.WatchFiles
@@ -118,6 +121,8 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 			return false, nil
 		}
 	}
+
+	fmt.Println("isForcePush", isForcePush)
 
 	err = a.pushLocal(pushParameters.Path,
 		changedFiles,

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -47,8 +47,8 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 	pushParameters := syncParameters.PushParams
 
 	// The logic for watch is:
-	// 1) If this is the first time that watch has called Push, then generate the file index using the file indexer, and use that to
-	//    sync files (don't use changed/deleted files from watch; they will be included in the index)
+	// 1) If this is the first time that watch has called Push (in this process), then generate the file index using the file indexer, and use that to
+	//    sync files (don't use changed/deleted files list from watch at this stage; these will be found by the indexer run)
 	// 2) For every other push/sync call after the first, don't run the file indexer, instead use the watch events to determine
 	//    what changed; ensure that the index is then updated based on the watch events.
 
@@ -267,9 +267,8 @@ func updateIndexWithWatchChanges(pushParameters common.PushParameters) error {
 		klog.V(4).Infof("Added/updated watched file in index: %s", relativePath)
 	}
 
-	util.WriteFile(fileIndex.Files, indexFilePath)
+	return util.WriteFile(fileIndex.Files, indexFilePath)
 
-	return nil
 }
 
 // getCmdToCreateSyncFolder returns the command used to create the remote sync folder on the running container

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -341,7 +341,7 @@ func TestPushLocal(t *testing.T) {
 	}
 }
 
-func TestUpdateIndexWithWatchChangesLocal(t *testing.T) {
+func TestUpdateIndexWithWatchChanges(t *testing.T) {
 
 	tests := []struct {
 		name                 string
@@ -381,7 +381,7 @@ func TestUpdateIndexWithWatchChangesLocal(t *testing.T) {
 			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to resolve index file path: %v", err)
 		}
 
-		if err := os.MkdirAll(filepath.Dir(fileIndexPath), 0644); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fileIndexPath), 0750); err != nil {
 			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to create directories for %s: %v", fileIndexPath, err)
 		}
 

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -157,12 +157,12 @@ func TestSyncFiles(t *testing.T) {
 			wantIsPushRequired: false,
 		},
 		{
-			name:   "Case 4: File change",
+			name:   "Case 4: No file change",
 			client: fakeClient,
 			syncParameters: common.SyncParameters{
 				PushParams: common.PushParameters{
 					Path:              directory,
-					WatchFiles:        []string{path.Join(directory, "test.log")},
+					WatchFiles:        []string{},
 					WatchDeletedFiles: []string{},
 					IgnoredFiles:      []string{},
 					ForceBuild:        false,
@@ -173,7 +173,7 @@ func TestSyncFiles(t *testing.T) {
 				ComponentExists: true,
 			},
 			wantErr:            false,
-			wantIsPushRequired: true,
+			wantIsPushRequired: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -433,7 +433,9 @@ func TestUpdateIndexWithWatchChangesLocal(t *testing.T) {
 				}
 			}
 
-			updateIndexWithWatchChanges(pushParams)
+			if err := updateIndexWithWatchChanges(pushParams); err != nil {
+				t.Fatalf("TestUpdateIndexWithWatchChangesLocal: unexpected error: %v", err)
+			}
 
 			postFileIndex, err := util.ReadFileIndex(fileIndexPath)
 			if err != nil || postFileIndex == nil {

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -166,6 +166,8 @@ func TestSyncFiles(t *testing.T) {
 					WatchDeletedFiles: []string{},
 					IgnoredFiles:      []string{},
 					ForceBuild:        false,
+					// The first invocation of watch requires this to be true, see SyncFiles(...) in 'sync/adapter.go' for details.
+					DevfileScanIndexForWatch: true,
 				},
 				CompInfo: common.ComponentInfo{
 					ContainerName: "abcd",

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/lclient"
 	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/openshift/odo/tests/helper"
 )
 
@@ -337,5 +338,117 @@ func TestPushLocal(t *testing.T) {
 	err = os.RemoveAll(directory)
 	if err != nil {
 		t.Errorf("TestPushLocal error: error deleting the temp dir %s", directory)
+	}
+}
+
+func TestUpdateIndexWithWatchChangesLocal(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		initialFilesToCreate []string
+		watchDeletedFiles    []string
+		watchAddedFiles      []string
+		expectedFilesInIndex []string
+	}{
+		{
+			name:                 "Case 1 - Watch file deleted should remove file from index",
+			initialFilesToCreate: []string{"file1", "file2"},
+			watchDeletedFiles:    []string{"file1"},
+			expectedFilesInIndex: []string{"file2"},
+		},
+		{
+			name:                 "Case 2 - Watch file added should add file to index",
+			initialFilesToCreate: []string{"file1"},
+			watchAddedFiles:      []string{"file2"},
+			expectedFilesInIndex: []string{"file1", "file2"},
+		},
+		{
+			name:                 "Case 3 - No watch changes should mean no index changes",
+			initialFilesToCreate: []string{"file1"},
+			expectedFilesInIndex: []string{"file1"},
+		},
+	}
+	for _, tt := range tests {
+
+		// create a temp dir for the fake component
+		directory, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
+		}
+
+		fileIndexPath, err := util.ResolveIndexFilePath(directory)
+		if err != nil {
+			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to resolve index file path: %v", err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(fileIndexPath), 0644); err != nil {
+			t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to create directories for %s: %v", fileIndexPath, err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			indexData := map[string]util.FileData{}
+
+			// Create initial files
+			for _, fileToCreate := range tt.initialFilesToCreate {
+				filePath := filepath.Join(directory, fileToCreate)
+
+				if err := ioutil.WriteFile(filePath, []byte("non-empty-string"), 0644); err != nil {
+					t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to write to index file path: %v", err)
+				}
+
+				key, fileDatum, err := util.GenerateNewFileDataEntry(filePath, directory)
+				if err != nil {
+					t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to generate new file: %v", err)
+				}
+				indexData[key] = *fileDatum
+			}
+
+			// Write the index based on those files
+			if err := util.WriteFile(indexData, fileIndexPath); err != nil {
+				t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to write index file: %v", err)
+			}
+
+			pushParams := common.PushParameters{
+				Path: directory,
+			}
+
+			// Add deleted files to pushParams (also delete the files)
+			for _, deletedFile := range tt.watchDeletedFiles {
+				deletedFilePath := filepath.Join(directory, deletedFile)
+				pushParams.WatchDeletedFiles = append(pushParams.WatchDeletedFiles, deletedFilePath)
+
+				if err := os.Remove(deletedFilePath); err != nil {
+					t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to delete file %s %v", deletedFilePath, err)
+				}
+			}
+
+			// Add added files to pushParams (also create the files)
+			for _, addedFile := range tt.watchAddedFiles {
+				addedFilePath := filepath.Join(directory, addedFile)
+				pushParams.WatchFiles = append(pushParams.WatchFiles, addedFilePath)
+
+				if err := ioutil.WriteFile(addedFilePath, []byte("non-empty-string"), 0644); err != nil {
+					t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to write to index file path: %v", err)
+				}
+			}
+
+			updateIndexWithWatchChanges(pushParams)
+
+			postFileIndex, err := util.ReadFileIndex(fileIndexPath)
+			if err != nil || postFileIndex == nil {
+				t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: read new file index: %v", err)
+			}
+
+			// Locate expected files
+			if len(postFileIndex.Files) != len(tt.expectedFilesInIndex) {
+				t.Fatalf("Mismatch between number expected files and actual files in index, post-index: %v   expected: %v", postFileIndex.Files, tt.expectedFilesInIndex)
+			}
+			for _, expectedFile := range tt.expectedFilesInIndex {
+				if _, exists := postFileIndex.Files[expectedFile]; !exists {
+					t.Fatalf("Unable to find '%s' in post index file, %v", expectedFile, postFileIndex.Files)
+				}
+			}
+		})
 	}
 }

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -157,12 +157,12 @@ func TestSyncFiles(t *testing.T) {
 			wantIsPushRequired: false,
 		},
 		{
-			name:   "Case 4: No file change",
+			name:   "Case 4: File change",
 			client: fakeClient,
 			syncParameters: common.SyncParameters{
 				PushParams: common.PushParameters{
 					Path:              directory,
-					WatchFiles:        []string{},
+					WatchFiles:        []string{path.Join(directory, "test.log")},
 					WatchDeletedFiles: []string{},
 					IgnoredFiles:      []string{},
 					ForceBuild:        false,
@@ -173,7 +173,7 @@ func TestSyncFiles(t *testing.T) {
 				ComponentExists: true,
 			},
 			wantErr:            false,
-			wantIsPushRequired: false,
+			wantIsPushRequired: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -41,7 +41,7 @@ type FileData struct {
 
 // read tries to read the odo index file from the given location and returns the data from the file
 // if no such file is present, it means the folder hasn't been walked and thus returns a empty list
-func readFileIndex(filePath string) (*FileIndex, error) {
+func ReadFileIndex(filePath string) (*FileIndex, error) {
 	// Read operation
 	var fi FileIndex
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
@@ -166,7 +166,7 @@ func RunIndexer(directory string, ignoreRules []string) (ret IndexerRet, err err
 	}
 
 	// read the odo index file
-	existingFileIndex, err := readFileIndex(ret.ResolvedPath)
+	existingFileIndex, err := ReadFileIndex(ret.ResolvedPath)
 	if err != nil {
 		return ret, err
 	}

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -244,7 +244,8 @@ func RunIndexer(directory string, ignoreRules []string) (ret IndexerRet, err err
 	return ret, nil
 }
 
-// CalculateFileDataKeyFromPath converts an absolute path to relative, and convert to OS-specific paths, for use as a map key in IndexerRet and FileIndex
+// CalculateFileDataKeyFromPath converts an absolute path to relative (and converts to OS-specific paths) for use
+// as a map key in IndexerRet and FileIndex
 func CalculateFileDataKeyFromPath(absolutePath string, rootDirectory string) (string, error) {
 
 	rootDirectory = filepath.FromSlash(rootDirectory)

--- a/pkg/util/file_indexer_test.go
+++ b/pkg/util/file_indexer_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,4 +127,111 @@ func mockDirectoryInfo(create bool, contextDir string, fs filesystem.Filesystem)
 	}
 
 	return nil
+}
+
+func TestCalculateFileDataKeyFromPath(t *testing.T) {
+
+	// create a temp dir for the fake component
+	directory, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
+	}
+
+	tests := []struct {
+		absolutePath   string
+		rootDirectory  string
+		expectedResult string
+	}{
+		{
+			absolutePath:   filepath.Join(directory, "/path/file1"),
+			rootDirectory:  filepath.Join(directory, "/path"),
+			expectedResult: "file1",
+		},
+		{
+			absolutePath:   filepath.Join(directory, "/path/path2/file1"),
+			rootDirectory:  filepath.Join(directory, "/path/"),
+			expectedResult: "path2/file1",
+		},
+		{
+			absolutePath:   filepath.Join(directory, "/path"),
+			rootDirectory:  filepath.Join(directory, "/"),
+			expectedResult: "path",
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run("Expect result: "+tt.expectedResult, func(t *testing.T) {
+
+			result, err := CalculateFileDataKeyFromPath(tt.absolutePath, tt.rootDirectory)
+			if err != nil {
+				t.Fatalf("unexpecter error occurred %v", err)
+			}
+
+			if result != filepath.FromSlash(tt.expectedResult) {
+				t.Fatalf("unexpected result: %v %v", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGenerateNewFileDataEntry(t *testing.T) {
+
+	// create a temp dir for the fake component
+	directory, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: error creating temporary directory for the indexer: %v", err)
+	}
+
+	tests := []struct {
+		testName      string
+		absolutePath  string
+		rootDirectory string
+		expectedKey   string
+	}{
+		{
+			absolutePath:  filepath.Join(directory, "/path/file1"),
+			rootDirectory: filepath.Join(directory, "/path"),
+			expectedKey:   "file1",
+		},
+		{
+			absolutePath:  filepath.Join(directory, "/path/path2/file1"),
+			rootDirectory: filepath.Join(directory, "/path/"),
+			expectedKey:   "path2/file1",
+		},
+		{
+			absolutePath:  filepath.Join(directory, "/path"),
+			rootDirectory: filepath.Join(directory, "/"),
+			expectedKey:   "path",
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run("Expected key "+tt.expectedKey, func(t *testing.T) {
+
+			if err := ioutil.WriteFile(tt.absolutePath, []byte("hi"), 0644); err != nil {
+				t.Fatalf("TestUpdateIndexWithWatchChangesLocal error: unable to write to index file path: %v", err)
+			}
+
+			key, filedata, err := GenerateNewFileDataEntry(tt.absolutePath, tt.rootDirectory)
+
+			if err != nil {
+				t.Fatalf("Unexpected error occurred %v", err)
+			}
+
+			if key != tt.expectedKey {
+				t.Fatalf("Key %s did not match expected key %s", key, tt.expectedKey)
+			}
+
+			if filedata == nil {
+				t.Fatalf("Filedata should not be null")
+			}
+
+			if filedata.Size == 0 || filedata.LastModifiedDate.IsZero() {
+				t.Fatalf("Invalid filedata values %v %v", filedata.Size, filedata.LastModifiedDate)
+			}
+
+		})
+	}
 }

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -99,7 +99,12 @@ func addRecursiveWatch(watcher *fsnotify.Watcher, path string, ignores []string)
 	folders := []string{}
 	err = filepath.Walk(path, func(newPath string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// Ignore the error if it's a 'path does not exist' error, no need to walk a non-existent path
+			if !util.CheckPathExists(newPath) {
+				klog.V(4).Infof("Walk func received an error for path %s, but the path doesn't exist so this is likely not an error. err: %v", path, err)
+				return nil
+			}
+			return errors.Wrapf(err, "unable to walk path: %s", newPath)
 		}
 
 		if info.IsDir() {
@@ -260,15 +265,12 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 					//	a. RENAME with event.Name empty
 					//	b. REMOVE with event.Name as file name
 					if !alreadyInChangedFiles && !matched && event.Name != "" {
-						relPath, err := filepath.Rel(parameters.Path, event.Name)
-						if err != nil {
-							watchError = errors.Wrapf(err, "failed to propagate delete of file %s as its relative to %s couldn't be found", event.Name, parameters.Path)
-						}
-						deletedPaths = append(deletedPaths, relPath)
+						deletedPaths = append(deletedPaths, event.Name)
 					}
 				} else {
 					// On other ops, recursively watch the resource (if applicable)
 					if e := addRecursiveWatch(watcher, event.Name, parameters.FileIgnores); e != nil && watchError == nil {
+						klog.V(4).Infof("Error occurred in addRecursiveWatch, setting watchError to %v", e)
 						watchError = e
 					}
 				}
@@ -302,11 +304,14 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 	}
 	showWaitingMessage := true
 
+	hasFirstSuccessfulPushOccurred := false
+
 	// This for{} loop waits for filesystem changes that are signaled by the above goroutine;
 	// - 'dirty' is used by the goroutine to indicate that at least one change has occurred
 	for {
 		changeLock.Lock()
 		if watchError != nil {
+			klog.V(4).Infof("Ending watch for {} loop with error %v\n", watchError)
 			return watchError
 		}
 		if showWaitingMessage {
@@ -322,6 +327,9 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 		// the filesystem is in the middle of changing due to a massive
 		// set of changes (such as a local build in progress).
 		if dirty && time.Now().After(lastChange.Add(delay)) {
+
+			deletedPaths = removeDuplicates(deletedPaths)
+
 			for _, file := range changedFiles {
 				fmt.Fprintf(out, "File %s changed\n", file)
 			}
@@ -336,17 +344,18 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 
 					if parameters.DevfileWatchHandler != nil {
 						pushParams := common.PushParameters{
-							Path:              parameters.Path,
-							WatchFiles:        changedFiles,
-							WatchDeletedFiles: deletedPaths,
-							IgnoredFiles:      parameters.FileIgnores,
-							ForceBuild:        false,
-							DevfileInitCmd:    parameters.DevfileInitCmd,
-							DevfileBuildCmd:   parameters.DevfileBuildCmd,
-							DevfileRunCmd:     parameters.DevfileRunCmd,
-							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
-							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
-							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
+							Path:                     parameters.Path,
+							WatchFiles:               changedFiles,
+							WatchDeletedFiles:        deletedPaths,
+							IgnoredFiles:             parameters.FileIgnores,
+							ForceBuild:               false,
+							DevfileInitCmd:           parameters.DevfileInitCmd,
+							DevfileBuildCmd:          parameters.DevfileBuildCmd,
+							DevfileRunCmd:            parameters.DevfileRunCmd,
+							DevfileScanIndexForWatch: !hasFirstSuccessfulPushOccurred,
+							EnvSpecificInfo:          *parameters.EnvSpecificInfo,
+							Debug:                    parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
+							DebugPort:                parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 
 						err = parameters.DevfileWatchHandler(pushParams, parameters)
@@ -362,17 +371,18 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 
 					if parameters.DevfileWatchHandler != nil {
 						pushParams := common.PushParameters{
-							Path:              pathDir,
-							WatchFiles:        changedFiles,
-							WatchDeletedFiles: deletedPaths,
-							IgnoredFiles:      parameters.FileIgnores,
-							ForceBuild:        false,
-							DevfileInitCmd:    parameters.DevfileInitCmd,
-							DevfileBuildCmd:   parameters.DevfileBuildCmd,
-							DevfileRunCmd:     parameters.DevfileRunCmd,
-							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
-							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
-							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
+							Path:                     pathDir,
+							WatchFiles:               changedFiles,
+							WatchDeletedFiles:        deletedPaths,
+							IgnoredFiles:             parameters.FileIgnores,
+							ForceBuild:               false,
+							DevfileInitCmd:           parameters.DevfileInitCmd,
+							DevfileBuildCmd:          parameters.DevfileBuildCmd,
+							DevfileRunCmd:            parameters.DevfileRunCmd,
+							DevfileScanIndexForWatch: !hasFirstSuccessfulPushOccurred,
+							EnvSpecificInfo:          *parameters.EnvSpecificInfo,
+							Debug:                    parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
+							DebugPort:                parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 
 						err = parameters.DevfileWatchHandler(pushParams, parameters)
@@ -388,6 +398,8 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 					// We don't want to break watch when push failed, it might be fixed with the next change.
 					klog.V(4).Infof("Error from Push: %v", err)
 					fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
+				} else {
+					hasFirstSuccessfulPushOccurred = true
 				}
 				dirty = false
 				showWaitingMessage = true
@@ -408,4 +420,17 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 // As an occlient instance is not needed for devfile components, it sets it to nil
 func DevfileWatchAndPush(out io.Writer, parameters WatchParameters) error {
 	return WatchAndPush(nil, out, parameters)
+}
+
+func removeDuplicates(input []string) []string {
+	valueMap := map[string]string{}
+	for _, str := range input {
+		valueMap[str] = str
+	}
+
+	result := []string{}
+	for str := range valueMap {
+		result = append(result, str)
+	}
+	return result
 }

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -53,9 +53,7 @@ type WatchParameters struct {
 	// DevfileBuildCmd takes the build command through the command line and overwrites devfile build command
 	DevfileBuildCmd string
 	// DevfileRunCmd takes the run command through the command line and overwrites devfile run command
-	DevfileRunCmd    string
-	DevfilePath      string
-	DevfileNamespace string
+	DevfileRunCmd string
 }
 
 // addRecursiveWatch handles adding watches recursively for the path provided

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -56,7 +56,6 @@ type WatchParameters struct {
 	DevfileRunCmd    string
 	DevfilePath      string
 	DevfileNamespace string
-	// IsDevfileWatchHandler bool
 }
 
 // addRecursiveWatch handles adding watches recursively for the path provided
@@ -327,7 +326,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				}
 				if fileInfo.IsDir() {
 					klog.V(4).Infof("Copying files %s to pod", changedFiles)
-					// if parameters.IsDevfileWatchHandler /*.DevfileWatchHandler != nil*/ {
+
 					if parameters.DevfileWatchHandler != nil {
 						pushParams := common.PushParameters{
 							Path:              parameters.Path,
@@ -352,7 +351,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				} else {
 					pathDir := filepath.Dir(parameters.Path)
 					klog.V(4).Infof("Copying file %s to pod", parameters.Path)
-					// if parameters.IsDevfileWatchHandler {
+
 					if parameters.DevfileWatchHandler != nil {
 						pushParams := common.PushParameters{
 							Path:              pathDir,
@@ -376,11 +375,10 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 				}
 				if err != nil {
 
-					fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
-
-					// Intentionally not exiting on error here.
+					// Log and output, but intentionally not exiting on error here.
 					// We don't want to break watch when push failed, it might be fixed with the next change.
 					klog.V(4).Infof("Error from Push: %v", err)
+					fmt.Fprintf(out, "%s - %s\n\n", PushErrorString, err.Error())
 				}
 				dirty = false
 				showWaitingMessage = true
@@ -396,26 +394,6 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 		}
 	}
 }
-
-// func RegenerateComponentAdapterFromWatchParams(parameters WatchParameters) (common.ComponentAdapter, error) {
-// 	// Parse devfile and validate
-// 	devObj, err := parser.ParseAndValidate(parameters.DevfilePath)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	var platformContext interface{}
-// 	if !pushtarget.IsPushTargetDocker() {
-// 		platformContext = kubernetes.KubernetesContext{
-// 			Namespace: parameters.DevfileNamespace,
-// 		}
-// 	} else {
-// 		platformContext = nil
-// 	}
-
-// 	return adapters.NewComponentAdapter(parameters.ComponentName, parameters.Path, devObj, platformContext)
-
-// }
 
 // DevfileWatchAndPush calls out to the WatchAndPush function.
 // As an occlient instance is not needed for devfile components, it sets it to nil

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -1,5 +1,3 @@
-// +build !osx
-
 package watch
 
 import (
@@ -108,7 +106,7 @@ type mockPushParameters struct {
 var mockPush mockPushParameters
 
 // Mocks the devFile push function that's called when odo watch pushes to a component
-func mockDevFilePush(parameters common.PushParameters) error {
+func mockDevFilePush(parameters common.PushParameters, _ WatchParameters) error {
 	muLock.Lock()
 	defer muLock.Unlock()
 	if parameters.Show != mockPush.show || parameters.Debug != mockPush.isDebug || parameters.DebugPort != mockPush.debugPort {
@@ -817,6 +815,7 @@ func TestWatchAndPush(t *testing.T) {
 					StartChan:     StartChan,
 					ExtChan:       ExtChan,
 					Show:          tt.show,
+					// IsDevfileWatchHandler: tt.isExperimental,
 				}
 
 				if tt.isExperimental {

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -1,3 +1,5 @@
+// +build !osx
+
 package watch
 
 import (
@@ -815,7 +817,6 @@ func TestWatchAndPush(t *testing.T) {
 					StartChan:     StartChan,
 					ExtChan:       ExtChan,
 					Show:          tt.show,
-					// IsDevfileWatchHandler: tt.isExperimental,
 				}
 
 				if tt.isExperimental {

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -7,6 +7,7 @@ import "github.com/onsi/gomega/gexec"
 type CliRunner interface {
 	Run(cmd string) *gexec.Session
 	ExecListDir(podName string, projectName string, dir string) string
+	Exec(podName string, projectName string, args ...string) string
 	CheckCmdOpInRemoteDevfilePod(podName string, containerName string, prjName string, cmd []string, checkOp func(cmdOp string, err error) bool) bool
 	GetRunningPodNameByComponent(compName string, namespace string) string
 	GetVolumeMountNamesandPathsFromContainer(deployName string, containerName, namespace string) string

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -22,39 +22,6 @@ func CreateNewContext() string {
 	return directory
 }
 
-// DeleteDir delete directory
-// func DeleteDir(dir string) {
-
-// 	expireTime := time.Now().Add(time.Minute * 2)
-// 	delayInSeconds := 1
-
-// 	err := error(nil)
-// 	attempts := 0
-
-// 	for {
-// 		fmt.Fprintf(GinkgoWriter, "Deleting dir: %s\n", dir)
-// 		err = os.RemoveAll(dir)
-
-// 		if err == nil || time.Now().After(expireTime) {
-// 			break
-// 		}
-
-// 		fmt.Printf("Unable to delete %s on attempt #%d, trying again in 5 seconds...\n", dir, attempts)
-// 		fmt.Fprintf(GinkgoWriter, "Unable to delete %s on attempt #%d, trying again in 5 seconds...\n", dir, attempts)
-
-// 		delayInSeconds *= 2 // exponential backoff
-// 		if delayInSeconds > 16 {
-// 			delayInSeconds = 16
-// 		}
-// 		time.Sleep(time.Duration(delayInSeconds) * time.Second)
-
-// 		attempts++
-
-// 	}
-// 	Expect(err).NotTo(HaveOccurred())
-
-// }
-
 func DeleteDir(dir string) {
 	attempts := 0
 

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -103,7 +103,6 @@ func ExtractSubString(output, start, end string) string {
 }
 
 // WatchNonRetCmdStdOut runs an 'odo watch' command and stores the process' stdout output into buffer.
-// - 'true' is sent on the startSimulationCh when the
 // - startIndicatorFunc should check stdout output and return true when simulation is ready to begin (for example, buffer contains "Waiting for something to change")
 // - startSimulationCh will be sent a 'true' when startIndicationFunc first returns true, at which point files/directories should be created by associated goroutine
 // - success function is passed stdout buffer, and should return if the test conditions have passes

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -102,33 +102,22 @@ func ExtractSubString(output, start, end string) string {
 	return ""
 }
 
-// WatchNonRetCmdStdOut run odo watch and get the cmdSTDOUT output into buffer.
-// startIndicatorFunc sets true and startSimulationCh starts, when buffer contain "Waiting for something to change"
-// check function checks for the changes into the buffer
-func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, check func(output string) bool, startSimulationCh chan bool, startIndicatorFunc func(output string) bool) (bool, error) {
+// WatchNonRetCmdStdOut runs an 'odo watch' command and stores the process' stdout output into buffer.
+// - 'true' is sent on the startSimulationCh when the
+// - startIndicatorFunc should check stdout output and return true when simulation is ready to begin (for example, buffer contains "Waiting for something to change")
+// - startSimulationCh will be sent a 'true' when startIndicationFunc first returns true, at which point files/directories should be created by associated goroutine
+// - success function is passed stdout buffer, and should return if the test conditions have passes
+func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, success func(output string) bool, startSimulationCh chan bool, startIndicatorFunc func(output string) bool) (bool, error) {
 	var cmd *exec.Cmd
 	var buf bytes.Buffer
 	var errBuf bytes.Buffer
-	var cmdStrParts []string
-	// interestingly "odo watch  --context" ( observe the 2 spaces between watch and --context ) becomes ["odo", "watch", "", "--context"] which falls
-	// apart with Error: unknown command "" for "odo watch" on cobra when used "cobra.NoArgs".
-	tmpParts := strings.Split(cmdStr, " ")
-	for i := 0; i < len(tmpParts); i++ {
-		trimedPart := strings.TrimSpace(tmpParts[i])
-		if trimedPart == "" {
-			continue
-		}
-		cmdStrParts = append(cmdStrParts, trimedPart)
-	}
-	cmdName := cmdStrParts[0]
-	_, err := fmt.Fprintln(GinkgoWriter, "Running command: ", cmdStrParts)
-	Expect(err).To(BeNil())
-	if len(cmdStrParts) > 1 {
-		cmdStrParts = cmdStrParts[1:]
-		cmd = exec.Command(cmdName, cmdStrParts...)
-	} else {
-		cmd = exec.Command(cmdName)
-	}
+
+	cmdStrParts := strings.Fields(cmdStr)
+
+	fmt.Fprintln(GinkgoWriter, "Running command: ", cmdStrParts)
+
+	cmd = exec.Command(cmdStrParts[0], cmdStrParts[1:]...)
+
 	cmd.Stdout = &buf
 	cmd.Stderr = &errBuf
 
@@ -156,18 +145,21 @@ func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, check func(outpu
 			}
 			errBufStr := errBuf.String()
 			if errBufStr != "" {
-				_, err = fmt.Fprintln(GinkgoWriter, "Output from stderr:")
+				_, err := fmt.Fprintln(GinkgoWriter, "Output from stderr:")
 				Expect(err).To(BeNil())
 				_, err = fmt.Fprintln(GinkgoWriter, errBufStr)
 				Expect(err).To(BeNil())
 			}
 			Fail(fmt.Sprintf("Timeout after %.2f minutes", timeout.Minutes()))
-		case <-ticker.C:
+		case <-ticker.C: // Every 10 seconds...
+
+			// If we have not yet begun file modification, query the parameter function to see if we should, do so if true
 			if !startedFileModification && startIndicatorFunc(buf.String()) {
 				startedFileModification = true
 				startSimulationCh <- true
 			}
-			if check(buf.String()) {
+			// Call success(...) to determine if stdout contains expected text, exit if true
+			if success(buf.String()) {
 				if err := cmd.Process.Kill(); err != nil {
 					return true, err
 				}

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -29,6 +29,17 @@ func (kubectl KubectlRunner) Run(cmd string) *gexec.Session {
 	return session
 }
 
+// Exec allows generic execution of commands, returning the contents of stdout
+func (kubectl KubectlRunner) Exec(podName string, projectName string, args ...string) string {
+
+	cmd := []string{"exec", podName, "--namespace", projectName}
+
+	cmd = append(cmd, args...)
+
+	stdOut := CmdShouldPass(kubectl.path, cmd...)
+	return stdOut
+}
+
 // ExecListDir returns dir list in specified location of pod
 func (kubectl KubectlRunner) ExecListDir(podName string, projectName string, dir string) string {
 	stdOut := CmdShouldPass(kubectl.path, "exec", podName, "--namespace", projectName,

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -132,6 +132,17 @@ func (oc OcRunner) ExecListDir(podName string, projectName string, dir string) s
 	return stdOut
 }
 
+// Exec allows generic execution of commands, returning the contents of stdout
+func (oc OcRunner) Exec(podName string, projectName string, args ...string) string {
+
+	cmd := []string{"exec", podName, "--namespace", projectName}
+
+	cmd = append(cmd, args...)
+
+	stdOut := CmdShouldPass(oc.path, cmd...)
+	return stdOut
+}
+
 // CheckCmdOpInRemoteCmpPod runs the provided command on remote component pod and returns the return value of command output handler function passed to it
 func (oc OcRunner) CheckCmdOpInRemoteCmpPod(cmpName string, appName string, prjName string, cmd []string, checkOp func(cmdOp string, err error) bool) bool {
 	cmpDCName := fmt.Sprintf("%s-%s", cmpName, appName)

--- a/tests/helper/helper_run.go
+++ b/tests/helper/helper_run.go
@@ -99,3 +99,13 @@ func CmdShouldFailWithRetry(maxRetry, intervalSeconds int, program string, args 
 	return ""
 
 }
+
+// WaitForOutputToContain waits for for the session stdout output to contain a particular substring
+func WaitForOutputToContain(substring string, timeoutInSeconds int, intervalInSeconds int, session *gexec.Session) {
+
+	Eventually(func() string {
+		contents := string(session.Out.Contents())
+		return contents
+	}, timeoutInSeconds, intervalInSeconds).Should(ContainSubstring(substring))
+
+}

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -157,7 +157,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
 
 			// File should exist, and its content should match what we initially set it to
-			execResult := cliRunner.Exec(podName, namespace, "cat", "/projects/nodejs-starter/"+filepath.Base(fileAPath))
+			execResult := cliRunner.Exec(podName, namespace, "cat", "/projects/"+filepath.Base(fileAPath))
 			Expect(execResult).To(ContainSubstring(fileAText))
 
 		})

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -147,7 +147,6 @@ var _ = Describe("odo devfile watch command tests", func() {
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			// 2) Create a new file A
-
 			fileAPath, fileAText := createSimpleFile(context)
 
 			// 3) Odo watch that project

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -1,7 +1,6 @@
 package devfile
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -50,61 +49,61 @@ var _ = Describe("odo devfile watch command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	// Context("when running help for watch command", func() {
-	// 	It("should display the help", func() {
-	// 		appHelp := helper.CmdShouldPass("odo", "watch", "-h")
-	// 		helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
-	// 	})
-	// })
+	Context("when running help for watch command", func() {
+		It("should display the help", func() {
+			appHelp := helper.CmdShouldPass("odo", "watch", "-h")
+			helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
+		})
+	})
 
-	// Context("when executing watch without pushing a devfile component", func() {
-	// 	It("should fail", func() {
-	// 		helper.Chdir(currentWorkingDirectory)
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
-	// 		output := helper.CmdShouldFail("odo", "watch", "--context", context)
-	// 		Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
-	// 	})
-	// })
+	Context("when executing watch without pushing a devfile component", func() {
+		It("should fail", func() {
+			helper.Chdir(currentWorkingDirectory)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+			output := helper.CmdShouldFail("odo", "watch", "--context", context)
+			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
+		})
+	})
 
-	// Context("when executing odo watch after odo push", func() {
-	// 	It("should listen for file changes", func() {
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	Context("when executing odo watch after odo push", func() {
+		It("should listen for file changes", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-	// 		output := helper.CmdShouldPass("odo", "push", "--project", namespace)
-	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-	// 		watchFlag := ""
-	// 		odoV2Watch := utils.OdoV2Watch{
-	// 			CmpName:            cmpName,
-	// 			StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
-	// 		}
-	// 		// odo watch and validate
-	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-	// 	})
-	// })
+			watchFlag := ""
+			odoV2Watch := utils.OdoV2Watch{
+				CmpName:            cmpName,
+				StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
+			}
+			// odo watch and validate
+			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+		})
+	})
 
-	// Context("when executing odo watch after odo push with flag commands", func() {
-	// 	It("should listen for file changes", func() {
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	Context("when executing odo watch after odo push with flag commands", func() {
+		It("should listen for file changes", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-	// 		output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
-	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-	// 		watchFlag := "--build-command build --run-command run"
-	// 		odoV2Watch := utils.OdoV2Watch{
-	// 			CmpName:            cmpName,
-	// 			StringsToBeMatched: []string{"Executing build command", "Executing run command"},
-	// 		}
-	// 		// odo watch and validate
-	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-	// 	})
-	// })
+			watchFlag := "--build-command build --run-command run"
+			odoV2Watch := utils.OdoV2Watch{
+				CmpName:            cmpName,
+				StringsToBeMatched: []string{"Executing build command", "Executing run command"},
+			}
+			// odo watch and validate
+			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+		})
+	})
 
 	Context("when executing odo watch", func() {
 		It("should show validation errors if the devfile is incorrect", func() {
@@ -193,7 +192,6 @@ func waitForOutputToContain(substring string, session *gexec.Session) {
 
 	Eventually(func() string {
 		contents := string(session.Out.Contents())
-		fmt.Println("jgw:", contents)
 		return contents
 	}, 180, 10).Should(ContainSubstring(substring))
 

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,7 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
+	"github.com/openshift/odo/pkg/util"
+	"github.com/openshift/odo/pkg/watch"
 	"github.com/openshift/odo/tests/helper"
+	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile watch command tests", func() {
@@ -48,90 +52,90 @@ var _ = Describe("odo devfile watch command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	// Context("when running help for watch command", func() {
-	// 	It("should display the help", func() {
-	// 		appHelp := helper.CmdShouldPass("odo", "watch", "-h")
-	// 		helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
-	// 	})
-	// })
+	Context("when running help for watch command", func() {
+		It("should display the help", func() {
+			appHelp := helper.CmdShouldPass("odo", "watch", "-h")
+			helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
+		})
+	})
 
-	// Context("when executing watch without pushing a devfile component", func() {
-	// 	It("should fail", func() {
-	// 		helper.Chdir(currentWorkingDirectory)
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
-	// 		output := helper.CmdShouldFail("odo", "watch", "--context", context)
-	// 		Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
-	// 	})
-	// })
+	Context("when executing watch without pushing a devfile component", func() {
+		It("should fail", func() {
+			helper.Chdir(currentWorkingDirectory)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+			output := helper.CmdShouldFail("odo", "watch", "--context", context)
+			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
+		})
+	})
 
-	// Context("when executing odo watch after odo push", func() {
-	// 	It("should listen for file changes", func() {
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	Context("when executing odo watch after odo push", func() {
+		It("should listen for file changes", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-	// 		output := helper.CmdShouldPass("odo", "push", "--project", namespace)
-	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-	// 		watchFlag := ""
-	// 		odoV2Watch := utils.OdoV2Watch{
-	// 			CmpName:            cmpName,
-	// 			StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
-	// 		}
-	// 		// odo watch and validate
-	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-	// 	})
-	// })
+			watchFlag := ""
+			odoV2Watch := utils.OdoV2Watch{
+				CmpName:            cmpName,
+				StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
+			}
+			// odo watch and validate
+			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+		})
+	})
 
-	// Context("when executing odo watch after odo push with flag commands", func() {
-	// 	It("should listen for file changes", func() {
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	Context("when executing odo watch after odo push with flag commands", func() {
+		It("should listen for file changes", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-	// 		output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
-	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-	// 		watchFlag := "--build-command build --run-command run"
-	// 		odoV2Watch := utils.OdoV2Watch{
-	// 			CmpName:            cmpName,
-	// 			StringsToBeMatched: []string{"Executing build command", "Executing run command"},
-	// 		}
-	// 		// odo watch and validate
-	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-	// 	})
-	// })
-
-	// Context("when executing odo watch", func() {
-	// 	It("should show validation errors if the devfile is incorrect", func() {
-	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
-
-	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
-
-	// 		output := helper.CmdShouldPass("odo", "push", "--project", namespace)
-	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-	// 		session := helper.CmdRunner("odo", "watch", "--context", context)
-	// 		defer session.Kill()
-
-	// 		waitForOutputToContain("Waiting for something to change", session)
-
-	// 		helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
-
-	// 		waitForOutputToContain(watch.PushErrorString, session)
-
-	// 		session.Kill()
-
-	// 		Eventually(session).Should(gexec.Exit())
-
-	// 	})
-	// })
+			watchFlag := "--build-command build --run-command run"
+			odoV2Watch := utils.OdoV2Watch{
+				CmpName:            cmpName,
+				StringsToBeMatched: []string{"Executing build command", "Executing run command"},
+			}
+			// odo watch and validate
+			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+		})
+	})
 
 	Context("when executing odo watch", func() {
-		It("should use index information from push", func() {
+		It("should show validation errors if the devfile is incorrect", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			session := helper.CmdRunner("odo", "watch", "--context", context)
+			defer session.Kill()
+
+			waitForOutputToContain("Waiting for something to change", session)
+
+			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
+
+			waitForOutputToContain(watch.PushErrorString, session)
+
+			session.Kill()
+
+			Eventually(session).Should(gexec.Exit())
+
+		})
+	})
+
+	Context("when executing odo watch", func() {
+		It("should use the index information from previous push operation", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
@@ -155,7 +159,6 @@ var _ = Describe("odo devfile watch command tests", func() {
 
 			// 4) Change some other file B
 			helper.ReplaceString(filepath.Join(context, "server.js"), "App started", "App is super started")
-			// helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
 			waitForOutputToContain("server.js", session)
 
 			session.Kill()
@@ -163,10 +166,8 @@ var _ = Describe("odo devfile watch command tests", func() {
 
 			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
 
-			// fmt.Println("list dir:", cliRunner.ExecListDir(podName, namespace, "/projects"))
-
+			// File should exist, and its content should match what we initially set it to
 			execResult := cliRunner.Exec(podName, namespace, "cat", "/projects/nodejs-starter/my-file.txt")
-
 			Expect(execResult).To(ContainSubstring("my name is my-file.txt"))
 
 		})
@@ -226,6 +227,61 @@ var _ = Describe("odo devfile watch command tests", func() {
 			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
 		})
 	})
+
+	Context("when executing odo watch", func() {
+		It("ensure that index information is updated by watch", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			// 1) Push a generic project
+			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			indexAfterPush, err := util.ReadFileIndex(filepath.Join(context, ".odo", "odo-file-index.json"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// 2) Odo watch that project
+			session := helper.CmdRunner("odo", "watch", "--context", context)
+			defer session.Kill()
+
+			waitForOutputToContain("Waiting for something to change", session)
+
+			// 3) Change server.js
+			helper.ReplaceString(filepath.Join(context, "server.js"), "App started", "App is super started")
+			waitForOutputToContain("server.js", session)
+
+			// 4) Wait for the size values in the old and new index files to differ, indicating that watch has updated the index
+			Eventually(func() bool {
+
+				newIndexAfterPush, err := util.ReadFileIndex(filepath.Join(context, ".odo", "odo-file-index.json"))
+				if err != nil {
+					fmt.Fprintln(GinkgoWriter, "New index not found or could not be read", err)
+					return false
+				}
+
+				beforePushValue, exists := indexAfterPush.Files["server.js"]
+				if !exists {
+					fmt.Fprintln(GinkgoWriter, "server.js not found in old index file")
+					return false
+				}
+
+				afterPushValue, exists := newIndexAfterPush.Files["server.js"]
+				if !exists {
+					fmt.Fprintln(GinkgoWriter, "server.js not found in new index file")
+					return false
+				}
+
+				fmt.Fprintln(GinkgoWriter, "comparing old and new file sizes", beforePushValue.Size, afterPushValue.Size)
+
+				return beforePushValue.Size != afterPushValue.Size
+
+			}, 180, 10).Should(Equal(true))
+
+		})
+	})
+
 })
 
 // Wait for the session stdout output to container a particular string

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -284,7 +284,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 
 })
 
-// Wait for the session stdout output to container a particular string
+// Wait for the session stdout output to contain a particular string
 func waitForOutputToContain(substring string, session *gexec.Session) {
 
 	Eventually(func() string {

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -9,9 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
-	"github.com/openshift/odo/pkg/watch"
 	"github.com/openshift/odo/tests/helper"
-	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile watch command tests", func() {
@@ -49,84 +48,126 @@ var _ = Describe("odo devfile watch command tests", func() {
 		os.Unsetenv("GLOBALODOCONFIG")
 	})
 
-	Context("when running help for watch command", func() {
-		It("should display the help", func() {
-			appHelp := helper.CmdShouldPass("odo", "watch", "-h")
-			helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
-		})
-	})
+	// Context("when running help for watch command", func() {
+	// 	It("should display the help", func() {
+	// 		appHelp := helper.CmdShouldPass("odo", "watch", "-h")
+	// 		helper.MatchAllInOutput(appHelp, []string{"Watch for changes", "git components"})
+	// 	})
+	// })
 
-	Context("when executing watch without pushing a devfile component", func() {
-		It("should fail", func() {
-			helper.Chdir(currentWorkingDirectory)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
-			output := helper.CmdShouldFail("odo", "watch", "--context", context)
-			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
-		})
-	})
+	// Context("when executing watch without pushing a devfile component", func() {
+	// 	It("should fail", func() {
+	// 		helper.Chdir(currentWorkingDirectory)
+	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--context", context, cmpName)
+	// 		output := helper.CmdShouldFail("odo", "watch", "--context", context)
+	// 		Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
+	// 	})
+	// })
 
-	Context("when executing odo watch after odo push", func() {
-		It("should listen for file changes", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	// Context("when executing odo watch after odo push", func() {
+	// 	It("should listen for file changes", func() {
+	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+	// 		output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-			watchFlag := ""
-			odoV2Watch := utils.OdoV2Watch{
-				CmpName:            cmpName,
-				StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
-			}
-			// odo watch and validate
-			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-		})
-	})
+	// 		watchFlag := ""
+	// 		odoV2Watch := utils.OdoV2Watch{
+	// 			CmpName:            cmpName,
+	// 			StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
+	// 		}
+	// 		// odo watch and validate
+	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+	// 	})
+	// })
 
-	Context("when executing odo watch after odo push with flag commands", func() {
-		It("should listen for file changes", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+	// Context("when executing odo watch after odo push with flag commands", func() {
+	// 	It("should listen for file changes", func() {
+	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+	// 		output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
+	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-			watchFlag := "--build-command build --run-command run"
-			odoV2Watch := utils.OdoV2Watch{
-				CmpName:            cmpName,
-				StringsToBeMatched: []string{"Executing build command", "Executing run command"},
-			}
-			// odo watch and validate
-			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
-		})
-	})
+	// 		watchFlag := "--build-command build --run-command run"
+	// 		odoV2Watch := utils.OdoV2Watch{
+	// 			CmpName:            cmpName,
+	// 			StringsToBeMatched: []string{"Executing build command", "Executing run command"},
+	// 		}
+	// 		// odo watch and validate
+	// 		utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, namespace, context, watchFlag, cliRunner, "kube")
+	// 	})
+	// })
+
+	// Context("when executing odo watch", func() {
+	// 	It("should show validation errors if the devfile is incorrect", func() {
+	// 		helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+	// 		helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+	// 		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+	// 		output := helper.CmdShouldPass("odo", "push", "--project", namespace)
+	// 		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+	// 		session := helper.CmdRunner("odo", "watch", "--context", context)
+	// 		defer session.Kill()
+
+	// 		waitForOutputToContain("Waiting for something to change", session)
+
+	// 		helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
+
+	// 		waitForOutputToContain(watch.PushErrorString, session)
+
+	// 		session.Kill()
+
+	// 		Eventually(session).Should(gexec.Exit())
+
+	// 	})
+	// })
 
 	Context("when executing odo watch", func() {
-		It("should show validation errors if the devfile is incorrect", func() {
+		It("should use index information from push", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
+			// 1) Push a generic project
 			output := helper.CmdShouldPass("odo", "push", "--project", namespace)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
+			// 2) Change some file A
+			textFilePath := filepath.Join(context, "my-file.txt")
+			textOne := []byte("my name is my-file.txt")
+			err := ioutil.WriteFile(textFilePath, textOne, 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// 3) Odo watch that project
 			session := helper.CmdRunner("odo", "watch", "--context", context)
 			defer session.Kill()
 
 			waitForOutputToContain("Waiting for something to change", session)
 
-			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
-
-			waitForOutputToContain(watch.PushErrorString, session)
+			// 4) Change some other file B
+			helper.ReplaceString(filepath.Join(context, "server.js"), "App started", "App is super started")
+			// helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "kind: build", "kind: run")
+			waitForOutputToContain("server.js", session)
 
 			session.Kill()
-
 			Eventually(session).Should(gexec.Exit())
+
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+
+			// fmt.Println("list dir:", cliRunner.ExecListDir(podName, namespace, "/projects"))
+
+			execResult := cliRunner.Exec(podName, namespace, "cat", "/projects/nodejs-starter/my-file.txt")
+
+			Expect(execResult).To(ContainSubstring("my name is my-file.txt"))
 
 		})
 

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -392,7 +392,7 @@ func OdoWatch(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, project, context, fl
 
 				for _, stringToBeMatched := range odoV2Watch.StringsToBeMatched {
 					if !strings.Contains(output, stringToBeMatched) {
-						fmt.Fprintln(GinkgoWriter, "Missing string: "+stringToBeMatched)
+						fmt.Fprintln(GinkgoWriter, "Missing string: ", stringToBeMatched)
 						stringsMatched = false
 					}
 				}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
- Fix the `odo watch` logic such that if you edit a devfile after watch has started, the changes to the devfile will now be picked up.
- Fix the `odo watch` logic such that it now updates the `.odo/odo-file-index.json` file, allowing it to play well with `odo push` if push is called immediately after watch
- Fix the `odo watch` logic to regenerate and use the file index to detect changes when `odo watch` is first invoked (in a particular session), with all subsequent updates during the session using the watched file list for changes
- Adds integration tests that test the behaviours that were failing in the linked issues
- Adds directory delete retry, with exponential backoff, to the `DeleteDir` test utility function, to fix Windows-issues seen by myself and others

**Which issue(s) this PR fixes**:
Fixes #3435
Fixes #3585

Windows test fixes:
Fixes #3371
Fixes #3540

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

To test #3435:
- Create and push a generic odo project
- Run `odo watch`
- Make a change that invalidates the devfile (for example, replace all instances of `"kind: build"` with `"kind: run"` in the file)
- `odo watch` will now report the same error as `odo push` would, against that devfile

To test #3585:
- Create and `odo push` a generic project
- Change some source file A
- `odo watch` that project
- Change some other source file B
- The k8s pod should include the both changes (source file A and B), and the index file (`.odo/odo-file-index.json`) should include both files
(See #3585 for another scenario you can test, if desired)
