### PR TITLE
Removing the unsupported ruby image test

### DIFF
--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -185,12 +185,6 @@ func componentTests(args ...string) {
 
 		})
 
-		It("should create the component from the branch ref when provided", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "ruby", "ref-test", "--project", project, "--git", "https://github.com/girishramnani/ruby-ex.git", "--ref", "develop")...)
-			helper.ValidateLocalCmpExist(context, "Type,ruby", "Name,ref-test", "Application,app")
-			helper.CmdShouldPass("odo", append(args, "push")...)
-		})
-
 		It("should list the component", func() {
 			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

PR removes the Ruby image component created from the branch ref

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

PR - openshift/release#10346 should be unblocked.
Run `make test-cmd-cmp` and `make test-cmd-cmp-sub`