### PR TITLE
Fix typo when setting PROJECTS_ROOT env on docker

### DIFF
--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -209,6 +209,8 @@ func (a Adapter) startComponent(mounts []mount.Mount, comp versionsCommon.Devfil
 			syncFolder = lclient.OdoSourceVolumeMount
 		}
 		utils.AddVolumeToContainer(a.projectVolumeName, syncFolder, &hostConfig)
+
+		// Set PROJECTS_ROOT as an env var in the container if not already set
 		if projectsRoot == "" {
 			envName := common.EnvProjectsRoot
 			envValue := syncFolder

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -209,7 +209,7 @@ func (a Adapter) startComponent(mounts []mount.Mount, comp versionsCommon.Devfil
 			syncFolder = lclient.OdoSourceVolumeMount
 		}
 		utils.AddVolumeToContainer(a.projectVolumeName, syncFolder, &hostConfig)
-		if projectsRoot != "" {
+		if projectsRoot == "" {
 			envName := common.EnvProjectsRoot
 			envValue := syncFolder
 			comp.Container.Env = append(comp.Container.Env, versionsCommon.Env{


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
@maysunfaisal found a bug with how we were setting `$PROJECTS_ROOT` in containers when on Docker. This was due to an improper if statement check when setting the env var in the container.

**Which issue(s) this PR fixes**:

No issue opened, but can open one if needed.

**How to test changes / Special notes to the reviewer**:
