### PR TITLE
Fix odo log for multi containers devfile

### DIFF
--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -190,7 +190,7 @@ func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
 func (c *Client) GetPodLogs(podName, containerName string, followLog bool) (io.ReadCloser, error) {
 
 	// Set standard log options
-	podLogOptions := corev1.PodLogOptions{Follow: false}
+	podLogOptions := corev1.PodLogOptions{Follow: false, Container: containerName}
 
 	// If the log is being followed, set it to follow / don't wait
 	if followLog {


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What does does this PR do / why we need it**:
passes container name for odo log, we are already passing container name for `odo log -f`, It seems it got missed from `odo log` 

Test updated to use springboot multi containers devfile, also refactored test code.

**Which issue(s) this PR fixes**:

Fixes #3711

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
