### PR TITLE
Improve `odo url create`

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -2,7 +2,9 @@ package url
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/odo/util/validation"
 	"strconv"
+	"strings"
 
 	"github.com/openshift/odo/pkg/config"
 	adapterutils "github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
@@ -83,6 +85,9 @@ type URLCreateOptions struct {
 	isRouteSupported bool
 	wantIngress      bool
 	urlType          envinfo.URLKind
+	isDevFile        bool
+	isDocker         bool
+	isExperimental   bool
 }
 
 // NewURLCreateOptions creates a new URLCreateOptions instance
@@ -91,10 +96,11 @@ func NewURLCreateOptions() *URLCreateOptions {
 }
 
 // Complete completes URLCreateOptions after they've been Created
-func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string) (err error) {
 	o.DevfilePath = clicomponent.DevfilePath
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	o.isDevFile = o.isExperimental && util.CheckPathExists(o.DevfilePath)
+	if o.isDevFile {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.now {
 		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
@@ -102,8 +108,8 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 		o.Context = genericclioptions.NewContext(cmd)
 	}
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
-		if !pushtarget.IsPushTargetDocker() {
+	if o.isDevFile {
+		if !o.isDocker {
 			o.Client = genericclioptions.Client(cmd)
 
 			o.isRouteSupported, err = o.Client.IsRouteSupported()
@@ -161,7 +167,7 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 			return err
 		}
 
-		if pushtarget.IsPushTargetDocker() {
+		if o.isDocker {
 			o.exposedPort, err = url.GetValidExposedPortNumber(o.exposedPort)
 			if err != nil {
 				return err
@@ -204,52 +210,62 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 
 // Validate validates the URLCreateOptions based on completed values
 func (o *URLCreateOptions) Validate() (err error) {
-	// Check if exist
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	if !util.CheckOutputFlag(o.OutputFlag) {
+		return fmt.Errorf("given output format %s is not supported", o.OutputFlag)
+	}
+
+	// if experimental mode is enabled, and devfile is provided.
+	errorList := make([]string, 0)
+	if o.isDevFile {
 		// check if a host is provided for route based URLs
-		if o.isRouteSupported && !o.wantIngress && len(o.host) > 0 {
-			return fmt.Errorf("host is not supported for URLs of Route Kind")
-		}
-		// if experimental mode is enabled, and devfile is provided.
-		// check if valid host is provided
-		if !pushtarget.IsPushTargetDocker() && len(o.host) <= 0 && (!o.isRouteSupported || o.wantIngress) {
-			return fmt.Errorf("host must be provided in order to create ingress")
+		if len(o.host) > 0 {
+			if o.urlType == envinfo.ROUTE {
+				errorList = append(errorList, "host is not supported for URLs of Route Kind")
+			}
+			if err := validation.ValidateHost(o.host); err != nil {
+				errorList = append(errorList, err.Error())
+			}
+		} else if o.urlType == envinfo.INGRESS {
+			errorList = append(errorList, "host must be provided in order to create URLS of Ingress Kind")
 		}
 		for _, localURL := range o.EnvSpecificInfo.GetURL() {
 			if o.urlName == localURL.Name {
-				return fmt.Errorf("the url %s already exists", o.urlName)
+				errorList = append(errorList, fmt.Sprintf("URL %s already exists", o.urlName))
 			}
 		}
 	} else {
 		for _, localURL := range o.LocalConfigInfo.GetURL() {
 			if o.urlName == localURL.Name {
-				return fmt.Errorf("the url %s already exists in the application: %s", o.urlName, o.Application)
+				errorList = append(errorList, fmt.Sprintf("URL %s already exists in application: %s", o.urlName, o.Application))
 			}
 		}
 	}
 	// Check if url name is more than 63 characters long
 	if len(o.urlName) > 63 {
-		return fmt.Errorf("url name must be shorter than 63 characters")
+		errorList = append(errorList, "URL name must be shorter than 63 characters")
 	}
 
-	if !util.CheckOutputFlag(o.OutputFlag) {
-		return fmt.Errorf("given output format %s is not supported", o.OutputFlag)
-	}
-	if !experimental.IsExperimentalModeEnabled() {
+	if !o.isExperimental {
 		if o.now {
-			err = o.ValidateComponentCreate()
-			if err != nil {
-				return err
+			if err = o.ValidateComponentCreate(); err != nil {
+				errorList = append(errorList, err.Error())
 			}
 		}
+	}
+
+	if len(errorList) > 0 {
+		for i := range errorList {
+			errorList[i] = fmt.Sprintf("\t- %s", errorList[i])
+		}
+		return fmt.Errorf("There are validation issues:\n%s", strings.Join(errorList, "\n"))
 	}
 	return
 }
 
 // Run contains the logic for the odo url create command
 func (o *URLCreateOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
-		if pushtarget.IsPushTargetDocker() {
+	if o.isDevFile {
+		if o.isDocker {
 			for _, localURL := range o.EnvSpecificInfo.GetURL() {
 				fmt.Printf("componentPort is %v, localUrl.port is %v", o.componentPort, localURL.Port)
 				if o.componentPort == localURL.Port && localURL.ExposedPort > 0 {
@@ -275,9 +291,9 @@ func (o *URLCreateOptions) Run() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "failed to persist the component settings to config file")
 	}
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	if o.isDevFile {
 		componentName := o.EnvSpecificInfo.GetName()
-		if pushtarget.IsPushTargetDocker() {
+		if o.isDocker {
 			log.Successf("URL %s created for component: %v with exposed port: %v", o.urlName, componentName, o.exposedPort)
 		} else {
 			log.Successf("URL %s created for component: %v", o.urlName, componentName)
@@ -286,7 +302,7 @@ func (o *URLCreateOptions) Run() (err error) {
 		log.Successf("URL %s created for component: %v", o.urlName, o.Component())
 	}
 	if o.now {
-		if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+		if o.isDevFile {
 			err = o.DevfilePush()
 		} else {
 			err = o.Push()
@@ -314,22 +330,24 @@ func NewCmdURLCreate(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	urlCreateCmd.Flags().IntVarP(&o.urlPort, "port", "", -1, "port number for the url of the component, required in case of components which expose more than one service port")
+	urlCreateCmd.Flags().IntVarP(&o.urlPort, "port", "", -1, "Port number for the url of the component, required in case of components which expose more than one service port")
 	// if experimental mode is enabled, add more flags to support ingress creation or docker application based on devfile
-	if experimental.IsExperimentalModeEnabled() {
-		if pushtarget.IsPushTargetDocker() {
-			urlCreateCmd.Flags().IntVarP(&o.exposedPort, "exposed-port", "", -1, "an external port to the application container")
+	o.isExperimental = experimental.IsExperimentalModeEnabled()
+	if o.isExperimental {
+		o.isDocker = pushtarget.IsPushTargetDocker()
+		if o.isDocker {
+			urlCreateCmd.Flags().IntVarP(&o.exposedPort, "exposed-port", "", -1, "External port to the application container")
 			urlCreateCmd.Flags().BoolVarP(&o.forceFlag, "force", "f", false, "Don't ask for confirmation, assign an exposed port directly")
 			urlCreateCmd.Example = fmt.Sprintf(urlCreateExampleDocker, fullName)
 		} else {
-			urlCreateCmd.Flags().StringVar(&o.tlsSecret, "tls-secret", "", "tls secret name for the url of the component if the user bring his own tls secret")
-			urlCreateCmd.Flags().StringVarP(&o.host, "host", "", "", "Cluster ip for this URL")
-			urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "creates a secure https url")
-			urlCreateCmd.Flags().BoolVar(&o.wantIngress, "ingress", false, "Creates an ingress instead of Route on OpenShift clusters")
+			urlCreateCmd.Flags().StringVar(&o.tlsSecret, "tls-secret", "", "TLS secret name for the url of the component if the user bring their own TLS secret")
+			urlCreateCmd.Flags().StringVarP(&o.host, "host", "", "", "Cluster IP for this URL")
+			urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "Create a secure HTTPS URL")
+			urlCreateCmd.Flags().BoolVar(&o.wantIngress, "ingress", false, "Create an Ingress instead of Route on OpenShift clusters")
 			urlCreateCmd.Example = fmt.Sprintf(urlCreateExampleExperimental, fullName)
 		}
 	} else {
-		urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "creates a secure https url")
+		urlCreateCmd.Flags().BoolVarP(&o.secureURL, "secure", "", false, "Create a secure HTTPS URL")
 		urlCreateCmd.Example = fmt.Sprintf(urlCreateExample, fullName)
 	}
 	genericclioptions.AddNowFlag(urlCreateCmd, &o.now)

--- a/pkg/odo/util/validation/validation.go
+++ b/pkg/odo/util/validation/validation.go
@@ -18,5 +18,14 @@ func ValidateName(name string) error {
 	}
 
 	return nil
+}
 
+// ValidateHost validates that the provided host is a valid subdomain according to DNS (RFC 1123) rules
+func ValidateHost(host string) error {
+	errorList := validation.IsDNS1123Subdomain(host)
+	if len(errorList) != 0 {
+		return fmt.Errorf("%s is not a valid host name:  %s", host, strings.Join(errorList, " "))
+	}
+
+	return nil
 }

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -195,6 +195,23 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.DontMatchAllInOutput(stdOut, []string{"successfully deleted", "created"})
 			Expect(stdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 		})
+
+		It("should not allow creating an invalid host", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--ingress")
+			Expect(stdOut).To(ContainSubstring("is not a valid host name"))
+		})
+		It("should not allow using tls secret if url is not secure", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--tls-secret", "foo", "--ingress")
+			Expect(stdOut).To(ContainSubstring("TLS secret is only available for secure URLs of Ingress kind"))
+		})
+		It("should report multiple issues when it's the case", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--tls-secret", "foo", "--ingress")
+			Expect(stdOut).To(And(ContainSubstring("is not a valid host name"), ContainSubstring("TLS secret is only available for secure URLs of Ingress kind")))
+		})
+
 	})
 
 	Context("Describing urls", func() {

--- a/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_url_test.go
@@ -82,7 +82,7 @@ var _ = Describe("odo docker devfile url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", url1)
 
 			stdout = helper.CmdShouldFail("odo", "url", "create", url1)
-			Expect(stdout).To(ContainSubstring("the url " + url1 + " already exists"))
+			Expect(stdout).To(ContainSubstring("URL " + url1 + " already exists"))
 
 		})
 

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -314,21 +314,24 @@ var _ = Describe("odo generic", func() {
 			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
 			Expect(stdOut).To(ContainSubstring("must be shorter than 63 characters"))
 		})
-		It("should not allow creating an invalid host", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--ingress")
-			Expect(stdOut).To(ContainSubstring("is not a valid host name"))
-		})
-		It("should not allow using tls secret if url is not secure", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-			stdOut := helper.CmdShouldFail("odo", "url", "create", "--tls-secret", "foo", "--ingress")
-			Expect(stdOut).To(ContainSubstring("TLS secret is only available for secure URLs of Ingress kind"))
-		})
-		It("should report multiple issues when it's the case", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--tls-secret", "foo", "--ingress")
-			Expect(stdOut).To(And(ContainSubstring("is not a valid host name"), ContainSubstring("TLS secret is only available for secure URLs of Ingress kind")))
-		})
+		/*
+			// these tests only work when experimental mode is activated
+			It("should not allow creating an invalid host", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+				stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--ingress")
+				Expect(stdOut).To(ContainSubstring("is not a valid host name"))
+			})
+			It("should not allow using tls secret if url is not secure", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+				stdOut := helper.CmdShouldFail("odo", "url", "create", "--tls-secret", "foo", "--ingress")
+				Expect(stdOut).To(ContainSubstring("TLS secret is only available for secure URLs of Ingress kind"))
+			})
+				It("should report multiple issues when it's the case", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+					stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--tls-secret", "foo", "--ingress")
+					Expect(stdOut).To(And(ContainSubstring("is not a valid host name"), ContainSubstring("TLS secret is only available for secure URLs of Ingress kind")))
+				})
+		*/
 	})
 
 	Context("when component's deployment config is deleted with oc", func() {

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -292,7 +292,7 @@ var _ = Describe("odo generic", func() {
 		})
 	})
 
-	Context("prevent the user from creating a URL with name that has more than 63 characters", func() {
+	Context("prevent the user from creating invalid URLs", func() {
 		var originalDir string
 
 		JustBeforeEach(func() {
@@ -312,7 +312,22 @@ var _ = Describe("odo generic", func() {
 		It("should not allow creating a URL with long name", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
 			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
-			Expect(stdOut).To(ContainSubstring("url name must be shorter than 63 characters"))
+			Expect(stdOut).To(ContainSubstring("must be shorter than 63 characters"))
+		})
+		It("should not allow creating an invalid host", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--ingress")
+			Expect(stdOut).To(ContainSubstring("is not a valid host name"))
+		})
+		It("should not allow using tls secret if url is not secure", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--tls-secret", "foo", "--ingress")
+			Expect(stdOut).To(ContainSubstring("TLS secret is only available for secure URLs of Ingress kind"))
+		})
+		It("should report multiple issues when it's the case", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--tls-secret", "foo", "--ingress")
+			Expect(stdOut).To(And(ContainSubstring("is not a valid host name"), ContainSubstring("TLS secret is only available for secure URLs of Ingress kind")))
 		})
 	})
 

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -314,24 +314,6 @@ var _ = Describe("odo generic", func() {
 			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
 			Expect(stdOut).To(ContainSubstring("must be shorter than 63 characters"))
 		})
-		/*
-			// these tests only work when experimental mode is activated
-			It("should not allow creating an invalid host", func() {
-				helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-				stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--ingress")
-				Expect(stdOut).To(ContainSubstring("is not a valid host name"))
-			})
-			It("should not allow using tls secret if url is not secure", func() {
-				helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-				stdOut := helper.CmdShouldFail("odo", "url", "create", "--tls-secret", "foo", "--ingress")
-				Expect(stdOut).To(ContainSubstring("TLS secret is only available for secure URLs of Ingress kind"))
-			})
-				It("should report multiple issues when it's the case", func() {
-					helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
-					stdOut := helper.CmdShouldFail("odo", "url", "create", "--host", "https://127.0.0.1:60104", "--tls-secret", "foo", "--ingress")
-					Expect(stdOut).To(And(ContainSubstring("is not a valid host name"), ContainSubstring("TLS secret is only available for secure URLs of Ingress kind")))
-				})
-		*/
 	})
 
 	Context("when component's deployment config is deleted with oc", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:

This PR improved `odo url create` flow by:
- avoiding to check experimental / docker / devfile mode all the time
- aggregate all validation errors so that they are reported at once instead of forcing the user to re-try the command several times in order to get things right
- add host name validation to avoid creating an invalid URL which would fail during `push`

**Which issue(s) this PR fixes**:

Fixes #3589 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

Before this PR: 
`odo url create --host https://127.0.0.1:60104 --ingress` would work without issue

After this PR:
`odo url create --host https://127.0.0.1:60104 --ingress` would fail with an error notifying the user that the host is invalid