### PR TITLE
Make Devfile the default deployment mechanism for odo

### DIFF
--- a/docs/dev/experimental-mode.adoc
+++ b/docs/dev/experimental-mode.adoc
@@ -123,3 +123,30 @@ $ odo delete myspring
 The devfile registry can be accessed link:https://github.com/elsony/devfile-registry[here]. 
 
 For more information on how to develop and write a devfile, please read the link:https://docs.google.com/document/d/1piBG2Zu2PqPZSl0WySj25UouK3X5MKcFKqPrfC9ZAsc[Odo stack creation] document.
+
+#### Forcing s2i type component creation over devfile type components:
+
+If there is an s2i type component with the same name as a devfile type component, you can use `--s2i` flag to force the creation of s2i type component over devfile type.
+If there is a devfile type component with a given name but no s2i component, `odo create --s2i` will fail.
+Also, using flags specific to s2i component creation without using --s2i would also fail the `odo create` command.
+
+In the above example output of `odo catalog list components` command, you can observe that `nodejs` component type is available in both s2i and devfile categories.
+
+The following command should create an s2i type component.
+```
+$ odo create nodejs mynode --s2i
+Experimental mode is enabled, use at your own risk
+
+Validation
+ ✓  Validating component [3s]
+
+Please use `odo push` command to create the component with source deployed
+```
+
+The following command would fail for using `--s2i` flag as there is no s2i component type available with name "java-spring-boot".
+```
+$ odo create java-spring-boot myspring --s2i
+Experimental mode is enabled, use at your own risk
+
+  ✗  Cannot select this component with --s2i flag
+```

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift/odo/pkg/exec"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/storage"
@@ -564,10 +563,10 @@ func ensureAndLogProperResourceUsage(resourceMin, resourceMax *string, resourceN
 //	componentConfig: Component configuration
 //	envSpecificInfo: Component environment specific information, available if uses devfile
 //  cmpExist: true if components exists in the cluster
+//  isS2I: Legacy option. Set as true if you want to use the old S2I method as it differentiates slightly.
 // Returns:
 //	err: Errors if any else nil
-func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool) (err error) {
-	isExperimentalModeEnabled := experimental.IsExperimentalModeEnabled()
+func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool, isS2I bool) (err error) {
 
 	if client == nil {
 		var err error
@@ -578,7 +577,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 		client.Namespace = envSpecificInfo.GetNamespace()
 	}
 
-	if !isExperimentalModeEnabled {
+	if isS2I {
 		// if component exist then only call the update function
 		if cmpExist {
 			if err = Update(client, componentConfig, componentConfig.GetSourceLocation(), stdout); err != nil {
@@ -589,7 +588,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 
 	var componentName string
 	var applicationName string
-	if !isExperimentalModeEnabled || kClient == nil {
+	if isS2I || kClient == nil {
 		componentName = componentConfig.GetName()
 		applicationName = componentConfig.GetApplication()
 	} else {
@@ -603,12 +602,12 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 	}
 
 	return urlpkg.Push(client, kClient, urlpkg.PushParameters{
-		ComponentName:             componentName,
-		ApplicationName:           applicationName,
-		ConfigURLs:                componentConfig.GetURL(),
-		EnvURLS:                   envSpecificInfo.GetURL(),
-		IsRouteSupported:          isRouteSupported,
-		IsExperimentalModeEnabled: isExperimentalModeEnabled,
+		ComponentName:    componentName,
+		ApplicationName:  applicationName,
+		ConfigURLs:       componentConfig.GetURL(),
+		EnvURLS:          envSpecificInfo.GetURL(),
+		IsRouteSupported: isRouteSupported,
+		IsS2I:            isS2I,
 	})
 }
 

--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/storage"
 	urlpkg "github.com/openshift/odo/pkg/url"
 	corev1 "k8s.io/api/core/v1"
@@ -190,22 +189,22 @@ func (cfd *ComponentFullDescription) Print(client *occlient.Client) error {
 	if len(cfd.Spec.URL.Items) > 0 {
 		var output string
 
-		if !experimental.IsExperimentalModeEnabled() {
-			// if the component is not pushed
-			for i, componentURL := range cfd.Spec.URL.Items {
-				if componentURL.Status.State == urlpkg.StateTypePushed {
-					output += fmt.Sprintf(" · %v exposed via %v\n", urlpkg.GetURLString(componentURL.Spec.Protocol, componentURL.Spec.Host, "", experimental.IsExperimentalModeEnabled()), componentURL.Spec.Port)
+		// For S2I Only..
+		// if the component is not pushed
+		for i, componentURL := range cfd.Spec.URL.Items {
+			if componentURL.Status.State == urlpkg.StateTypePushed {
+				output += fmt.Sprintf(" · %v exposed via %v\n", urlpkg.GetURLString(componentURL.Spec.Protocol, componentURL.Spec.Host, "", true), componentURL.Spec.Port)
+			} else {
+				var p string
+				if i >= len(cfd.Spec.Ports) {
+					p = cfd.Spec.Ports[len(cfd.Spec.Ports)-1]
 				} else {
-					var p string
-					if i >= len(cfd.Spec.Ports) {
-						p = cfd.Spec.Ports[len(cfd.Spec.Ports)-1]
-					} else {
-						p = cfd.Spec.Ports[i]
-					}
-					output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL.Name, p)
+					p = cfd.Spec.Ports[i]
 				}
+				output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL.Name, p)
 			}
 		}
+
 		// Cut off the last newline and output
 		if len(output) > 0 {
 			output = output[:len(output)-1]

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -47,7 +47,7 @@ const (
 	// StateTypePushed means that Storage is present both locally and on cluster
 	StateTypePushed State = "Pushed"
 	// StateTypeNotPushed means that Storage is only in local config, but not on the cluster
-	StateTypeNotPushed = "Not Pushed"
+	StateTypeNotPushed State = "Not Pushed"
 	// StateTypeUnknown means that odo cannot tell its state
-	StateTypeUnknown = "Unknown"
+	StateTypeUnknown State = "Unknown"
 )

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -124,7 +124,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
 	}
 
-	err = component.ApplyConfig(nil, &a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists)
+	err = component.ApplyConfig(nil, &a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists, false)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -126,7 +126,7 @@ func TestValidateComponents(t *testing.T) {
 		got := validateComponents(components)
 		want := "size randomgarbage for volume component myvol is invalid"
 
-		if !strings.Contains(got.Error(), want) {
+		if got != nil && !strings.Contains(got.Error(), want) {
 			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
 		}
 	})

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/util"
 
@@ -751,11 +750,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 			}
 		}
 		if e != nil && err != nil {
-			// Imagestream not found in openshift and current namespaces
-			if experimental.IsExperimentalModeEnabled() {
-				return nil, fmt.Errorf("component type %q not found", imageName)
-			}
-			return nil, err
+			return nil, fmt.Errorf("component type %q not found", imageName)
 		}
 
 		// Required tag not in openshift and current namespaces

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -24,7 +24,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/version"
 	"github.com/openshift/odo/pkg/odo/util"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -205,12 +204,10 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 		debug.NewCmdDebug(debug.RecommendedCommandName, util.GetFullName(fullName, debug.RecommendedCommandName)),
 	)
 
-	if experimental.IsExperimentalModeEnabled() {
-		rootCmd.AddCommand(
-			registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
-			component.NewCmdTest(component.TestRecommendedCommandName, util.GetFullName(fullName, component.TestRecommendedCommandName)),
-		)
-	}
+	rootCmd.AddCommand(
+		registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
+		component.NewCmdTest(component.TestRecommendedCommandName, util.GetFullName(fullName, component.TestRecommendedCommandName)),
+	)
 
 	odoutil.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
 

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/secret"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/openshift/odo/pkg/util"
@@ -38,6 +37,8 @@ type commonLinkOptions struct {
 	secretName       string
 	isTargetAService bool
 
+	devfilePath string
+
 	suppliedName  string
 	operation     func(secretName, componentName, applicationName string) error
 	operationName string
@@ -55,12 +56,13 @@ func newCommonLinkOptions() *commonLinkOptions {
 
 // Complete completes LinkOptions after they've been created
 func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []string) (err error) {
+
 	o.operationName = name
 
 	suppliedName := args[0]
 	o.suppliedName = suppliedName
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		oclient, err := occlient.New()
@@ -161,7 +163,7 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 
 func (o *commonLinkOptions) validate(wait bool) (err error) {
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		// let's validate if the service exists
 		svcFullName := strings.Join([]string{o.serviceType, o.serviceName}, "/")
 		svcExists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
@@ -227,7 +229,8 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 }
 
 func (o *commonLinkOptions) run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+
+	if util.CheckPathExists(o.devfilePath) {
 		// convert service binding request into a ma[string]interface{} type so
 		// as to use it with dynamic client
 		sbrMap := make(map[string]interface{})

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -127,7 +127,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		}
 	}
 	// Apply config
-	err := component.ApplyConfig(cpo.Context.Client, nil, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist)
+	err := component.ApplyConfig(cpo.Context.Client, nil, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist, true)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -73,6 +73,8 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	componentCmd.Flags().AddFlagSet(componentGetCmd.Flags())
 
 	componentCmd.AddCommand(componentGetCmd, createCmd, deleteCmd, describeCmd, linkCmd, unlinkCmd, listCmd, logCmd, pushCmd, updateCmd, watchCmd, execCmd)
+
+	// Experimental feature to be added, "odo test" command.
 	if experimental.IsExperimentalModeEnabled() {
 		componentCmd.AddCommand(testCmd)
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -397,6 +397,9 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		// Validate user specify devfile path
 		if co.devfileMetadata.devfilePath.value != "" {
+			if co.forceS2i {
+				return errors.New("You can't set --s2i flag as true if you want to use the devfile that is specified via --devfile")
+			}
 			fileErr := util.ValidateFile(co.devfileMetadata.devfilePath.value)
 			urlErr := util.ValidateURL(co.devfileMetadata.devfilePath.value)
 			if fileErr != nil && urlErr != nil {
@@ -410,6 +413,10 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		// Validate user specify registry
 		if co.devfileMetadata.devfileRegistry.Name != "" {
+
+			if co.forceS2i {
+				return errors.New("You can't specify registry via --registry if you want to force the S2I build with --s2i")
+			}
 
 			if co.devfileMetadata.devfilePath.value != "" {
 				return errors.New("you can't specify registry via --registry if you want to use the devfile that is specified via --devfile")

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	"github.com/openshift/odo/pkg/util"
 
@@ -81,23 +80,11 @@ const CreateRecommendedCommandName = "create"
 // since the application will always be in the same directory as `.odo`, we will always set this as: ./
 const LocalDirectoryDefaultLocation = "./"
 
-// Constants for devfile component
-const (
-	devFile = "devfile.yaml"
-)
-
 var (
 	envFile    = filepath.Join(".odo", "env", "env.yaml")
 	configFile = filepath.Join(".odo", "config.yaml")
 	envDir     = filepath.Join(".odo", "env")
 )
-
-// DevfilePath is the devfile path that is used by odo,
-// which means odo can:
-// 1. Directly use the devfile in DevfilePath
-// 2. Download devfile from registry to DevfilePath then use the devfile in DevfilePath
-// 3. Copy user's own devfile (path is specified via --devfile flag) to DevfilePath then use the devfile in DevfilePath
-var DevfilePath = filepath.Join(LocalDirectoryDefaultLocation, devFile)
 
 // EnvFilePath is the path of env file for devfile component
 var EnvFilePath = filepath.Join(LocalDirectoryDefaultLocation, envFile)
@@ -356,13 +343,12 @@ func (co *CreateOptions) checkConflictingDevfileFlags() error {
 
 // Complete completes create args
 func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+
 	// this populates the LocalConfigInfo as well
 	co.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
 
-	if experimental.IsExperimentalModeEnabled() {
-		// Add a disclaimer that we are in *experimental mode*
-		log.Experimental("Experimental mode is enabled, use at your own risk")
-
+	// If not using --s2i
+	if !co.forceS2i {
 		err = co.checkConflictingFlags()
 		if err != nil {
 			return
@@ -848,29 +834,27 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 // Validate validates the create parameters
 func (co *CreateOptions) Validate() (err error) {
 
-	if experimental.IsExperimentalModeEnabled() {
-		if !co.forceS2i && co.devfileMetadata.devfileSupport {
-			// Validate if the devfile component that user wants to create already exists
-			spinner := log.Spinner("Validating devfile component")
-			defer spinner.End(false)
+	if !co.forceS2i && co.devfileMetadata.devfileSupport {
+		// Validate if the devfile component that user wants to create already exists
+		spinner := log.Spinner("Validating devfile component")
+		defer spinner.End(false)
 
-			err = util.ValidateK8sResourceName("component name", co.devfileMetadata.componentName)
+		err = util.ValidateK8sResourceName("component name", co.devfileMetadata.componentName)
+		if err != nil {
+			return err
+		}
+
+		// Only validate namespace if pushtarget isn't docker
+		if !pushtarget.IsPushTargetDocker() {
+			err := util.ValidateK8sResourceName("component namespace", co.devfileMetadata.componentNamespace)
 			if err != nil {
 				return err
 			}
-
-			// Only validate namespace if pushtarget isn't docker
-			if !pushtarget.IsPushTargetDocker() {
-				err := util.ValidateK8sResourceName("component namespace", co.devfileMetadata.componentNamespace)
-				if err != nil {
-					return err
-				}
-			}
-
-			spinner.End(true)
-
-			return nil
 		}
+
+		spinner.End(true)
+
+		return nil
 	}
 
 	log.Info("Validation")
@@ -1002,92 +986,90 @@ func (co *CreateOptions) downloadProject(projectPassed string) error {
 
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		if !co.forceS2i && co.devfileMetadata.devfileSupport {
-			// Use existing devfile directly from --devfile flag
-			if co.devfileMetadata.devfilePath.value != "" {
-				if co.devfileMetadata.devfilePath.protocol == "http(s)" {
-					// User specify devfile path is http(s) URL
-					params := util.DownloadParams{
-						Request: util.HTTPRequestParams{
-							URL:   co.devfileMetadata.devfilePath.value,
-							Token: co.devfileMetadata.token,
-						},
-						Filepath: DevfilePath,
-					}
-					err = util.DownloadFile(params)
-					if err != nil {
-						return errors.Wrapf(err, "failed to download devfile for devfile component from %s", co.devfileMetadata.devfilePath.value)
-					}
-				} else if co.devfileMetadata.devfilePath.protocol == "file" {
-					// User specify devfile path is file system link
-					info, err := os.Stat(co.devfileMetadata.devfilePath.value)
-					if err != nil {
-						return err
-					}
-					err = util.CopyFile(co.devfileMetadata.devfilePath.value, DevfilePath, info)
-					if err != nil {
-						return errors.Wrapf(err, "failed to copy devfile from %s to %s", co.devfileMetadata.devfilePath, DevfilePath)
-					}
-				}
-			}
-
-			if !util.CheckPathExists(DevfilePath) {
-				// Download devfile from registry
+	if !co.forceS2i && co.devfileMetadata.devfileSupport {
+		// Use existing devfile directly from --devfile flag
+		if co.devfileMetadata.devfilePath.value != "" {
+			if co.devfileMetadata.devfilePath.protocol == "http(s)" {
+				// User specify devfile path is http(s) URL
 				params := util.DownloadParams{
 					Request: util.HTTPRequestParams{
-						URL: co.devfileMetadata.devfileRegistry.URL + co.devfileMetadata.devfileLink,
+						URL:   co.devfileMetadata.devfilePath.value,
+						Token: co.devfileMetadata.token,
 					},
 					Filepath: DevfilePath,
 				}
-				if registryUtil.IsSecure(co.devfileMetadata.devfileRegistry.Name) {
-					token, err := keyring.Get(util.CredentialPrefix+co.devfileMetadata.devfileRegistry.Name, "default")
-					if err != nil {
-						return errors.Wrap(err, "unable to get secure registry credential from keyring")
-					}
-					params.Request.Token = token
-				}
-				err := util.DownloadFile(params)
+				err = util.DownloadFile(params)
 				if err != nil {
-					return errors.Wrapf(err, "failed to download devfile for devfile component from %s", co.devfileMetadata.devfileRegistry.URL+co.devfileMetadata.devfileLink)
+					return errors.Wrapf(err, "failed to download devfile for devfile component from %s", co.devfileMetadata.devfilePath.value)
 				}
-			}
-
-			if util.CheckPathExists(DevfilePath) && co.devfileMetadata.starter != "" {
-				err = co.downloadProject(co.devfileMetadata.starter)
+			} else if co.devfileMetadata.devfilePath.protocol == "file" {
+				// User specify devfile path is file system link
+				info, err := os.Stat(co.devfileMetadata.devfilePath.value)
 				if err != nil {
-					return errors.Wrap(err, "failed to download project for devfile component")
+					return err
+				}
+				err = util.CopyFile(co.devfileMetadata.devfilePath.value, DevfilePath, info)
+				if err != nil {
+					return errors.Wrapf(err, "failed to copy devfile from %s to %s", co.devfileMetadata.devfilePath, DevfilePath)
 				}
 			}
-
-			// Generate env file
-			err = co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{
-				Name:      co.devfileMetadata.componentName,
-				Namespace: co.devfileMetadata.componentNamespace,
-				AppName:   co.appName,
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to create env file for devfile component")
-			}
-
-			sourcePath, err := util.GetAbsPath(co.componentContext)
-			if err != nil {
-				return errors.Wrap(err, "unable to get source path")
-			}
-
-			ignoreFile, err := util.CheckGitIgnoreFile(sourcePath)
-			if err != nil {
-				return err
-			}
-
-			err = util.AddFileToIgnoreFile(ignoreFile, filepath.Join(co.componentContext, envDir))
-			if err != nil {
-				return err
-			}
-
-			log.Italic("\nPlease use `odo push` command to create the component with source deployed")
-			return nil
 		}
+
+		if !util.CheckPathExists(DevfilePath) {
+			// Download devfile from registry
+			params := util.DownloadParams{
+				Request: util.HTTPRequestParams{
+					URL: co.devfileMetadata.devfileRegistry.URL + co.devfileMetadata.devfileLink,
+				},
+				Filepath: DevfilePath,
+			}
+			if registryUtil.IsSecure(co.devfileMetadata.devfileRegistry.Name) {
+				token, err := keyring.Get(util.CredentialPrefix+co.devfileMetadata.devfileRegistry.Name, "default")
+				if err != nil {
+					return errors.Wrap(err, "unable to get secure registry credential from keyring")
+				}
+				params.Request.Token = token
+			}
+			err := util.DownloadFile(params)
+			if err != nil {
+				return errors.Wrapf(err, "failed to download devfile for devfile component from %s", co.devfileMetadata.devfileRegistry.URL+co.devfileMetadata.devfileLink)
+			}
+		}
+
+		if util.CheckPathExists(DevfilePath) && co.devfileMetadata.starter != "" {
+			err = co.downloadProject(co.devfileMetadata.starter)
+			if err != nil {
+				return errors.Wrap(err, "failed to download project for devfile component")
+			}
+		}
+
+		// Generate env file
+		err = co.EnvSpecificInfo.SetComponentSettings(envinfo.ComponentSettings{
+			Name:      co.devfileMetadata.componentName,
+			Namespace: co.devfileMetadata.componentNamespace,
+			AppName:   co.appName,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to create env file for devfile component")
+		}
+
+		sourcePath, err := util.GetAbsPath(co.componentContext)
+		if err != nil {
+			return errors.Wrap(err, "unable to get source path")
+		}
+
+		ignoreFile, err := util.CheckGitIgnoreFile(sourcePath)
+		if err != nil {
+			return err
+		}
+
+		err = util.AddFileToIgnoreFile(ignoreFile, filepath.Join(co.componentContext, envDir))
+		if err != nil {
+			return err
+		}
+
+		log.Italic("\nPlease use `odo push` command to create the component with source deployed")
+		return nil
 	}
 
 	err = co.LocalConfigInfo.SetComponentSettings(co.componentSettings)
@@ -1176,14 +1158,12 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	componentCreateCmd.Flags().StringSliceVarP(&co.componentPorts, "port", "p", []string{}, "Ports to be used when the component is created (ex. 8080,8100/tcp,9100/udp)")
 	componentCreateCmd.Flags().StringSliceVar(&co.componentEnvVars, "env", []string{}, "Environmental variables for the component. For example --env VariableName=Value")
 
-	if experimental.IsExperimentalModeEnabled() {
-		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.starter, "starter", "", "Download a project specified in the devfile")
-		componentCreateCmd.Flags().Lookup("starter").NoOptDefVal = defaultProjectName //Default value to pass to the flag if one is not specified.
-		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfileRegistry.Name, "registry", "", "Create devfile component from specific registry")
-		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfilePath.value, "devfile", "", "Path to the user specify devfile")
-		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.token, "token", "", "Token to be used when downloading devfile from the devfile path that is specified via --devfile")
-		componentCreateCmd.Flags().BoolVar(&co.forceS2i, "s2i", false, "Enforce S2I type components")
-	}
+	componentCreateCmd.Flags().StringVar(&co.devfileMetadata.starter, "starter", "", "Download a project specified in the devfile")
+	componentCreateCmd.Flags().Lookup("starter").NoOptDefVal = defaultProjectName //Default value to pass to the flag if one is not specified.
+	componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfileRegistry.Name, "registry", "", "Create devfile component from specific registry")
+	componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfilePath.value, "devfile", "", "Path to the user specify devfile")
+	componentCreateCmd.Flags().StringVar(&co.devfileMetadata.token, "token", "", "Token to be used when downloading devfile from the devfile path that is specified via --devfile")
+	componentCreateCmd.Flags().BoolVar(&co.forceS2i, "s2i", false, "Path to the user specify devfile")
 
 	componentCreateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -201,7 +201,7 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 
 	// Error out by default if no type of sources were passed..
 	default:
-		return fmt.Errorf("The source can be either --binary or --local or --git")
+		return fmt.Errorf("the source can be either --binary or --local or --git")
 
 	}
 
@@ -212,7 +212,7 @@ func (co *CreateOptions) setComponentSourceAttributes() (err error) {
 
 	// Error out if reference is passed but no --git flag passed
 	if len(co.componentGit) == 0 && len(co.componentGitRef) != 0 {
-		return fmt.Errorf("The --ref flag is only valid for --git flag")
+		return fmt.Errorf("the --ref flag is only valid for --git flag")
 	}
 
 	return
@@ -346,11 +346,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		}
 
 		if util.CheckPathExists(ConfigFilePath) || util.CheckPathExists(EnvFilePath) {
-			return errors.New("This directory already contains a component")
+			return errors.New("this directory already contains a component")
 		}
 
 		if util.CheckPathExists(DevfilePath) && co.devfileMetadata.devfilePath.value != "" && !util.PathEqual(DevfilePath, co.devfileMetadata.devfilePath.value) {
-			return errors.New("This directory already contains a devfile, you can't specify devfile via --devfile")
+			return errors.New("this directory already contains a devfile, you can't specify devfile via --devfile")
 		}
 
 		co.appName = genericclioptions.ResolveAppFlag(cmd)
@@ -367,12 +367,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// Validate user specify devfile path
 		if co.devfileMetadata.devfilePath.value != "" {
 			if co.forceS2i {
-				return errors.New("You can't set --s2i flag as true if you want to use the devfile that is specified via --devfile")
+				return errors.New("you can't set --s2i flag as true if you want to use the devfile that is specified via --devfile")
 			}
 			fileErr := util.ValidateFile(co.devfileMetadata.devfilePath.value)
 			urlErr := util.ValidateURL(co.devfileMetadata.devfilePath.value)
 			if fileErr != nil && urlErr != nil {
-				return errors.Errorf("The devfile path you specify is invalid with either file error \"%v\" or url error \"%v\"", fileErr, urlErr)
+				return errors.Errorf("the devfile path you specify is invalid with either file error \"%v\" or url error \"%v\"", fileErr, urlErr)
 			} else if fileErr == nil {
 				co.devfileMetadata.devfilePath.protocol = "file"
 			} else if urlErr == nil {
@@ -383,19 +383,19 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// Validate user specify registry
 		if co.devfileMetadata.devfileRegistry.Name != "" {
 			if co.forceS2i {
-				return errors.New("You can't specify registry via --registry if you want to force the S2I build with --s2i")
+				return errors.New("you can't specify registry via --registry if you want to force the S2I build with --s2i")
 			}
 
 			if co.devfileMetadata.devfilePath.value != "" {
-				return errors.New("You can't specify registry via --registry if you want to use the devfile that is specified via --devfile")
+				return errors.New("you can't specify registry via --registry if you want to use the devfile that is specified via --devfile")
 			}
 
 			registryList, err := catalog.GetDevfileRegistries(co.devfileMetadata.devfileRegistry.Name)
 			if err != nil {
-				return errors.Wrap(err, "Failed to get registry")
+				return errors.Wrap(err, "failed to get registry")
 			}
 			if len(registryList) == 0 {
-				return errors.Errorf("Registry %s doesn't exist, please specify a valid registry via --registry", co.devfileMetadata.devfileRegistry.Name)
+				return errors.Errorf("registry %s doesn't exist, please specify a valid registry via --registry", co.devfileMetadata.devfileRegistry.Name)
 			}
 		}
 
@@ -461,11 +461,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 				// Use existing devfile directly
 
 				if co.forceS2i {
-					return errors.Errorf("Existing devfile component detected. Please remove the devfile component before creating an s2i component")
+					return errors.Errorf("existing devfile component detected. Please remove the devfile component before creating an s2i component")
 				}
 
 				if len(args) > 1 {
-					return errors.Errorf("Accepts between 0 and 1 arg when using existing devfile, received %d", len(args))
+					return errors.Errorf("accepts between 0 and 1 arg when using existing devfile, received %d", len(args))
 				}
 
 				// If user can use existing devfile directly, the first arg is component name instead of component type
@@ -500,7 +500,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					return err
 				}
 				if co.devfileMetadata.devfileRegistry.Name != "" && catalogDevfileList.Items == nil {
-					return errors.Errorf("Can't create devfile component from registry %s", co.devfileMetadata.devfileRegistry.Name)
+					return errors.Errorf("can't create devfile component from registry %s", co.devfileMetadata.devfileRegistry.Name)
 				}
 
 				if len(catalogDevfileList.DevfileRegistries) == 0 {
@@ -588,7 +588,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					}
 				}
 				if !s2iOverride {
-					return errors.New("Cannot select this component with --s2i flag")
+					return errors.New("cannot select this devfile component type with --s2i flag")
 				}
 			}
 

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/odo/pkg/envinfo"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 
 	"github.com/openshift/odo/pkg/util"
@@ -67,7 +66,7 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 	ConfigFilePath = filepath.Join(do.componentContext, configFile)
 
 	// if experimental mode is enabled and devfile is present
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		do.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(do.componentContext)
 		if err != nil {
 			return err
@@ -92,7 +91,7 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 func (do *DeleteOptions) Validate() (err error) {
 
 	// if experimental mode is enabled and devfile is present
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		return nil
 	}
 
@@ -119,7 +118,7 @@ func (do *DeleteOptions) Run() (err error) {
 	klog.V(4).Infof("component delete called")
 	klog.V(4).Infof("args: %#v", do)
 
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		return do.DevFileRun()
 	}
 

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openshift/odo/pkg/devfile"
@@ -31,6 +32,18 @@ the feature will be available with experimental mode enabled.
 The behaviour of this feature is subject to change as development for this
 feature progresses.
 */
+
+// Constants for devfile component
+const (
+	devFile = "devfile.yaml"
+)
+
+// DevfilePath is the devfile path that is used by odo,
+// which means odo can:
+// 1. Directly use the devfile in DevfilePath
+// 2. Download devfile from registry to DevfilePath then use the devfile in DevfilePath
+// 3. Copy user's own devfile (path is specified via --devfile flag) to DevfilePath then use the devfile in DevfilePath
+var DevfilePath = filepath.Join(LocalDirectoryDefaultLocation, devFile)
 
 // DevfilePush has the logic to perform the required actions for a given devfile
 func (po *PushOptions) DevfilePush() error {

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
+	"github.com/openshift/odo/pkg/util"
 
 	"path/filepath"
 
@@ -63,7 +63,7 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 
 	eo.devfilePath = filepath.Join(eo.componentContext, eo.devfilePath)
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(eo.devfilePath) {
 		eo.componentOptions.Context = genericclioptions.NewDevfileContext(cmd)
 
 		if !pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -2,17 +2,17 @@ package component
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	sbo "github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/util"
 
-	"github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
@@ -88,6 +88,7 @@ odo link EtcdCluster/myetcd
 type LinkOptions struct {
 	waitForTarget    bool
 	componentContext string
+
 	*commonLinkOptions
 }
 
@@ -101,8 +102,10 @@ func NewLinkOptions() *LinkOptions {
 
 // Complete completes LinkOptions after they've been created
 func (o *LinkOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.commonLinkOptions.devfilePath = filepath.Join(o.componentContext, DevfilePath)
+
 	err = o.complete(name, cmd, args)
-	if !experimental.IsExperimentalModeEnabled() {
+	if !util.CheckPathExists(o.commonLinkOptions.devfilePath) {
 		o.operation = o.Client.LinkSecret
 	}
 	return err
@@ -115,7 +118,8 @@ func (o *LinkOptions) Validate() (err error) {
 		return err
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	// Wat?
+	if util.CheckPathExists(o.commonLinkOptions.devfilePath) {
 		return
 	}
 
@@ -160,22 +164,27 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 
-	linkCmd.SetUsageTemplate(util.CmdUsageTemplate)
+	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// Modifications for the case when experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		linkCmd.Use = fmt.Sprintf("%s <service-type>/<service-name>", name)
-		linkCmd.Example = fmt.Sprintf(linkExampleExperimental, fullName)
-		linkCmd.Long = linkLongDescExperimental
-	}
+	// Update the use / example / long to the Devfile description
+	linkCmd.Use = fmt.Sprintf("%s <service-type>/<service-name>", name)
+	linkCmd.Example = fmt.Sprintf(linkExampleExperimental, fullName)
+	linkCmd.Long = linkLongDescExperimental
+
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(linkCmd)
-	//Adding `--application` flag
-	if !experimental.IsExperimentalModeEnabled() {
-		appCmd.AddApplicationFlag(linkCmd)
-	}
+
+	// Adding `--application` flag
+	// Should we just remove this if Devfile is default? I guess so!
+	/*
+		if !experimental.IsExperimentalModeEnabled() {
+			appCmd.AddApplicationFlag(linkCmd)
+		}
+	*/
+
 	//Adding `--component` flag
 	AddComponentFlag(linkCmd)
+
 	//Adding context flag
 	genericclioptions.AddContextFlag(linkCmd, &o.componentContext)
 

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -11,7 +11,6 @@ import (
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
@@ -48,7 +47,7 @@ func (lo *LogOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	lo.devfilePath = filepath.Join(lo.componentContext, lo.devfilePath)
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
+	if util.CheckPathExists(lo.devfilePath) {
 		lo.ComponentOptions.Context = genericclioptions.NewDevfileContext(cmd)
 		return nil
 	}
@@ -66,7 +65,7 @@ func (lo *LogOptions) Run() (err error) {
 	stdout := os.Stdout
 
 	// If experimental mode is enabled, use devfile push
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
+	if util.CheckPathExists(lo.devfilePath) {
 		err = lo.DevfileComponentLog()
 	} else {
 		// Retrieve the log

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -211,10 +211,10 @@ func (po *PushOptions) Run() (err error) {
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
 		return po.DevfilePush()
-	} else {
-		// Legacy odo push
-		return po.Push()
 	}
+
+	// Legacy odo push
+	return po.Push()
 }
 
 // NewCmdPush implements the push odo command

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -15,7 +15,6 @@ import (
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -85,7 +84,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.CompleteDevfilePath()
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 
 		po.Devfile, err = devfile.ParseAndValidate(po.DevfilePath)
 		if err != nil {
@@ -176,7 +175,7 @@ func (po *PushOptions) Validate() (err error) {
 	// If the experimental flag is set and devfile is present, then we do *not* validate
 	// TODO: We need to clean this section up a bit.. We should also validate Devfile here
 	// too.
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 		return nil
 	}
 
@@ -208,7 +207,7 @@ func (po *PushOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run() (err error) {
 	// If experimental mode is enabled, use devfile push
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
 		return po.DevfilePush()
 	}
@@ -224,14 +223,8 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	annotations := map[string]string{"command": "component"}
 
 	pushCmdExampleText := pushCmdExample
-
-	if experimental.IsExperimentalModeEnabled() {
-		// The '-o json' option should only appear in help output when experimental mode is enabled.
-		annotations["machineoutput"] = "json"
-
-		// The '-o json' example should likewise only appear in experimental only.
-		pushCmdExampleText += pushCmdExampleExperimentalOnly
-	}
+	annotations["machineoutput"] = "json"
+	pushCmdExampleText += pushCmdExampleExperimentalOnly
 
 	var pushCmd = &cobra.Command{
 		Use:         fmt.Sprintf("%s [component name]", name),
@@ -252,15 +245,12 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Flags().BoolVar(&po.pushSource, "source", false, "Use source flag to only push latest source on to cluster")
 	pushCmd.Flags().BoolVarP(&po.forceBuild, "force-build", "f", false, "Use force-build flag to force building the component")
 
-	// enable devfile flag if experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		pushCmd.Flags().StringVar(&po.namespace, "namespace", "", "Namespace to push the component to")
-		pushCmd.Flags().StringVar(&po.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
-		pushCmd.Flags().StringVar(&po.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
-		pushCmd.Flags().StringVar(&po.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
-		pushCmd.Flags().BoolVar(&po.debugRun, "debug", false, "Runs the component in debug mode")
-		pushCmd.Flags().StringVar(&po.devfileDebugCommand, "debug-command", "", "Devfile Debug Command to execute")
-	}
+	pushCmd.Flags().StringVar(&po.namespace, "namespace", "", "Namespace to push the component to")
+	pushCmd.Flags().StringVar(&po.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
+	pushCmd.Flags().StringVar(&po.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
+	pushCmd.Flags().StringVar(&po.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
+	pushCmd.Flags().BoolVar(&po.debugRun, "debug", false, "Runs the component in debug mode")
+	pushCmd.Flags().StringVar(&po.devfileDebugCommand, "debug-command", "", "Devfile Debug Command to execute")
 
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(pushCmd)

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -78,10 +77,7 @@ func NewUpdateOptions() *UpdateOptions {
 func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	uo.devfilePath = filepath.Join(uo.componentContext, DevfilePath)
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
-		// Add a disclaimer that we are in *experimental mode*
-		log.Experimental("Experimental mode is enabled, use at your own risk")
-
+	if util.CheckPathExists(uo.devfilePath) {
 		// Configure the devfile context
 		uo.Context = genericclioptions.NewDevfileContext(cmd)
 		return
@@ -99,7 +95,7 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 func (uo *UpdateOptions) Validate() (err error) {
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
+	if util.CheckPathExists(uo.devfilePath) {
 		return nil
 	}
 
@@ -171,8 +167,8 @@ func (uo *UpdateOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (uo *UpdateOptions) Run() (err error) {
 
-	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
+	// if devfile is present
+	if util.CheckPathExists(uo.devfilePath) {
 		return errors.New(devfileErrorString)
 	}
 

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -2,11 +2,13 @@ package debug
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -20,8 +22,8 @@ type InfoOptions struct {
 	Namespace       string
 	PortForwarder   *debug.DefaultPortForwarder
 	*genericclioptions.Context
-	contextDir  string
-	DevfilePath string
+	componentContext string
+	devfilePath      string
 }
 
 var (
@@ -46,7 +48,9 @@ func NewInfoOptions() *InfoOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
+
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut
@@ -103,10 +107,7 @@ func NewCmdInfo(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(opts, cmd, args)
 		},
 	}
-	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
-	if experimental.IsExperimentalModeEnabled() {
-		cmd.Flags().StringVar(&opts.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
-	}
+	genericclioptions.AddContextFlag(cmd, &opts.componentContext)
 
 	return cmd
 }

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -5,14 +5,15 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 
 	"github.com/spf13/cobra"
@@ -30,8 +31,8 @@ type PortForwardOptions struct {
 	// PortPair is the combination of local and remote port in the format "local:remote"
 	PortPair string
 
-	localPort  int
-	contextDir string
+	localPort        int
+	componentContext string
 
 	PortForwarder *debug.DefaultPortForwarder
 	// StopChannel is used to stop port forwarding
@@ -39,7 +40,7 @@ type PortForwardOptions struct {
 	// ReadChannel is used to receive status of port forwarding ( ready or not ready )
 	ReadyChannel chan struct{}
 	*genericclioptions.Context
-	DevfilePath string
+	devfilePath string
 
 	isExperimental bool
 }
@@ -71,12 +72,11 @@ func NewPortForwardOptions() *PortForwardOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
 
 	var remotePort int
 
-	o.isExperimental = experimental.IsExperimentalModeEnabled()
-
-	if o.isExperimental && util.CheckPathExists(o.DevfilePath) {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut
@@ -181,10 +181,7 @@ func NewCmdPortForward(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(opts, cmd, args)
 		},
 	}
-	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
-	if experimental.IsExperimentalModeEnabled() {
-		cmd.Flags().StringVar(&opts.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
-	}
+	genericclioptions.AddContextFlag(cmd, &opts.componentContext)
 	cmd.Flags().IntVarP(&opts.localPort, "local-port", "l", config.DefaultDebugPort, "Set the local port")
 
 	return cmd

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -17,6 +19,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	svc "github.com/openshift/odo/pkg/service"
+	"github.com/openshift/odo/pkg/util"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -107,6 +110,9 @@ type ServiceCreateOptions struct {
 	// Location of the file in which yaml specification of CR is stored.
 	// TODO: remove this after service create's interactive mode supports creating operator backed services
 	fromFile string
+
+	// Devfile
+	devfilePath string
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -128,11 +134,13 @@ func NewDynamicCRD() *DynamicCRD {
 
 // Complete completes ServiceCreateOptions after they've been created
 func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
+
 	if len(args) == 0 || !cmd.HasFlags() {
 		o.interactive = true
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.componentContext != "" {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -144,8 +152,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 
 	var class scv1beta1.ClusterServiceClass
 
-	if experimental.IsExperimentalModeEnabled() {
-		// we don't support interactive mode for Operator Hub yet
+	if util.CheckPathExists(o.devfilePath) {
 		o.interactive = false
 
 		// if user has just used "odo service create", simply return
@@ -209,7 +216,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		}
 		// if only one arg is given, then it is considered as service name and service type both
 		// ONLY if not running in Experimental mode
-		if !experimental.IsExperimentalModeEnabled() {
+		if !util.CheckPathExists(o.devfilePath) {
 			// This is because an operator with name
 			// "etcdoperator.v0.9.4-clusterwide" would lead to creation of a
 			// serice with name like
@@ -277,7 +284,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 	}
 
 	// we want to find an Operator only if something's passed to the crd flag on CLI
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		d := NewDynamicCRD()
 		// if the user wants to create service from a file, we check for
 		// existence of file and validate if the requested operator and CR
@@ -430,7 +437,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
 	s := &log.Status{}
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		// in case of an opertor backed service, name of the service is
 		// provided by the yaml specification in alm-examples. It might also
 		// happen that a user spins up Service Catalog based service in
@@ -445,7 +452,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
 	}
 
-	if experimental.IsExperimentalModeEnabled() && o.CustomResource != "" {
+	if util.CheckPathExists(o.devfilePath) && o.CustomResource != "" {
 		// if experimental mode is enabled and o.CustomResource is not empty, we're expected to create an Operator backed service
 		if o.DryRun {
 			// if it's dry run, only print the alm-example (o.CustomResourceDefinition) and exit
@@ -512,15 +519,13 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
-		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
-		serviceCreateCmd.Short = createShortDescExperimental
-		serviceCreateCmd.Long = createLongDescExperimental
-		serviceCreateCmd.Example += fmt.Sprintf("\n\n") + fmt.Sprintf(createOperatorExample, fullName)
-		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
-		// remove this feature after enabling service create interactive mode for operator backed services
-		serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
-	}
+	serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
+	serviceCreateCmd.Short = createShortDescExperimental
+	serviceCreateCmd.Long = createLongDescExperimental
+	serviceCreateCmd.Example += fmt.Sprintf("\n\n") + fmt.Sprintf(createOperatorExample, fullName)
+	serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
+	// remove this feature after enabling service create interactive mode for operator backed services
+	serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
 
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringArrayVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -3,16 +3,18 @@ package service
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	svc "github.com/openshift/odo/pkg/service"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -34,6 +36,8 @@ type ServiceListOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
+
+	devfilePath string
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -43,7 +47,9 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
+
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -53,7 +59,8 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
-	if !experimental.IsExperimentalModeEnabled() {
+
+	if !util.CheckPathExists(o.devfilePath) {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
@@ -66,7 +73,8 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+
+	if util.CheckPathExists(o.devfilePath) {
 		// if experimental mode is enabled, we list only operator hub backed
 		// services and not service catalog ones
 		var list []unstructured.Unstructured

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -2,13 +2,14 @@ package url
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ type URLDeleteOptions struct {
 	urlName            string
 	urlForceDeleteFlag bool
 	now                bool
+	componentContext   string
+	devfilePath        string
 }
 
 // NewURLDeleteOptions creates a new URLDeleteOptions instance
@@ -40,9 +43,9 @@ func NewURLDeleteOptions() *URLDeleteOptions {
 
 // Complete completes URLDeleteOptions after they've been Deleted
 func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
-
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.urlName = args[0]
 		err = o.InitEnvInfoFromContext()
@@ -77,7 +80,7 @@ func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []stri
 // Validate validates the URLDeleteOptions based on completed values
 func (o *URLDeleteOptions) Validate() (err error) {
 	var exists bool
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		urls := o.EnvSpecificInfo.GetURL()
 		componentName := o.EnvSpecificInfo.GetName()
 		for _, url := range urls {
@@ -113,7 +116,7 @@ func (o *URLDeleteOptions) Validate() (err error) {
 // Run contains the logic for the odo url delete command
 func (o *URLDeleteOptions) Run() (err error) {
 	if o.urlForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the url %v", o.urlName)) {
-		if experimental.IsExperimentalModeEnabled() {
+		if util.CheckPathExists(o.devfilePath) {
 			err = o.EnvSpecificInfo.DeleteURL(o.urlName)
 			if err != nil {
 				return err
@@ -162,10 +165,12 @@ func NewCmdURLDelete(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(urlDeleteExample, fullName),
 	}
 	urlDeleteCmd.Flags().BoolVarP(&o.urlForceDeleteFlag, "force", "f", false, "Delete url without prompting")
-	o.AddContextFlag(urlDeleteCmd)
+
+	genericclioptions.AddContextFlag(urlDeleteCmd, &o.componentContext)
 	urlDeleteCmd.Flags().StringVar(&o.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
 	genericclioptions.AddNowFlag(urlDeleteCmd, &o.now)
 	completion.RegisterCommandHandler(urlDeleteCmd, completion.URLCompletionHandler)
 	completion.RegisterCommandFlagHandler(urlDeleteCmd, "context", completion.FileCompletionHandler)
+
 	return urlDeleteCmd
 }

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/storage"
 	urlPkg "github.com/openshift/odo/pkg/url"
 
@@ -137,26 +136,26 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 	if componentDesc.Spec.URL != nil {
 		var output string
 
-		if !experimental.IsExperimentalModeEnabled() {
-			// if the component is not pushed
-			if componentDesc.Status.State == component.StateTypeNotPushed {
-				// Gather the output
-				for i, componentURL := range componentDesc.Spec.URL {
-					output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL, componentDesc.Spec.Ports[i])
-				}
-			} else {
-				// Retrieve the URLs
-				urls, err := urlPkg.ListPushed(client, currentComponentName, applicationName)
-				LogErrorAndExit(err, "")
-
-				// Gather the output
-				for _, componentURL := range componentDesc.Spec.URL {
-					url := urls.Get(componentURL)
-					output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, "", experimental.IsExperimentalModeEnabled()), url.Spec.Port)
-				}
-
+		// S2I Only (odo describe exits by default on Devfile by default anyways..)
+		// if the component is not pushed
+		if componentDesc.Status.State == component.StateTypeNotPushed {
+			// Gather the output
+			for i, componentURL := range componentDesc.Spec.URL {
+				output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL, componentDesc.Spec.Ports[i])
 			}
+		} else {
+			// Retrieve the URLs
+			urls, err := urlPkg.ListPushed(client, currentComponentName, applicationName)
+			LogErrorAndExit(err, "")
+
+			// Gather the output
+			for _, componentURL := range componentDesc.Spec.URL {
+				url := urls.Get(componentURL)
+				output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, "", true), url.Spec.Port)
+			}
+
 		}
+
 		// Cut off the last newline and output
 		if len(output) > 0 {
 			output = output[:len(output)-1]

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -35,16 +35,16 @@ import (
 
 func TestCreate(t *testing.T) {
 	type args struct {
-		componentName             string
-		applicationName           string
-		urlName                   string
-		portNumber                int
-		secure                    bool
-		host                      string
-		urlKind                   envinfo.URLKind
-		isRouteSupported          bool
-		isExperimentalModeEnabled bool
-		tlsSecret                 string
+		componentName    string
+		applicationName  string
+		urlName          string
+		portNumber       int
+		secure           bool
+		host             string
+		urlKind          envinfo.URLKind
+		isRouteSupported bool
+		isS2I            bool
+		tlsSecret        string
 	}
 	tests := []struct {
 		name               string
@@ -64,6 +64,7 @@ func TestCreate(t *testing.T) {
 				urlName:          "nodejs",
 				portNumber:       8080,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -99,6 +100,7 @@ func TestCreate(t *testing.T) {
 				urlName:          "example-url",
 				portNumber:       9100,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -135,6 +137,7 @@ func TestCreate(t *testing.T) {
 				portNumber:       9100,
 				secure:           true,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -170,13 +173,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 4: Create a ingress, with same name as component,instead of route on openshift cluster",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "nodejs",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "nodejs",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress: fake.GetSingleIngress("nodejs", "nodejs"),
 			want:            "http://nodejs.com",
@@ -185,13 +187,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 5: Create a ingress, with different name as component,instead of route on openshift cluster",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -222,14 +223,13 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 6: Create a secure ingress, instead of route on openshift cluster, default tls exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:  fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists: true,
@@ -239,14 +239,13 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 7: Create a secure ingress, instead of route on openshift cluster and default tls doesn't exist",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:  fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists: false,
@@ -256,15 +255,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 8: Fail when while creating ingress when user given tls secret doesn't exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -275,15 +273,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 9: Create a secure ingress, instead of route on openshift cluster, user tls secret does exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -295,15 +292,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 10: invalid url kind",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   "blah",
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          "blah",
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -314,12 +310,11 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 11: route is not supported on the cluster",
 			args: args{
-				componentName:             "nodejs",
-				applicationName:           "app",
-				urlName:                   "example",
-				isRouteSupported:          false,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.ROUTE,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example",
+				isRouteSupported: false,
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -330,13 +325,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 11: secretName used without secure flag",
 			args: args{
-				componentName:             "nodejs",
-				applicationName:           "app",
-				urlName:                   "example",
-				isRouteSupported:          false,
-				isExperimentalModeEnabled: true,
-				tlsSecret:                 "secret",
-				urlKind:                   envinfo.ROUTE,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example",
+				isRouteSupported: false,
+				tlsSecret:        "secret",
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -412,7 +406,7 @@ func TestCreate(t *testing.T) {
 				urlKind:         tt.args.urlKind,
 			}
 
-			got, err := Create(client, fakeKClient, urlCreateParameters, tt.args.isRouteSupported, tt.args.isExperimentalModeEnabled)
+			got, err := Create(client, fakeKClient, urlCreateParameters, tt.args.isRouteSupported, tt.args.isS2I)
 
 			if err == nil && !tt.wantErr {
 				if tt.args.urlKind == envinfo.INGRESS {
@@ -741,8 +735,8 @@ func TestGetValidPortNumber(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	type args struct {
-		isRouteSupported          bool
-		isExperimentalModeEnabled bool
+		isRouteSupported bool
+		isS2I            bool
 	}
 	tests := []struct {
 		name                string
@@ -761,6 +755,7 @@ func TestPush(t *testing.T) {
 			name: "no urls on local config and cluster",
 			args: args{
 				isRouteSupported: true,
+				isS2I:            true,
 			},
 			componentName:   "nodejs",
 			applicationName: "app",
@@ -770,7 +765,10 @@ func TestPush(t *testing.T) {
 			name:            "2 urls on local config and 0 on openshift cluster",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args: args{
+				isRouteSupported: true,
+				isS2I:            true,
+			},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example",
@@ -811,7 +809,7 @@ func TestPush(t *testing.T) {
 			name:            "0 url on local config and 2 on openshift cluster",
 			componentName:   "wildfly",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			returnedRoutes:  testingutil.GetRouteListWithMultiple("wildfly", "app"),
 			deletedURLs: []URL{
 				getMachineReadableFormat(testingutil.GetSingleRoute("example-app", 8080, "nodejs", "app")),
@@ -822,7 +820,7 @@ func TestPush(t *testing.T) {
 			name:            "2 url on local config and 2 on openshift cluster, but they are different",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example-local-0",
@@ -867,7 +865,7 @@ func TestPush(t *testing.T) {
 			name:            "2 url on local config and openshift cluster are in sync",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example",
@@ -888,7 +886,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "0 urls on env file and cluster",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			returnedRoutes:      &routev1.RouteList{},
 			returnedIngress:     &extensionsv1.IngressList{},
@@ -896,7 +894,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and 0 on openshift cluster",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example",
@@ -943,7 +941,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "0 urls on env file and 2 on openshift cluster",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			returnedRoutes:      &routev1.RouteList{},
 			returnedIngress:     fake.GetIngressListWithMultiple("nodejs"),
@@ -963,7 +961,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and 2 on openshift cluster, but they are different",
 			componentName: "wildfly",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example-local-0",
@@ -1022,7 +1020,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and openshift cluster are in sync",
 			componentName: "wildfly",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example-0",
@@ -1047,7 +1045,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 (1 ingress,1 route) urls on env file and 2 on openshift cluster (1 ingress,1 route), but they are different",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example-local-0",
@@ -1104,7 +1102,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a ingress on a kubernetes cluster",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: false, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: false},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:      "example",
@@ -1136,7 +1134,9 @@ func TestPush(t *testing.T) {
 		{
 			name:          "url with same name exists on env and cluster but with different specs",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args: args{
+				isRouteSupported: true,
+			},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example-local-0",
@@ -1176,7 +1176,7 @@ func TestPush(t *testing.T) {
 			name:            "url with same name exists on config and cluster but with different specs",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true, isExperimentalModeEnabled: false},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example-local-0",
@@ -1215,7 +1215,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure route url",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example",
@@ -1242,7 +1242,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure ingress url with empty user given tls secret",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:   "example",
@@ -1271,7 +1271,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure ingress url with user given tls secret",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:      "example",
@@ -1338,12 +1338,12 @@ func TestPush(t *testing.T) {
 			})
 
 			if err := Push(fakeClient, fakeKClient, PushParameters{
-				ComponentName:             tt.componentName,
-				ApplicationName:           tt.applicationName,
-				ConfigURLs:                tt.existingConfigURLs,
-				EnvURLS:                   tt.existingEnvInfoURLs,
-				IsRouteSupported:          tt.args.isRouteSupported,
-				IsExperimentalModeEnabled: tt.args.isExperimentalModeEnabled,
+				ComponentName:    tt.componentName,
+				ApplicationName:  tt.applicationName,
+				ConfigURLs:       tt.existingConfigURLs,
+				EnvURLS:          tt.existingEnvInfoURLs,
+				IsRouteSupported: tt.args.isRouteSupported,
+				IsS2I:            tt.args.isS2I,
 			}); (err != nil) != tt.wantErr {
 				t.Errorf("Push() error = %v, wantErr %v", err, tt.wantErr)
 			} else {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -116,7 +116,7 @@ func componentTests(args ...string) {
 
 		It("should show an error when ref flag is provided with sources except git", func() {
 			outputErr := helper.CmdShouldFail("odo", append(args, "create", "nodejs", "--project", project, "cmp-git", "--ref", "test")...)
-			Expect(outputErr).To(ContainSubstring("The --ref flag is only valid for --git flag"))
+			Expect(outputErr).To(ContainSubstring("the --ref flag is only valid for --git flag"))
 		})
 
 		It("create component twice fails from same directory", func() {

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
@@ -127,4 +128,38 @@ var _ = Describe("odo devfile catalog command tests", func() {
 			helper.MatchAllInOutput(output, []string{"accepts 1 arg(s), received 0"})
 		})
 	})
+
+	Context("When executing catalog list components with experimental mode set to true", func() {
+
+		componentName := "nodejs"
+
+		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
+
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
+
+			wantOutput := []string{componentName}
+
+			var data map[string]interface{}
+
+			err := json.Unmarshal([]byte(output), &data)
+
+			if err != nil {
+				Expect(err).Should(BeNil())
+			}
+			outputBytes, err := json.Marshal(data["s2iItems"])
+			if err == nil {
+				output = string(outputBytes)
+			}
+
+			helper.MatchAllInOutput(output, wantOutput)
+
+			outputBytes, err = json.Marshal(data["devfileItems"])
+			if err == nil {
+				output = string(outputBytes)
+			}
+
+			helper.MatchAllInOutput(output, wantOutput)
+		})
+	})
+
 })

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
@@ -71,6 +72,22 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
+	Context("Disabling experimental preference should error out on providing --s2i flag", func() {
+		JustBeforeEach(func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("Skipping test because s2i image is not supported on Kubernetes cluster")
+			}
+		})
+		It("checks that the --s2i flag is unrecognised when Experimental is set to false for create", func() {
+			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "false", "-f")
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+
+			// Check that it will contain the experimental mode output
+			s2iFlagUnknownMsg := "Error: unknown flag: --s2i"
+			Expect(helper.CmdShouldFail("odo", "create", "nodejs", "--s2i")).To(ContainSubstring(s2iFlagUnknownMsg))
+		})
+	})
+
 	Context("When executing odo create with devfile component type argument", func() {
 		It("should successfully create the devfile component", func() {
 			helper.CmdShouldPass("odo", "create", "java-openliberty")
@@ -110,6 +127,91 @@ var _ = Describe("odo devfile create command tests", func() {
 			componentName := helper.RandString(64)
 			output := helper.CmdShouldFail("odo", "create", "java-openliberty", componentName)
 			helper.MatchAllInOutput(output, []string{"Contain at most 63 characters"})
+		})
+	})
+
+	Context("When executing odo create with component type argument and --s2i flag", func() {
+
+		JustBeforeEach(func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("Skipping test because s2i image is not supported on Kubernetes cluster")
+			}
+		})
+
+		componentType := "nodejs"
+
+		It("should successfully create the localconfig component", func() {
+			componentName := helper.RandString(6)
+			helper.CopyExample(filepath.Join("source", componentType), context)
+			helper.CmdShouldPass("odo", "create", componentType, componentName, "--s2i")
+			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+componentName, "Application,app")
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v4")
+
+			// clean up
+			helper.CmdShouldPass("odo", "app", "delete", "app", "-f")
+			helper.CmdShouldFail("odo", "app", "delete", "app", "-f")
+			helper.CmdShouldFail("odo", "delete", componentName, "-f")
+
+		})
+
+		It("should successfully create the localconfig component with --git flag", func() {
+			componentName := "cmp-git"
+			helper.CmdShouldPass("odo", "create", componentType, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--s2i", "true", "--app", "testing")
+			helper.CmdShouldPass("odo", "push", "--context", context, "-v4")
+
+			// clean up
+			helper.CmdShouldPass("odo", "app", "delete", "testing", "-f")
+			helper.CmdShouldFail("odo", "app", "delete", "testing", "-f")
+			helper.CmdShouldFail("odo", "delete", componentName, "-f")
+		})
+
+		It("should fail to create the devfile component which doesn't have an s2i component of same name", func() {
+			componentName := helper.RandString(6)
+
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
+
+			wantOutput := []string{"java-openliberty"}
+
+			var data map[string]interface{}
+
+			err := json.Unmarshal([]byte(output), &data)
+
+			if err != nil {
+				Expect(err).Should(BeNil())
+			}
+			outputBytes, err := json.Marshal(data["s2iItems"])
+			if err == nil {
+				output = string(outputBytes)
+			}
+
+			helper.DontMatchAllInOutput(output, wantOutput)
+
+			outputBytes, err = json.Marshal(data["devfileItems"])
+			if err == nil {
+				output = string(outputBytes)
+			}
+
+			helper.MatchAllInOutput(output, wantOutput)
+
+			helper.CmdShouldFail("odo", "create", "java-openliberty", componentName, "--s2i")
+		})
+
+		It("should fail the create command as --git flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			output := helper.CmdShouldFail("odo", "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")
+			Expect(output).Should(ContainSubstring("flag --git, requires --s2i flag to be set, when in experimental mode."))
+		})
+
+		It("should fail the create command as --binary flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
+
+			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(context, "sb.jar"), "--context", context)
+			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when in experimental mode."))
+		})
+
+		It("should fail the create command as --now flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			componentName := helper.RandString(6)
+			output := helper.CmdShouldFail("odo", "create", "nodejs", componentName, "--now")
+			Expect(output).Should(ContainSubstring("flag --now, requires --s2i flag to be set, when in experimental mode."))
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind feature

**What does does this PR do / why we need it**:

Makes Devfile the default deployment mechanism, removing S2I in favour
of Devfile deployment.

**Which issue(s) this PR fixes**:

Closes https://github.com/openshift/odo/issues/3550

**How to test changes / Special notes to the reviewer**:

Run:

```sh
odo preference set experimental false
odo create --starter nodejs
odo push
```