### PR TITLE
Docker test container for travis login

### DIFF
--- a/openshift-ci/build-root/Dockerfile.travislogin
+++ b/openshift-ci/build-root/Dockerfile.travislogin
@@ -1,0 +1,23 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+
+RUN yum -y install sudo make wget gcc git httpd-tools ruby ruby-devel gcc-c++ patch \
+    readline readline-devel zlib zlib-devel libffi-devel openssl-devel make bzip2 \
+    autoconf automake libtool bison sqlite-devel
+
+RUN sudo curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+RUN sleep 5
+RUN sudo curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
+
+RUN curl -L get.rvm.io | bash -s stable
+
+RUN source /etc/profile.d/rvm.sh \
+    rvm reload
+
+RUN rvm requirements run
+RUN rvm install 2.7
+
+RUN ruby --version
+
+RUN gem install travis --pre --no-document


### PR DESCRIPTION
**What type of PR is this?**
/kind Feature

**What does does this PR do / why we need it**:
we are in process of getting the odo-bot GitHub token injected into prow. So creating a test container from where all these short of operation like travis cli install, travis login... etc will be launched 

**Which issue(s) this PR fixes**:

Fixes : part of #2540 

**PR acceptance criteria**:

Should not break master

**How to test changes / Special notes to the reviewer**:
```
$ docker run -it registry.svc.ci.openshift.org/openshift/release:golang-1.13
$ yum -y install sudo make wget gcc git httpd-tools ruby ruby-devel gcc-c++ patch \
    readline readline-devel zlib zlib-devel libffi-devel openssl-devel make bzip2 \
    autoconf automake libtool bison sqlite-devel
$ sudo curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
$ sleep 5
$ sudo curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
$ curl -L get.rvm.io | bash -s stable
$ source /etc/profile.d/rvm.sh
$ rvm reload
$ rvm requirements run
$ rvm install 2.7
$ gem install travis --pre --no-document
```