### PR TITLE
Fixes GetRunningPodNameByComponent for the CLI runners

### DIFF
--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -57,10 +56,9 @@ func (kubectl KubectlRunner) CheckCmdOpInRemoteDevfilePod(podName string, contai
 // GetRunningPodNameByComponent executes kubectl command and returns the running pod name of a delopyed
 // devfile component by passing component name as a argument
 func (kubectl KubectlRunner) GetRunningPodNameByComponent(compName string, namespace string) string {
-	stdOut := CmdShouldPass(kubectl.path, "get", "pods", "--namespace", namespace, "--show-labels")
-	re := regexp.MustCompile(`(` + compName + `-\S+)\s+\S+\s+Running.*component=` + compName)
-	podName := re.FindStringSubmatch(stdOut)[1]
-	return strings.TrimSpace(podName)
+	selector := fmt.Sprintf("--selector=component=%s", compName)
+	stdOut := CmdShouldPass(kubectl.path, "get", "pods", "--namespace", namespace, selector, "-o", "jsonpath={.items[*].metadata.name}")
+	return strings.TrimSpace(stdOut)
 }
 
 // GetPVCSize executes kubectl command and returns the bound storage size

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -373,10 +373,9 @@ func (oc OcRunner) GetRunningPodNameOfComp(compName string, namespace string) st
 // GetRunningPodNameByComponent executes oc command and returns the running pod name of a delopyed
 // devfile component by passing component name as a argument
 func (oc OcRunner) GetRunningPodNameByComponent(compName string, namespace string) string {
-	stdOut := CmdShouldPass(oc.path, "get", "pods", "--namespace", namespace, "--show-labels")
-	re := regexp.MustCompile(`(` + compName + `-\S+)\s+\S+\s+Running.*component=` + compName)
-	podName := re.FindStringSubmatch(stdOut)[1]
-	return strings.TrimSpace(podName)
+	selector := fmt.Sprintf("--selector=component=%s", compName)
+	stdOut := CmdShouldPass(oc.path, "get", "pods", "--namespace", namespace, selector, "-o", "jsonpath={.items[*].metadata.name}")
+	return strings.TrimSpace(stdOut)
 }
 
 // GetPVCSize executes oc command and returns the bound storage size


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Fixes GetRunningPodNameByComponent() to prevent panics like https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_odo/3651/pull-ci-openshift-odo-master-v4.5-integration-e2e/1288802599100747776#1:build-log.txt%3A935

**Which issue(s) this PR fixes**:

Fixes #NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

Tests should pass