### PR TITLE
Including exit code in stderr verification

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -28,7 +28,7 @@ odo login -u developer -p developer
 oc whoami
 
 # Integration tests
-GINKGO_TEST_ARGS=-v make test-integration
+make test-integration
 make test-integration-devfile
 make test-cmd-login-logout
 make test-cmd-project

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -48,7 +48,7 @@ func (kubectl KubectlRunner) CheckCmdOpInRemoteDevfilePod(podName string, contai
 	session := CmdRunner(kubectl.path, args...)
 	stdOut := string(session.Wait().Out.Contents())
 	stdErr := string(session.Wait().Err.Contents())
-	if stdErr != "" {
+	if stdErr != "" && session.ExitCode() != 0 {
 		return checkOp(stdOut, fmt.Errorf("cmd %s failed with error %s on pod %s", cmd, stdErr, podName))
 	}
 	return checkOp(stdOut, nil)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -143,9 +143,7 @@ func (oc OcRunner) CheckCmdOpInRemoteCmpPod(cmpName string, appName string, prjN
 		"-c", cmpDCName, "--"}, cmd...)...)
 	stdOut := string(session.Wait().Out.Contents())
 	stdErr := string(session.Wait().Err.Contents())
-	fmt.Println("exec output for s2i image package", stdOut)
-	fmt.Println("exec error for s2i image package", stdErr)
-	if stdErr != "" {
+	if stdErr != "" && session.ExitCode() != 0 {
 		return checkOp(stdOut, fmt.Errorf("cmd %s failed with error %s on pod %s", cmd, stdErr, podName))
 	}
 	return checkOp(stdOut, nil)
@@ -162,7 +160,7 @@ func (oc OcRunner) CheckCmdOpInRemoteDevfilePod(podName string, containerName st
 	session := CmdRunner(oc.path, args...)
 	stdOut := string(session.Wait().Out.Contents())
 	stdErr := string(session.Wait().Err.Contents())
-	if stdErr != "" {
+	if stdErr != "" && session.ExitCode() != 0 {
 		return checkOp(stdOut, fmt.Errorf("cmd %s failed with error %s on pod %s", cmd, stdErr, podName))
 	}
 	return checkOp(stdOut, nil)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -504,7 +504,6 @@ func componentTests(args ...string) {
 				project,
 				[]string{"sh", "-c", "ls -la $ODO_S2I_DEPLOYMENT_DIR/package.json"},
 				func(cmdOp string, err error) bool {
-					fmt.Println("cmdOp error is", err)
 					return err == nil
 				},
 			)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
On a successful oc command execution debug log goes to stderr channel. So widening the error check condition to avoid test script false alarm
**Which issue(s) this PR fixes**:

Fixes #3547

**PR acceptance criteria**:

- [ ] Unit test : NA

- [ ] Integration test : NA

- [ ] Documentation : NA

**How to test changes / Special notes to the reviewer**:
pr https://github.com/openshift/release/pull/9431 should pass