### PR TITLE
Adds runMode to env for debugging with odo watch.

### DIFF
--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -31,8 +31,8 @@ type ComponentSettings struct {
 type RUNMode string
 
 const (
-	RunMODE   RUNMode = "run"
-	DebugMODE RUNMode = "debug"
+	Run   RUNMode = "run"
+	Debug RUNMode = "debug"
 )
 
 // URLKind is an enum to indicate the type of the URL i.e ingress/route
@@ -49,7 +49,7 @@ const (
 	DefaultDebugPort = 5858
 
 	// DefaultRunMode is the default run mode of the component
-	DefaultRunMode = "run"
+	DefaultRunMode = Run
 )
 
 // EnvInfoURL holds URL related information

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -23,7 +23,17 @@ type ComponentSettings struct {
 
 	// DebugPort controls the port used by the pod to run the debugging agent on
 	DebugPort *int `yaml:"DebugPort,omitempty"`
+
+	// RunMode indicates the mode of run used for a successful push
+	RunMode *RUNMode `yaml:"RunMode,omitempty"`
 }
+
+type RUNMode string
+
+const (
+	RunMODE   RUNMode = "run"
+	DebugMODE RUNMode = "debug"
+)
 
 // URLKind is an enum to indicate the type of the URL i.e ingress/route
 type URLKind string
@@ -37,6 +47,9 @@ const (
 
 	// DefaultDebugPort is the default port used for debugging on remote pod
 	DefaultDebugPort = 5858
+
+	// DefaultRunMode is the default run mode of the component
+	DefaultRunMode = "run"
 )
 
 // EnvInfoURL holds URL related information
@@ -304,6 +317,20 @@ func (ei *EnvInfo) GetDebugPort() int {
 		return DefaultDebugPort
 	}
 	return *ei.componentSettings.DebugPort
+}
+
+// GetRunMode returns the RunMode, returns default if nil
+func (ei *EnvInfo) GetRunMode() RUNMode {
+	if ei.componentSettings.RunMode == nil {
+		return DefaultRunMode
+	}
+	return *ei.componentSettings.RunMode
+}
+
+// SetRunMode sets the RunMode in the env file
+func (esi *EnvSpecificInfo) SetRunMode(runMode RUNMode) error {
+	esi.componentSettings.RunMode = &runMode
+	return esi.writeToFile()
 }
 
 // GetNamespace returns component namespace

--- a/pkg/envinfo/fake.go
+++ b/pkg/envinfo/fake.go
@@ -1,0 +1,7 @@
+package envinfo
+
+func GetFakeEnvInfo(settings ComponentSettings) *EnvInfo {
+	return &EnvInfo{
+		componentSettings: settings,
+	}
+}

--- a/pkg/envinfo/fake.go
+++ b/pkg/envinfo/fake.go
@@ -1,5 +1,6 @@
 package envinfo
 
