### PR TITLE
moved the deprecation warning from examples and moved to long desc

### DIFF
--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -50,15 +50,17 @@ var updateCmdExample = ktemplates.Examples(`  # Change the source code path of c
 	  # Change the source code path of of currently active component to a binary named sample.war in ./downloads directory
 	  %[1]s --binary ./downloads/sample.war
 
-	  WARNING: %[1]s is not available for Devfile based components and will be removed in the future odo versions.
 	`)
 
-var deprecationWarning string = `WARNING: 'odo update' command will be removed in the future odo version.
+const (
+	descDeprecationWarning = "WARNING: 'odo update' command will be removed in the future odo version."
+
+	deprecationWarning = `WARNING: 'odo update' command will be removed in the future odo version.
 	     You should be using 'odo config' command instead.
 	     example:
 		odo config set SourceType git
 		odo config set SourceLocation https://github.com/example/example`
-
+)
 const devfileErrorString string = "'odo update' command is not available for Devfile based components."
 
 // NewUpdateOptions returns new instance of UpdateOptions
@@ -206,7 +208,7 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 		Use:     name,
 		Args:    cobra.MaximumNArgs(0),
 		Short:   "Update the source code path of a component",
-		Long:    "Update the source code path of a component",
+		Long:    fmt.Sprint("Update the source code path of a component\n", descDeprecationWarning),
 		Example: fmt.Sprintf(updateCmdExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(uo, cmd, args)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

No issue - just noticed

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

----- ## Before -------
```
Update the source code path of a component

Usage:
  odo update [flags]

Examples:
  # Change the source code path of currently active component to local with source in ./frontend directory
  odo update --local ./frontend
  
  
  # Change the source code path of currently active component to git
  odo update --git https://github.com/openshift/nodejs-ex.git
  
  # Change the source code path of of currently active component to a binary named sample.war in ./downloads directory
  odo update --binary ./downloads/sample.war
  
  WARNING: odo update is not available for Devfile based components and will be removed in the future odo versions.
```

---- ## After -----------
```
Update the source code path of a component
WARNING: 'odo update' command will be removed in the future odo version.

Usage:
  odo update [flags]

Examples:
  # Change the source code path of currently active component to local with source in ./frontend directory
  odo update --local ./frontend
  
  
  # Change the source code path of currently active component to git
  odo update --git https://github.com/openshift/nodejs-ex.git
  
  # Change the source code path of of currently active component to a binary named sample.war in ./downloads directory
  odo update --binary ./downloads/sample.war
```

