### PR TITLE
Adds storage create and delete commands for devfiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "preference, config, url and debug command integration tests"
+      name: "preference, config, url,storage and debug command integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -89,6 +89,7 @@ jobs:
         - travis_wait make test-cmd-devfile-url
         - travis_wait make test-cmd-debug
         - travis_wait make test-cmd-devfile-debug
+        - travis_wait make test-cmd-devfile-storage
         - odo logout
 
     # Run service-catalog e2e tests
@@ -184,7 +185,7 @@ jobs:
     # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test
       stage: test
-      name: "devfile catalog,url, watch, push, debug, delete, exec, test, log and create command integration tests on kubernetes cluster"
+      name: "devfile catalog,url, watch, push, debug, delete, exec, test, log, storage and create command integration tests on kubernetes cluster"
       env:
         - MINIKUBE_WANTUPDATENOTIFICATION=false
         - MINIKUBE_WANTREPORTERRORPROMPT=false
@@ -218,3 +219,4 @@ jobs:
         - travis_wait make test-cmd-devfile-url
         - travis_wait make test-cmd-devfile-test
         - travis_wait make test-cmd-devfile-log
+        - travis_wait make test-cmd-devfile-storage

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,11 @@ test-cmd-devfile-debug:
 	ginkgo $(GINKGO_FLAGS) -focus="odo devfile debug command tests" tests/integration/devfile/
 	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo devfile debug command serial tests" tests/integration/devfile/debug
 
+# Run odo storage devfile command tests
+.PHONY: test-cmd-devfile-storage
+test-cmd-devfile-storage:
+	ginkgo $(GINKGO_FLAGS) -focus="odo devfile storage command tests" tests/integration/devfile/
+
 # Run odo log devfile command tests
 .PHONY: test-cmd-devfile-log
 test-cmd-devfile-log:

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -97,7 +97,7 @@ func TestGetDevfileVolumeComponents(t *testing.T) {
 
 		{
 			name:                 "Case 5: Valid devfile with correct component type (Volume)",
-			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvol")},
+			component:            []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvol", "4Gi")},
 			expectedMatchesCount: 1,
 		},
 	}
