### PR TITLE
Makes service create command consistent with how it's done for Service Catalog

### DIFF
--- a/docs/public/operator-hub.adoc
+++ b/docs/public/operator-hub.adoc
@@ -77,7 +77,7 @@ In this example, we will be deploying our link:https://operatorhub.io/operator/e
 +
 [source,sh]
 ----
-  $ odo service create etcdoperator.v0.9.4 --crd EtcdCluster
+  $ odo service create etcdoperator.v0.9.4/EtcdCluster
 ----
 
 . Confirm the Operator backed service was deployed:
@@ -105,7 +105,7 @@ Deploying via YAML is a **temporary** feature as we add support for link:https:/
 +
 [source,shell]
 ----
-  $ odo service create etcdoperator.v0.9.4 --crd EtcdCluster --dry-run > etcd.yaml
+  $ odo service create etcdoperator.v0.9.4/EtcdCluster --dry-run > etcd.yaml
 ----
 
 . Modify the YAML file by redefining the name and size:

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -674,12 +674,3 @@ func isRequired(required []string, name string) bool {
 	}
 	return false
 }
-
-func IsValidServiceCreateName(name string) (string, string, error) {
-	serviceType, serviceName, err := SplitServiceKindName(name)
-	if err != nil {
-		return "", "", errors.Wrapf(err, "Invalid syntax. Please refer %q for help.", "odo service create -h")
-	}
-
-	return serviceType, serviceName, nil
-}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -145,9 +145,9 @@ func DeleteServiceAndUnlinkComponents(client *occlient.Client, serviceName strin
 // TODO: make it unlink the service from component as a part of
 // https://github.com/openshift/odo/issues/3563
 func DeleteOperatorService(client *kclient.Client, serviceName string) error {
-	kind, name, err := splitServiceKindName(serviceName)
+	kind, name, err := SplitServiceKindName(serviceName)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Refer %q to see list of running services", serviceName)
 	}
 
 	csv, err := client.GetCSVWithCR(kind)
@@ -514,9 +514,9 @@ func SvcExists(client *occlient.Client, serviceName, applicationName string) (bo
 // It doesn't bother about application since
 // https://github.com/openshift/odo/issues/2801 is blocked
 func OperatorSvcExists(client *kclient.Client, serviceName string) (bool, error) {
-	kind, name, err := splitServiceKindName(serviceName)
+	kind, name, err := SplitServiceKindName(serviceName)
 	if err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "Refer %q to see list of running services", serviceName)
 	}
 
 	// Get the CSV (Operator) that provides the CR
@@ -552,12 +552,12 @@ func OperatorSvcExists(client *kclient.Client, serviceName string) (bool, error)
 	return false, nil
 }
 
-// splitServiceKindName splits the service name provided for deletion by the
+// SplitServiceKindName splits the service name provided for deletion by the
 // user. It has to be of the format <service-kind>/<service-name>. Example: EtcdCluster/myetcd
-func splitServiceKindName(serviceName string) (string, string, error) {
+func SplitServiceKindName(serviceName string) (string, string, error) {
 	sn := strings.SplitN(serviceName, "/", 2)
 	if len(sn) != 2 || sn[0] == "" || sn[1] == "" {
-		return "", "", fmt.Errorf("Invalid service name. Refer %q to see list of running services", "odo service list")
+		return "", "", fmt.Errorf("couldn't split %q into exactly two", serviceName)
 	}
 
 	kind := sn[0]
@@ -673,4 +673,13 @@ func isRequired(required []string, name string) bool {
 		}
 	}
 	return false
+}
+
+func IsValidServiceCreateName(name string) (string, string, error) {
+	serviceType, serviceName, err := SplitServiceKindName(name)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Invalid syntax. Please refer %q for help.", "odo service create -h")
+	}
+
+	return serviceType, serviceName, nil
 }

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -77,7 +77,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
@@ -106,7 +106,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", name)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
@@ -120,7 +120,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			})
 
 			// now try creating service with same name again. it should fail
-			stdOut := helper.CmdShouldFail("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", name)
+			stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
 			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
 
 			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
@@ -133,7 +133,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 			for _, name := range names {
 				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+				Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
 			}
 		})
 	})
@@ -153,7 +153,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
 			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
 		})
 	})
@@ -195,7 +195,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
 
 			// stdOut contains the yaml specification. Store it to a file
 			randomFileName := helper.RandString(6) + ".yaml"
@@ -226,7 +226,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster", "--dry-run")
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
 
 			// stdOut contains the yaml specification. Store it to a file
 			randomFileName := helper.RandString(6) + ".yaml"
@@ -325,7 +325,7 @@ spec:
 		It("should list the services if they exist", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
@@ -419,7 +419,7 @@ spec:
 			// start the Operator backed service first
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", etcdOperator, "--crd", "EtcdCluster")
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind code-refactoring

**What does this PR do / why we need it**:
This PR changes the `odo service create` command for Operator backed service to make it more user friendly than what it currently is.

**Which issue(s) this PR fixes**:

Fixes #3594 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
```sh
# below command should fail
$ odo service create etcdoperator.v0.9.4-clusterwide --crd EtcdCluster

# new way to create service is
$odo service create etcdoperator.v0.9.4-clusterwide/EtcdCluster
```