+// GetFakeEnvInfo gets a fake envInfo using the given componentSettings
 func GetFakeEnvInfo(settings ComponentSettings) *EnvInfo {
 	return &EnvInfo{
 		componentSettings: settings,

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -49,7 +49,17 @@ func (po *PushOptions) DevfilePush() error {
 		os.Exit(1)
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	// push is successful, save the runMode used
+	runMode := envinfo.Run
+	if po.debugRun {
+		runMode = envinfo.Debug
+	}
+
+	return po.EnvSpecificInfo.SetRunMode(runMode)
 }
 
 func (po *PushOptions) devfilePushInner() (err error) {

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -210,7 +210,18 @@ func (po *PushOptions) Run() (err error) {
 	// If experimental mode is enabled, use devfile push
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
-		return po.DevfilePush()
+		err := po.DevfilePush()
+		if err != nil {
+			return err
+		}
+
+		// push is successful, save the runMode used
+		runMode := envinfo.RunMODE
+		if po.debugRun {
+			runMode = envinfo.DebugMODE
+		}
+
+		return po.EnvSpecificInfo.SetRunMode(runMode)
 	} else {
 		// Legacy odo push
 		return po.Push()

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -210,18 +210,7 @@ func (po *PushOptions) Run() (err error) {
 	// If experimental mode is enabled, use devfile push
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
-		err := po.DevfilePush()
-		if err != nil {
-			return err
-		}
-
-		// push is successful, save the runMode used
-		runMode := envinfo.Run
-		if po.debugRun {
-			runMode = envinfo.Debug
-		}
-
-		return po.EnvSpecificInfo.SetRunMode(runMode)
+		return po.DevfilePush()
 	} else {
 		// Legacy odo push
 		return po.Push()

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -216,9 +216,9 @@ func (po *PushOptions) Run() (err error) {
 		}
 
 		// push is successful, save the runMode used
-		runMode := envinfo.RunMODE
+		runMode := envinfo.Run
 		if po.debugRun {
-			runMode = envinfo.DebugMODE
+			runMode = envinfo.Debug
 		}
 
 		return po.EnvSpecificInfo.SetRunMode(runMode)

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -291,6 +291,9 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 			return watchError
 		}
 		if showWaitingMessage {
+			if parameters.EnvSpecificInfo != nil && parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE {
+				fmt.Fprintf(out, "Component is running in debug mode\nPlease start port-forwarding in a different terminal\n")
+			}
 			fmt.Fprintf(out, "Waiting for something to change in %s\n", parameters.Path)
 			showWaitingMessage = false
 		}
@@ -322,6 +325,8 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							DevfileBuildCmd:   parameters.DevfileBuildCmd,
 							DevfileRunCmd:     parameters.DevfileRunCmd,
 							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
+							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE,
+							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 
 						err = parameters.DevfileWatchHandler(pushParams)
@@ -343,6 +348,8 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							DevfileBuildCmd:   parameters.DevfileBuildCmd,
 							DevfileRunCmd:     parameters.DevfileRunCmd,
 							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
+							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE,
+							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 
 						err = parameters.DevfileWatchHandler(pushParams)

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -291,7 +291,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 			return watchError
 		}
 		if showWaitingMessage {
-			if parameters.EnvSpecificInfo != nil && parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE {
+			if parameters.EnvSpecificInfo != nil && parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug {
 				fmt.Fprintf(out, "Component is running in debug mode\nPlease start port-forwarding in a different terminal\n")
 			}
 			fmt.Fprintf(out, "Waiting for something to change in %s\n", parameters.Path)
@@ -325,7 +325,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							DevfileBuildCmd:   parameters.DevfileBuildCmd,
 							DevfileRunCmd:     parameters.DevfileRunCmd,
 							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
-							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE,
+							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
 							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 
@@ -348,7 +348,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							DevfileBuildCmd:   parameters.DevfileBuildCmd,
 							DevfileRunCmd:     parameters.DevfileRunCmd,
 							EnvSpecificInfo:   *parameters.EnvSpecificInfo,
-							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.DebugMODE,
+							Debug:             parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
 							DebugPort:         parameters.EnvSpecificInfo.GetDebugPort(),
 						}
 

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -821,9 +821,9 @@ func TestWatchAndPush(t *testing.T) {
 
 				if tt.isExperimental {
 					watchParameters.DevfileWatchHandler = mockDevFilePush
-					runMode := envinfo.RunMODE
+					runMode := envinfo.Run
 					if tt.isDebug {
-						runMode = envinfo.DebugMODE
+						runMode = envinfo.Debug
 					}
 					watchParameters.EnvSpecificInfo = &envinfo.EnvSpecificInfo{
 						EnvInfo: *envinfo.GetFakeEnvInfo(envinfo.ComponentSettings{

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -101,6 +101,8 @@ type mockPushParameters struct {
 	isForcePush     bool
 	globExps        []string
 	show            bool
+	isDebug         bool
+	debugPort       int
 }
 
 var mockPush mockPushParameters
@@ -109,9 +111,11 @@ var mockPush mockPushParameters
 func mockDevFilePush(parameters common.PushParameters) error {
 	muLock.Lock()
 	defer muLock.Unlock()
-	if parameters.Show != mockPush.show {
+	if parameters.Show != mockPush.show || parameters.Debug != mockPush.isDebug || parameters.DebugPort != mockPush.debugPort {
 		fmt.Printf("some of the push parameters are different, wanted: %v, got: %v", mockPush, []string{
 			"show:" + strconv.FormatBool(parameters.Show),
+			"debug:" + strconv.FormatBool(parameters.Debug),
+			"debugPort:" + strconv.Itoa(parameters.DebugPort),
 		})
 		os.Exit(1)
 	}
@@ -198,6 +202,8 @@ func TestWatchAndPush(t *testing.T) {
 		requiredFilePaths []testingutil.FileProperties
 		setupEnv          func(componentName string, requiredFilePaths []testingutil.FileProperties) (string, map[string]testingutil.FileProperties, error)
 		isExperimental    bool
+		isDebug           bool
+		debugPort         int
 	}{
 		{
 			name:            "Case 1: Valid watch with list of files to be ignored with a append event",
@@ -303,6 +309,8 @@ func TestWatchAndPush(t *testing.T) {
 			want:        []string{"src/read_licenses.py", "__init__.py"},
 			wantDeleted: []string{},
 			setupEnv:    setUpF8AnalyticsComponentSrc,
+			debugPort:   5858,
+			isDebug:     true,
 		},
 		{
 			name:            "Case 2: Valid watch with list of files to be ignored with a append and a delete event",
@@ -732,6 +740,8 @@ func TestWatchAndPush(t *testing.T) {
 					isForcePush:     tt.forcePush,
 					globExps:        tt.ignores,
 					show:            tt.show,
+					debugPort:       tt.debugPort,
+					isDebug:         tt.isDebug,
 				}
 
 				ExpectedChangedFiles = tt.want
@@ -811,7 +821,16 @@ func TestWatchAndPush(t *testing.T) {
 
 				if tt.isExperimental {
 					watchParameters.DevfileWatchHandler = mockDevFilePush
-					watchParameters.EnvSpecificInfo = &envinfo.EnvSpecificInfo{}
+					runMode := envinfo.RunMODE
+					if tt.isDebug {
+						runMode = envinfo.DebugMODE
+					}
+					watchParameters.EnvSpecificInfo = &envinfo.EnvSpecificInfo{
+						EnvInfo: *envinfo.GetFakeEnvInfo(envinfo.ComponentSettings{
+							DebugPort: &tt.debugPort,
+							RunMode:   &runMode,
+						}),
+					}
 				} else {
 					watchParameters.ApplicationName = tt.applicationName
 					watchParameters.WatchHandler = mockPushLocal

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -239,3 +239,12 @@ func FileIsEmpty(filename string) (bool, error) {
 
 	return true, nil
 }
+
+// ReadFile reads the file from the filePath
+func ReadFile(filePath string) (string, error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -96,6 +96,11 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CmdShouldPass("odo", "push")
 			helper.CmdShouldPass("odo", "push", "--debug")
 
+			// check the env for the runMode
+			envOutput, err := helper.ReadFile(filepath.Join(projectDirPath, ".odo/env/env.yaml"))
+			Expect(err).To(BeNil())
+			Expect(envOutput).To(ContainSubstring(" RunMode: debug"))
+
 			stopChannel := make(chan bool)
 			go func() {
 				helper.CmdShouldRunAndTerminate(60*time.Second, stopChannel, "odo", "debug", "port-forward")

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -166,6 +166,12 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
+
+			// check the env for the runMode
+			envOutput, err := helper.ReadFile(filepath.Join(context, ".odo/env/env.yaml"))
+			Expect(err).To(BeNil())
+			Expect(envOutput).To(ContainSubstring(" RunMode: run"))
+
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
 			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})


### PR DESCRIPTION
/kind bug

**What does does this PR do / why we need it**:

If runMode is debug, odo watch will trigger push with debug settings else it will trigger normal  push.

**Which issue(s) this PR fixes**:

Fixes #3480 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

- Execute `odo push --debug`
- Execute `odo watch` and check if it detects debug mode for pushing files.
- Revert to `odo push` and check if it uses normal mode for pushing files.