### PR TITLE
Stop other commands in case of restart false

### DIFF
--- a/pkg/devfile/adapters/common/command_supervisor.go
+++ b/pkg/devfile/adapters/common/command_supervisor.go
@@ -32,12 +32,9 @@ func newSupervisorInitCommand(command common.DevfileCommand, adapter commandExec
 }
 
 // newSupervisorStopCommand creates a command implementation that stops the specified command via the supervisor
-func newSupervisorStopCommand(command common.DevfileCommand, cmd string, executor commandExecutor) (command, error) {
-	if cmd == "" {
-		cmd = "all"
-	}
-	cmdLine := []string{SupervisordBinaryPath, SupervisordCtlSubCommand, "stop", cmd}
-	if stop, err := newOverriddenSimpleCommand(command, executor, cmdLine); err == nil {
+func newSupervisorStopCommand(command common.DevfileCommand, executor commandExecutor) (command, error) {
+	cmd := []string{SupervisordBinaryPath, SupervisordCtlSubCommand, "stop", "all"}
+	if stop, err := newOverriddenSimpleCommand(command, executor, cmd); err == nil {
 		// use empty spinner message to avoid showing it altogether
 		stop.msg = ""
 		return stop, err

--- a/pkg/devfile/adapters/common/command_supervisor.go
+++ b/pkg/devfile/adapters/common/command_supervisor.go
@@ -32,9 +32,12 @@ func newSupervisorInitCommand(command common.DevfileCommand, adapter commandExec
 }
 
 // newSupervisorStopCommand creates a command implementation that stops the specified command via the supervisor
-func newSupervisorStopCommand(command common.DevfileCommand, executor commandExecutor) (command, error) {
-	cmd := []string{SupervisordBinaryPath, SupervisordCtlSubCommand, "stop", "all"}
-	if stop, err := newOverriddenSimpleCommand(command, executor, cmd); err == nil {
+func newSupervisorStopCommand(command common.DevfileCommand, cmd string, executor commandExecutor) (command, error) {
+	if cmd == "" {
+		cmd = "all"
+	}
+	cmdLine := []string{SupervisordBinaryPath, SupervisordCtlSubCommand, "stop", cmd}
+	if stop, err := newOverriddenSimpleCommand(command, executor, cmdLine); err == nil {
 		// use empty spinner message to avoid showing it altogether
 		stop.msg = ""
 		return stop, err

--- a/pkg/devfile/adapters/common/generic.go
+++ b/pkg/devfile/adapters/common/generic.go
@@ -153,21 +153,21 @@ func (a GenericAdapter) ExecDevfile(commandsMap PushCommandsMap, componentExists
 			var otherDefaultCmd string
 			if params.Debug {
 				// Stop Run command if we are running debug
-				if otherCommand, ok = commandsMap[common.RunCommandGroupType]; ok {
-					otherDefaultCmd = string(DefaultDevfileRunCommand)
-				}
-
+				otherCommand, ok = commandsMap[common.RunCommandGroupType]
+				otherDefaultCmd = string(DefaultDevfileRunCommand)
 			} else {
 				// Stop Debug command if we are running run
-				if otherCommand, ok = commandsMap[common.DebugCommandGroupType]; ok {
-					otherDefaultCmd = string(DefaultDevfileDebugCommand)
-				}
+				otherCommand, ok = commandsMap[common.DebugCommandGroupType]
+				otherDefaultCmd = string(DefaultDevfileDebugCommand)
 			}
-			if cmd, err := newSupervisorStopCommand(otherCommand, otherDefaultCmd, a); cmd != nil && ok {
-				if err != nil {
-					return err
+
+			if ok {
+				if cmd, err := newSupervisorStopCommand(otherCommand, otherDefaultCmd, a); cmd != nil {
+					if err != nil {
+						return err
+					}
+					commands = append(commands, cmd)
 				}
-				commands = append(commands, cmd)
 			}
 			klog.V(4).Infof("restart:false, not restarting %s", defaultCmd)
 		}

--- a/pkg/devfile/adapters/common/generic.go
+++ b/pkg/devfile/adapters/common/generic.go
@@ -149,18 +149,8 @@ func (a GenericAdapter) ExecDevfile(commandsMap PushCommandsMap, componentExists
 
 		// if we need to restart, issue supervisor command to stop all running commands first
 		if componentExists {
-			if restart {
-				klog.V(4).Infof("restart:true, restarting %s", defaultCmd)
-				if cmd, err := newSupervisorStopCommand(command, a); cmd != nil {
-					if err != nil {
-						return err
-					}
-					commands = append(commands, cmd)
-				}
-			} else if !restart && previousMode != currentMode {
-				// If we are switching from odo push to odo push --debug, even if restart:false
-				// We need to stop the previous command
-				klog.V(4).Infof("restart:false, switching modes stopping previous %s command", previousMode)
+			if restart || (previousMode != currentMode) {
+				klog.V(4).Infof("supervisord stop command %s to restart or start other command", previousMode)
 				if cmd, err := newSupervisorStopCommand(command, a); cmd != nil {
 					if err != nil {
 						return err
@@ -170,29 +160,6 @@ func (a GenericAdapter) ExecDevfile(commandsMap PushCommandsMap, componentExists
 			} else {
 				klog.V(4).Infof("restart:false, not restarting %s", defaultCmd)
 			}
-
-		}
-
-		if componentExists && restart {
-			klog.V(4).Infof("restart:true, restarting %s", defaultCmd)
-			if cmd, err := newSupervisorStopCommand(command, a); cmd != nil {
-				if err != nil {
-					return err
-				}
-				commands = append(commands, cmd)
-			}
-		} else if componentExists && previousMode != currentMode && !restart {
-			// If we are switching from odo push to odo push --debug, even if restart:false
-			// We need to stop the previous command
-			klog.V(4).Infof("restart:false, switching modes stopping previous %s command", previousMode)
-			if cmd, err := newSupervisorStopCommand(command, a); cmd != nil {
-				if err != nil {
-					return err
-				}
-				commands = append(commands, cmd)
-			}
-		} else {
-			klog.V(4).Infof("restart:false, not restarting %s", defaultCmd)
 		}
 
 		// with restart false, executing only supervisord start command, if the command is already running, supvervisord will not restart it.


### PR DESCRIPTION
stop debug command, if we are running run command and vice versa

**What type of PR is this?**
 /kind bug


**What does does this PR do / why we need it**:
to restart any command in supervisord the way is to stop it and start it, in case of `restart:false` we are omitting the stop supervisord command step. It creates a problem when user switch modes during `odo push` (run/debug). This PR updates in case of `restart:false` we stop other command, like if it is `odo push --debug`,  we stop run command. 

**Which issue(s) this PR fixes**:

Fixes #3738 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
