### PR TITLE
Validate exec subcommands in a composite

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/odo/pkg/devfile/parser/data"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
 
@@ -208,8 +209,7 @@ func validateCompositeCommand(data data.DevfileData, compositeCommand *common.Co
 		} else {
 			err := validateCommand(data, subCommand)
 			if err != nil {
-				// Don't wrap the error message here to make the error message more readable to the user
-				return err
+				return errors.Wrapf(err, "the composite command %q references an invalid command %q", compositeCommand.Id, subCommand.GetID())
 			}
 		}
 	}

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -143,7 +143,7 @@ func validateCommand(data data.DevfileData, command common.DevfileCommand) (err 
 	if command.Composite != nil {
 		parentCommands := make(map[string]string)
 		commandsMap := GetCommandsMap(data.GetCommands())
-		return validateCompositeCommand(command.Composite, parentCommands, commandsMap)
+		return validateCompositeCommand(data, command.Composite, parentCommands, commandsMap)
 	}
 
 	// component must be specified
@@ -173,7 +173,7 @@ func validateCommand(data data.DevfileData, command common.DevfileCommand) (err 
 }
 
 // validateCompositeCommand checks that the specified composite command is valid
-func validateCompositeCommand(compositeCommand *common.Composite, parentCommands map[string]string, devfileCommands map[string]common.DevfileCommand) error {
+func validateCompositeCommand(data data.DevfileData, compositeCommand *common.Composite, parentCommands map[string]string, devfileCommands map[string]common.DevfileCommand) error {
 	if compositeCommand.Group != nil && compositeCommand.Group.Kind == common.RunCommandGroupType {
 		return fmt.Errorf("composite commands of run Kind are not supported currently")
 	}
@@ -200,12 +200,17 @@ func validateCompositeCommand(compositeCommand *common.Composite, parentCommands
 
 		if subCommand.Composite != nil {
 			// Recursively validate the composite subcommand
-			err := validateCompositeCommand(subCommand.Composite, parentCommands, devfileCommands)
+			err := validateCompositeCommand(data, subCommand.Composite, parentCommands, devfileCommands)
 			if err != nil {
 				// Don't wrap the error message here to make the error message more readable to the user
 				return err
 			}
-
+		} else {
+			err := validateCommand(data, subCommand)
+			if err != nil {
+				// Don't wrap the error message here to make the error message more readable to the user
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -1868,6 +1868,33 @@ func TestValidateCompositeCommand(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Case 6: Invalid composite command, points to invalid exec command",
+			compositeCommands: []common.Composite{
+				{
+					Id:       id[3],
+					Commands: []string{id[0], id[1]},
+					Group:    &versionsCommon.Group{Kind: buildGroup},
+				},
+			},
+			execCommands: []common.Exec{
+				{
+					Id:          id[0],
+					CommandLine: command[0],
+					Component:   component,
+					Group:       &common.Group{Kind: runGroup},
+					WorkingDir:  workDir[0],
+				},
+				{
+					Id:          id[1],
+					CommandLine: command[1],
+					Component:   "some-fake-component",
+					Group:       &common.Group{Kind: runGroup},
+					WorkingDir:  workDir[1],
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		devObj := devfileParser.DevfileObj{
@@ -1882,7 +1909,7 @@ func TestValidateCompositeCommand(t *testing.T) {
 			commandsMap := GetCommandsMap(devObj.Data.GetCommands())
 			parentCommands := make(map[string]string)
 
-			err := validateCompositeCommand(cmd.Composite, parentCommands, commandsMap)
+			err := validateCompositeCommand(devObj.Data, cmd.Composite, parentCommands, commandsMap)
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("TestValidateAction unexpected error: %v", err)
 				return

--- a/tests/examples/source/devfiles/nodejs/devfileCompositeInvalidComponent.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfileCompositeInvalidComponent.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  version: 1.0.0
+projects:
+  - name: nodejs-starter
+    git:
+      location: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - container:
+      name: runtime
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      mountSources: true
+      endpoints:
+        - name: http-3000
+          targetPort: 3000
+commands:
+  - exec:
+      id: install
+      component: runtime
+      commandLine: npm install
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
+      group:
+        kind: build
+        isDefault: false
+  - exec:
+      id: mkdir
+      component: fakecomponent
+      commandLine: mkdir /projects/testfolder
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
+      group:
+        kind: build
+        isDefault: false
+  - exec:
+      id: run
+      component: runtime
+      commandLine: npm start
+      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
+      group:
+        kind: run
+        isDefault: true
+  - composite:
+         id: buildAndMkdir
+         label: Build and Mkdir
+         commands:
+           - mkdir
+           - install
+         parallel: false
+         group: 
+            kind: build
+            isDefault: true

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -241,6 +241,17 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(output).To(ContainSubstring("cannot indirectly reference itself"))
 		})
 
+		It("should throw a validation error for composite command that has invalid exec subcommand", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeInvalidComponent.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			// Verify odo push failed
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("references an invalid command"))
+		})
+
 		It("checks that odo push works outside of the context directory", func() {
 			helper.Chdir(currentWorkingDirectory)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR fixes an issue with composite commands where exec subcommands are not validated (such as exec commands that reference an invalid component). With this PR, when we recursively validate the command-tree in a composite command, we now make sure to validate any exec commands. 

Composite subcommands were already being validated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3656

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

**How to test changes / Special notes to the reviewer**:
1. Run integreation and unit tests
2. Test with sample devfile:
```
schemaVersion: 2.0.0
metadata:
  name: nodejs
  version: 1.0.0
projects:
  - name: nodejs-starter
    git:
      location: "https://github.com/odo-devfiles/nodejs-ex.git"
components:
  - container:
      name: runtime
      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
      memoryLimit: 1024Mi
      mountSources: true
      endpoints:
        - name: http-3000
          targetPort: 3000
commands:
  - exec:
      id: install
      component: runtime
      commandLine: npm install
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: build
        isDefault: false
  - exec:
      id: mkdir
      component: fakecomponent
      commandLine: mkdir /projects/testfolder
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: build
        isDefault: false
  - exec:
      id: run
      component: runtime
      commandLine: npm start
      workingDir: ${CHE_PROJECTS_ROOT}/nodejs-starter
      group:
        kind: run
        isDefault: true
  - composite:
         id: buildAndMkdir
         label: Build and Mkdir
         commands:
           - mkdir
           - install
         parallel: false
         group: 
            kind: build
            isDefault: true
```
This devfile has a composite command whose exec subcommand points to a non-existent component. Odo will spit out the following error when you try to push: `the composite command "buildandmkdir" references an invalid command "mkdir": the command does not map to a supported component`
