### PR TITLE
Sync operation within the Push command does not remove deleted/renamed files

### DIFF
--- a/pkg/devfile/adapters/common/exec.go
+++ b/pkg/devfile/adapters/common/exec.go
@@ -42,7 +42,7 @@ func ExecuteCommand(client ExecClient, compInfo ComponentInfo, command []string,
 		// It is safe to read from cmdOutput here, as the goroutines are guaranteed to have terminated at this point.
 		klog.V(4).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
 
-		return errors.Wrapf(err, "Unable to exec command %v: \n%v", command, cmdOutput)
+		return errors.Wrapf(err, "unable to exec command %v: \n%v", command, cmdOutput)
 	}
 
 	return

--- a/pkg/devfile/adapters/common/exec.go
+++ b/pkg/devfile/adapters/common/exec.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/pkg/errors"
 )
 
 // ExecClient  is a wrapper around ExecCMDInContainer which executes a command in a specific container of a pod.
@@ -39,9 +40,9 @@ func ExecuteCommand(client ExecClient, compInfo ComponentInfo, command []string,
 
 	if err != nil {
 		// It is safe to read from cmdOutput here, as the goroutines are guaranteed to have terminated at this point.
-		log.Errorf("\nUnable to exec command %v: \n%v", command, cmdOutput)
+		klog.V(4).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
 
-		return err
+		return errors.Wrapf(err, "Unable to exec command %v: \n%v", command, cmdOutput)
 	}
 
 	return

--- a/pkg/devfile/adapters/common/exec_test.go
+++ b/pkg/devfile/adapters/common/exec_test.go
@@ -17,11 +17,11 @@ func TestCreateConsoleOutputWriterAndChannel(t *testing.T) {
 		},
 		{
 			Name:  "Close channel with a single line of text sent",
-			Input: []string{"hi"},
+			Input: []string{"one"},
 		},
 		{
 			Name:  "Close channel with multiple lines of text sent",
-			Input: []string{"hi"},
+			Input: []string{"one", "two", "three", "four", "five"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/devfile/adapters/common/exec_test.go
+++ b/pkg/devfile/adapters/common/exec_test.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateConsoleOutputWriterAndChannel(t *testing.T) {
+
+	tests := []struct {
+		Name  string
+		Input []string
+	}{
+		{
+			Name:  "Close channel with no text sent",
+			Input: []string{},
+		},
+		{
+			Name:  "Close channel with a single line of text sent",
+			Input: []string{"hi"},
+		},
+		{
+			Name:  "Close channel with multiple lines of text sent",
+			Input: []string{"hi"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+
+			inputWriter, outputChan := CreateConsoleOutputWriterAndChannel()
+
+			// Write input text
+			for _, toSend := range tt.Input {
+				inputWriter.Write([]byte(toSend + "\n"))
+			}
+
+			// Close and wait for result
+			inputWriter.Close()
+			out := <-outputChan
+
+			// Ouput text read from channel should exactly match input text
+			if len(out) != len(tt.Input) {
+				t.Fatal("Output response did not match input", out)
+			}
+			if !reflect.DeepEqual(tt.Input, out) {
+				t.Fatal("Output response did not match input", out)
+			}
+
+		})
+	}
+
+}

--- a/pkg/devfile/adapters/common/exec_test.go
+++ b/pkg/devfile/adapters/common/exec_test.go
@@ -31,7 +31,10 @@ func TestCreateConsoleOutputWriterAndChannel(t *testing.T) {
 
 			// Write input text
 			for _, toSend := range tt.Input {
-				inputWriter.Write([]byte(toSend + "\n"))
+				_, err := inputWriter.Write([]byte(toSend + "\n"))
+				if err != nil {
+					t.Fatalf("Unable to write to channel %v", err)
+				}
 			}
 
 			// Close and wait for result

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -220,7 +220,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		// If isForcePush is set, then the entire local directory contents will be copied over by CopyFile(...), thus
 		// we first need to clear the remote target folder.
 
-		err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, true, nil, nil)
+		err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, false, nil, nil)
 		if err != nil {
 			// This command will return a non-zero error code if 'syncFolder' cannot be removed; this occurs
 			// if the folder is owned by a different container user (for example, if it is a source volume mount) or

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -216,7 +216,9 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	}
 
 	if isForcePush {
-		// if syncFolder != kclient.OdoSourceVolumeMount {
+		// If isForcePush is set, then the entire local directory contents will be copied over by CopyFile(...), thus
+		// we first need to clear the remote target folder.
+
 		err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, true, nil, nil)
 		if err != nil {
 			// This command may fail if the parent directory permissions are restrictive; since this doesn't
@@ -228,20 +230,6 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 			return err
 		}
 
-		// } else {
-
-		// 	cmdRmFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/*"}
-		// 	err = exec.ExecuteCommand(a.Client, compInfo, cmdRmFiles, false, nil, nil)
-		// 	if err != nil {
-		// 		klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
-		// 	}
-
-		// 	cmdRmDotFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/.*"}
-		// 	err = exec.ExecuteCommand(a.Client, compInfo, cmdRmDotFiles, false, nil, nil)
-		// 	if err != nil {
-		// 		klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
-		// 	}
-		// }
 	}
 
 	if isForcePush || len(files) > 0 {

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -216,30 +216,32 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	}
 
 	if isForcePush {
-		if syncFolder != kclient.OdoSourceVolumeMount {
-			err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, true, nil, nil)
-			if err != nil {
-				return err
-			}
-			err = exec.ExecuteCommand(a.Client, compInfo, []string{"mkdir", "-p", syncFolder}, false, nil, nil)
-			if err != nil {
-				return err
-			}
-
-		} else {
-
-			cmdRmFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/*"}
-			err = exec.ExecuteCommand(a.Client, compInfo, cmdRmFiles, false, nil, nil)
-			if err != nil {
-				klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
-			}
-
-			cmdRmDotFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/.*"}
-			err = exec.ExecuteCommand(a.Client, compInfo, cmdRmDotFiles, false, nil, nil)
-			if err != nil {
-				klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
-			}
+		// if syncFolder != kclient.OdoSourceVolumeMount {
+		err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, true, nil, nil)
+		if err != nil {
+			// This command may fail if the parent directory permissions are restrictive; since this doesn't
+			// affect our ability to delete the files _within_ the directory, we merely log it here.
+			klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. error: %v", err)
 		}
+		err = exec.ExecuteCommand(a.Client, compInfo, getCmdToCreateSyncFolder(syncFolder), false, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		// } else {
+
+		// 	cmdRmFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/*"}
+		// 	err = exec.ExecuteCommand(a.Client, compInfo, cmdRmFiles, false, nil, nil)
+		// 	if err != nil {
+		// 		klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
+		// 	}
+
+		// 	cmdRmDotFiles := []string{"sh", "-c", "rm -rf '" + syncFolder + "'/.*"}
+		// 	err = exec.ExecuteCommand(a.Client, compInfo, cmdRmDotFiles, false, nil, nil)
+		// 	if err != nil {
+		// 		klog.V(4).Infof("error on deleting sync folder, but this is most likely an expected error. cmd: %v  error: %v", cmdRmFiles, err)
+		// 	}
+		// }
 	}
 
 	if isForcePush || len(files) > 0 {

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -220,7 +220,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		// If isForcePush is set, then the entire local directory contents will be copied over by CopyFile(...), thus
 		// we first need to clear the remote target folder.
 
-		err = exec.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, false, nil, nil)
+		err = common.ExecuteCommand(a.Client, compInfo, []string{"rm", "-rf", syncFolder}, false, nil, nil)
 		if err != nil {
 			// This command will return a non-zero error code if 'syncFolder' cannot be removed; this occurs
 			// if the folder is owned by a different container user (for example, if it is a source volume mount) or
@@ -235,7 +235,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 		}
 
 		// (Re)create the folder
-		err = exec.ExecuteCommand(a.Client, compInfo, getCmdToCreateSyncFolder(syncFolder), false, nil, nil)
+		err = common.ExecuteCommand(a.Client, compInfo, getCmdToCreateSyncFolder(syncFolder), false, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -326,10 +326,10 @@ func updateIndexWithWatchChanges(pushParameters common.PushParameters) error {
 // isRemoteFolderEmpty returns true if the 'syncFolder' path in the pod contains no files/folders, false otherwise
 func isRemoteFolderEmpty(a Adapter, compInfo common.ComponentInfo, syncFolder string) (bool, error) {
 
-	stdoutWriter, stdoutOutputChan := exec.CreateConsoleOutputWriterAndChannel()
-	stderrWriter, stderrOutputChan := exec.CreateConsoleOutputWriterAndChannel()
+	stdoutWriter, stdoutOutputChan := common.CreateConsoleOutputWriterAndChannel()
+	stderrWriter, stderrOutputChan := common.CreateConsoleOutputWriterAndChannel()
 
-	if err := exec.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
+	if err := common.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
 		return false, err
 	}
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -329,7 +329,7 @@ func isRemoteFolderEmpty(a Adapter, compInfo common.ComponentInfo, syncFolder st
 	stdoutWriter, stdoutOutputChan := exec.CreateConsoleOutputWriterAndChannel()
 	stderrWriter, stderrOutputChan := exec.CreateConsoleOutputWriterAndChannel()
 
-	for err := exec.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
+	if err := exec.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
 		return false, err
 	}
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -329,8 +329,7 @@ func isRemoteFolderEmpty(a Adapter, compInfo common.ComponentInfo, syncFolder st
 	stdoutWriter, stdoutOutputChan := exec.CreateConsoleOutputWriterAndChannel()
 	stderrWriter, stderrOutputChan := exec.CreateConsoleOutputWriterAndChannel()
 
-	err := exec.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter)
-	if err != nil {
+	for err := exec.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
 		return false, err
 	}
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo-47/odo/pkg/exec"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
@@ -278,33 +277,6 @@ func updateIndexWithWatchChanges(pushParameters common.PushParameters) error {
 	// Write the result
 	return util.WriteFile(fileIndex.Files, indexFilePath)
 
-}
-
-// isRemoteFolderEmpty returns true if the 'syncFolder' path in the pod contains no files/folders, false otherwise
-func isRemoteFolderEmpty(a Adapter, compInfo common.ComponentInfo, syncFolder string) (bool, error) {
-
-	stdoutWriter, stdoutOutputChan := common.CreateConsoleOutputWriterAndChannel()
-	stderrWriter, stderrOutputChan := common.CreateConsoleOutputWriterAndChannel()
-
-	if err := common.ExecuteCommand(a.Client, compInfo, []string{"ls", "-a", syncFolder}, false, stdoutWriter, stderrWriter); err != nil {
-		return false, err
-	}
-
-	stdoutWriter.Close()
-	stdout := <-stdoutOutputChan
-
-	stderrWriter.Close()
-	stderr := <-stderrOutputChan
-
-	// Count the number of lines from ls, should be 0 (excluding . and ..)
-	stdoutLinesFiltered := 0
-	for _, line := range stdout {
-		if line != ".." && line != "." {
-			stdoutLinesFiltered++
-		}
-	}
-
-	return stdoutLinesFiltered == 0 && len(stderr) == 0, nil
 }
 
 // getCmdToCreateSyncFolder returns the command used to create the remote sync folder on the running container

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -167,8 +167,6 @@ func TestSyncFiles(t *testing.T) {
 					WatchDeletedFiles: []string{},
 					IgnoredFiles:      []string{},
 					ForceBuild:        false,
-					// The first invocation of watch requires this to be true, see SyncFiles(...) in 'sync/adapter.go' for details.
-					DevfileScanIndexForWatch: true,
 				},
 				CompInfo: common.ComponentInfo{
 					ContainerName: "abcd",

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -137,14 +137,14 @@ func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, success func(out
 		select {
 		case <-timeoutCh:
 			if buf.String() != "" {
-				_, err := fmt.Fprintln(GinkgoWriter, "Output from stdout:")
+				_, err := fmt.Fprintln(GinkgoWriter, "Output from stdout ["+cmdStr+"]:")
 				Expect(err).To(BeNil())
 				_, err = fmt.Fprintln(GinkgoWriter, buf.String())
 				Expect(err).To(BeNil())
 			}
 			errBufStr := errBuf.String()
 			if errBufStr != "" {
-				_, err := fmt.Fprintln(GinkgoWriter, "Output from stderr:")
+				_, err := fmt.Fprintln(GinkgoWriter, "Output from stderr ["+cmdStr+"]:")
 				Expect(err).To(BeNil())
 				_, err = fmt.Fprintln(GinkgoWriter, errBufStr)
 				Expect(err).To(BeNil())

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -848,11 +847,6 @@ var _ = Describe("odo devfile push command tests", func() {
 	})
 
 })
-
-func runningCmd(cmd *exec.Cmd) string {
-	prog := filepath.Base(cmd.Path)
-	return fmt.Sprintf("Running %s with args %v", prog, cmd.Args)
-}
 
 // Wait for the session stdout output to contain a particular string
 func waitForOutputToContain(substring string, session *gexec.Session) {

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -2,19 +2,22 @@ package devfile
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/util"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/odo/pkg/util"
 
 	"github.com/openshift/odo/tests/helper"
 	"github.com/openshift/odo/tests/integration/devfile/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("odo devfile push command tests", func() {
@@ -802,4 +805,40 @@ var _ = Describe("odo devfile push command tests", func() {
 
 		})
 	})
+
+	Context("Verify devfile push works", func() {
+
+		It("should mooooooo", func() {
+
+			helper.CmdShouldPass("odo", "create", "java-springboot", "--project", namespace, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
+
+			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			err := os.Rename(filepath.Join(context, "pom.xml"), filepath.Join(context, "pom.xml.renamed"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// session := helper.CmdRunner("odo", "push", "-v", "5", "--namespace", namespace)
+			session := helper.CmdRunner("odo", "push", "-v", "5", "-f", "--namespace", namespace)
+			waitForOutputToContain("Non-readable POM", session)
+
+		})
+	})
+
 })
+
+func runningCmd(cmd *exec.Cmd) string {
+	prog := filepath.Base(cmd.Path)
+	return fmt.Sprintf("Running %s with args %v", prog, cmd.Args)
+}
+
+// Wait for the session stdout output to contain a particular string
+func waitForOutputToContain(substring string, session *gexec.Session) {
+
+	Eventually(func() string {
+		contents := string(session.Out.Contents())
+		return contents
+	}, 180, 10).Should(ContainSubstring(substring))
+
+}

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -16,7 +16,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("odo devfile push command tests", func() {
@@ -543,7 +542,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			// 3) Ensure that the build fails due to missing 'pom.xml', which ensures that the sync operation
 			// correctly renamed pom.xml to pom.xml.renamed.
 			session := helper.CmdRunner("odo", "push", "-v", "5", "-f", "--namespace", namespace)
-			waitForOutputToContain("Non-readable POM", session)
+			helper.WaitForOutputToContain("Non-readable POM", 180, 10, session)
 
 		})
 
@@ -847,13 +846,3 @@ var _ = Describe("odo devfile push command tests", func() {
 	})
 
 })
-
-// Wait for the session stdout output to contain a particular string
-func waitForOutputToContain(substring string, session *gexec.Session) {
-
-	Eventually(func() string {
-		contents := string(session.Out.Contents())
-		return contents
-	}, 180, 10).Should(ContainSubstring(substring))
-
-}

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -825,24 +825,4 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
-	Context("Verify devfile push works", func() {
-
-		It("should mooooooo", func() {
-
-			helper.CmdShouldPass("odo", "create", "java-springboot", "--project", namespace, cmpName)
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), context)
-
-			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace)
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			err := os.Rename(filepath.Join(context, "pom.xml"), filepath.Join(context, "pom.xml.renamed"))
-			Expect(err).NotTo(HaveOccurred())
-
-			// session := helper.CmdRunner("odo", "push", "-v", "5", "--namespace", namespace)
-			session := helper.CmdRunner("odo", "push", "-v", "5", "-f", "--namespace", namespace)
-			waitForOutputToContain("Non-readable POM", session)
-
-		})
-	})
-
 })

--- a/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
+++ b/tests/integration/devfile/utils/cmd_devfile_push_test_utils.go
@@ -24,6 +24,10 @@ func AnalyzePushConsoleOutput(pushConsoleOutput string) {
 			continue
 		}
 
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+
 		// fmt.Println("Processing output line: " + line)
 
 		lineWrapper := machineoutput.MachineEventWrapper{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

- This PR ensures that if `forcePush` is set during a sync operation, that the sync directory is cleared before updated files are copied to the sync directory. 
- This PR adds a test that verifies the correct behaviour described in the original issue.


**Which issue(s) this PR fixes**:

Fixes #3460


**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
See issue #3460 for step-by-step reproduction steps.