### PR TITLE
Fix post start event logged message

### DIFF
--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -137,9 +137,10 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 
 	// PostStart events from the devfile will only be executed when the component
 	// didn't previously exist
-	if !componentExists {
-		log.Infof("\nExecuting preStart lifecycle event commands for component %s", a.ComponentName)
-		err = a.execDevfileEvent(a.Devfile.Data.GetEvents().PostStart, containers)
+	postStartEvents := a.Devfile.Data.GetEvents().PostStart
+	if !componentExists && len(postStartEvents) > 0 {
+		log.Infof("\nExecuting postStart event commands for component %s", a.ComponentName)
+		err = a.execDevfileEvent(postStartEvents, containers)
 		if err != nil {
 			return err
 		}

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -379,29 +379,28 @@ func (a Adapter) execDevfile(commandsMap common.PushCommandsMap, componentExists
 // Each Devfile Command associated with the given event is retrieved, and executed in the container specified
 // in the command
 func (a Adapter) execDevfileEvent(events []string, containers []types.Container) error {
-	if len(events) > 0 {
 
-		commandMap := common.GetCommandMap(a.Devfile.Data)
+	commandMap := common.GetCommandMap(a.Devfile.Data)
 
-		for _, commandName := range events {
-			// Convert commandName to lower because GetCommands converts Command.Exec.Id's to lower
-			command, ok := commandMap[strings.ToLower(commandName)]
-			if !ok {
-				return errors.New("unable to find devfile command " + commandName)
-			}
-
-			// If composite would go here & recursive loop
-
-			// Get container for command
-			containerID := utils.GetContainerIDForAlias(containers, command.Exec.Component)
-			compInfo := common.ComponentInfo{ContainerName: containerID}
-
-			// Execute command in container
-			err := exec.ExecuteDevfileCommandSynchronously(&a.Client, *command.Exec, command.Exec.Id, compInfo, false, a.machineEventLogger)
-			if err != nil {
-				return errors.Wrapf(err, "unable to execute devfile command "+commandName)
-			}
+	for _, commandName := range events {
+		// Convert commandName to lower because GetCommands converts Command.Exec.Id's to lower
+		command, ok := commandMap[strings.ToLower(commandName)]
+		if !ok {
+			return errors.New("unable to find devfile command " + commandName)
 		}
+
+		// If composite would go here & recursive loop
+
+		// Get container for command
+		containerID := utils.GetContainerIDForAlias(containers, command.Exec.Component)
+		compInfo := common.ComponentInfo{ContainerName: containerID}
+
+		// Execute command in container
+		err := exec.ExecuteDevfileCommandSynchronously(&a.Client, *command.Exec, command.Exec.Id, compInfo, false, a.machineEventLogger)
+		if err != nil {
+			return errors.Wrapf(err, "unable to execute devfile command "+commandName)
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What does does this PR do / why we need it**:
post start event message gets printed as pre-start and printed also when there are no events.
```
Syncing to component nodejs
 ✓  Checking files for pushing [749597ns]
 ✓  Syncing files to the component [183ms]

Executing preStart lifecycle event commands for component nodejs
```

This PR updates from `preStart` to `postStart` and prints the message only when post start event present in devfile
**Which issue(s) this PR fixes**:

Fixes #

**PR acceptance criteria**:

- [ ] Unit test  No need

- [ ] Integration test No need

- [ ] Documentation  No need

**How to test changes / Special notes to the reviewer**:
run `odo push`, no event message gets printed if there are no events in devfile and correct event type is printed.
