### PR TITLE
moved odo specific logic out of devfile/parser package

### DIFF
--- a/pkg/devfile/parse.go
+++ b/pkg/devfile/parse.go
@@ -1,0 +1,53 @@
+package devfile
+
+import (
+	"github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/devfile/validate"
+)
+
+// This is the top level parse code which has validation code specific to odo hence it cannot be kept inside the
+// devfile/parser package. That package is supposed to be independent of odo.
+
+// ParseInMemoryAndValidate func parses the devfile data in memory
+// and validates the devfile integrity with the schema
+// and validates the devfile data.
+// Creates devfile context and runtime objects.
+func ParseInMemoryAndValidate(data []byte) (d parser.DevfileObj, err error) {
+
+	// read and parse devfile from given data
+	d, err = parser.ParseInMemory(data)
+	if err != nil {
+		return d, err
+	}
+
+	// odo specific validation on devfile content
+	err = validate.ValidateDevfileData(d.Data)
+	if err != nil {
+		return d, err
+	}
+
+	// Successful
+	return d, nil
+}
+
+// ParseAndValidate func parses the devfile data
+// and validates the devfile integrity with the schema
+// and validates the devfile data.
+// Creates devfile context and runtime objects.
+func ParseAndValidate(path string) (d parser.DevfileObj, err error) {
+
+	// read and parse devfile from given path
+	d, err = parser.Parse(path)
+	if err != nil {
+		return d, err
+	}
+
+	// odo specific validation on devfile content
+	err = validate.ValidateDevfileData(d.Data)
+	if err != nil {
+		return d, err
+	}
+
+	// Successful
+	return d, nil
+}

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -5,7 +5,6 @@ import (
 
 	devfileCtx "github.com/openshift/odo/pkg/devfile/parser/context"
 	"github.com/openshift/odo/pkg/devfile/parser/data"
-	"github.com/openshift/odo/pkg/devfile/validate"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +36,7 @@ func parseDevfile(d DevfileObj) (DevfileObj, error) {
 
 // Parse func populates the devfile data, parses and validates the devfile integrity.
 // Creates devfile context and runtime objects
-func parse(path string) (d DevfileObj, err error) {
+func Parse(path string) (d DevfileObj, err error) {
 
 	// NewDevfileCtx
 	d.Ctx = devfileCtx.NewDevfileCtx(path)
@@ -50,31 +49,9 @@ func parse(path string) (d DevfileObj, err error) {
 	return parseDevfile(d)
 }
 
-// ParseAndValidate func parses the devfile data
-// and validates the devfile integrity with the schema
-// and validates the devfile data.
-// Creates devfile context and runtime objects.
-func ParseAndValidate(path string) (d DevfileObj, err error) {
-
-	// read and parse devfile from given path
-	d, err = parse(path)
-	if err != nil {
-		return d, err
-	}
-
-	// odo specific validation on devfile content
-	err = validate.ValidateDevfileData(d.Data)
-	if err != nil {
-		return d, err
-	}
-
-	// Successful
-	return d, nil
-}
-
-// parseInMemory func populates the data from memory, parses and validates the devfile integrity.
+// ParseInMemory func populates the data from memory, parses and validates the devfile integrity.
 // Creates devfile context and runtime objects
-func parseInMemory(bytes []byte) (d DevfileObj, err error) {
+func ParseInMemory(bytes []byte) (d DevfileObj, err error) {
 
 	// Fill the fields of DevfileCtx struct
 	err = d.Ctx.PopulateFromBytes(bytes)
@@ -82,26 +59,4 @@ func parseInMemory(bytes []byte) (d DevfileObj, err error) {
 		return d, err
 	}
 	return parseDevfile(d)
-}
-
-// ParseInMemoryAndValidate func parses the devfile data in memory
-// and validates the devfile integrity with the schema
-// and validates the devfile data.
-// Creates devfile context and runtime objects.
-func ParseInMemoryAndValidate(data []byte) (d DevfileObj, err error) {
-
-	// read and parse devfile from given data
-	d, err = parseInMemory(data)
-	if err != nil {
-		return d, err
-	}
-
-	// odo specific validation on devfile content
-	err = validate.ValidateDevfileData(d.Data)
-	if err != nil {
-		return d, err
-	}
-
-	// Successful
-	return d, nil
 }

--- a/pkg/devfile/parser/types.go
+++ b/pkg/devfile/parser/types.go
@@ -7,8 +7,8 @@ import (
 
 // Default filenames for create devfile
 const (
-	OutputDevfileJsonPath = "odo-devfile.json"
-	OutputDevfileYamlPath = "odo-devfile.yaml"
+	OutputDevfileJsonPath = "devfile.json"
+	OutputDevfileYamlPath = "devfile.yaml"
 )
 
 // DevfileObj is the runtime devfile object

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -12,8 +12,8 @@ var (
 	ErrorNoContainerComponent = fmt.Sprintf("odo requires atleast one component of type '%s' in devfile", common.ContainerComponentType)
 )
 
-// ValidateComponents validates all the devfile components
-func ValidateComponents(components []common.DevfileComponent) error {
+// validateComponents validates all the devfile components
+func validateComponents(components []common.DevfileComponent) error {
 
 	// components cannot be empty
 	if len(components) < 1 {

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 )
 
-func TestValidateComponents(t *testing.T) {
+func TestvalidateComponents(t *testing.T) {
 
 	t.Run("No components present", func(t *testing.T) {
 
 		// Empty components
 		components := []common.DevfileComponent{}
 
-		got := ValidateComponents(components)
+		got := validateComponents(components)
 		want := fmt.Errorf(ErrorNoComponents)
 
 		if !reflect.DeepEqual(got, want) {
@@ -33,7 +33,7 @@ func TestValidateComponents(t *testing.T) {
 			},
 		}
 
-		got := ValidateComponents(components)
+		got := validateComponents(components)
 
 		if got != nil {
 			t.Errorf("Not expecting an error: '%v'", got)

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 )
 
-func TestvalidateComponents(t *testing.T) {
+func TestValidateComponents(t *testing.T) {
 
 	t.Run("No components present", func(t *testing.T) {
 

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"k8s.io/klog"
 
@@ -23,7 +24,7 @@ func ValidateDevfileData(data interface{}) error {
 	}
 
 	// Validate Components
-	if err := ValidateComponents(components); err != nil {
+	if err := validateComponents(components); err != nil {
 		return err
 	}
 

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/openshift/odo/pkg/catalog"
+	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/log"
@@ -186,7 +187,7 @@ func GetDevfile(devfileComponent catalog.DevfileComponentType) (parser.DevfileOb
 	if err != nil {
 		return devObj, errors.Wrapf(err, "Failed to download devfile.yaml for devfile component: %s", devfileComponent.Name)
 	}
-	devObj, err = parser.ParseInMemoryAndValidate(data)
+	devObj, err = devfile.ParseInMemoryAndValidate(data)
 	if err != nil {
 		return devObj, err
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/config"
-	"github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
@@ -844,7 +844,7 @@ func (co *CreateOptions) Validate() (err error) {
 func (co *CreateOptions) downloadProject(projectPassed string) error {
 	var project common.DevfileProject
 	// Parse devfile and validate
-	devObj, err := parser.ParseAndValidate(DevfilePath)
+	devObj, err := devfile.ParseAndValidate(DevfilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -55,7 +55,7 @@ func (po *PushOptions) DevfilePush() error {
 func (po *PushOptions) devfilePushInner() (err error) {
 
 	// Parse devfile and validate
-	devObj, err := parser.ParseAndValidate(po.DevfilePath)
+	devObj, err := devfile.ParseAndValidate(po.DevfilePath)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 // DevfileComponentLog fetch and display log from devfile components
 func (lo LogOptions) DevfileComponentLog() error {
 	// Parse devfile
-	devObj, err := parser.ParseAndValidate(lo.devfilePath)
+	devObj, err := devfile.ParseAndValidate(lo.devfilePath)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func getComponentName(context string) (string, error) {
 // DevfileComponentDelete deletes the devfile component
 func (do *DeleteOptions) DevfileComponentDelete() error {
 	// Parse devfile and validate
-	devObj, err := parser.ParseAndValidate(do.devfilePath)
+	devObj, err := devfile.ParseAndValidate(do.devfilePath)
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func warnIfURLSInvalid(url []envinfo.EnvInfoURL) {
 // DevfileComponentExec executes the given user command inside the component
 func (eo *ExecOptions) DevfileComponentExec(command []string) error {
 	// Parse devfile
-	devObj, err := parser.ParseAndValidate(eo.devfilePath)
+	devObj, err := devfile.ParseAndValidate(eo.devfilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -86,7 +87,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 
-		po.Devfile, err = parser.ParseAndValidate(po.DevfilePath)
+		po.Devfile, err = devfile.ParseAndValidate(po.DevfilePath)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse devfile")
 		}

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/openshift/odo/pkg/devfile"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -16,7 +17,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-// RecommendedCommandName is the recommended command name
+// TestRecommendedCommandName is the recommended test command name
 const TestRecommendedCommandName = "test"
 
 // TestOptions encapsulates the options for the odo command
@@ -53,7 +54,7 @@ func (to *TestOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the TestOptions based on completed values
 func (to *TestOptions) Validate() (err error) {
-	devObj, err := devfileParser.ParseAndValidate(to.devfilePath)
+	devObj, err := devfile.ParseAndValidate(to.devfilePath)
 	if err != nil {
 		return errors.Wrap(err, "fail to parse devfile")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/adapters"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes"
-	"github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/occlient"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -100,7 +100,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		}
 
 		// Parse devfile and validate
-		devObj, err := parser.ParseAndValidate(wo.devfilePath)
+		devObj, err := devfile.ParseAndValidate(wo.devfilePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/devfile"
 	adapterutils "github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
-	"github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/log"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
@@ -128,7 +128,7 @@ func (o *URLCreateOptions) Complete(name string, cmd *cobra.Command, args []stri
 		}
 
 		// Parse devfile and validate
-		devObj, err := parser.ParseAndValidate(o.DevfilePath)
+		devObj, err := devfile.ParseAndValidate(o.DevfilePath)
 		if err != nil {
 			return fmt.Errorf("fail to parse the devfile %s, with error: %s", o.DevfilePath, err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


 /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
Moved odo specific logic ( validation ) out of devfile/parser package as we need that package to be independent of odo code.
This effort is important because other projects like che/devconsole can use odo's parser without having any dependency on odo.

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test - no need

- [ ] Integration test - no need

- [X] Documentation 

**How to test changes / Special notes to the reviewer**:
Tests should pass