### PR TITLE
CI support for ODO on IBM P

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ configure-installer-tests-cluster:
 configure-installer-tests-cluster-s390x:
 	. ./scripts/configure-installer-tests-cluster-s390x.sh
 
+# configure cluster to run tests on ppc64le arch
+.PHONY: configure-installer-tests-cluster-ppc64le
+configure-installer-tests-cluster-ppc64le:
+	. ./scripts/configure-installer-tests-cluster-ppc64le.sh
+
 .PHONY: configure-supported-311-is
 configure-supported-311-is:
 	. ./scripts/supported-311-is.sh

--- a/docs/dev/test-architecture-ppc64le.adoc
+++ b/docs/dev/test-architecture-ppc64le.adoc
@@ -1,0 +1,18 @@
+= test-architecture-ppc64le
+For all tests on ppc64le arch, the openshift cluster version is 4.3 or newer.
+The prerequisites, please refer to default https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc[test-architecture]!
+
+== Running integration and e2e tests locally
+
+Odo CI for ppc64le is running locally now.The scripts/configure-installer-tests-cluster-ppc64le.sh is available in the https://github.com/openshift/odo/tree/master/scripts[odo] repository to help configure the test environment and the scripts/openshiftci-presubmit-all-tests.sh is available in the https://github.com/openshift/odo/tree/master/scripts[odo] repository to run integration and e2e tests covered on ppc64le arch.  
+For running all covered integration and e2e tests on 4.x cluster, you can run:
+----
+	./scripts/openshiftci-presubmit-all-tests.sh
+----
+
+Similarly for running specific test on 4.x cluster, you can run:
+----
+	./scripts/configure-installer-tests-cluster-ppc64le.sh
+	make test-xxx-xxx
+----
+

--- a/scripts/configure-installer-tests-cluster-ppc64le.sh
+++ b/scripts/configure-installer-tests-cluster-ppc64le.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+set -x
+# Setup to find nessasary data from cluster setup
+## Constants
+HTPASSWD_FILE="./htpass"
+USERPASS="developer"
+HTPASSWD_SECRET="htpasswd-secret"
+#SETUP_OPERATORS="./scripts/setup-operators.sh"
+# Overrideable information
+DEFAULT_INSTALLER_ASSETS_DIR=${DEFAULT_INSTALLER_ASSETS_DIR:-$(pwd)}
+KUBEADMIN_USER=${KUBEADMIN_USER:-"kubeadmin"}
+KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeadmin-password"}
+# Default values
+OC_STABLE_LOGIN="false"
+#CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
+# Exported to current env
+ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeconfig"}
+export KUBECONFIG=$ORIGINAL_KUBECONFIG
+
+# List of users to create
+USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
+
+# Attempt resolution of kubeadmin, only if a CI is not set
+if [ -z $CI ]; then
+    # Check if nessasary files exist
+    if [ ! -f $KUBEADMIN_PASSWORD_FILE ]; then
+        echo "Could not find kubeadmin password file"
+        exit 1
+    fi
+
+    if [ ! -f $KUBECONFIG ]; then
+        echo "Could not find kubeconfig file"
+        exit 1
+    fi
+
+    # Get kubeadmin password from file
+    KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
+
+    # Login as admin user
+    oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD
+else
+    # Copy kubeconfig to temporary kubeconfig file
+    # Read and Write permission to temporary kubeconfig file
+    TMP_DIR=$(mktemp -d)
+    cp $KUBECONFIG $TMP_DIR/kubeconfig
+    chmod 640 $TMP_DIR/kubeconfig
+    export KUBECONFIG=$TMP_DIR/kubeconfig
+fi
+
+# Setup the cluster for Operator tests
+
+## Create a new namesapce which will be used for OperatorHub checks
+#oc new-project $CI_OPERATOR_HUB_PROJECT
+## Let developer user have access to the project
+oc adm policy add-role-to-user edit developer
+
+#sh $SETUP_OPERATORS
+# OperatorHub setup complete
+
+# Remove existing htpasswd file, if any
+if [ -f $HTPASSWD_FILE ]; then
+    rm -rf $HTPASSWD_FILE
+fi
+
+# Set so first time -c parameter gets applied to htpasswd
+HTPASSWD_CREATED=" -c "
+
+# Create htpasswd entries for all listed users
+for i in `echo $USERS`; do
+    htpasswd -b $HTPASSWD_CREATED $HTPASSWD_FILE $i $USERPASS
+    HTPASSWD_CREATED=""
+done
+
+# Workarounds - Note we should find better soulutions asap
+## Missing wildfly in OpenShift Adding it manually to cluster Please remove once wildfly is again visible
+#oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/x86_64/community/wildfly/imagestreams/wildfly-centos7.json
+oc import-image nodejs --from=registry.redhat.io/rhscl/nodejs-12-rhel7 --confirm -n openshift
+sleep 15
+oc annotate istag/nodejs:latest tags=builder -n openshift --overwrite
+oc import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
+sleep 15
+oc annotate istag/java:8 --namespace=openshift tags=builder --overwrite
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/ruby/imagestreams/ruby-rhel7.json
+sleep 15
+oc annotate istag/ruby:latest --namespace=openshift tags=builder --overwrite
+oc import-image wildfly:latest --confirm \--from docker.io/saomany/wildfly-120-centos7:ppc64le --insecure -n openshift
+sleep 15
+oc annotate istag/wildfly:latest --namespace=openshift tags=builder --overwrite
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/nginx/imagestreams/nginx-rhel7.json
+sleep 15
+oc annotate istag/nginx:latest --namespace=openshift tags=builder --overwrite
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/community/dotnet/imagestreams/dotnet-centos7.json
+sleep 15
+oc annotate istag/dotnet:latest --namespace=openshift tags=builder --overwrite
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/php/imagestreams/php-rhel7.json
+sleep 15
+oc annotate istag/php:latest --namespace=openshift tags=builder --overwrite
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/python/imagestreams/python-rhel7.json
+sleep 15
+oc annotate istag/python:latest --namespace=openshift tags=builder --overwrite
+
+# Create secret in cluster, removing if it already exists
+oc get secret $HTPASSWD_SECRET -n openshift-config &> /dev/null
+if [ $? -eq 0 ]; then
+    oc delete secret $HTPASSWD_SECRET -n openshift-config &> /dev/null
+fi
+oc create secret generic ${HTPASSWD_SECRET} --from-file=htpasswd=${HTPASSWD_FILE} -n openshift-config
+
+# Upload htpasswd as new login config
+oc apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: htpassidp1
+    challenge: true
+    login: true
+    mappingMethod: claim
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: ${HTPASSWD_SECRET}
+EOF
+
+# Login as developer and check for stable server
+for i in {1..40}; do
+    # Try logging in as developer
+    #oc login -u developer -p $USERPASS &> /dev/null
+    KUBEADMIN_PASSWORD=`cat $KUBEADMIN_PASSWORD_FILE`
+    oc login -u $KUBEADMIN_USER -p $KUBEADMIN_PASSWORD &> /dev/null
+    if [ $? -eq 0 ]; then
+        # If login succeeds, assume success
+	    OC_STABLE_LOGIN="true"
+        # Attempt failure of `oc whoami`
+        for j in {1..25}; do
+            oc whoami &> /dev/null
+            if [ $? -ne 0 ]; then
+                # If `oc whoami` fails, assume fail and break out of trying `oc whoami`
+                OC_STABLE_LOGIN="false"
+                break
+            fi
+            sleep 2
+        done
+        # If `oc whoami` never failed, break out trying to login again
+        if [ $OC_STABLE_LOGIN == "true" ]; then
+            break
+        fi
+    fi
+    sleep 3
+done
+
+if [ $OC_STABLE_LOGIN == "false" ]; then
+    echo "Failed to login as developer"
+    exit 1
+fi
+
+# Setup project
+oc new-project myproject
+sleep 4
+oc version
+oc get secret pull-secret -n openshift-config -o yaml --export | oc create -f -
+
+# KUBECONFIG cleanup only if CI is set
+if [ ! -f $CI ]; then
+    rm -rf $KUBECONFIG
+    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+fi

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -9,6 +9,8 @@ ARCH=$(uname -m)
 export CI="openshift"
 if [ "${ARCH}" == "s390x" ]; then
     make configure-installer-tests-cluster-s390x
