### PR TITLE
adding tests to verify the private registry images

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -116,8 +116,9 @@ var _ = Describe("odo supported images e2e tests", func() {
 
 	Context("odo supported private registry images deployment", func() {
 		JustBeforeEach(func() {
+			// Issue for configuring login secret for travis CI https://github.com/openshift/odo/issues/3640
 			if os.Getenv("CI") != "openshift" {
-				Skip("This is an openShift CI specific scenario, skipping")
+				Skip("Skipping it on travis CI, skipping")
 			}
 		})
 

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -112,5 +112,15 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
+
+		It("Should be able to verify the openjdk-11-rhel8 image", func() {
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "java:8", project)
+			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "openjdk", "java:8", project, appName, context)
+		})
+
+		It("Should be able to verify the nodejs-12-rhel7 image", func() {
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs:latest", project)
+			verifySupportedImage(filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
+		})
 	})
 })

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -112,6 +112,14 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("rhscl", "nodejs-10-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
+	})
+
+	Context("odo supported private registry images deployment", func() {
+		JustBeforeEach(func() {
+			if os.Getenv("CI") != "openshift" {
+				Skip("This is an openShift CI specific scenario, skipping")
+			}
+		})
 
 		It("Should be able to verify the openjdk-11-rhel8 image", func() {
 			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "java:8", project)
@@ -123,4 +131,5 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage(filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
 		})
 	})
+
 })


### PR DESCRIPTION
**What type of PR is this?**

/king test
/kind failing-test

**What does does this PR do / why we need it**:

Verify test for private registry images. As per [comment](https://github.com/openshift/odo/issues/2537#issuecomment-635941209) It should work with multistage

**Which issue(s) this PR fixes**:

Fixes #2537 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

It should verify tests for private registry successfully as per [comment](https://github.com/openshift/odo/issues/2537#issuecomment-635941209) 

Run `make test-e2e-images`