### PR TITLE
increase timeout on odo log -f in tests to resolve a flake

### DIFF
--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -59,7 +59,7 @@ var _ = Describe("odo devfile log command tests", func() {
 			Expect(output).To(ContainSubstring("ODO_COMMAND_RUN"))
 
 			// test with follow flag
-			output = helper.CmdShouldRunWithTimeout(1*time.Second, "odo", "log", "-f")
+			output = helper.CmdShouldRunWithTimeout(5*time.Second, "odo", "log", "-f")
 			Expect(output).To(ContainSubstring("program=devrun"))
 
 		})


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
 /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3610

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
failing test should pass in multiple runs