+elif [ "${ARCH}" == "ppc64le" ]; then
+    make configure-installer-tests-cluster-ppc64le
 else
     make configure-installer-tests-cluster
 fi
@@ -33,13 +35,28 @@ odo login -u developer -p developer
 oc whoami
 
 # import the odo-init-image for s390x arch
-if [ "${ARCH}" == "s390x" ]; then
+if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
     export ODO_BOOTSTRAPPER_IMAGE=registry.redhat.io/ocp-tools-4/odo-init-container-rhel8:1.1.4
 fi
 
 if [ "${ARCH}" == "s390x" ]; then
     # Integration tests
     make test-generic
+    make test-cmd-link-unlink
+    make test-cmd-pref-config
+    make test-cmd-watch
+    make test-cmd-debug
+    make test-cmd-login-logout
+    make test-cmd-project
+    make test-cmd-app
+    make test-cmd-storage
+    make test-cmd-push
+    make test-cmd-watch
+    # E2e tests
+    make test-e2e-beta
+elif  [ "${ARCH}" == "ppc64le" ]; then
+    # Integration tests
+    #make test-generic
     make test-cmd-link-unlink
     make test-cmd-pref-config
     make test-cmd-watch

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -34,11 +34,6 @@ odo login -u developer -p developer
 # Check login user name for debugging purpose
 oc whoami
 
-# import the odo-init-image for s390x arch
-if [ "${ARCH}" == "s390x" ] || [ "${ARCH}" == "ppc64le" ]; then
-    export ODO_BOOTSTRAPPER_IMAGE=registry.redhat.io/ocp-tools-4/odo-init-container-rhel8:1.1.4
-fi
-
 if [ "${ARCH}" == "s390x" ]; then
     # Integration tests
     make test-generic
@@ -56,7 +51,7 @@ if [ "${ARCH}" == "s390x" ]; then
     make test-e2e-beta
 elif  [ "${ARCH}" == "ppc64le" ]; then
     # Integration tests
-    #make test-generic
+    make test-generic
     make test-cmd-link-unlink
     make test-cmd-pref-config
     make test-cmd-watch


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
Enable upstream CI on ppc64le arch.

**How to test changes / Special notes to the reviewer**:
This PR is based on similar PR for IBM Z - https://github.com/openshift/odo/pull/3529

We have setup OCP 4.4 on IBM P. We download this ODO code from upstream and run the scripts/openshiftci-presubmit-all-tests.sh to trigger CI tests on IBM P.