### PR TITLE
Add Json output for registry output

### DIFF
--- a/pkg/machineoutput/registry.go
+++ b/pkg/machineoutput/registry.go
@@ -1,0 +1,22 @@
+package machineoutput
+
+import (
+	"github.com/openshift/odo/pkg/preference"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RegistryListOutput struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	RegistryList      *[]preference.Registry `json:"registries,omitempty"`
+}
+
+func NewRegistryListOutput(registryList *[]preference.Registry) RegistryListOutput {
+	return RegistryListOutput{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: APIVersion,
+		},
+		RegistryList: registryList,
+	}
+}

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -8,6 +8,8 @@ import (
 	"text/tabwriter"
 
 	// Third-party packages
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
@@ -58,6 +60,12 @@ func (o *ListOptions) Run() (err error) {
 	if len(*registryList) == 0 {
 		return fmt.Errorf("No devfile registries added to the configuration. Refer `odo registry add -h` to add one")
 	}
+
+	if log.IsJSON() {
+		machineoutput.OutputSuccess(machineoutput.NewRegistryListOutput(registryList))
+		return
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "NAME", "\t", "URL", "\t", "SECURE")
 	o.printRegistryList(w, registryList)
@@ -83,11 +91,12 @@ func (o *ListOptions) printRegistryList(w io.Writer, registryList *[]preference.
 func NewCmdList(name, fullName string) *cobra.Command {
 	o := NewListOptions()
 	registryListCmd := &cobra.Command{
-		Use:     name,
-		Short:   listDesc,
-		Long:    listDesc,
-		Example: fmt.Sprintf(fmt.Sprint(listExample), fullName),
-		Args:    cobra.ExactArgs(0),
+		Use:         name,
+		Short:       listDesc,
+		Long:        listDesc,
+		Example:     fmt.Sprintf(fmt.Sprint(listExample), fullName),
+		Annotations: map[string]string{"machineoutput": "json"},
+		Args:        cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -48,6 +48,11 @@ var _ = Describe("odo devfile registry command tests", func() {
 			helper.MatchAllInOutput(output, []string{"DefaultDevfileRegistry"})
 		})
 
+		It("Should list all default registries with json", func() {
+			output := helper.CmdShouldPass("odo", "registry", "list", "-o", "json")
+			helper.MatchAllInOutput(output, []string{"DefaultDevfileRegistry"})
+		})
+
 		It("Should fail with an error with no registries", func() {
 			helper.CmdShouldPass("odo", "registry", "delete", "DefaultDevfileRegistry", "-f")
 			output := helper.CmdShouldFail("odo", "registry", "list")


### PR DESCRIPTION
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3659 
add json output method for `registry list` command

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
`odo registry list -o json`