### PR TITLE
Skiping s2iItem check on kubernetes cluster

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -206,3 +206,14 @@ func GetCliRunner() CliRunner {
 func Suffocate(s string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(s, " ", ""), "\t", "")
 }
+
+// Find takes a slice and looks for the element in it.
+// return a bool accordingly.
+func Find(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -206,14 +206,3 @@ func GetCliRunner() CliRunner {
 func Suffocate(s string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(s, " ", ""), "\t", "")
 }
-
-// Find takes a slice and looks for the element in it.
-// return a bool accordingly.
-func Find(slice []string, val string) bool {
-	for _, item := range slice {
-		if item == val {
-			return true
-		}
-	}
-	return false
-}

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -132,7 +132,8 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog list components with experimental mode set to true", func() {
 		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			err := utils.VerifyCatalogListComponent(output)
+			componentName := []string{"nodejs"}
+			err := utils.VerifyCatalogListComponent(output, componentName)
 			Expect(err).Should(BeNil())
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -132,7 +132,8 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog list components with experimental mode set to true", func() {
 		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			utils.VerifyCatalogListComponent(output)
+			err := utils.VerifyCatalogListComponent(output)
+			Expect(err).Should(BeNil())
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -132,8 +132,8 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog list components with experimental mode set to true", func() {
 		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			wantOutput := []string{"nodejs"}
-			err := utils.VerifyCatalogListComponent(output, wantOutput)
+			cmpName := []string{"nodejs"}
+			err := utils.VerifyCatalogListComponent(output, cmpName)
 			Expect(err).Should(BeNil())
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -1,7 +1,6 @@
 package devfile
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
@@ -9,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
+	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile catalog command tests", func() {
@@ -130,35 +130,9 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	})
 
 	Context("When executing catalog list components with experimental mode set to true", func() {
-
-		componentName := "nodejs"
-
 		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
-
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-
-			wantOutput := []string{componentName}
-
-			var data map[string]interface{}
-
-			err := json.Unmarshal([]byte(output), &data)
-
-			if err != nil {
-				Expect(err).Should(BeNil())
-			}
-			outputBytes, err := json.Marshal(data["s2iItems"])
-			if err == nil {
-				output = string(outputBytes)
-			}
-
-			helper.MatchAllInOutput(output, wantOutput)
-
-			outputBytes, err = json.Marshal(data["devfileItems"])
-			if err == nil {
-				output = string(outputBytes)
-			}
-
-			helper.MatchAllInOutput(output, wantOutput)
+			utils.VerifyCatalogListComponent(output)
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -132,8 +132,8 @@ var _ = Describe("odo devfile catalog command tests", func() {
 	Context("When executing catalog list components with experimental mode set to true", func() {
 		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			componentName := []string{"nodejs"}
-			err := utils.VerifyCatalogListComponent(output, componentName)
+			wantOutput := []string{"nodejs"}
+			err := utils.VerifyCatalogListComponent(output, wantOutput)
 			Expect(err).Should(BeNil())
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -1,7 +1,6 @@
 package devfile
 
 import (
-	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/openshift/odo/tests/helper"
+	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile create command tests", func() {
@@ -167,32 +167,10 @@ var _ = Describe("odo devfile create command tests", func() {
 
 		It("should fail to create the devfile component which doesn't have an s2i component of same name", func() {
 			componentName := helper.RandString(6)
-
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-
 			wantOutput := []string{"java-openliberty"}
-
-			var data map[string]interface{}
-
-			err := json.Unmarshal([]byte(output), &data)
-
-			if err != nil {
-				Expect(err).Should(BeNil())
-			}
-			outputBytes, err := json.Marshal(data["s2iItems"])
-			if err == nil {
-				output = string(outputBytes)
-			}
-
-			helper.DontMatchAllInOutput(output, wantOutput)
-
-			outputBytes, err = json.Marshal(data["devfileItems"])
-			if err == nil {
-				output = string(outputBytes)
-			}
-
-			helper.MatchAllInOutput(output, wantOutput)
-
+			err := utils.VerifyCatalogListComponent(output, wantOutput)
+			Expect(err).Should(BeNil())
 			helper.CmdShouldFail("odo", "create", "java-openliberty", componentName, "--s2i")
 		})
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/openshift/odo/tests/helper"
-	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile create command tests", func() {
@@ -166,12 +165,7 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 
 		It("should fail to create the devfile component which doesn't have an s2i component of same name", func() {
-			componentName := helper.RandString(6)
-			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			wantOutput := []string{"java-openliberty"}
-			err := utils.VerifyCatalogListComponent(output, wantOutput)
-			Expect(err).Should(BeNil())
-			helper.CmdShouldFail("odo", "create", "java-openliberty", componentName, "--s2i")
+			helper.CmdShouldFail("odo", "create", "java-openliberty", cmpName, "--s2i")
 		})
 
 		It("should fail the create command as --git flag, which is specific to s2i component creation, is used without --s2i flag", func() {

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -587,8 +587,9 @@ func DeleteLocalConfig(args ...string) {
 	helper.MatchAllInOutput(output, expectedOutput)
 }
 
-// VerifyCatalogListComponent verifies component exists in both S2I Component list and Devfile Component list
-func VerifyCatalogListComponent(output string, componentName []string) error {
+// VerifyCatalogListComponent verifies components inside wantOutput exists or not
+// in both S2I Component list and Devfile Component list
+func VerifyCatalogListComponent(output string, wantOutput []string) error {
 	var data map[string]interface{}
 	listItems := []string{"devfileItems"}
 
@@ -607,7 +608,11 @@ func VerifyCatalogListComponent(output string, componentName []string) error {
 			return err
 		}
 		output = string(outputBytes)
-		helper.MatchAllInOutput(output, componentName)
+		if items != "devfileItems" && helper.Find(wantOutput, "java-openliberty") {
+			helper.DontMatchAllInOutput(output, wantOutput)
+			return err
+		}
+		helper.MatchAllInOutput(output, wantOutput)
 	}
 	return err
 }

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -588,11 +588,7 @@ func DeleteLocalConfig(args ...string) {
 }
 
 // VerifyCatalogListComponent verifies component exists in both S2I Component list and Devfile Component list
-func VerifyCatalogListComponent(output string) error {
-
-	componentName := "nodejs"
-	wantOutput := []string{componentName}
-
+func VerifyCatalogListComponent(output string, componentName []string) error {
 	var data map[string]interface{}
 	listItems := []string{"devfileItems"}
 
@@ -611,7 +607,7 @@ func VerifyCatalogListComponent(output string) error {
 			return err
 		}
 		output = string(outputBytes)
-		helper.MatchAllInOutput(output, wantOutput)
+		helper.MatchAllInOutput(output, componentName)
 	}
 	return err
 }

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -589,12 +589,11 @@ func DeleteLocalConfig(args ...string) {
 
 // VerifyCatalogListComponent verifies components inside wantOutput exists or not
 // in both S2I Component list and Devfile Component list
-func VerifyCatalogListComponent(output string, wantOutput []string) error {
+func VerifyCatalogListComponent(output string, cmpName []string) error {
 	var data map[string]interface{}
 	listItems := []string{"devfileItems"}
 
-	err := json.Unmarshal([]byte(output), &data)
-	if err != nil {
+	if err := json.Unmarshal([]byte(output), &data); err != nil {
 		return err
 	}
 
@@ -608,11 +607,7 @@ func VerifyCatalogListComponent(output string, wantOutput []string) error {
 			return err
 		}
 		output = string(outputBytes)
-		if items != "devfileItems" && helper.Find(wantOutput, "java-openliberty") {
-			helper.DontMatchAllInOutput(output, wantOutput)
-			return err
-		}
-		helper.MatchAllInOutput(output, wantOutput)
+		helper.MatchAllInOutput(output, cmpName)
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind failing-test
/kind code-refactoring

**What does does this PR do / why we need it**:

PR skin s2i image check for kubernetes clusters due to the fact that imagestreams are not there with k8s.
Also code clean up.

**Which issue(s) this PR fixes**:

Fixes #3713 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

`make test-cmd-devfile-catalog` should run on both openshift and kubernetes cluster