### PR TITLE
PreStop Event Feature

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -44,7 +44,7 @@ func getCommandFromDevfile(data data.DevfileData, groupType common.DevfileComman
 		cmdGroup := command.GetGroup()
 		if cmdGroup != nil && cmdGroup.Kind == groupType {
 			if cmdGroup.IsDefault {
-				return command, validateCommand(data, command)
+				return command, ValidateCommand(data, command)
 			} else if reflect.DeepEqual(onlyCommand, common.DevfileCommand{}) {
 				// return the only remaining command for the group if there is no default command
 				// NOTE: we return outside the for loop since the next iteration can have a default command
@@ -55,7 +55,7 @@ func getCommandFromDevfile(data data.DevfileData, groupType common.DevfileComman
 
 	// if default command is not found return the first command found for the matching type.
 	if !reflect.DeepEqual(onlyCommand, common.DevfileCommand{}) {
-		return onlyCommand, validateCommand(data, onlyCommand)
+		return onlyCommand, ValidateCommand(data, onlyCommand)
 	}
 
 	msg := fmt.Sprintf("the command group of kind \"%v\" is not found in the devfile", groupType)
@@ -90,7 +90,7 @@ func getCommandFromFlag(data data.DevfileData, groupType common.DevfileCommandGr
 				return command, fmt.Errorf("command group mismatched, command %s is of group %v in devfile.yaml", commandName, command.Exec.Group.Kind)
 			}
 
-			return command, validateCommand(data, command)
+			return command, ValidateCommand(data, command)
 		}
 	}
 
@@ -129,11 +129,12 @@ func validateCommandsForGroup(data data.DevfileData, groupType common.DevfileCom
 	return nil
 }
 
-// validateCommand validates the given command
-// 1. command has to be of type exec or composite
+// ValidateCommand validates the given command
+// 1. command has to be of type exec or composite, if composite command is validated further
 // 2. component should be present
-// 4. command must have group
-func validateCommand(data data.DevfileData, command common.DevfileCommand) (err error) {
+// 3. commandline should be present
+// 4. command must map to a valid container component
+func ValidateCommand(data data.DevfileData, command common.DevfileCommand) (err error) {
 
 	// type must be exec or composite
 	if command.Exec == nil && command.Composite == nil {

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -208,7 +208,7 @@ func validateCompositeCommand(data data.DevfileData, compositeCommand *common.Co
 				return err
 			}
 		} else {
-			err := validateCommand(data, subCommand)
+			err := ValidateCommand(data, subCommand)
 			if err != nil {
 				return errors.Wrapf(err, "the composite command %q references an invalid command %q", compositeCommand.Id, subCommand.GetID())
 			}

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -943,7 +943,7 @@ func TestValidateCommand(t *testing.T) {
 			} else {
 				cmd = common.DevfileCommand{Exec: &tt.exec[0]}
 			}
-			err := validateCommand(devObj.Data, cmd)
+			err := ValidateCommand(devObj.Data, cmd)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("TestValidateAction unexpected error: %v", err)
 				return

--- a/pkg/devfile/adapters/common/interface.go
+++ b/pkg/devfile/adapters/common/interface.go
@@ -6,7 +6,7 @@ import "io"
 type ComponentAdapter interface {
 	Push(parameters PushParameters) error
 	DoesComponentExist(cmpName string) (bool, error)
-	Delete(labels map[string]string) error
+	Delete(labels map[string]string, show bool) error
 	Test(testCmd string, show bool) error
 	Log(follow, debug bool) (io.ReadCloser, error)
 	Exec(command []string) error

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -14,6 +14,9 @@ import (
 // PredefinedDevfileCommands encapsulates constants for predefined devfile commands
 type PredefinedDevfileCommands string
 
+// DevfileEventType encapsulates constants for devfile events
+type DevfileEventType string
+
 const (
 	// DefaultDevfileInitCommand is a predefined devfile command for init
 	DefaultDevfileInitCommand PredefinedDevfileCommands = "devinit"
@@ -84,6 +87,18 @@ const (
 
 	// SupervisordCtlSubCommand is the supervisord sub command ctl
 	SupervisordCtlSubCommand = "ctl"
+
+	// PreStart is a devfile event
+	PreStart DevfileEventType = "preStart"
+
+	// PostStart is a devfile event
+	PostStart DevfileEventType = "postStart"
+
+	// PreStop is a devfile event
+	PreStop DevfileEventType = "preStop"
+
+	// PostStop is a devfile event
+	PostStop DevfileEventType = "postStop"
 )
 
 // CommandNames is a struct to store the default and adapter names for devfile commands

--- a/pkg/devfile/adapters/docker/adapter.go
+++ b/pkg/devfile/adapters/docker/adapter.go
@@ -41,8 +41,8 @@ func (d Adapter) DoesComponentExist(cmpName string) (bool, error) {
 }
 
 // Delete attempts to delete the component with the specified labels, returning an error if it fails
-func (d Adapter) Delete(labels map[string]string) error {
-	return d.componentAdapter.Delete(labels)
+func (d Adapter) Delete(labels map[string]string, show bool) error {
+	return d.componentAdapter.Delete(labels, show)
 }
 
 // Test runs devfile test command

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -207,7 +207,7 @@ func getFirstContainerWithSourceVolume(containers []types.Container) (string, st
 }
 
 // Delete attempts to delete the component with the specified labels, returning an error if it fails
-func (a Adapter) Delete(labels map[string]string) error {
+func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 	componentName, exists := labels["component"]
 	if !exists {

--- a/pkg/devfile/adapters/docker/component/adapter_test.go
+++ b/pkg/devfile/adapters/docker/component/adapter_test.go
@@ -468,7 +468,7 @@ func TestAdapterDelete(t *testing.T) {
 				}
 			}
 
-			if err := a.Delete(tt.args.labels); (err != nil) != tt.wantErr {
+			if err := a.Delete(tt.args.labels, false); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -814,7 +814,7 @@ func TestAdapterDeleteVolumes(t *testing.T) {
 				mockDockerClient.EXPECT().VolumeRemove(gomock.Any(), deleteExpected, gomock.Any()).Return(nil)
 			}
 
-			err := a.Delete(arg)
+			err := a.Delete(arg, false)
 			if err != nil {
 				t.Errorf("Delete() unexpected error = %v", err)
 			}

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -45,9 +45,9 @@ func (k Adapter) DoesComponentExist(cmpName string) (bool, error) {
 }
 
 // Delete deletes the Kubernetes resources that correspond to the devfile
-func (k Adapter) Delete(labels map[string]string) error {
+func (k Adapter) Delete(labels map[string]string, show bool) error {
 
-	err := k.componentAdapter.Delete(labels)
+	err := k.componentAdapter.Delete(labels, show)
 	if err != nil {
 		return err
 	}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -571,7 +571,7 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 	log.Infof("\nGathering information for component %s", a.ComponentName)
-	podSpinner := log.Spinnerf("Retrieving pod for component %s", a.ComponentName)
+	podSpinner := log.Spinnerf("Checking status for component %s", a.ComponentName)
 	defer podSpinner.End(false)
 
 	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -581,7 +581,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 		podSpinner.End(false)
 		log.Warningf("%v", err)
 		return nil
-	} else if e, ok := err.(*kclient.NoPodFoundError); ok {
+	} else if e, ok := err.(*kclient.PodNotFoundError); ok {
 		podSpinner.End(false)
 		log.Warningf("%v", e)
 		return nil

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -571,7 +571,7 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 	log.Infof("\nGathering information for component %s", a.ComponentName)
-	podSpinner := log.Spinnerf("Checking status for component %s", a.ComponentName)
+	podSpinner := log.Spinner("Checking status for component")
 	defer podSpinner.End(false)
 
 	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
@@ -604,8 +604,8 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 		}
 	}
 
-	log.Infof("\nDeleting devfile component %s", a.ComponentName)
-	spinner := log.Spinnerf("Deleting Kubernetes resources for component %s", a.ComponentName)
+	log.Infof("\nDeleting component %s", a.ComponentName)
+	spinner := log.Spinner("Deleting Kubernetes resources for component")
 	defer spinner.End(false)
 
 	err = a.Client.DeleteDeployment(labels)

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -542,7 +542,7 @@ func TestAdapterDelete(t *testing.T) {
 
 			fkclientset.Kubernetes.PrependReactor("list", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 				if tt.componentName == "nocomponent" {
-					return true, emptyPods, &kclient.NoPodFoundError{Selector: "somegarbage"}
+					return true, emptyPods, &kclient.PodNotFoundError{Selector: "somegarbage"}
 				} else if tt.componentName == "resourceforbidden" {
 					return true, emptyPods, kerrors.NewForbidden(schema.GroupResource{}, "", nil)
 				} else if tt.componentName == "componenterror" {

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -428,63 +428,85 @@ func TestAdapterDelete(t *testing.T) {
 		labels map[string]string
 	}
 
-	emptyDeployment := testingutil.CreateFakeDeployment("")
+	emptyPods := &corev1.PodList{
+		Items: []corev1.Pod{},
+	}
 
 	tests := []struct {
-		name               string
-		args               args
-		existingDeployment *v1.Deployment
-		componentName      string
-		componentExists    bool
-		wantErr            bool
+		name            string
+		args            args
+		existingPod     *corev1.PodList
+		componentName   string
+		componentExists bool
+		wantErr         bool
 	}{
 		{
 			name: "case 1: component exists and given labels are valid",
 			args: args{labels: map[string]string{
 				"component": "component",
 			}},
-			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
-			componentName:      "component",
-			componentExists:    true,
-			wantErr:            false,
+			existingPod: &corev1.PodList{
+				Items: []corev1.Pod{
+					*testingutil.CreateFakePod("component", "component"),
+				},
+			},
+			componentName:   "component",
+			componentExists: true,
+			wantErr:         false,
 		},
 		{
-			name:               "case 2: component exists and given labels are not valid",
-			args:               args{labels: nil},
-			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
-			componentName:      "component",
-			componentExists:    true,
-			wantErr:            true,
+			name: "case 2: component exists and given labels are not valid",
+			args: args{labels: nil},
+			existingPod: &corev1.PodList{
+				Items: []corev1.Pod{
+					*testingutil.CreateFakePod("component", "component"),
+				},
+			},
+			componentName:   "component",
+			componentExists: true,
+			wantErr:         true,
 		},
 		{
 			name: "case 3: component doesn't exists",
 			args: args{labels: map[string]string{
 				"component": "component",
 			}},
-			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
-			componentName:      "component",
-			componentExists:    false,
-			wantErr:            false,
+			existingPod: &corev1.PodList{
+				Items: []corev1.Pod{
+					*testingutil.CreateFakePod("component", "component"),
+				},
+			},
+			componentName:   "nocomponent",
+			componentExists: false,
+			wantErr:         false,
 		},
 		{
 			name: "case 4: resource forbidden",
 			args: args{labels: map[string]string{
 				"component": "component",
 			}},
-			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
-			componentName:      "resourceforbidden",
-			componentExists:    false,
-			wantErr:            false,
+			existingPod: &corev1.PodList{
+				Items: []corev1.Pod{
+					*testingutil.CreateFakePod("component", "component"),
+				},
+			},
+			componentName:   "resourceforbidden",
+			componentExists: false,
+			wantErr:         false,
 		},
 		{
 			name: "case 5: component check error",
 			args: args{labels: map[string]string{
 				"component": "component",
 			}},
-			existingDeployment: testingutil.CreateFakeDeployment("fronted"),
-			componentName:      "componenterror",
-			componentExists:    true,
-			wantErr:            true,
+			existingPod: &corev1.PodList{
+				Items: []corev1.Pod{
+					*testingutil.CreateFakePod("component", "component"),
+				},
+			},
+			componentName:   "componenterror",
+			componentExists: true,
+			wantErr:         true,
 		},
 	}
 	for _, tt := range tests {
@@ -518,18 +540,18 @@ func TestAdapterDelete(t *testing.T) {
 				return true, nil, nil
 			})
 
-			fkclientset.Kubernetes.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
-				if action.(ktesting.GetAction).GetName() != tt.componentName {
-					return true, emptyDeployment, kerrors.NewNotFound(schema.GroupResource{}, "")
+			fkclientset.Kubernetes.PrependReactor("list", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if tt.componentName == "nocomponent" {
+					return true, emptyPods, &kclient.NoPodFoundError{Selector: "somegarbage"}
 				} else if tt.componentName == "resourceforbidden" {
-					return true, emptyDeployment, kerrors.NewForbidden(schema.GroupResource{}, "", nil)
+					return true, emptyPods, kerrors.NewForbidden(schema.GroupResource{}, "", nil)
 				} else if tt.componentName == "componenterror" {
-					return true, emptyDeployment, errors.Errorf("component check error")
+					return true, emptyPods, errors.Errorf("pod check error")
 				}
-				return true, tt.existingDeployment, nil
+				return true, tt.existingPod, nil
 			})
 
-			if err := a.Delete(tt.args.labels); (err != nil) != tt.wantErr {
+			if err := a.Delete(tt.args.labels, false); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -49,3 +49,13 @@ type MissingVolumeMountError struct {
 func (e *MissingVolumeMountError) Error() string {
 	return fmt.Sprintf("unable to find volume mount %s in devfile volume components", e.volumeName)
 }
+
+// InvalidEventError returns an error if the devfile event type has invalid events
+type InvalidEventError struct {
+	eventType string
+	event     string
+}
+
+func (e *InvalidEventError) Error() string {
+	return fmt.Sprintf("%s type event %s invalid", e.eventType, e.event)
+}

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -53,9 +53,9 @@ func (e *MissingVolumeMountError) Error() string {
 // InvalidEventError returns an error if the devfile event type has invalid events
 type InvalidEventError struct {
 	eventType string
-	event     string
+	errorMsg  string
 }
 
 func (e *InvalidEventError) Error() string {
-	return fmt.Sprintf("%s type event %s invalid", e.eventType, e.event)
+	return fmt.Sprintf("%s type events is invalid: %s", e.eventType, e.errorMsg)
 }

--- a/pkg/devfile/validate/events.go
+++ b/pkg/devfile/validate/events.go
@@ -1,0 +1,83 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"k8s.io/klog"
+)
+
+// Errors
+var (
+	ErrorInvalidEvent = "%s type event %s invalid"
+)
+
+// validateEvents validates all the devfile events
+func validateEvents(events common.DevfileEvents, commands []common.DevfileCommand) error {
+
+	var preStartErr, postStartErr, preStopErr, postStopErr error
+
+	switch {
+	case len(events.PreStart) > 0:
+		klog.V(4).Info("Validating preStart events")
+		preStartErr = isEventValid(events.PreStart, "preStart", commands)
+		fallthrough
+	case len(events.PostStart) > 0:
+		klog.V(4).Info("Validating postStart events")
+		postStartErr = isEventValid(events.PostStart, "postStart", commands)
+		fallthrough
+	case len(events.PreStop) > 0:
+		klog.V(4).Info("Validating preStop events")
+		preStopErr = isEventValid(events.PreStop, "preStop", commands)
+		fallthrough
+	case len(events.PostStop) > 0:
+		klog.V(4).Info("Validating postStop events")
+		postStopErr = isEventValid(events.PostStop, "postStop", commands)
+	}
+
+	eventErrors := ""
+	if preStartErr != nil {
+		eventErrors += fmt.Sprintf("\n%s", preStartErr.Error())
+	}
+	if postStartErr != nil {
+		eventErrors += fmt.Sprintf("\n%s", postStartErr.Error())
+	}
+	if preStopErr != nil {
+		eventErrors += fmt.Sprintf("\n%s", preStopErr.Error())
+	}
+	if postStopErr != nil {
+		eventErrors += fmt.Sprintf("\n%s", postStopErr.Error())
+	}
+
+	if len(eventErrors) > 0 {
+		return fmt.Errorf("devfile events validation error: %s", eventErrors)
+	}
+
+	return nil
+}
+
+func isEventValid(eventNames []string, eventType string, commands []common.DevfileCommand) error {
+	var invalidEvents []string
+
+	for _, eventName := range eventNames {
+		isValid := false
+		for _, command := range commands {
+			if command.Exec != nil && command.Exec.Id == strings.ToLower(eventName) {
+				isValid = true
+				break
+			}
+		}
+
+		if !isValid {
+			klog.V(4).Infof(ErrorInvalidEvent, eventType, eventName)
+			invalidEvents = append(invalidEvents, eventName)
+		}
+	}
+
+	if len(invalidEvents) > 0 {
+		return fmt.Errorf(ErrorInvalidEvent, eventType, strings.Join(invalidEvents, ","))
+	}
+
+	return nil
+}

--- a/pkg/devfile/validate/events.go
+++ b/pkg/devfile/validate/events.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/klog"
 )
 
-// validateEvents validates all the devfile events
+// validateEvents validates all the devfile events against the devfile commands
 func validateEvents(events common.DevfileEvents, commands []common.DevfileCommand) error {
 
 	eventErrors := ""
@@ -47,6 +47,7 @@ func validateEvents(events common.DevfileEvents, commands []common.DevfileComman
 	return nil
 }
 
+// isEventValid checks if events belonging to a specific event type are valid
 func isEventValid(eventNames []string, eventType string, commands []common.DevfileCommand) error {
 	var invalidEvents []string
 

--- a/pkg/devfile/validate/events_test.go
+++ b/pkg/devfile/validate/events_test.go
@@ -43,7 +43,7 @@ func TestValidateEvents(t *testing.T) {
 			errorShouldContain: nil,
 		},
 		{
-			name: "Case 1: Valid events",
+			name: "Case 2: Invalid events",
 			events: common.DevfileEvents{
 				PostStop: []string{
 					"event1",

--- a/pkg/devfile/validate/events_test.go
+++ b/pkg/devfile/validate/events_test.go
@@ -1,0 +1,157 @@
+package validate
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+)
+
+func TestValidateEvents(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		events             common.DevfileEvents
+		commands           []common.DevfileCommand
+		wantErr            bool
+		errorShouldContain []string
+	}{
+		{
+			name: "Case 1: Valid events",
+			events: common.DevfileEvents{
+				PostStart: []string{
+					"event1",
+				},
+				PreStop: []string{
+					"event2",
+				},
+			},
+			commands: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						Id: "event1",
+					},
+				},
+				{
+					Composite: &common.Composite{
+						Id: "event2",
+					},
+				},
+			},
+			wantErr:            false,
+			errorShouldContain: nil,
+		},
+		{
+			name: "Case 1: Valid events",
+			events: common.DevfileEvents{
+				PostStop: []string{
+					"event1",
+				},
+				PreStart: []string{
+					"event2",
+				},
+			},
+			commands: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						Id: "event11",
+					},
+				},
+				{
+					Composite: &common.Composite{
+						Id: "event22",
+					},
+				},
+			},
+			wantErr: true,
+			errorShouldContain: []string{
+				"preStart type event event2 invalid",
+				"postStop type event event1 invalid",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEvents(tt.events, tt.commands)
+			if err != nil && !tt.wantErr {
+				t.Errorf("TestValidateEvents error - %v", err)
+			} else if err != nil && tt.wantErr {
+				for _, errorString := range tt.errorShouldContain {
+					if !strings.Contains(err.Error(), errorString) {
+						t.Errorf("TestValidateEvents error mismatch, %v does not contain %s", err.Error(), errorString)
+					}
+				}
+			}
+		})
+	}
+
+}
+
+func TestIsEventValid(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		eventNames []string
+		eventType  string
+		commands   []common.DevfileCommand
+		wantErr    bool
+	}{
+		{
+			name: "Case 1: Valid events",
+			eventNames: []string{
+				"event1",
+				"event2",
+			},
+			eventType: "preStart",
+			commands: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						Id: "event1",
+					},
+				},
+				{
+					Composite: &common.Composite{
+						Id: "event2",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 2: Invalid events",
+			eventNames: []string{
+				"event1",
+				"event2",
+			},
+			eventType: "postStop",
+			commands: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						Id: "event11",
+					},
+				},
+				{
+					Composite: &common.Composite{
+						Id: "event22",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := isEventValid(tt.eventNames, tt.eventType, tt.commands)
+			if err != nil && !tt.wantErr {
+				t.Errorf("TestIsEventValid error: %v", err)
+			} else if err != nil && tt.wantErr {
+				want := &InvalidEventError{eventType: tt.eventType, event: strings.Join(tt.eventNames, ",")}
+				if !reflect.DeepEqual(err, want) {
+					t.Errorf("TestIsEventValid error mismatch - got: %v want: %v", err, want)
+				}
+			}
+		})
+	}
+
+}

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -13,27 +13,23 @@ import (
 // ValidateDevfileData validates whether sections of devfile are odo compatible
 func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
-	var events common.DevfileEvents
-	var commands []common.DevfileCommand
 
 	switch d := data.(type) {
 	case *v100.Devfile100:
 		components = d.GetComponents()
 	case *v200.Devfile200:
 		components = d.GetComponents()
-		events = d.GetEvents()
-		commands = d.GetCommands()
+
+		// Validate Events
+		if err := validateEvents(d); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown devfile type %T", d)
 	}
 
 	// Validate Components
 	if err := validateComponents(components); err != nil {
-		return err
-	}
-
-	// Validate Events
-	if err := validateEvents(events, commands); err != nil {
 		return err
 	}
 

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -13,18 +13,27 @@ import (
 // ValidateDevfileData validates whether sections of devfile are odo compatible
 func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
+	var events common.DevfileEvents
+	var commands []common.DevfileCommand
 
 	switch d := data.(type) {
 	case *v100.Devfile100:
 		components = d.GetComponents()
 	case *v200.Devfile200:
 		components = d.GetComponents()
+		events = d.GetEvents()
+		commands = d.GetCommands()
 	default:
 		return fmt.Errorf("unknown devfile type %T", d)
 	}
 
 	// Validate Components
 	if err := validateComponents(components); err != nil {
+		return err
+	}
+
+	// Validate Events
+	if err := validateEvents(events, commands); err != nil {
 		return err
 	}
 

--- a/pkg/kclient/errors.go
+++ b/pkg/kclient/errors.go
@@ -2,11 +2,11 @@ package kclient
 
 import "fmt"
 
-// NoPodFoundError returns an error if no pod is found with the selector
-type NoPodFoundError struct {
+// PodNotFoundError returns an error if no pod is found with the selector
+type PodNotFoundError struct {
 	Selector string
 }
 
-func (e *NoPodFoundError) Error() string {
-	return fmt.Sprintf("no Pod was found for the selector: %s", e.Selector)
+func (e *PodNotFoundError) Error() string {
+	return fmt.Sprintf("pod not found for the selector: %s", e.Selector)
 }

--- a/pkg/kclient/errors.go
+++ b/pkg/kclient/errors.go
@@ -1,0 +1,12 @@
+package kclient
+
+import "fmt"
+
+// NoPodFoundError returns an error if no pod is found with the selector
+type NoPodFoundError struct {
+	selector string
+}
+
+func (e *NoPodFoundError) Error() string {
+	return fmt.Sprintf("no Pod was found for the selector: %s", e.selector)
+}

--- a/pkg/kclient/errors.go
+++ b/pkg/kclient/errors.go
@@ -4,9 +4,9 @@ import "fmt"
 
 // NoPodFoundError returns an error if no pod is found with the selector
 type NoPodFoundError struct {
-	selector string
+	Selector string
 }
 
 func (e *NoPodFoundError) Error() string {
-	return fmt.Sprintf("no Pod was found for the selector: %s", e.selector)
+	return fmt.Sprintf("no Pod was found for the selector: %s", e.Selector)
 }

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -168,7 +168,7 @@ func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
 	}
 	numPods := len(pods.Items)
 	if numPods == 0 {
-		return nil, &NoPodFoundError{selector: selector}
+		return nil, &NoPodFoundError{Selector: selector}
 	} else if numPods > 1 {
 		return nil, fmt.Errorf("multiple Pods exist for the selector: %v. Only one must be present", selector)
 	}

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -168,7 +168,7 @@ func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
 	}
 	numPods := len(pods.Items)
 	if numPods == 0 {
-		return nil, &NoPodFoundError{Selector: selector}
+		return nil, &PodNotFoundError{Selector: selector}
 	} else if numPods > 1 {
 		return nil, fmt.Errorf("multiple Pods exist for the selector: %v. Only one must be present", selector)
 	}

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -162,11 +162,13 @@ func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
 		LabelSelector: selector,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get Pod for the selector: %v", selector)
+		// Dont wrap error since we want to know if its a forbidden error
+		// if we wrap, we lose the err status reason and callers of this api rely on it
+		return nil, err
 	}
 	numPods := len(pods.Items)
 	if numPods == 0 {
-		return nil, fmt.Errorf("no Pod was found for the selector: %v", selector)
+		return nil, &NoPodFoundError{selector: selector}
 	} else if numPods > 1 {
 		return nil, fmt.Errorf("multiple Pods exist for the selector: %v. Only one must be present", selector)
 	}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -48,12 +48,13 @@ type DeleteOptions struct {
 	// devfile path
 	devfilePath     string
 	namespace       string
+	show            bool
 	EnvSpecificInfo *envinfo.EnvSpecificInfo
 }
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, false, false, "", false, &ComponentOptions{}, "", "", nil}
+	return &DeleteOptions{false, false, false, false, "", false, &ComponentOptions{}, "", "", false, nil}
 }
 
 // Complete completes log args
@@ -298,6 +299,11 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteAllFlag, "all", "a", false, "Delete component and local config")
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteWaitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteS2iFlag, "s2i", "", false, "Delete s2i component if devfile and s2i both component present with same name")
+
+	// enable show flag if experimental mode is enabled
+	if experimental.IsExperimentalModeEnabled() {
+		componentDeleteCmd.Flags().BoolVar(&do.show, "show-log", false, "If enabled, logs will be shown when deleted")
+	}
 
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -225,6 +225,7 @@ func (do *DeleteOptions) DevFileRun() (err error) {
 	}
 
 	if do.componentDeleteAllFlag {
+		log.Info("\nDeleting local config")
 		// Prompt and delete env folder
 		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete env folder?")) {
 			if !do.EnvSpecificInfo.EnvInfoFileExists() {

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -54,7 +54,19 @@ type DeleteOptions struct {
 
 // NewDeleteOptions returns new instance of DeleteOptions
 func NewDeleteOptions() *DeleteOptions {
-	return &DeleteOptions{false, false, false, false, "", false, &ComponentOptions{}, "", "", false, nil}
+	return &DeleteOptions{
+		componentForceDeleteFlag: false,
+		componentDeleteAllFlag:   false,
+		componentDeleteWaitFlag:  false,
+		componentDeleteS2iFlag:   false,
+		componentContext:         "",
+		isCmpExists:              false,
+		ComponentOptions:         &ComponentOptions{},
+		devfilePath:              "",
+		namespace:                "",
+		show:                     false,
+		EnvSpecificInfo:          nil,
+	}
 }
 
 // Complete completes log args

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -222,7 +222,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		return err
 	}
 
-	return devfileHandler.Delete(labels)
+	return devfileHandler.Delete(labels, do.show)
 }
 
 // RunTestCommand runs the specific test command in devfile

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -10,6 +10,7 @@ type TestDevfileData struct {
 	Components        []versionsCommon.DevfileComponent
 	ExecCommands      []versionsCommon.Exec
 	CompositeCommands []versionsCommon.Composite
+	Events            common.DevfileEvents
 }
 
 // GetComponents is a mock function to get the components from a devfile
@@ -24,7 +25,7 @@ func (d TestDevfileData) GetMetadata() versionsCommon.DevfileMetadata {
 
 // GetEvents is a mock function to get events from devfile
 func (d TestDevfileData) GetEvents() versionsCommon.DevfileEvents {
-	return versionsCommon.DevfileEvents{}
+	return d.Events
 }
 
 // GetParent is a mock function to get parent from devfile

--- a/pkg/testingutil/pods.go
+++ b/pkg/testingutil/pods.go
@@ -1,0 +1,22 @@
+package testingutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateFakePod creates a fake pod with the given pod name and component name
+func CreateFakePod(componentName, podName string) *corev1.Pod {
+	fakePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+			Labels: map[string]string{
+				"component": componentName,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	return fakePod
+}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -31,6 +31,11 @@ commands:
       component: runtime
       workingDir: /
   - exec:
+      id: wrongPostStart
+      commandLine: echo I am also a PostStart
+      component: wrongruntime
+      workingDir: /
+  - exec:
       id: myPreStop
       commandLine: echo I am a PreStop
       component: tools
@@ -50,6 +55,13 @@ commands:
       label: Build and Mkdir
       commands:
         - secondPreStop
+        - thirdPreStop
+      parallel: true
+  - composite:
+      id: myWrongCompCmd
+      label: Build and Mkdir
+      commands:
+        - secondPreStopisWrong
         - thirdPreStop
       parallel: true
   - exec:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -31,6 +31,28 @@ commands:
       component: runtime
       workingDir: /
   - exec:
+      id: myPreStop
+      commandLine: echo I am a PreStop
+      component: tools
+      workingDir: /
+  - exec:
+      id: secondPreStop
+      commandLine: echo I am also a PreStop
+      component: runtime
+      workingDir: /
+  - exec:
+      id: thirdPreStop
+      commandLine: echo I am a third PreStop
+      component: runtime
+      workingDir: /
+  - composite:
+      id: myCompCmd
+      label: Build and Mkdir
+      commands:
+        - secondPreStop
+        - thirdPreStop
+      parallel: true
+  - exec:
       id: devbuild
       component: runtime
       commandLine: npm install
@@ -63,4 +85,7 @@ commands:
 events:
   postStart:
     - "myPostStart" 
-    - "secondPostStart"
+    - "secondpoststart"
+  preStop:
+    - "myCompCmd" 
+    - "myPreStop"

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -391,7 +391,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			})
 		})
 
-		It("should err out on invalid events", func() {
+		It("should err out on an event not mentioned in the devfile commands", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
@@ -400,7 +400,31 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.ReplaceString("devfile.yaml", "secondpoststart", "secondpoststart12345")
 
 			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"postStart type event secondpoststart12345 invalid"})
+			helper.MatchAllInOutput(output, []string{"does not map to a valid devfile command"})
+		})
+
+		It("should err out on an event command not mapping to a devfile container component", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.ReplaceString("devfile.yaml", "secondpoststart", "wrongPostStart")
+
+			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
+			helper.MatchAllInOutput(output, []string{"the command does not map to a supported component"})
+		})
+
+		It("should err out on an event composite command mentioning an invalid child command", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.ReplaceString("devfile.yaml", "secondpoststart", "myWrongCompCmd")
+
+			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
+			helper.MatchAllInOutput(output, []string{"does not exist in the devfile"})
 		})
 
 		It("should be able to handle a missing build command group", func() {

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -377,7 +377,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-post-start.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace)
 			helper.MatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})
@@ -389,6 +389,18 @@ var _ = Describe("odo devfile push command tests", func() {
 				"Executing devbuild command",
 				"Executing devrun command",
 			})
+		})
+
+		It("should err out on invalid events", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.ReplaceString("devfile.yaml", "secondpoststart", "secondpoststart12345")
+
+			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
+			helper.MatchAllInOutput(output, []string{"postStart type event secondpoststart12345 invalid"})
 		})
 
 		It("should be able to handle a missing build command group", func() {

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -52,7 +52,7 @@ var _ = Describe("odo devfile test command tests", func() {
 
 			output := helper.CmdShouldFail("odo", "test", "--context", context)
 
-			Expect(output).To(ContainSubstring("error occurred while getting the pod: no Pod was found for the selector"))
+			Expect(output).To(ContainSubstring("error occurred while getting the pod: pod not found for the selector"))
 		})
 
 		It("should show error if no test group is defined", func() {

--- a/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_push_test.go
@@ -187,7 +187,7 @@ var _ = Describe("odo docker devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-post-start.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			output := helper.CmdShouldPass("odo", "push")
 			helper.MatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
- Executes `preStop` events, if present, before deleting the component
- Minor `odo delete` label/heading changes to reflect addition of preStop feature
- Add show flag to postStart event execution
- Add show flag to delete command on experimental
- Validate devfile events before using them
- Unit & Integration tests

**Which issue(s) this PR fixes**:

Fixes #3566
Fixes #3632
Fixes #3655

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
- Add in preStop events to a devfile or you may try with this sample:
```
schemaVersion: 2.0.0
metadata:
  name: nodejs
projects:
  - name: nodejs-starter
    git:
      location: "https://github.com/odo-devfiles/nodejs-ex.git"
components:
  - container:
      name: runtime
      image: quay.io/eclipse/che-nodejs10-ubi:nightly
      memoryLimit: 1024Mi
      endpoints:
        - name: "3000/tcp"
          configuration:
            protocol: tcp
            scheme: http
          targetPort: 3000 
      mountSources: true
  - container:
      name: "tools"
      image: quay.io/eclipse/che-nodejs10-ubi:nightly
      mountSources: true
      memoryLimit: 1024Mi
commands:
  - exec:
      id: myPostStart
      commandLine: echo I am a PostStart
      component: tools
      workingDir: /
  - exec:
      id: secondPostStart
      commandLine: echo I am also a PostStart
      component: runtime
      workingDir: /
  - exec:
      id: devbuild
      component: runtime
      commandLine: npm install
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: build
        isDefault: false
  - exec:
      id: build
      component: runtime
      commandLine: npm install
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: build
  - exec:
      id: devrun
      component: runtime
      commandLine: npm start
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: run
        isDefault: true
  - exec:
      id: run
      component: runtime
      commandLine: npm start
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: run
  - composite:
         id: mycompevent
         label: Build and Mkdir
         commands:
           - myPostStart
           - secondPostStart
         parallel: true
         group:
          kind: build
          isDefault: true
events:
  preStart:
    - "myPostStart" 
    - "secondPostStarssst"
  postStart:
    - "mycompevent" 
    - "secondPostStart"
  preStop:
    - "mycompevent" 
    - "secondPostStart"
  postStop:
    - "myPostStart" 
    - "secondPostStart"
```

should output:
```
Maysuns-MacBook-Pro:nodejs-ex maysun$ odo delete -f

Gathering information for component madridnode
 ✓  Checking status for component madridnode [132ms]

Executing preStop event commands for component madridnode
 •  Executing secondpoststart command "echo I am also a PostStart"  ...
 •  Executing mypoststart command "echo I am a PostStart"  ...
 ✓  Executing secondpoststart command "echo I am also a PostStart" [1s]
 ✓  Executing mypoststart command "echo I am a PostStart" [1s]
 ✓  Executing secondpoststart command "echo I am also a PostStart" [941ms]

Deleting devfile component madridnode
 ✓  Deleting Kubernetes resources for component madridnode [129ms]
 ✓  Successfully deleted component
```
