### PR TITLE
Applying secret to namespace for authenticated registry

### DIFF
--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -20,6 +20,9 @@ export KUBECONFIG=$ORIGINAL_KUBECONFIG
 # List of users to create
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
+# list of namespace to create
+NAMESPACE="openjdk-11-rhel8 nodejs-12-rhel7"
+
 # Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then
     # Check if nessasary files exist
@@ -49,17 +52,23 @@ fi
 
 # Setup the cluster for Operator tests
 
-## Create a new namesapce which will be used for OperatorHub checks
+# Create a new namesapce which will be used for OperatorHub checks
 oc new-project $CI_OPERATOR_HUB_PROJECT
+# Let developer user have access to the project
+oc adm policy add-role-to-user edit developer
+
 sh $SETUP_OPERATORS
 # OperatorHub setup complete
 
-## Create two namespace for authenticated registry e2e image test
-oc new-project openjdk-11-rhel8
-oc new-project nodejs-12-rhel7
-
-## Let developer user have access to the project
-oc adm policy add-role-to-user edit developer
+# Create the namespace for e2e inage test apply pull sceret to the namespace
+for i in `echo $NAMESPACE`; do
+    # create the namespace
+    oc new-project $i
+    # Applying pull sceret to the namespace which will be used for pulling images from authenticated registry
+    oc get secret pull-secret -n openshift-config -o yaml | sed "s/openshift-config/$i/g" | oc apply -f -
+    # Let developer user have access to the project
+    oc adm policy add-role-to-user edit developer
+done
 
 # Remove existing htpasswd file, if any
 if [ -f $HTPASSWD_FILE ]; then
@@ -76,11 +85,8 @@ for i in `echo $USERS`; do
 done
 
 # Workarounds - Note we should find better soulutions asap
-## Missing wildfly in OpenShift Adding it manually to cluster Please remove once wildfly is again visible
+# Missing wildfly in OpenShift Adding it manually to cluster Please remove once wildfly is again visible
 oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/x86_64/community/wildfly/imagestreams/wildfly-centos7.json
-## Applying pull sceret to the namespace which will be used for pulling images from authenticated registry
-oc get secret pull-secret -n openshift-config -o yaml | sed 's/openshift-config/openjdk-11-rhel8/g' | oc apply -f -
-oc get secret pull-secret -n openshift-config -o yaml | sed 's/openshift-config/nodejs-12-rhel7/g' | oc apply -f -
 
 # Create secret in cluster, removing if it already exists
 oc get secret $HTPASSWD_SECRET -n openshift-config &> /dev/null

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -21,7 +21,7 @@ export KUBECONFIG=$ORIGINAL_KUBECONFIG
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
 # list of namespace to create
-NAMESPACE="openjdk-11-rhel8 nodejs-12-rhel7"
+IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7"
 
 # Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then
@@ -61,7 +61,7 @@ sh $SETUP_OPERATORS
 # OperatorHub setup complete
 
 # Create the namespace for e2e inage test apply pull sceret to the namespace
-for i in `echo $NAMESPACE`; do
+for i in `echo $IMAGE_TEST_NAMESPACES`; do
     # create the namespace
     oc new-project $i
     # Applying pull sceret to the namespace which will be used for pulling images from authenticated registry

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -60,11 +60,11 @@ oc adm policy add-role-to-user edit developer
 sh $SETUP_OPERATORS
 # OperatorHub setup complete
 
-# Create the namespace for e2e inage test apply pull sceret to the namespace
+# Create the namespace for e2e image test apply pull secret to the namespace
 for i in `echo $IMAGE_TEST_NAMESPACES`; do
     # create the namespace
     oc new-project $i
-    # Applying pull sceret to the namespace which will be used for pulling images from authenticated registry
+    # Applying pull secret to the namespace which will be used for pulling images from authenticated registry
     oc get secret pull-secret -n openshift-config -o yaml | sed "s/openshift-config/$i/g" | oc apply -f -
     # Let developer user have access to the project
     oc adm policy add-role-to-user edit developer

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -126,13 +126,13 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the openjdk-11-rhel8 image", func() {
-			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "java:8", project)
-			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "openjdk", "java:8", project, appName, context)
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "java:8", "openjdk-11-rhel8")
+			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel8:latest"), "openjdk", "java:8", "openjdk-11-rhel8", appName, context)
 		})
 
 		It("Should be able to verify the nodejs-12-rhel7 image", func() {
-			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs:latest", project)
-			verifySupportedImage(filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs", "nodejs:latest", project, appName, context)
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs:latest", "nodejs-12-rhel7")
+			verifySupportedImage(filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs", "nodejs:latest", "nodejs-12-rhel7", appName, context)
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What does does this PR do / why we need it**:

The issue I am facing right now is, pulling registry from registry.redhat.io test fails on ocp cluster 4.2, 4.3 and 4.4 prow periodic job with unauthorized error, however same test passes in ocp 4.5 prow pr job
```
[oc] ! error: Import failed (InternalError): Internal error occurred: Get https://registry.redhat.io/v2/openjdk/openjdk
-11-rhel8/manifests/latest: unauthorized: Please login to the Red Hat Registry using your Customer Portal 
credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication
```
So we need to copy the default secret to the namespace

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test : NA

- [x] Integration test 

- [ ] Documentation : NA

**How to test changes / Special notes to the reviewer**:
make configure-installer-tests-cluster
make test-e2e-images