### PR TITLE
PreStart Feature PR

### DIFF
--- a/docs/file-reference/index.md
+++ b/docs/file-reference/index.md
@@ -552,15 +552,15 @@ events:
 
 ## preStartObject
 
-> preStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
+PreStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
 
 ## postStartObject
 
-> postStart events are executed when the Kubernetes deployment for the odo component is created. 
+PostStart events are executed when the Kubernetes deployment for the odo component is created. 
 
 ## preStopObject
 
-> preStop events are executed before the Kubernetes deployment for the odo component is deleted. 
+PreStop events are executed before the Kubernetes deployment for the odo component is deleted. 
 
 # Universal objects
 

--- a/docs/file-reference/index.md
+++ b/docs/file-reference/index.md
@@ -153,6 +153,53 @@ commands:
 | commandObject | [commandObject](#command-object) | Command to be executed in an existing component container |
 
 
+## events
+
+> Example of various events
+
+```yaml
+commands:
+  - exec:
+      id: copy
+      commandLine: "cp /tools/myfile.txt tools.txt"
+      component: tools
+      workingDir: /
+  - exec:
+      id: initCache
+      commandLine: "./init_cache.sh"
+      component: tools
+      workingDir: /
+  - exec:
+      id: connectDB
+      commandLine: "./connect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: disconnectDB
+      commandLine: "./disconnect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: cleanup
+      commandLine: "./cleanup.sh"
+      component: tools
+      workingDir: /
+events:
+  preStart:
+    - "connectDB"
+  postStart:
+    - "copy" 
+    - "initCache"
+  preStop:
+    - "disconnectDB"
+  postStop:
+    - "cleanup"
+```
+
+| Key           | Type                             | Description                                      |
+|---------------|----------------------------------|--------------------------------------------------|
+| eventObject  | [eventObject](#event-object)     | Events to be executed during a project lifecycle |
+
 # Metadata Object
 
 > Example using metadata
@@ -460,6 +507,61 @@ commands:
 | kind      | string  | yes      | Kind of group the command is part of. Options: `build`, `run`, `test`, `debug`                              |
 | isDefault | boolean | no       | Identifies that it is the default command to be ran. Only one default command can be defined for each group |
 
+# Event Object
+
+> Example of using life cycle events where each event is an array of devfile commands to be executed of type `exec` or `composite`
+
+```yaml
+commands:
+  - exec:
+      id: copy
+      commandLine: "cp /tools/myfile.txt tools.txt"
+      component: tools
+      workingDir: /
+  - exec:
+      id: initCache
+      commandLine: "./init_cache.sh"
+      component: tools
+      workingDir: /
+  - exec:
+      id: connectDB
+      commandLine: "./connect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: disconnectDB
+      commandLine: "./disconnect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: cleanup
+      commandLine: "./cleanup.sh"
+      component: tools
+      workingDir: /
+events:
+  preStart:
+    - "connectDB"
+  postStart:
+    - "copy" 
+    - "initCache"
+  preStop:
+    - "disconnectDB"
+  postStop:
+    - "cleanup"
+```
+
+## preStartObject
+
+> preStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
+
+## postStartObject
+
+> postStart events are executed when the Kubernetes deployment for the odo component is created. 
+
+## preStopObject
+
+> preStop events are executed before the Kubernetes deployment for the odo component is deleted. 
+
 # Universal objects
 
 List of objects which are found in multiple parts of devfile. For example, the [envObject](#envobject) is found within [containerObject](#containerobject) and [execObject](#execobject).
@@ -509,7 +611,7 @@ Please refer to the below table for a list of features which are *not yet* imple
 | starterProjects[].clonePath        | [starterProjectObject](#starterproject-object) | IN PROGRESS | Refer to issue: https://github.com/openshift/odo/issues/3729                                     |
 | projects[]                         | [projectObject](#projectobject)                        | IN PROGRESS | Entire object not yet implemented. Refer to issue: https://github.com/openshift/odo/issues/3798 |
 | parent                             | [parentObject](#parent-object)                 | IN PROGRESS | Refer to issue: https://github.com/openshift/odo/issues/2936                                    |
-| events                             | [eventObject](#event-object)                   | IN PROGRESS | Refer to issue: https://github.com/openshift/odo/issues/2919                                    |
+| events                             | [eventObject](#event-object)                   | IN PROGRESS | Refer to postStop issue: https://github.com/openshift/odo/issues/3577                                    |
 | component[].kubernetes             | [kubernetesObject](#kubernetesobject)          | IN PROGRESS |                                                                                                 |
 | component[].openshift              | [openshiftObject](#openshiftobject)            | IN PROGRESS |                                                                                                 |
 | component[].volume                 | [volumeObject](#volumeobject)                  | IN PROGRESS | Refer to: https://github.com/openshift/odo/issues/3407                                          |

--- a/docs/public/using-devfile-lifecycle-events.adoc
+++ b/docs/public/using-devfile-lifecycle-events.adoc
@@ -71,6 +71,8 @@ preStart events are executed as init containers for the project pod in the order
 
 In the above example, preStart is going to execute the devfile command `connectDB` as an init container for the odo component's main pod.
 
+Caution should be exercised when using preStart with devfile container component that mount sources. File operations with preStart on the project sync directory may result in inconsistent behaviour.
+
 ### postStart
 
 postStart events are executed when the Kubernetes deployment for the odo component is created. 

--- a/docs/public/using-devfile-lifecycle-events.adoc
+++ b/docs/public/using-devfile-lifecycle-events.adoc
@@ -1,0 +1,84 @@
+# Using devfile lifecycle events
+
+`odo` uses devfiles to build and deploy components. You can also use devfile events with a component during it's lifecycle. The four different types of devfile events are `preStart`, `postStart`, `preStop` and `postStop`
+
+Each event is an array of devfile commands to be executed. The devfile command to be executed should be of type `exec` or `composite`:
+
+```yaml
+components:
+  - container:
+      name: runtime
+      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000/tcp"
+          targetPort: 3000 
+      mountSources: true
+      command: ['tail']
+      args: [ '-f', '/dev/null']
+  - container:
+      name: "tools"
+      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      mountSources: true
+      memoryLimit: 1024Mi
+commands:
+  - exec:
+      id: copy
+      commandLine: "cp /tools/myfile.txt tools.txt"
+      component: tools
+      workingDir: /
+  - exec:
+      id: initCache
+      commandLine: "./init_cache.sh"
+      component: tools
+      workingDir: /
+  - exec:
+      id: connectDB
+      commandLine: "./connect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: disconnectDB
+      commandLine: "./disconnect_db.sh"
+      component: runtime
+      workingDir: /
+  - exec:
+      id: cleanup
+      commandLine: "./cleanup.sh"
+      component: tools
+      workingDir: /
+  - composite:
+      id: postStartCompositeCmd
+      label: Copy and Init Cache
+      commands:
+        - copy
+        - initCache
+      parallel: true
+events:
+  preStart:
+    - "connectDB"
+  postStart:
+    - "postStartCompositeCmd" 
+  preStop:
+    - "disconnectDB"
+  postStop:
+    - "cleanup"
+```
+
+### preStart
+
+preStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
+
+In the above example, preStart is going to execute the devfile command `connectDB` as an init container for the odo component's main pod.
+
+### postStart
+
+postStart events are executed when the Kubernetes deployment for the odo component is created. 
+
+In the above example, postStart is going to execute the composite command `postStartCompositeCmd` once the odo component's deployment is created and the pod is up and running. The composite command `postStartCompositeCmd`'s sub-command `copy` and `initCache` are going to be executed in parallel.
+
+### preStop
+
+preStop events are executed before the Kubernetes deployment for the odo component is deleted. 
+
+In the above example, postStop is going to execute the devfile command `disconnectDB` before the odo component deployment is deleted.

--- a/docs/public/using-devfile-lifecycle-events.adoc
+++ b/docs/public/using-devfile-lifecycle-events.adoc
@@ -67,20 +67,20 @@ events:
 
 ### preStart
 
-preStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
+PreStart events are executed as init containers for the project pod in the order they are specified. The devfile command's `commandLine` and `workingDir` become the init container's command and as a result the devfile component container's `command` and `args` or the container image's `Command` and `Args` are overwritten. If a composite command with `parallel: true` is used, it will be executed sequentially as Kubernetes init containers only execute in sequence.
 
-In the above example, preStart is going to execute the devfile command `connectDB` as an init container for the odo component's main pod.
+In the above example, PreStart is going to execute the devfile command `connectDB` as an init container for the odo component's main pod.
 
 Caution should be exercised when using preStart with devfile container component that mount sources. File operations with preStart on the project sync directory may result in inconsistent behaviour.
 
 ### postStart
 
-postStart events are executed when the Kubernetes deployment for the odo component is created. 
+PostStart events are executed when the Kubernetes deployment for the odo component is created. 
 
-In the above example, postStart is going to execute the composite command `postStartCompositeCmd` once the odo component's deployment is created and the pod is up and running. The composite command `postStartCompositeCmd`'s sub-command `copy` and `initCache` are going to be executed in parallel.
+In the above example, PostStart is going to execute the composite command `postStartCompositeCmd` once the odo component's deployment is created and the pod is up and running. The composite command `postStartCompositeCmd`'s sub-command `copy` and `initCache` are going to be executed in parallel.
 
 ### preStop
 
-preStop events are executed before the Kubernetes deployment for the odo component is deleted. 
+PreStop events are executed before the Kubernetes deployment for the odo component is deleted. 
 
-In the above example, postStop is going to execute the devfile command `disconnectDB` before the odo component deployment is deleted.
+In the above example, PreStop is going to execute the devfile command `disconnectDB` before the odo component deployment is deleted.

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -704,13 +704,13 @@ func TestGetCommandsFromEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			devObj := devfileParser.DevfileObj{
-				Data: testingutil.TestDevfileData{
+				Data: &testingutil.TestDevfileData{
 					ExecCommands:      execCommands,
 					CompositeCommands: compCommands,
 				},
 			}
 
-			commandsMap := GetCommandsMap(devObj.Data.GetCommands())
+			commandsMap := devObj.Data.GetCommands()
 			commands := GetCommandsFromEvent(commandsMap, tt.eventName)
 			if !reflect.DeepEqual(tt.wantCommands, commands) {
 				t.Errorf("TestGetCommandsFromEvent error - got %v expected %v", commands, tt.wantCommands)

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -654,3 +654,68 @@ func TestGetComponentEnvVar(t *testing.T) {
 	}
 
 }
+
+func TestGetCommandsFromEvent(t *testing.T) {
+
+	execCommands := []versionsCommon.Exec{
+		{
+			Id: "exec1",
+		},
+		{
+			Id: "exec2",
+		},
+		{
+			Id: "exec3",
+		},
+	}
+
+	compCommands := []versionsCommon.Composite{
+		{
+			Id: "comp1",
+			Commands: []string{
+				"exec1",
+				"exec3",
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		eventName    string
+		wantCommands []string
+	}{
+		{
+			name:      "Case 1: composite event",
+			eventName: "comp1",
+			wantCommands: []string{
+				"exec1",
+				"exec3",
+			},
+		},
+		{
+			name:      "Case 2: exec event",
+			eventName: "exec2",
+			wantCommands: []string{
+				"exec2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					ExecCommands:      execCommands,
+					CompositeCommands: compCommands,
+				},
+			}
+
+			commandsMap := GetCommandsMap(devObj.Data.GetCommands())
+			commands := GetCommandsFromEvent(commandsMap, tt.eventName)
+			if !reflect.DeepEqual(tt.wantCommands, commands) {
+				t.Errorf("TestGetCommandsFromEvent error - got %v expected %v", commands, tt.wantCommands)
+			}
+		})
+	}
+
+}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -298,11 +298,11 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		containersMap := utils.GetContainersMap(containers)
 
 		for _, event := range preStartEvents {
-			eventSubCommands := utils.GetCommandsFromEvent(commandsMap, strings.ToLower(event))
+			eventSubCommands := common.GetCommandsFromEvent(commandsMap, strings.ToLower(event))
 			eventCommands = append(eventCommands, eventSubCommands...)
 		}
 
-		klog.V(3).Infof(">>> >>> MJF preStart events commands are: %v", strings.Join(eventCommands, ","))
+		klog.V(4).Infof("preStart events commands are: %v", strings.Join(eventCommands, ","))
 		utils.AddPreStartEventInitContainer(podTemplateSpec, commandsMap, eventCommands, containersMap)
 		if len(eventCommands) > 0 {
 			log.Successf("preStart commands will be executed during pod startup: %s", strings.Join(eventCommands, ","))

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -293,7 +293,6 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	preStartEvents := a.Devfile.Data.GetEvents().PreStart
 	if len(preStartEvents) > 0 {
 		var eventCommands []string
-		// execCommandInfo := make(map[string]common.ExecCommandInfo)
 		commandsMap := common.GetCommandsMap(a.Devfile.Data.GetCommands())
 		containersMap := utils.GetContainersMap(containers)
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -301,10 +301,10 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 			eventCommands = append(eventCommands, eventSubCommands...)
 		}
 
-		klog.V(4).Infof("preStart events commands are: %v", strings.Join(eventCommands, ","))
+		klog.V(4).Infof("PreStart event commands are: %v", strings.Join(eventCommands, ","))
 		utils.AddPreStartEventInitContainer(podTemplateSpec, commandsMap, eventCommands, containersMap)
 		if len(eventCommands) > 0 {
-			log.Successf("preStart commands will be executed during pod startup: %s", strings.Join(eventCommands, ","))
+			log.Successf("PreStart commands have been added to the component: %s", strings.Join(eventCommands, ","))
 		}
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -293,7 +293,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	preStartEvents := a.Devfile.Data.GetEvents().PreStart
 	if len(preStartEvents) > 0 {
 		var eventCommands []string
-		commandsMap := common.GetCommandsMap(a.Devfile.Data.GetCommands())
+		commandsMap := a.Devfile.Data.GetCommands()
 		containersMap := utils.GetContainersMap(containers)
 
 		for _, event := range preStartEvents {

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -79,7 +79,7 @@ func Create(Client *kclient.Client, name, size, componentName, pvcName string) (
 // GeneratePVCNameFromDevfileVol generates a PVC name from the Devfile volume name and component name
 func GeneratePVCNameFromDevfileVol(volName, componentName string) (string, error) {
 
-	pvcName := fmt.Sprintf("%v-%v", volName, componentName)
+	pvcName := fmt.Sprintf("%s-%s", volName, componentName)
 	pvcName = util.TruncateString(pvcName, pvcNameMaxLen)
 	randomChars := util.GenerateRandomString(4)
 	pvcName, err := util.NamespaceOpenShiftObject(pvcName, randomChars)

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -336,28 +336,6 @@ func generateEnvFromSource(ei envinfo.EnvSpecificInfo) []corev1.EnvFromSource {
 	return envFrom
 }
 
-// GetCommandsFromEvent returns the list of commands from the event name.
-// If the event is a composite command, it returns the sub-commands from the tree
-func GetCommandsFromEvent(commandsMap map[string]common.DevfileCommand, eventName string) []string {
-	var commands []string
-
-	if command, ok := commandsMap[eventName]; ok {
-		if command.IsComposite() {
-			klog.V(4).Infof("%s is a composite command", command.GetID())
-			for _, compositeSubCmd := range command.Composite.Commands {
-				klog.V(4).Infof("checking if sub-command %s is either an exec or a composite command ", compositeSubCmd)
-				subCommands := GetCommandsFromEvent(commandsMap, strings.ToLower(compositeSubCmd))
-				commands = append(commands, subCommands...)
-			}
-		} else {
-			klog.V(4).Infof("%s is an exec command", command.GetID())
-			commands = append(commands, command.GetID())
-		}
-	}
-
-	return commands
-}
-
 // GetContainersMap gets the map of container name to containers
 func GetContainersMap(containers []corev1.Container) map[string]corev1.Container {
 	containersMap := make(map[string]corev1.Container)

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -283,7 +283,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 func GetResourceReqs(comp common.DevfileComponent) corev1.ResourceRequirements {
 	reqs := corev1.ResourceRequirements{}
 	limits := make(corev1.ResourceList)
-	if &comp.Container.MemoryLimit != nil {
+	if comp.Container.MemoryLimit != "" {
 		memoryLimit, err := resource.ParseQuantity(comp.Container.MemoryLimit)
 		if err == nil {
 			limits[corev1.ResourceMemory] = memoryLimit

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
@@ -11,6 +12,7 @@ import (
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -617,6 +619,191 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 
 			if len(tt.execCommands) >= 2 && (!envDebugMatched || !envDebugWorkDirMatched || !envDebugPortMatched) {
 				t.Errorf("TestUpdateContainersWithSupervisord error: could not find env vars for supervisord in container %v, found debug env: %v, found work dir env: %v, found debug port env: %v", component, envDebugMatched, envDebugWorkDirMatched, envDebugPortMatched)
+			}
+		})
+	}
+
+}
+
+func TestGetContainersMap(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		containers       []corev1.Container
+		wantContainerKey []string
+	}{
+		{
+			name: "Case 1: single entry",
+			containers: []corev1.Container{
+				testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
+			},
+			wantContainerKey: []string{
+				"container1",
+			},
+		},
+		{
+			name: "Case 1: multiple entries",
+			containers: []corev1.Container{
+				testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
+				testingutil.CreateFakeContainer("container2", "image2", []string{"containercommand2"}, []string{"args2"}),
+			},
+			wantContainerKey: []string{
+				"container1",
+				"container2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			containerMap := GetContainersMap(tt.containers)
+
+			for _, containerName := range tt.wantContainerKey {
+				if _, ok := containerMap[containerName]; !ok {
+					t.Errorf("TestGetContainersMap error - could not find key %s in %v", containerName, containerMap)
+				}
+			}
+
+		})
+	}
+
+}
+
+func TestAddPreStartEventInitContainer(t *testing.T) {
+
+	containers := []corev1.Container{
+		testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
+		testingutil.CreateFakeContainer("container2", "image2", []string{"containercommand2"}, []string{"args2"}),
+	}
+
+	execCommands := []versionsCommon.Exec{
+		{
+			Id:          "exec1",
+			CommandLine: "execcommand1",
+			WorkingDir:  "execworkdir1",
+			Component:   "container1",
+		},
+		{
+			Id:          "exec2",
+			CommandLine: "execcommand2",
+			WorkingDir:  "",
+			Component:   "container1",
+		},
+		{
+			Id:          "exec3",
+			CommandLine: "execcommand3",
+			WorkingDir:  "execworkdir3",
+			Component:   "container2",
+		},
+	}
+
+	compCommands := []versionsCommon.Composite{
+		{
+			Id: "comp1",
+			Commands: []string{
+				"exec1",
+				"exec3",
+			},
+		},
+	}
+
+	componentName := "testcomponent"
+	namespace := "testnamespace"
+	labels := map[string]string{"component": componentName}
+
+	objectMeta := kclient.CreateObjectMeta(componentName, namespace, labels, nil)
+
+	longContainerName := "thisisaverylongcontainerandkuberneteshasalimitforanamesize-exec2"
+	trimmedLongContainerName := util.TruncateString(longContainerName, containerNameMaxLen)
+
+	tests := []struct {
+		name              string
+		eventCommands     []string
+		wantInitContainer map[string]corev1.Container
+		longName          bool
+	}{
+		{
+			name: "Case 1: Composite and Exec events",
+			eventCommands: []string{
+				"exec1",
+				"exec3",
+				"exec2",
+			},
+			wantInitContainer: map[string]corev1.Container{
+				"container1-exec1": {
+					Command: []string{adaptersCommon.ShellExecutable, "-c", "cd execworkdir1 && execcommand1"},
+				},
+				"container1-exec2": {
+					Command: []string{adaptersCommon.ShellExecutable, "-c", "execcommand2"},
+				},
+				"container2-exec3": {
+					Command: []string{adaptersCommon.ShellExecutable, "-c", "cd execworkdir3 && execcommand3"},
+				},
+			},
+		},
+		{
+			name: "Case 2: Long Container Name",
+			eventCommands: []string{
+				"exec2",
+			},
+			wantInitContainer: map[string]corev1.Container{
+				trimmedLongContainerName: {
+					Command: []string{adaptersCommon.ShellExecutable, "-c", "execcommand2"},
+				},
+			},
+			longName: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.longName {
+				containers[0].Name = longContainerName
+				execCommands[1].Component = longContainerName
+			}
+
+			podTemplateSpec := kclient.GeneratePodTemplateSpec(objectMeta, containers)
+
+			devObj := devfileParser.DevfileObj{
+				Data: testingutil.TestDevfileData{
+					ExecCommands:      execCommands,
+					CompositeCommands: compCommands,
+				},
+			}
+
+			commandsMap := adaptersCommon.GetCommandsMap(devObj.Data.GetCommands())
+			containersMap := GetContainersMap(containers)
+
+			AddPreStartEventInitContainer(podTemplateSpec, commandsMap, tt.eventCommands, containersMap)
+
+			if len(tt.wantInitContainer) != len(podTemplateSpec.Spec.InitContainers) {
+				t.Errorf("TestAddPreStartEventInitContainer error: init container length mismatch, wanted %v got %v", len(tt.wantInitContainer), len(podTemplateSpec.Spec.InitContainers))
+			}
+
+			for _, initContainer := range podTemplateSpec.Spec.InitContainers {
+				nameMatched := false
+				commandMatched := false
+				for containerName, container := range tt.wantInitContainer {
+					if strings.Contains(initContainer.Name, containerName) {
+						nameMatched = true
+					}
+
+					if reflect.DeepEqual(initContainer.Command, container.Command) {
+						commandMatched = true
+					}
+
+					if !reflect.DeepEqual(initContainer.Args, []string{}) {
+						t.Errorf("TestAddPreStartEventInitContainer error: init container args not empty, got %v", initContainer.Args)
+					}
+				}
+
+				if !nameMatched {
+					t.Errorf("TestAddPreStartEventInitContainer error: init container name mismatch, container name not present in %v", initContainer.Name)
+				}
+
+				if !commandMatched {
+					t.Errorf("TestAddPreStartEventInitContainer error: init container command mismatch, command not found in %v", initContainer.Command)
+				}
 			}
 		})
 	}

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -642,7 +642,7 @@ func TestGetContainersMap(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 1: multiple entries",
+			name: "Case 2: multiple entries",
 			containers: []corev1.Container{
 				testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
 				testingutil.CreateFakeContainer("container2", "image2", []string{"containercommand2"}, []string{"args2"}),

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -765,13 +765,13 @@ func TestAddPreStartEventInitContainer(t *testing.T) {
 			podTemplateSpec := kclient.GeneratePodTemplateSpec(objectMeta, containers)
 
 			devObj := devfileParser.DevfileObj{
-				Data: testingutil.TestDevfileData{
+				Data: &testingutil.TestDevfileData{
 					ExecCommands:      execCommands,
 					CompositeCommands: compCommands,
 				},
 			}
 
-			commandsMap := adaptersCommon.GetCommandsMap(devObj.Data.GetCommands())
+			commandsMap := devObj.Data.GetCommands()
 			containersMap := GetContainersMap(containers)
 
 			AddPreStartEventInitContainer(podTemplateSpec, commandsMap, tt.eventCommands, containersMap)

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -635,7 +635,7 @@ func TestGetContainersMap(t *testing.T) {
 		{
 			name: "Case 1: single entry",
 			containers: []corev1.Container{
-				testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
+				testingutil.CreateFakeContainer("container1"),
 			},
 			wantContainerKey: []string{
 				"container1",
@@ -644,8 +644,8 @@ func TestGetContainersMap(t *testing.T) {
 		{
 			name: "Case 2: multiple entries",
 			containers: []corev1.Container{
-				testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
-				testingutil.CreateFakeContainer("container2", "image2", []string{"containercommand2"}, []string{"args2"}),
+				testingutil.CreateFakeContainer("container1"),
+				testingutil.CreateFakeContainer("container2"),
 			},
 			wantContainerKey: []string{
 				"container1",
@@ -672,8 +672,8 @@ func TestGetContainersMap(t *testing.T) {
 func TestAddPreStartEventInitContainer(t *testing.T) {
 
 	containers := []corev1.Container{
-		testingutil.CreateFakeContainer("container1", "image1", []string{"containercommand1"}, []string{"args1"}),
-		testingutil.CreateFakeContainer("container2", "image2", []string{"containercommand2"}, []string{"args2"}),
+		testingutil.CreateFakeContainer("container1"),
+		testingutil.CreateFakeContainer("container2"),
 	}
 
 	execCommands := []versionsCommon.Exec{

--- a/pkg/devfile/parser/data/common/command_helper.go
+++ b/pkg/devfile/parser/data/common/command_helper.go
@@ -36,3 +36,40 @@ func (dc DevfileCommand) GetGroup() *Group {
 
 	return nil
 }
+
+// GetExecComponent returns the component of the exec command
+func (dc DevfileCommand) GetExecComponent() string {
+	if dc.Exec != nil {
+		return dc.Exec.Component
+	}
+
+	return ""
+}
+
+// GetExecCommandLine returns the command line of the exec command
+func (dc DevfileCommand) GetExecCommandLine() string {
+	if dc.Exec != nil {
+		return dc.Exec.CommandLine
+	}
+
+	return ""
+}
+
+// GetExecWorkingDir returns the working dir of the exec command
+func (dc DevfileCommand) GetExecWorkingDir() string {
+	if dc.Exec != nil {
+		return dc.Exec.WorkingDir
+	}
+
+	return ""
+}
+
+// IsComposite checks if the command is a composite command
+func (dc DevfileCommand) IsComposite() bool {
+	isComposite := false
+	if dc.Composite != nil {
+		isComposite = true
+	}
+
+	return isComposite
+}

--- a/pkg/devfile/parser/data/common/command_helper_test.go
+++ b/pkg/devfile/parser/data/common/command_helper_test.go
@@ -102,3 +102,174 @@ func TestGetGroup(t *testing.T) {
 	}
 
 }
+
+func TestGetExecComponent(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		command DevfileCommand
+		want    string
+	}{
+		{
+			name: "Case 1: Exec component present",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id:        "exec1",
+					Component: "component1",
+				},
+			},
+			want: "component1",
+		},
+		{
+			name: "Case 2: Exec component absent",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id: "exec1",
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "Case 3: Empty command",
+			command: DevfileCommand{},
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			component := tt.command.GetExecComponent()
+			if component != tt.want {
+				t.Errorf("expected %v, actual %v", tt.want, component)
+			}
+		})
+	}
+
+}
+
+func TestGetExecCommandLine(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		command DevfileCommand
+		want    string
+	}{
+		{
+			name: "Case 1: Exec command line present",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id:          "exec1",
+					CommandLine: "commandline1",
+				},
+			},
+			want: "commandline1",
+		},
+		{
+			name: "Case 2: Exec command line absent",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id: "exec1",
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "Case 3: Empty command",
+			command: DevfileCommand{},
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commandLine := tt.command.GetExecCommandLine()
+			if commandLine != tt.want {
+				t.Errorf("expected %v, actual %v", tt.want, commandLine)
+			}
+		})
+	}
+
+}
+
+func TestGetExecWorkingDir(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		command DevfileCommand
+		want    string
+	}{
+		{
+			name: "Case 1: Exec working dir present",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id:         "exec1",
+					WorkingDir: "workingdir1",
+				},
+			},
+			want: "workingdir1",
+		},
+		{
+			name: "Case 2: Exec working dir absent",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id: "exec1",
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "Case 3: Empty command",
+			command: DevfileCommand{},
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := tt.command.GetExecWorkingDir()
+			if workingDir != tt.want {
+				t.Errorf("expected %v, actual %v", tt.want, workingDir)
+			}
+		})
+	}
+
+}
+
+func TestIsComposite(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		command DevfileCommand
+		want    bool
+	}{
+		{
+			name: "Case 1: Exec command",
+			command: DevfileCommand{
+				Exec: &Exec{
+					Id: "exec1",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Case 2: composite command",
+			command: DevfileCommand{
+				Composite: &Composite{
+					Id: "comp1",
+				},
+			},
+			want: true,
+		},
+		{
+			name:    "Case 3: Empty command",
+			command: DevfileCommand{},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isCompositeCmd := tt.command.IsComposite()
+			if isCompositeCmd != tt.want {
+				t.Errorf("expected %v, actual %v", tt.want, isCompositeCmd)
+			}
+		})
+	}
+
+}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -26,7 +26,7 @@ commands:
       component: tools
   - exec:
       id: secondPreStart
-      commandLine: echo I am also a myPreStart
+      commandLine: echo hello test >> $PROJECTS_ROOT/test.txt
       component: runtime
       workingDir: /
   - composite:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -21,6 +21,22 @@ components:
       memoryLimit: 1024Mi
 commands:
   - exec:
+      id: myPreStart
+      commandLine: echo I am a myPreStart
+      component: tools
+  - exec:
+      id: secondPreStart
+      commandLine: echo I am also a myPreStart
+      component: runtime
+      workingDir: /
+  - composite:
+      id: preStartComp
+      label: pre start composite
+      commands:
+        - myPreStart
+        - secondPreStart
+      parallel: true
+  - exec:
       id: myPostStart
       commandLine: echo I am a PostStart
       component: tools
@@ -95,6 +111,9 @@ commands:
       group:
         kind: run
 events:
+  preStart:
+    - "myPreStart" 
+    - "preStartComp"
   postStart:
     - "myPostStart" 
     - "secondpoststart"

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -22,7 +22,7 @@ components:
 commands:
   - exec:
       id: myPreStart
-      commandLine: echo I am a myPreStart
+      commandLine: echo hello test2 >> $PROJECTS_ROOT/test.txt
       component: tools
   - exec:
       id: secondPreStart

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -18,4 +18,5 @@ type CliRunner interface {
 	GetEnvsDevFileDeployment(componentName string, projectName string) map[string]string
 	GetPVCSize(compName, storageName, namespace string) string
 	GetAllPVCNames(namespace string) []string
+	GetPodInitContainers(compName, namespace string) []string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -79,6 +79,13 @@ func (kubectl KubectlRunner) GetPVCSize(compName, storageName, namespace string)
 	return strings.TrimSpace(stdOut)
 }
 
+// GetPodInitContainers executes kubectl command and returns the init containers of the pod
+func (kubectl KubectlRunner) GetPodInitContainers(compName string, namespace string) []string {
+	selector := fmt.Sprintf("--selector=component=%s", compName)
+	stdOut := CmdShouldPass(kubectl.path, "get", "pods", "--namespace", namespace, selector, "-o", "jsonpath={.items[*].spec.initContainers[*].name}")
+	return strings.Split(stdOut, " ")
+}
+
 // GetVolumeMountNamesandPathsFromContainer returns the volume name and mount path in the format name:path\n
 func (kubectl KubectlRunner) GetVolumeMountNamesandPathsFromContainer(deployName string, containerName, namespace string) string {
 	volumeName := CmdShouldPass(kubectl.path, "get", "deploy", deployName, "--namespace", namespace,

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -396,6 +396,13 @@ func (oc OcRunner) GetPVCSize(compName, storageName, namespace string) string {
 	return strings.TrimSpace(stdOut)
 }
 
+// GetPodInitContainers executes oc command and returns the init containers of the pod
+func (oc OcRunner) GetPodInitContainers(compName string, namespace string) []string {
+	selector := fmt.Sprintf("--selector=component=%s", compName)
+	stdOut := CmdShouldPass(oc.path, "get", "pods", "--namespace", namespace, selector, "-o", "jsonpath={.items[*].spec.initContainers[*].name}")
+	return strings.Split(stdOut, " ")
+}
+
 // GetRoute returns route URL
 func (oc OcRunner) GetRoute(urlName string, appName string) string {
 	session := CmdRunner(oc.path, "get", "routes", urlName+"-"+appName,

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -377,6 +377,20 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(cmdOutput).To(ContainSubstring("/myproject/app.jar"))
 		})
 
+		It("should execute PreStart commands if present on every pod startup", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--namespace", namespace)
+			helper.MatchAllInOutput(output, []string{"preStart commands will be executed during pod startup"})
+
+			// Need to force so build and run get triggered again with the component already created.
+			output = helper.CmdShouldPass("odo", "push", "--namespace", namespace, "-f")
+			helper.MatchAllInOutput(output, []string{"preStart commands will be executed during pod startup"})
+		})
+
 		It("should execute PostStart commands if present and not execute when component already exists", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -389,6 +389,11 @@ var _ = Describe("odo devfile push command tests", func() {
 			// Need to force so build and run get triggered again with the component already created.
 			output = helper.CmdShouldPass("odo", "push", "--namespace", namespace, "-f")
 			helper.MatchAllInOutput(output, []string{"preStart commands will be executed during pod startup"})
+
+			initContainers := cliRunner.GetPodInitContainers(cmpName, namespace)
+			// 3 preStart events + 1 supervisord init containers
+			Expect(len(initContainers)).To(Equal(4))
+			helper.MatchAllInOutput(strings.Join(initContainers, ","), []string{"tools-myprestart", "runtime-secondprestart"})
 		})
 
 		It("should execute PostStart commands if present and not execute when component already exists", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What does does this PR do / why we need it**:
- Implements PreStart feature Issue
- Executes PreStart events as init containers for the odo component pod
- updates docs

**Which issue(s) this PR fixes**:

Fixes #3565

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

**How to test changes / Special notes to the reviewer**:

- Add in `preStart` event to your devfile and check the init containers on the odo component pod

You can also utilize this devfile that I've been using for testing, that has a mixture of exec and composite commands as preStart:
```
schemaVersion: 2.0.0
metadata:
  name: nodejs
projects:
  - name: nodejs-starter
    git:
      location: "https://github.com/odo-devfiles/nodejs-ex.git"
components:
  - container:
      name: runtime
      image: quay.io/eclipse/che-nodejs10-ubi:nightly
      memoryLimit: 1024Mi
      endpoints:
        - name: "3000/tcp"
          targetPort: 3000 
      mountSources: true
  - container:
      name: "tools"
      image: quay.io/eclipse/che-nodejs10-ubi:nightly
      mountSources: true
      memoryLimit: 1024Mi
commands:
  - exec:
      id: myPreStart
      commandLine: echo I am a myPreStart
      component: tools
      workingDir: /
  - exec:
      id: secondPreStart
      commandLine: echo hello there >> $PROJECTS_ROOT/test.txt
      component: runtime
      workingDir: /
  - exec:
      id: devbuild
      component: runtime
      commandLine: npm install
      workingDir: ${PROJECTS_ROOT}
      group:
        kind: build
        isDefault: true
  - exec:
      id: devrun
      component: runtime
      commandLine: npm start
      workingDir: ${PROJECTS_ROOT}
      group:
        kind: run
        isDefault: true
  - composite:
         id: mycompevent
         label: mycompevent
         commands:
           - myPreStart
           - mycompevent2
         parallel: true
         group:
          kind: build
          isDefault: false
  - composite:
         id: mycompevent2
         label: mycompevent2
         commands:
           - secondPreStart
           - myPreStart
         parallel: true
         group:
          kind: build
          isDefault: false
events:
  preStart:
    - "myPreStart" 
    - "mycompevent"
```
