### PR TITLE
Fix odo log flake

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -180,8 +180,8 @@ func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, check func(outpu
 }
 
 // RunCmdWithMatchOutputFromBuffer starts the command, and command stdout is attached to buffer.
-// we read data from buffer line by line, and if expected string is matcher it reutrns true
-// It is diffrent from WaitforCmdOut which gives stdout in one go usinf session.Out.Contents()
+// we read data from buffer line by line, and if expected string is matched it returns true
+// It is different from WaitforCmdOut which gives stdout in one go using session.Out.Contents()
 // for commands like odo log -f which streams continuous data and does not terminate by their own
 // we need to read the stream data from buffer.
 func RunCmdWithMatchOutputFromBuffer(timeoutAfter time.Duration, matchString, program string, args ...string) (bool, error) {
@@ -223,7 +223,6 @@ func RunCmdWithMatchOutputFromBuffer(timeoutAfter time.Duration, matchString, pr
 		}
 	}()
 
-	// if we do not expected output timeout.
 	for {
 		select {
 		case <-timeoutCh:

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -3,7 +3,9 @@ package helper
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -175,6 +177,64 @@ func WatchNonRetCmdStdOut(cmdStr string, timeout time.Duration, check func(outpu
 			}
 		}
 	}
+}
+
+// RunCmdWithMatchOutputFromBuffer starts the command, and command stdout is attached to buffer.
+// we read data from buffer line by line, and if expected string is matcher it reutrns true
+// It is diffrent from WaitforCmdOut which gives stdout in one go usinf session.Out.Contents()
+// for commands like odo log -f which streams continuous data and does not terminate by their own
+// we need to read the stream data from buffer.
+func RunCmdWithMatchOutputFromBuffer(timeoutAfter time.Duration, matchString, program string, args ...string) (bool, error) {
+	var buf bytes.Buffer
+
+	command := exec.Command(program, args...)
+	command.Stdout = &buf
+
+	timeoutCh := time.After(timeoutAfter)
+	matchOutputCh := make(chan bool)
+	errorCh := make(chan error)
+
+	_, err := fmt.Fprintln(GinkgoWriter, runningCmd(command))
+	if err != nil {
+		return false, err
+	}
+
+	err = command.Start()
+	if err != nil {
+		return false, err
+	}
+
+	// go routine which is reading data from buffer until expected string matched
+	go func() {
+		for {
+			line, err := buf.ReadString('\n')
+			if err != nil && err != io.EOF {
+				errorCh <- err
+			}
+			if len(line) > 0 {
+				_, err = fmt.Fprintln(GinkgoWriter, line)
+				if err != nil {
+					errorCh <- err
+				}
+				if strings.Contains(line, matchString) {
+					matchOutputCh <- true
+				}
+			}
+		}
+	}()
+
+	// if we do not expected output timeout.
+	for {
+		select {
+		case <-timeoutCh:
+			return false, errors.New("Timeout waiting for the conditon")
+		case <-matchOutputCh:
+			return true, nil
+		case <-errorCh:
+			return false, <-errorCh
+		}
+	}
+
 }
 
 // GetUserHomeDir gets the user home directory

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -189,6 +189,7 @@ func RunCmdWithMatchOutputFromBuffer(timeoutAfter time.Duration, matchString, pr
 
 	command := exec.Command(program, args...)
 	command.Stdout = &buf
+	command.Stderr = &buf
 
 	timeoutCh := time.After(timeoutAfter)
 	matchOutputCh := make(chan bool)
@@ -226,10 +227,12 @@ func RunCmdWithMatchOutputFromBuffer(timeoutAfter time.Duration, matchString, pr
 	for {
 		select {
 		case <-timeoutCh:
+			fmt.Fprintln(GinkgoWriter, buf.String())
 			return false, errors.New("Timeout waiting for the conditon")
 		case <-matchOutputCh:
 			return true, nil
 		case <-errorCh:
+			fmt.Fprintln(GinkgoWriter, buf.String())
 			return false, <-errorCh
 		}
 	}

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -58,9 +58,10 @@ var _ = Describe("odo devfile log command tests", func() {
 			output := helper.CmdShouldPass("odo", "log")
 			Expect(output).To(ContainSubstring("ODO_COMMAND_RUN"))
 
-			// test with follow flag
-			output = helper.CmdShouldRunWithTimeout(1*time.Second, "odo", "log", "-f")
-			Expect(output).To(ContainSubstring("program=devrun"))
+			// Test odo log -f
+			match, err := helper.RunCmdWithMatchOutputFromBuffer(30*time.Second, "program=devrun", "odo", "log", "-f")
+			Expect(err).To(BeNil())
+			Expect(match).To(BeTrue())
 
 		})
 
@@ -83,8 +84,9 @@ var _ = Describe("odo devfile log command tests", func() {
 			Expect(output).To(ContainSubstring("ODO_COMMAND_DEBUG"))
 
 			// test with follow flag
-			output = helper.CmdShouldRunWithTimeout(1*time.Second, "odo", "log", "-f")
-			Expect(output).To(ContainSubstring("program=debugrun"))
+			match, err := helper.RunCmdWithMatchOutputFromBuffer(30*time.Second, "program=debugrun", "odo", "log", "-f")
+			Expect(err).To(BeNil())
+			Expect(match).To(BeTrue())
 
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind flake


**What does does this PR do / why we need it**:
Fixes the flag for `odo log -f` test. This PR updates the test to check the log until expected log is printed and timeout if it doesn't gets logged in specified timeout duration.

**Which issue(s) this PR fixes**:

Fixes #3610

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
