### PR TITLE
make odo catalog list components work outside of experimental mode

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -183,33 +183,24 @@ func ListDevfileComponents(registryName string) (DevfileComponentTypeList, error
 
 // ListComponents lists all the available component types
 func ListComponents(client *occlient.Client) (ComponentTypeList, error) {
-	supported, err := client.IsImageStreamSupported()
+
+	catalogList, err := getDefaultBuilderImages(client)
 	if err != nil {
-		return ComponentTypeList{}, err
+		return ComponentTypeList{}, errors.Wrap(err, "unable to get image streams")
 	}
 
-	if supported {
-
-		catalogList, err := getDefaultBuilderImages(client)
-		if err != nil {
-			return ComponentTypeList{}, errors.Wrap(err, "unable to get image streams")
-		}
-
-		if len(catalogList) == 0 {
-			return ComponentTypeList{}, errors.New("unable to retrieve any catalog images from the OpenShift cluster")
-		}
-
-		return ComponentTypeList{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "List",
-				APIVersion: apiVersion,
-			},
-			Items: catalogList,
-		}, nil
-
+	if len(catalogList) == 0 {
+		return ComponentTypeList{}, errors.New("unable to retrieve any catalog images from the OpenShift cluster")
 	}
 
-	return ComponentTypeList{}, nil
+	return ComponentTypeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: apiVersion,
+		},
+		Items: catalogList,
+	}, nil
+
 }
 
 // SearchComponent searches for the component

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -45,15 +45,21 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 
 	if !pushtarget.IsPushTargetDocker() {
 		o.Context = genericclioptions.NewContext(cmd)
+		supported, err := o.Client.IsImageStreamSupported()
+		if err != nil {
+			return err
+		}
 
-		tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-			o.catalogList, err = catalog.ListComponents(o.Client)
-			if err != nil {
-				errChannel <- err
-			} else {
-				o.catalogList.Items = catalogutil.FilterHiddenComponents(o.catalogList.Items)
-			}
-		}})
+		if supported {
+			tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
+				o.catalogList, err = catalog.ListComponents(o.Client)
+				if err != nil {
+					errChannel <- err
+				} else {
+					o.catalogList.Items = catalogutil.FilterHiddenComponents(o.catalogList.Items)
+				}
+			}})
+		}
 	}
 
 	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -127,7 +127,18 @@ func (o *ListComponentsOptions) Run() (err error) {
 			}
 		}
 
+		if len(o.catalogDevfileList.Items) != 0 {
+			fmt.Fprintln(w, "Odo Devfile Components:")
+			fmt.Fprintln(w, "NAME", "\t", "DESCRIPTION", "\t", "REGISTRY")
+
+			o.printDevfileCatalogList(w, o.catalogDevfileList.Items, "")
+		}
+
 		if len(supCatalogList) != 0 || len(unsupCatalogList) != 0 {
+			// add a new line of there was something before this
+			if len(o.catalogDevfileList.Items) != 0 {
+				fmt.Fprintln(w)
+			}
 			fmt.Fprintln(w, "Odo OpenShift Components:")
 			fmt.Fprintln(w, "NAME", "\t", "PROJECT", "\t", "TAGS", "\t", "SUPPORTED")
 
@@ -141,14 +152,7 @@ func (o *ListComponentsOptions) Run() (err error) {
 				o.printCatalogList(w, unsupCatalogList, supported)
 			}
 
-			fmt.Fprintln(w)
-		}
-
-		if len(o.catalogDevfileList.Items) != 0 {
-			fmt.Fprintln(w, "Odo Devfile Components:")
-			fmt.Fprintln(w, "NAME", "\t", "DESCRIPTION", "\t", "REGISTRY")
-
-			o.printDevfileCatalogList(w, o.catalogDevfileList.Items, "")
+			fmt.Fprint(w)
 		}
 
 		w.Flush()

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 const componentsRecommendedCommandName = "components"
@@ -47,7 +48,7 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 		o.Context = genericclioptions.NewContext(cmd)
 		supported, err := o.Client.IsImageStreamSupported()
 		if err != nil {
-			return err
+			klog.V(4).Info("ignoring error while checking imagestream support:", err.Error())
 		}
 
 		if supported {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test

/kind feature


**What does does this PR do / why we need it**:
make odo catalog list components work outside of experimental mode

**Which issue(s) this PR fixes**:

Works towards experimental mode

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
```
odo catalog list components 
odo catalog list components -o json
```
both should work with openshift and kube cluster outside of experimental mode