@@ -121,6 +121,8 @@ func TestGetDevfileVolumeComponents(t *testing.T) {
 
 func TestGetVolumes(t *testing.T) {
 
+	size := "4Gi"
+
 	tests := []struct {
 		name                       string
 		component                  []versionsCommon.DevfileComponent
@@ -128,12 +130,12 @@ func TestGetVolumes(t *testing.T) {
 	}{
 		{
 			name:      "Case 1: Valid devfile with container referencing a volume component",
-			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume1")},
+			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume1", size)},
 			wantContainerNameToVolumes: map[string][]DevfileVolume{
 				"comp1": {
 					{
 						Name:          "myvolume1",
-						Size:          "4Gi",
+						Size:          size,
 						ContainerPath: "/my/volume/mount/path1",
 					},
 				},
@@ -142,9 +144,9 @@ func TestGetVolumes(t *testing.T) {
 		{
 			name: "Case 2: Valid devfile with container referencing multiple volume components",
 			component: []versionsCommon.DevfileComponent{
-				testingutil.GetFakeVolumeComponent("myvolume1"),
-				testingutil.GetFakeVolumeComponent("myvolume2"),
-				testingutil.GetFakeVolumeComponent("myvolume3"),
+				testingutil.GetFakeVolumeComponent("myvolume1", size),
+				testingutil.GetFakeVolumeComponent("myvolume2", size),
+				testingutil.GetFakeVolumeComponent("myvolume3", size),
 				{
 					Container: &versionsCommon.Container{
 						Name:  "mycontainer",
@@ -166,12 +168,12 @@ func TestGetVolumes(t *testing.T) {
 				"mycontainer": {
 					{
 						Name:          "myvolume1",
-						Size:          "4Gi",
+						Size:          size,
 						ContainerPath: "/myvolume1",
 					},
 					{
 						Name:          "myvolume2",
-						Size:          "4Gi",
+						Size:          size,
 						ContainerPath: "/myvolume2",
 					},
 				},
@@ -179,7 +181,7 @@ func TestGetVolumes(t *testing.T) {
 		},
 		{
 			name:      "Case 3: Valid devfile with container referencing no volume component",
-			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume2")},
+			component: []versionsCommon.DevfileComponent{testingutil.GetFakeContainerComponent("comp1"), testingutil.GetFakeVolumeComponent("myvolume2", size)},
 			wantContainerNameToVolumes: map[string][]DevfileVolume{
 				"comp1": {
 					{
@@ -193,7 +195,7 @@ func TestGetVolumes(t *testing.T) {
 		{
 			name: "Case 4: Valid devfile with no container volume mounts",
 			component: []versionsCommon.DevfileComponent{
-				testingutil.GetFakeVolumeComponent("myvolume2"),
+				testingutil.GetFakeVolumeComponent("myvolume2", size),
 				{
 					Container: &versionsCommon.Container{
 						Name:  "mycontainer",
@@ -375,7 +377,7 @@ func TestIsVolume(t *testing.T) {
 	}{
 		{
 			name:            "Case 1: Volume component",
-			component:       testingutil.GetFakeVolumeComponent("myvol"),
+			component:       testingutil.GetFakeVolumeComponent("myvol", "4Gi"),
 			wantIsSupported: true,
 		},
 		{

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -318,6 +318,11 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		}
 	}
 
+	err = storage.DeleteOldPVCs(&a.Client, componentName, processedVolumes)
+	if err != nil {
+		return err
+	}
+
 	// Add PVC and Volume Mounts to the podTemplateSpec
 	err = kclient.AddPVCAndVolumeMount(podTemplateSpec, volumeNameToPVCName, containerNameToVolumes)
 	if err != nil {

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/storage/labels"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 
@@ -44,8 +45,8 @@ func CreateComponentStorage(Client *kclient.Client, storages []common.Storage, c
 func Create(Client *kclient.Client, name, size, componentName, pvcName string) (*corev1.PersistentVolumeClaim, error) {
 
 	labels := map[string]string{
-		"component":    componentName,
-		"storage-name": name,
+		"component":                componentName,
+		labels.DevfileStorageLabel: name,
 	}
 
 	quantity, err := resource.ParseQuantity(size)
@@ -92,7 +93,7 @@ func GeneratePVCNameFromDevfileVol(volName, componentName string) (string, error
 // GetExistingPVC checks if a PVC is present and return the name if it exists
 func GetExistingPVC(Client *kclient.Client, volumeName, componentName string) (string, error) {
 
-	label := "component=" + componentName + ",storage-name=" + volumeName
+	label := fmt.Sprintf("component=%s,%s=%s", componentName, labels.DevfileStorageLabel, volumeName)
 
 	klog.V(4).Infof("Checking PVC for volume %v and label %v\n", volumeName, label)
 
@@ -114,13 +115,13 @@ func GetExistingPVC(Client *kclient.Client, volumeName, componentName string) (s
 
 // DeleteOldPVCs deletes all the old PVCs which are not in the processedVolumes map
 func DeleteOldPVCs(Client *kclient.Client, componentName string, processedVolumes map[string]bool) error {
-	label := "component=" + componentName
+	label := fmt.Sprintf("component=%s", componentName)
 	PVCs, err := Client.GetPVCsFromSelector(label)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to get PVC with selectors "+label)
+		return errors.Wrapf(err, "unable to get PVC with selectors "+label)
 	}
 	for _, pvc := range PVCs {
-		storageName, ok := pvc.GetLabels()["storage-name"]
+		storageName, ok := pvc.GetLabels()[labels.DevfileStorageLabel]
 		if ok && !processedVolumes[storageName] {
 			// the pvc is not in the processedVolumes map
 			// thus deleting those PVCs

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -96,3 +96,7 @@ func (d *DevfileCtx) Validate() error {
 	// Validate devfile
 	return d.ValidateDevfileSchema()
 }
+
+func (d *DevfileCtx) GetAbsPath() string {
+	return d.absPath
+}

--- a/pkg/devfile/parser/context/fake.go
+++ b/pkg/devfile/parser/context/fake.go
@@ -1,0 +1,10 @@
+package parser
+
+import "github.com/openshift/odo/pkg/testingutil/filesystem"
+
+func FakeContext(fs filesystem.Filesystem, absPath string) DevfileCtx {
+	return DevfileCtx{
+		Fs:      fs,
+		absPath: absPath,
+	}
+}

--- a/pkg/devfile/parser/data/1.0.0/components.go
+++ b/pkg/devfile/parser/data/1.0.0/components.go
@@ -253,3 +253,11 @@ func (d *Devfile100) GetEvents() common.DevfileEvents { return common.DevfileEve
 func (d *Devfile100) AddEvents(events common.DevfileEvents) error { return nil }
 
 func (d *Devfile100) UpdateEvents(postStart, postStop, preStart, preStop []string) {}
+
+func (d *Devfile100) AddVolume(volume common.Volume, path string) error { return nil }
+
+func (d *Devfile100) DeleteVolume(name string) error { return nil }
+
+func (d *Devfile100) GetVolumeMountPath(name string) (string, error) {
+	return "", nil
+}

--- a/pkg/devfile/parser/data/1.0.0/components.go
+++ b/pkg/devfile/parser/data/1.0.0/components.go
@@ -258,6 +258,4 @@ func (d *Devfile100) AddVolume(volume common.Volume, path string) error { return
 
 func (d *Devfile100) DeleteVolume(name string) error { return nil }
 
-func (d *Devfile100) GetVolumeMountPath(name string) (string, error) {
-	return "", nil
-}
+func (d *Devfile100) GetVolumeMountPath(name string) (string, error) { return "", nil }

--- a/pkg/devfile/parser/data/2.0.0/components.go
+++ b/pkg/devfile/parser/data/2.0.0/components.go
@@ -1,6 +1,7 @@
 package version200
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
@@ -226,4 +227,82 @@ func (d *Devfile200) UpdateEvents(postStart, postStop, preStart, preStop []strin
 	if len(preStop) != 0 {
 		d.Events.PreStop = preStop
 	}
+}
+
+// AddVolume adds the volume to the devFile and mounts it to all the container components
+func (d *Devfile200) AddVolume(volume common.Volume, path string) error {
+	for _, component := range d.Components {
+		if component.Container != nil {
+			for _, volumeMount := range component.Container.VolumeMounts {
+				if volumeMount.Path == path {
+					return fmt.Errorf("another volume, %s, is mounted to the same path: %s, on the container: %s", volumeMount.Name, path, component.Container.Name)
+				}
+			}
+			component.Container.VolumeMounts = append(component.Container.VolumeMounts, common.VolumeMount{
+				Name: volume.Name,
+				Path: path,
+			})
+		} else if component.Volume != nil && component.Volume.Name == volume.Name {
+			return fmt.Errorf("volume %s already exists", volume.Name)
+		}
+	}
+
+	d.Components = append(d.Components, common.DevfileComponent{
+		Volume: &volume,
+	})
+
+	return nil
+}
+
+// DeleteVolume removes the volume from the devFile and removes all the related volume mounts
+func (d *Devfile200) DeleteVolume(name string) error {
+	found := false
+	for i := len(d.Components) - 1; i >= 0; i-- {
+		if d.Components[i].Container != nil {
+			var tmp []common.VolumeMount
+			for _, volumeMount := range d.Components[i].Container.VolumeMounts {
+				if volumeMount.Name != name {
+					tmp = append(tmp, volumeMount)
+				}
+			}
+			d.Components[i].Container.VolumeMounts = tmp
+		} else if d.Components[i].Volume != nil {
+			if d.Components[i].Volume.Name == name {
+				found = true
+				d.Components = append(d.Components[:i], d.Components[i+1:]...)
+			}
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("volume %s is not found", name)
+	}
+
+	return nil
+}
+
+// GetVolumeMountPath gets the mount path of the required volume
+func (d *Devfile200) GetVolumeMountPath(name string) (string, error) {
+	volumeFound := false
+	mountFound := false
+	path := ""
+
+	for _, component := range d.Components {
+		if component.Container != nil {
+			for _, volumeMount := range component.Container.VolumeMounts {
+				if volumeMount.Name == name {
+					mountFound = true
+					path = volumeMount.Path
+				}
+			}
+		} else if component.Volume != nil {
+			volumeFound = true
+		}
+	}
+	if volumeFound && mountFound {
+		return path, nil
+	} else if !mountFound {
+		return "", fmt.Errorf("volume not mounted to any component")
+	}
+	return "", fmt.Errorf("volume not found")
 }

--- a/pkg/devfile/parser/data/2.0.0/components.go
+++ b/pkg/devfile/parser/data/2.0.0/components.go
@@ -243,7 +243,10 @@ func (d *Devfile200) AddVolume(volume common.Volume, path string) error {
 				Path: path,
 			})
 		} else if component.Volume != nil && component.Volume.Name == volume.Name {
-			return fmt.Errorf("volume %s already exists", volume.Name)
+			return &common.AlreadyExistError{
+				Field: "volume",
+				Name:  volume.Name,
+			}
 		}
 	}
 
@@ -275,7 +278,10 @@ func (d *Devfile200) DeleteVolume(name string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("volume %s is not found", name)
+		return &common.NotFoundError{
+			Field: "volume",
+			Name:  name,
+		}
 	}
 
 	return nil
@@ -301,8 +307,11 @@ func (d *Devfile200) GetVolumeMountPath(name string) (string, error) {
 	}
 	if volumeFound && mountFound {
 		return path, nil
-	} else if !mountFound {
+	} else if !mountFound && volumeFound {
 		return "", fmt.Errorf("volume not mounted to any component")
 	}
-	return "", fmt.Errorf("volume not found")
+	return "", &common.NotFoundError{
+		Field: "volume",
+		Name:  "name",
+	}
 }

--- a/pkg/devfile/parser/data/2.0.0/components_test.go
+++ b/pkg/devfile/parser/data/2.0.0/components_test.go
@@ -1,0 +1,418 @@
+package version200
+
+import (
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/openshift/odo/pkg/testingutil"
+	"reflect"
+	"testing"
+)
+
+func TestDevfile200_AddVolume(t *testing.T) {
+	image0 := "some-image-0"
+	container0 := "container0"
+
+	image1 := "some-image-1"
+	container1 := "container1"
+
+	volume0 := "volume0"
+	volume1 := "volume1"
+
+	type args struct {
+		volume common.Volume
+		path   string
+	}
+	tests := []struct {
+		name              string
+		currentComponents []common.DevfileComponent
+		wantComponents    []common.DevfileComponent
+		args              args
+		wantErr           bool
+	}{
+		{
+			name: "case 1: it should add the volume to all the containers",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+					},
+				},
+			},
+			args: args{
+				volume: testingutil.GetFakeVolume(volume0, "5Gi"),
+				path:   "/path",
+			},
+			wantComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume0, "/path"),
+						},
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume0, "/path"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume0, "5Gi"),
+			},
+		},
+		{
+			name: "case 2: it should add the volume when other volumes are present",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+			},
+			args: args{
+				volume: testingutil.GetFakeVolume(volume0, "5Gi"),
+				path:   "/path",
+			},
+			wantComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+							testingutil.GetFakeVolumeMount(volume0, "/path"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume0, "5Gi"),
+			},
+		},
+		{
+			name: "case 3: error out when same volume is present",
+			currentComponents: []common.DevfileComponent{
+				testingutil.GetFakeVolumeComponent(volume0, "1Gi"),
+			},
+			args: args{
+				volume: testingutil.GetFakeVolume(volume0, "5Gi"),
+				path:   "/path",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 4: it should error out when another volume is mounted to the same path",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/path"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			args: args{
+				volume: testingutil.GetFakeVolume(volume0, "5Gi"),
+				path:   "/path",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Devfile200{
+				Components: tt.currentComponents,
+			}
+
+			err := d.AddVolume(tt.args.volume, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddVolume() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil && tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(d.Components, tt.wantComponents) {
+				t.Errorf("wanted: %v, got: %v, difference at %v", tt.wantComponents, d.Components, pretty.Compare(tt.wantComponents, d.Components))
+			}
+		})
+	}
+}
+
+func TestDevfile200_DeleteVolume(t *testing.T) {
+	image0 := "some-image-0"
+	container0 := "container0"
+
+	image1 := "some-image-1"
+	container1 := "container1"
+
+	volume0 := "volume0"
+	volume1 := "volume1"
+
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name              string
+		currentComponents []common.DevfileComponent
+		wantComponents    []common.DevfileComponent
+		args              args
+		wantErr           bool
+	}{
+		{
+			name: "case 1: volume is present and mounted to multiple components",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume0, "/path"),
+						},
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+						VolumeMounts: []common.VolumeMount{
+							{
+								Name: volume0,
+								Path: "/path",
+							},
+						},
+					},
+				},
+				{
+					Volume: &common.Volume{
+						Name: volume0,
+						Size: "5Gi",
+					},
+				},
+			},
+			wantComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+					},
+				},
+			},
+			args: args{
+				name: volume0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "case 2: delete only the required volume in case of multiples",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume0, "/path"),
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume0, "5Gi"),
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			wantComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+				{
+					Container: &common.Container{
+						Name:  container1,
+						Image: image1,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			args: args{
+				name: volume0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "case 3: volume is not present",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						Name:  container0,
+						Image: image0,
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/data"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			wantComponents: []common.DevfileComponent{},
+			args: args{
+				name: volume0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 4: volume is present but not mounted to any component",
+			currentComponents: []common.DevfileComponent{
+				testingutil.GetFakeVolumeComponent(volume0, "5Gi"),
+			},
+			wantComponents: []common.DevfileComponent{},
+			args: args{
+				name: volume0,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Devfile200{
+				Components: tt.currentComponents,
+			}
+			err := d.DeleteVolume(tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteVolume() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil && tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(d.Components, tt.wantComponents) {
+				t.Errorf("wanted: %v, got: %v, difference at %v", tt.wantComponents, d.Components, pretty.Compare(tt.wantComponents, d.Components))
+			}
+		})
+	}
+}
+
+func TestDevfile200_GetVolumeMountPath(t *testing.T) {
+	volume1 := "volume1"
+
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name              string
+		currentComponents []common.DevfileComponent
+		wantPath          string
+		args              args
+		wantErr           bool
+	}{
+		{
+			name: "case 1: volume is present and mounted on a component",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/path"),
+						},
+					},
+				},
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			wantPath: "/path",
+			args: args{
+				name: volume1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "case 2: volume is not present but mounted on a component",
+			currentComponents: []common.DevfileComponent{
+				{
+					Container: &common.Container{
+						VolumeMounts: []common.VolumeMount{
+							testingutil.GetFakeVolumeMount(volume1, "/path"),
+						},
+					},
+				},
+			},
+			args: args{
+				name: volume1,
+			},
+			wantErr: true,
+		},
+		{
+			name:              "case 3: volume is not present and not mounted on a component",
+			currentComponents: []common.DevfileComponent{},
+			args: args{
+				name: volume1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 4: volume is present but not mounted",
+			currentComponents: []common.DevfileComponent{
+				testingutil.GetFakeVolumeComponent(volume1, "5Gi"),
+			},
+			args: args{
+				name: volume1,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Devfile200{
+				Components: tt.currentComponents,
+			}
+			got, err := d.GetVolumeMountPath(tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetVolumeMountPath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil && tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.wantPath) {
+				t.Errorf("wanted: %v, got: %v, difference at %v", tt.wantPath, got, pretty.Compare(tt.wantPath, got))
+			}
+		})
+	}
+}

--- a/pkg/devfile/parser/data/common/errors.go
+++ b/pkg/devfile/parser/data/common/errors.go
@@ -2,7 +2,7 @@ package common
 
 import "fmt"
 
-// AlreadyExistError error returned if tried to add already exisitng field
+// AlreadyExistError error returned if tried to add already existing field
 type AlreadyExistError struct {
 	// field which already exist
 	Field string
@@ -11,5 +11,17 @@ type AlreadyExistError struct {
 }
 
 func (e *AlreadyExistError) Error() string {
-	return fmt.Sprintf("%s %s already exists in devfile", e.Field, e.Name)
+	return fmt.Sprintf("%s %s already exists in the devfile", e.Field, e.Name)
+}
+
+// NotFoundError error returned if the field with the name is not found
+type NotFoundError struct {
+	// field which doesn't exist
+	Field string
+	// field name
+	Name string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("%s %s is not found in the devfile", e.Field, e.Name)
 }

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -89,18 +89,18 @@ type Container struct {
 
 // Endpoint holds information about how an application is exposed
 type Endpoint struct {
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network. public|internal|none. Default value is "public"
-	Exposure string `json:"exposure,omitempty"`
+	Exposure string `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 
-	Path       string `json:"path,omitempty"`
-	Secure     bool   `json:"secure,omitempty"`
-	Name       string `json:"name"`
-	TargetPort int32  `json:"targetPort"`
+	Path       string `json:"path,omitempty" yaml:"path,omitempty"`
+	Secure     bool   `json:"secure,omitempty" yaml:"secure,omitempty"`
+	Name       string `json:"name" yaml:"name"`
+	TargetPort int32  `json:"targetPort" yaml:"targetPort"`
 
 	// Describes the application and transport protocols of the traffic that will go through this endpoint. Default value is "http"
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 }
 
 // Env

--- a/pkg/devfile/parser/data/interface.go
+++ b/pkg/devfile/parser/data/interface.go
@@ -35,4 +35,8 @@ type DevfileData interface {
 	GetCommands() []common.DevfileCommand
 	AddCommands(commands []common.DevfileCommand) error
 	UpdateCommand(command common.DevfileCommand)
+
+	AddVolume(volume common.Volume, path string) error
+	DeleteVolume(name string) error
+	GetVolumeMountPath(name string) (string, error)
 }

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -40,7 +40,7 @@ func (d *DevfileObj) WriteYamlDevfile() error {
 
 	// Write to devfile.yaml
 	fs := d.Ctx.GetFs()
-	err = fs.WriteFile(OutputDevfileYamlPath, yamlData, 0644)
+	err = fs.WriteFile(d.Ctx.GetAbsPath(), yamlData, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create devfile yaml file")
 	}

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -19,7 +19,7 @@ func (d *DevfileObj) WriteJsonDevfile() error {
 
 	// Write to devfile.json
 	fs := d.Ctx.GetFs()
-	err = fs.WriteFile(OutputDevfileJsonPath, jsonData, 0644)
+	err = fs.WriteFile(d.Ctx.GetAbsPath(), jsonData, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create devfile json file")
 	}

--- a/pkg/devfile/parser/writer_test.go
+++ b/pkg/devfile/parser/writer_test.go
@@ -11,16 +11,18 @@ import (
 func TestWriteJsonDevfile(t *testing.T) {
 
 	var (
-		devfileTempPath = "devfile.yaml"
-		apiVersion      = "1.0.0"
-		testName        = "TestName"
+		apiVersion = "1.0.0"
+		testName   = "TestName"
 	)
 
 	t.Run("write json devfile", func(t *testing.T) {
 
+		// Use fakeFs
+		fs := filesystem.NewFakeFs()
+
 		// DevfileObj
 		devfileObj := DevfileObj{
-			Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+			Ctx: devfileCtx.FakeContext(fs, OutputDevfileJsonPath),
 			Data: &v100.Devfile100{
 				ApiVersion: v100.ApiVersion(apiVersion),
 				Metadata: v100.Metadata{
@@ -28,10 +30,6 @@ func TestWriteJsonDevfile(t *testing.T) {
 				},
 			},
 		}
-
-		// Use fakeFs
-		fs := filesystem.NewFakeFs()
-		devfileObj.Ctx.Fs = fs
 
 		// test func()
 		err := devfileObj.WriteJsonDevfile()
@@ -46,9 +44,12 @@ func TestWriteJsonDevfile(t *testing.T) {
 
 	t.Run("write yaml devfile", func(t *testing.T) {
 
+		// Use fakeFs
+		fs := filesystem.NewFakeFs()
+
 		// DevfileObj
 		devfileObj := DevfileObj{
-			Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+			Ctx: devfileCtx.FakeContext(fs, OutputDevfileYamlPath),
 			Data: &v100.Devfile100{
 				ApiVersion: v100.ApiVersion(apiVersion),
 				Metadata: v100.Metadata{
@@ -56,10 +57,6 @@ func TestWriteJsonDevfile(t *testing.T) {
 				},
 			},
 		}
-
-		// Use fakeFs
-		fs := filesystem.NewFakeFs()
-		devfileObj.Ctx.Fs = fs
 
 		// test func()
 		err := devfileObj.WriteYamlDevfile()

--- a/pkg/kclient/volumes.go
+++ b/pkg/kclient/volumes.go
@@ -32,6 +32,11 @@ func (c *Client) CreatePVC(objectMeta metav1.ObjectMeta, pvcSpec corev1.Persiste
 	return createdPvc, nil
 }
 
+// DeletePVC deletes the required PVC resource from the cluster
+func (c *Client) DeletePVC(pvcName string) error {
+	return c.KubeClient.CoreV1().PersistentVolumeClaims(c.Namespace).Delete(pvcName, &metav1.DeleteOptions{})
+}
+
 // AddPVCToPodTemplateSpec adds the given PVC to the podTemplateSpec
 func AddPVCToPodTemplateSpec(podTemplateSpec *corev1.PodTemplateSpec, volumeName, pvcName string) {
 

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -2,7 +2,8 @@ package storage
 
 import (
 	"fmt"
-
+	"github.com/openshift/odo/pkg/devfile"
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -24,49 +25,98 @@ var (
 	`)
 )
 
+const defaultStorageSize = "1Gi"
+
 type StorageCreateOptions struct {
 	storageName      string
 	storageSize      string
 	storagePath      string
 	componentContext string
+
+	devfilePath   string
+	isDevfile     bool
+	componentName string
 	*genericclioptions.Context
 }
 
 // NewStorageCreateOptions creates a new StorageCreateOptions instance
 func NewStorageCreateOptions() *StorageCreateOptions {
-	return &StorageCreateOptions{}
+	return &StorageCreateOptions{devfilePath: "./devfile.yaml"}
 }
 
 // Complete completes StorageCreateOptions after they've been created
 func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.Context = genericclioptions.NewContext(cmd)
+	if o.isDevfile {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+
+		o.componentName = o.EnvSpecificInfo.GetName()
+		if o.storageSize == "" {
+			o.storageSize = defaultStorageSize
+		}
+	} else {
+		o.Context = genericclioptions.NewContext(cmd)
+		o.componentName = o.LocalConfigInfo.GetName()
+	}
+
 	if len(args) != 0 {
 		o.storageName = args[0]
 	} else {
-		o.storageName = o.Component() + "-" + util.GenerateRandomString(4)
+		o.storageName = o.componentName + "-" + util.GenerateRandomString(4)
 	}
 	return
 }
 
 // Validate validates the StorageCreateOptions based on completed values
 func (o *StorageCreateOptions) Validate() (err error) {
+	if o.isDevfile {
+		return
+	}
 	// validate storage path
 	return o.LocalConfigInfo.ValidateStorage(o.storageName, o.storagePath)
 }
 
-// Run contains the logic for the odo storage create command
-func (o *StorageCreateOptions) Run() (err error) {
-	storageResult, err := o.LocalConfigInfo.StorageCreate(o.storageName, o.storageSize, o.storagePath)
+func (o *StorageCreateOptions) devfileRun() error {
+	devFile, err := devfile.ParseAndValidate(o.devfilePath)
 	if err != nil {
 		return err
 	}
 
-	storageResultMachineReadable := storage.GetMachineReadableFormat(storageResult.Name, storageResult.Size, storageResult.Path)
+	err = devFile.Data.AddVolume(common.Volume{
+		Name: o.storageName,
+		Size: o.storageSize,
+	}, o.storagePath)
+
+	if err != nil {
+		return err
+	}
+	err = devFile.WriteYamlDevfile()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Run contains the logic for the odo storage create command
+func (o *StorageCreateOptions) Run() (err error) {
+	if o.isDevfile {
+		err := o.devfileRun()
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := o.LocalConfigInfo.StorageCreate(o.storageName, o.storageSize, o.storagePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	storageResultMachineReadable := storage.GetMachineReadableFormat(o.storageName, o.storageSize, o.storagePath)
 
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(storageResultMachineReadable)
 	} else {
-		log.Successf("Added storage %v to %v", o.storageName, o.LocalConfigInfo.GetName())
+		log.Successf("Added storage %v to %v", o.storageName, o.componentName)
+
 		log.Italic("\nPlease use `odo push` command to make the storage accessible to the component")
 	}
 	return
@@ -87,10 +137,15 @@ func NewCmdStorageCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
+	o.isDevfile = util.CheckPathExists(o.devfilePath)
+
 	storageCreateCmd.Flags().StringVar(&o.storageSize, "size", "", "Size of storage to add")
 	storageCreateCmd.Flags().StringVar(&o.storagePath, "path", "", "Path to mount the storage on")
+
 	_ = storageCreateCmd.MarkFlagRequired("path")
-	_ = storageCreateCmd.MarkFlagRequired("size")
+	if !o.isDevfile {
+		_ = storageCreateCmd.MarkFlagRequired("size")
+	}
 
 	genericclioptions.AddContextFlag(storageCreateCmd, &o.componentContext)
 	completion.RegisterCommandFlagHandler(storageCreateCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/storage"
@@ -41,7 +42,7 @@ type StorageCreateOptions struct {
 
 // NewStorageCreateOptions creates a new StorageCreateOptions instance
 func NewStorageCreateOptions() *StorageCreateOptions {
-	return &StorageCreateOptions{devfilePath: "./devfile.yaml"}
+	return &StorageCreateOptions{devfilePath: component.DevfilePath}
 }
 
 // Complete completes StorageCreateOptions after they've been created
@@ -61,7 +62,7 @@ func (o *StorageCreateOptions) Complete(name string, cmd *cobra.Command, args []
 	if len(args) != 0 {
 		o.storageName = args[0]
 	} else {
-		o.storageName = o.componentName + "-" + util.GenerateRandomString(4)
+		o.storageName = fmt.Sprintf("%s-%s", o.componentName, util.GenerateRandomString(4))
 	}
 	return
 }

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"github.com/openshift/odo/pkg/devfile"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
-	"github.com/openshift/odo/pkg/odo/cli/component"
-	"github.com/openshift/odo/pkg/storage"
-	"github.com/openshift/odo/pkg/util"
-
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/storage"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
+	"path/filepath"
 )
 
 const deleteRecommendedCommandName = "delete"
@@ -45,6 +45,8 @@ func NewStorageDeleteOptions() *StorageDeleteOptions {
 
 // Complete completes StorageDeleteOptions after they've been created
 func (o *StorageDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.componentContext, o.devfilePath)
+	o.isDevfile = util.CheckPathExists(o.devfilePath)
 	if o.isDevfile {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
@@ -140,8 +142,6 @@ func NewCmdStorageDelete(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-
-	o.isDevfile = util.CheckPathExists(o.devfilePath)
 
 	storageDeleteCmd.Flags().BoolVarP(&o.storageForceDeleteFlag, "force", "f", false, "Delete storage without prompting")
 	completion.RegisterCommandHandler(storageDeleteCmd, completion.StorageDeleteCompletionHandler)

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/openshift/odo/pkg/devfile"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/storage"
 	"github.com/openshift/odo/pkg/util"
 
@@ -39,7 +40,7 @@ type StorageDeleteOptions struct {
 
 // NewStorageDeleteOptions creates a new StorageDeleteOptions instance
 func NewStorageDeleteOptions() *StorageDeleteOptions {
-	return &StorageDeleteOptions{devfilePath: "./devfile.yaml"}
+	return &StorageDeleteOptions{devfilePath: component.DevfilePath}
 }
 
 // Complete completes StorageDeleteOptions after they've been created
@@ -49,7 +50,7 @@ func (o *StorageDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 
 		o.componentName = o.EnvSpecificInfo.GetName()
 	} else {
-		// this initializes the LocalConfigInfo as well
+		// This initializes the LocalConfigInfo as well
 		o.Context = genericclioptions.NewContext(cmd)
 
 		o.componentName = o.LocalConfigInfo.GetName()

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -2,6 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/devfile"
+	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/util"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
@@ -26,24 +29,40 @@ type StorageDeleteOptions struct {
 	storageName            string
 	storageForceDeleteFlag bool
 	componentContext       string
+
+	isDevfile     bool
+	devfilePath   string
+	componentName string
 	*genericclioptions.Context
 }
 
 // NewStorageDeleteOptions creates a new StorageDeleteOptions instance
 func NewStorageDeleteOptions() *StorageDeleteOptions {
-	return &StorageDeleteOptions{}
+	return &StorageDeleteOptions{devfilePath: "./devfile.yaml"}
 }
 
 // Complete completes StorageDeleteOptions after they've been created
 func (o *StorageDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	// this initializes the LocalConfigInfo as well
-	o.Context = genericclioptions.NewContext(cmd)
+	if o.isDevfile {
+		o.Context = genericclioptions.NewDevfileContext(cmd)
+
+		o.componentName = o.EnvSpecificInfo.GetName()
+	} else {
+		// this initializes the LocalConfigInfo as well
+		o.Context = genericclioptions.NewContext(cmd)
+
+		o.componentName = o.LocalConfigInfo.GetName()
+	}
 	o.storageName = args[0]
 	return
 }
 
 // Validate validates the StorageDeleteOptions based on completed values
 func (o *StorageDeleteOptions) Validate() (err error) {
+	if o.isDevfile {
+		return
+	}
+
 	exists := o.LocalConfigInfo.StorageExists(o.storageName)
 	if !exists {
 		return fmt.Errorf("the storage %v does not exists in the application %v, cause %v", o.storageName, o.Application, err)
@@ -56,17 +75,41 @@ func (o *StorageDeleteOptions) Validate() (err error) {
 func (o *StorageDeleteOptions) Run() (err error) {
 	var deleteMsg string
 
-	mPath := o.LocalConfigInfo.GetMountPath(o.storageName)
+	var devFile devfileParser.DevfileObj
+	mPath := ""
+	if o.isDevfile {
+		devFile, err = devfile.ParseAndValidate(o.devfilePath)
+		if err != nil {
+			return err
+		}
+		mPath, err = devFile.Data.GetVolumeMountPath(o.storageName)
+		if err != nil {
+			return err
+		}
+	} else {
+		mPath = o.LocalConfigInfo.GetMountPath(o.storageName)
+	}
 
-	deleteMsg = fmt.Sprintf("Are you sure you want to delete the storage %v mounted to %v in %v component", o.storageName, mPath, o.LocalConfigInfo.GetName())
+	deleteMsg = fmt.Sprintf("Are you sure you want to delete the storage %v mounted to %v in %v component", o.storageName, mPath, o.componentName)
 
 	if o.storageForceDeleteFlag || ui.Proceed(deleteMsg) {
-		err = o.LocalConfigInfo.StorageDelete(o.storageName)
-		if err != nil {
-			return fmt.Errorf("failed to delete storage, cause %v", err)
+		if o.isDevfile {
+			err = devFile.Data.DeleteVolume(o.storageName)
+			if err != nil {
+				return err
+			}
+			err = devFile.WriteYamlDevfile()
+			if err != nil {
+				return err
+			}
+		} else {
+			err = o.LocalConfigInfo.StorageDelete(o.storageName)
+			if err != nil {
+				return fmt.Errorf("failed to delete storage, cause %v", err)
+			}
 		}
 
-		log.Infof("Deleted storage %v from %v", o.storageName, o.LocalConfigInfo.GetName())
+		log.Infof("Deleted storage %v from %v", o.storageName, o.componentName)
 		log.Italic("\nPlease use `odo push` command to delete the storage from the cluster")
 	} else {
 		return fmt.Errorf("aborting deletion of storage: %v", o.storageName)
@@ -88,6 +131,8 @@ func NewCmdStorageDelete(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+
+	o.isDevfile = util.CheckPathExists(o.devfilePath)
 
 	storageDeleteCmd.Flags().BoolVarP(&o.storageForceDeleteFlag, "force", "f", false, "Delete storage without prompting")
 	completion.RegisterCommandHandler(storageDeleteCmd, completion.StorageDeleteCompletionHandler)

--- a/pkg/storage/labels/labels.go
+++ b/pkg/storage/labels/labels.go
@@ -8,6 +8,10 @@ import (
 // that are created
 const StorageLabel = "app.kubernetes.io/storage-name"
 
+// DevfileStorageLabel is the label key that is applied to all storage resources for devfile components
+// that are created
+const DevfileStorageLabel = "storage-name"
+
 // GetLabels gets the labels to be applied to the given storage besides the
 // component labels and application labels.
 func GetLabels(storageName string, componentName string, applicationName string, additional bool) map[string]string {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/machineoutput"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
@@ -531,4 +532,21 @@ func ConvertListLocalToMachine(storageListConfig []config.ComponentStorageSettin
 	}
 
 	return GetMachineReadableFormatForList(storageListLocal)
+}
+
+// MachineReadableSuccessOutput outputs a success output that includes
+// storage information
+func MachineReadableSuccessOutput(storageName string, message string) {
+	machineOutput := machineoutput.GenericSuccess{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "storage",
+			APIVersion: apiVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storageName,
+		},
+		Message: message,
+	}
+
+	machineoutput.OutputSuccess(machineOutput)
 }

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -93,6 +93,14 @@ func (d TestDevfileData) GetCommands() []versionsCommon.DevfileCommand {
 	}
 }
 
+func (d TestDevfileData) AddVolume(volume common.Volume, path string) error { return nil }
+
+func (d TestDevfileData) DeleteVolume(name string) error { return nil }
+
+func (d TestDevfileData) GetVolumeMountPath(name string) (string, error) {
+	return "", nil
+}
+
 // Validate is a mock validation that always validates without error
 func (d TestDevfileData) Validate() error {
 	return nil
@@ -147,9 +155,7 @@ func GetFakeContainerComponent(name string) versionsCommon.DevfileComponent {
 }
 
 // GetFakeVolumeComponent returns a fake volume component for testing
-func GetFakeVolumeComponent(name string) versionsCommon.DevfileComponent {
-	size := "4Gi"
-
+func GetFakeVolumeComponent(name, size string) versionsCommon.DevfileComponent {
 	return versionsCommon.DevfileComponent{
 		Volume: &versionsCommon.Volume{
 			Name: name,
@@ -185,5 +191,13 @@ func GetFakeVolumeMount(name, path string) versionsCommon.VolumeMount {
 	return versionsCommon.VolumeMount{
 		Name: name,
 		Path: path,
+	}
+}
+
+// GetFakeVolume returns a fake volume for testing
+func GetFakeVolume(name, size string) versionsCommon.Volume {
+	return versionsCommon.Volume{
+		Name: name,
+		Size: size,
 	}
 }

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -16,4 +16,5 @@ type CliRunner interface {
 	DeleteNamespaceProject(projectName string)
 	GetEnvsDevFileDeployment(componentName string, projectName string) map[string]string
 	GetPVCSize(compName, storageName, namespace string) string
+	GetAllPVCNames(namespace string) []string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -142,3 +142,13 @@ func (kubectl KubectlRunner) GetEnvsDevFileDeployment(componentName string, proj
 	}
 	return mapOutput
 }
+
+func (kubectl KubectlRunner) GetAllPVCNames(namespace string) []string {
+	session := CmdRunner(kubectl.path, "get", "pvc", "--namespace", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+	Eventually(session).Should(gexec.Exit(0))
+	output := string(session.Wait().Out.Contents())
+	if output == "" {
+		return []string{}
+	}
+	return strings.Split(output, " ")
+}

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -558,3 +558,13 @@ func (oc OcRunner) DeleteNamespaceProject(projectName string) {
 	session := CmdShouldPass("odo", "project", "delete", projectName, "-f")
 	Expect(session).To(ContainSubstring("Deleted project : " + projectName))
 }
+
+func (oc OcRunner) GetAllPVCNames(namespace string) []string {
+	session := CmdRunner(oc.path, "get", "pvc", "--namespace", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+	Eventually(session).Should(gexec.Exit(0))
+	output := string(session.Wait().Out.Contents())
+	if output == "" {
+		return []string{}
+	}
+	return strings.Split(output, " ")
+}

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -44,9 +44,9 @@ var _ = Describe("odo storage command tests", func() {
 		It("should fail", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
-			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1")
+			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1", "--context", context)
 			Expect(stdErr).To(ContainSubstring("required flag"))
-			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--path", "/data")
+			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--path", "/data", "--context", context)
 			helper.MatchAllInOutput(stdErr, []string{"size", "required"})
 			//helper.CmdShouldFail("odo", "storage", "create", "pv1", "-o", "json")
 		})

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -46,6 +46,8 @@ var _ = Describe("odo storage command tests", func() {
 			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
 			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1")
 			Expect(stdErr).To(ContainSubstring("required flag"))
+			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--path", "/data")
+			helper.MatchAllInOutput(stdErr, []string{"size", "required"})
 			//helper.CmdShouldFail("odo", "storage", "create", "pv1", "-o", "json")
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -25,8 +25,6 @@ var _ = Describe("odo devfile storage command tests", func() {
 		currentWorkingDirectory = helper.Getwd()
 		cmpName = helper.RandString(6)
 
-		helper.Chdir(context)
-
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
 		// Devfile push requires experimental mode to be set


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

Adds storage create and delete commands for devfile v2.

**Which issue(s) this PR fixes**:

part of #3398 
fixes #3641 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

- Create a devfile component
- Create a storage for the component `odo storage create <name> --path <path>`
- Check if the new volume was added to the devfile and mounted to all the container components.
- Execute `odo push`  and `oc get pvc` and check if the PVC was created or not.

- Delete the storage `odo storage delete <name> -f`
- Check the volume is removed from the devfile and unmounted from all the container components.
- Execute `odo push`  and `oc get pvc` and check if the PVC was deleted or not.
- Try out the json output for the commands.