### PR TITLE
Add support for unlinking component from service

### DIFF
--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -328,14 +328,23 @@ func (esi *EnvSpecificInfo) DeleteURL(parameter string) error {
 }
 
 func (esi *EnvSpecificInfo) DeleteLink(parameter string) error {
+	index := -1
+
 	for i, link := range *esi.componentSettings.Link {
 		if link.Name == parameter {
-			s := *esi.componentSettings.Link
-			s = append(s[:i], s[i+1:]...)
-			esi.componentSettings.Link = &s
+			index = i
+			break
 		}
 	}
-	return esi.writeToFile()
+
+	if index != -1 {
+		s := *esi.componentSettings.Link
+		s = append(s[:index], s[index+1:]...)
+		esi.componentSettings.Link = &s
+		return esi.writeToFile()
+	} else {
+		return nil
+	}
 }
 
 // GetComponentSettings returns the componentSettings from envinfo

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -327,6 +327,17 @@ func (esi *EnvSpecificInfo) DeleteURL(parameter string) error {
 	return esi.writeToFile()
 }
 
+func (esi *EnvSpecificInfo) DeleteLink(parameter string) error {
+	for i, link := range *esi.componentSettings.Link {
+		if link.Name == parameter {
+			s := *esi.componentSettings.Link
+			s = append(s[:i], s[i+1:]...)
+			esi.componentSettings.Link = &s
+		}
+	}
+	return esi.writeToFile()
+}
+
 // GetComponentSettings returns the componentSettings from envinfo
 func (esi *EnvSpecificInfo) GetComponentSettings() ComponentSettings {
 	return esi.componentSettings

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -141,6 +141,12 @@ func DeleteServiceAndUnlinkComponents(client *occlient.Client, serviceName strin
 	return nil
 }
 
+// DeleteServiceBindingRequest deletes a service binding request (when user
+// does odo unlink). It's just a wrapper on DeleteOperatorService
+func DeleteServiceBindingRequest(client *kclient.Client, serviceName string) error {
+	return DeleteOperatorService(client, serviceName)
+}
+
 // DeleteOperatorService deletes an Operator backed service
 // TODO: make it unlink the service from component as a part of
 // https://github.com/openshift/odo/issues/3563

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -407,7 +407,7 @@ spec:
 			Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
 		})
 
-		It("should successfully connect a component with an existing service", func() {
+		It("should successfully connect and disconnect a component with an existing service", func() {
 			if os.Getenv("KUBERNETES") == "true" {
 				Skip("This is a OpenShift specific scenario, skipping")
 			}
@@ -433,6 +433,13 @@ spec:
 
 			stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
 			Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
+			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("already linked with the service"))
+
+			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
 		})
 	})
 })

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -438,8 +438,17 @@ spec:
 
 			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
 			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+
+			// verify that sbr is deleted
 			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
 			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+
+			// next, delete a link outside of odo (using oc) and ensure that it throws an error
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+			sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
+			helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
Adds support for unlinking a component from an Operator backed service with `odo unlink` command

**Which issue(s) this PR fixes**:

Fixes #3563

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
1. Install "Service Binding Operator" on the OpenShift cluster.
1. Create a `nodejs` component using https://github.com/akashshinde/node-todo. Use this devfile for things to work fine:
    <details>
    
    ```yaml
    schemaVersion: 2.0.0
    metadata:
      name: nodejs
      version: 1.0.0
    projects:
      - name: nodejs-starter
        git:
          location: "https://github.com/odo-devfiles/nodejs-ex.git"
    components:
      - container:
          name: runtime
          image: registry.access.redhat.com/ubi8/nodejs-12:1-36
          memoryLimit: 1024Mi
          mountSources: true
          endpoints:
            - name: http-8080
              targetPort: 8080
              configuration:
                protocol: tcp
                scheme: http
                type: terminal
    commands:
      - exec:
          id: install
          component: runtime
          commandLine: npm install
          workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
          group:
            kind: build
            isDefault: true
      - exec:
          id: run
          component: runtime
          commandLine: npm start
          workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
          group:
            kind: run
            isDefault: true

    ```
    </details>

1. Create a URL for it using `odo url create`. Hit the URL and see that it's showing a loading animation. That's because it needs to be connected to an EtcdCluster.
1. Create an EtcdCluster using `odo service create etcdoperator.v0.9.4-clusterwide --crd EtcdCluster` (exact command depends upon the etcd Operator you've installed in the namesapce).
1. Link the two by doing `odo link EtcdCluster/example` (follows the `odo link <servicetype>/<servicename>` syntax since it's perfectly valid to create different kinds of service with same name when working with Operator Hub. Refer https://github.com/openshift/odo/issues/2920#issuecomment-638124662.
1. Check the contents of `.odo/env/env.yaml`.
1. Do an `odo push` to make sure that link is applied. We didn't require `odo push` when linking with Service Catalog backed services but require it for Operator backed service. Refer: https://github.com/openshift/odo/issues/2920#issuecomment-653091994.
1. Now load the URL created in earlier step again. The app should now be ready to take items. Play around with this ToDo app to make sure things work.
1. Doing `odo unlink EtcdCluster/example` for the component would delete "ServiceBindingRequest" that binds the component with the Operator backed service and also delete the `Link` information from `.odo/env/env.yaml`.

**Example shell flow**:

<details>

```sh
$ git clone https://github.com/akashshinde/node-todo
$ cd node-todo

$ odo create nodejs node-todo
# now replace the devfile or make changes

$ odo push
$ odo url create --now
# hit the URL and check the "Loading" animation

# replace Operator name with what's on your cluster
$ odo  service create etcdoperator.v0.9.4-clusterwide --crd EtcdCluster
$ odo service list

$ odo link EtcdCluster/example
$ cat .odo/env/env.yaml
$ odo push
# hit the URL and play with the todo app

$ odo unlink EtcdCluster/example
$ cat .odo/env/env.yaml
$ odo push
# refresh the URL; you'll see the "Loading" animation again
```
</details>