### PR TITLE
Fixes odo url list for s2i components

### DIFF
--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	odoUtil "github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/url"
 	"github.com/openshift/odo/pkg/util"
@@ -71,7 +71,7 @@ func (o *URLListOptions) Complete(name string, cmd *cobra.Command, args []string
 
 // Validate validates the URLListOptions based on completed values
 func (o *URLListOptions) Validate() (err error) {
-	return odoUtil.CheckOutputFlag(o.OutputFlag)
+	return odoutil.CheckOutputFlag(o.OutputFlag)
 }
 
 // Run contains the logic for the odo url list command

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -364,5 +364,21 @@ var _ = Describe("odo devfile url command tests", func() {
 			output := helper.CmdShouldPass("oc", "get", "routes", "--namespace", namespace)
 			Expect(output).Should(ContainSubstring(url1))
 		})
+
+		// remove once https://github.com/openshift/odo/issues/3550 is resolved
+		It("should list URLs for s2i components", func() {
+			url1 := helper.RandString(5)
+			url2 := helper.RandString(5)
+
+			componentName := helper.RandString(6)
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", namespace, componentName, "--s2i")
+
+			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
+			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8080", "--context", context, "--ingress", "--host", "com")
+
+			stdout := helper.CmdShouldPass("odo", "url", "list", "--context", context)
+			helper.MatchAllInOutput(stdout, []string{url1, url2})
+		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

Fixes `odo url list` for s2i components with experimental mode on.

**Which issue(s) this PR fixes**:

Fixes #3474

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

- turn on experimental mode
- `odo create nodejs --s2i`
- trigger `odo url create` for both ingress and routes
- `odo url list` should display both the URLs