### PR TITLE
Update e2e supported images test to support s390x arch.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,40 +32,48 @@ Existing tools such as `oc` are more operations-focused and require a deep-under
 === Officially supported languages and corresponding container images
 
 .Supported container images
-[cols=",,",options="header",]
+[cols=",,,",options="header",]
 |===
-|Language |Container Image |Supported Package Manager
+|Language |Container Image |Supported Package Manager |Supported Platform
 |*Node.js*
 |https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-10-rhel7[rhscl/nodejs-10-rhel7]
 |NPM
+|amd64, s390x, ppc64le
 
 |
 |https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-12-rhel7[rhscl/nodejs-12-rhel7]
 |NPM
+|amd64, s390x, ppc64le
 
 |
 |https://access.redhat.com/articles/3376841[rhoar-nodejs/nodejs-10]
 |NPM
+|amd64
 
 |
 |https://github.com/sclorg/s2i-nodejs-container[centos/nodejs-10-centos7]
 |NPM
+|amd64
 
 |
 |https://github.com/sclorg/s2i-nodejs-container[centos/nodejs-12-centos7]
 |NPM
+|amd64
 
 |*Java*
 |https://access.redhat.com/containers/#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift[redhat-openjdk-18/openjdk18-openshift]
 |Maven, Gradle
+|amd64, s390x, ppc64le
 
 |
 |https://access.redhat.com/containers/#/registry.access.redhat.com/openjdk/openjdk-11-rhel8[openjdk/openjdk-11-rhel8]
 |Maven, Gradle
+|amd64, s390x, ppc64le
 
 |
 |https://access.redhat.com/containers/#/registry.access.redhat.com/openjdk/openjdk-11-rhel7[openjdk/openjdk-11-rhel7]
 |Maven, Gradle
+|amd64, s390x, ppc64le
 |===
 
 [id="odo-listing-available-images"]

--- a/scripts/configure-installer-tests-cluster-s390x.sh
+++ b/scripts/configure-installer-tests-cluster-s390x.sh
@@ -70,9 +70,17 @@ for i in `echo $USERS`; do
     HTPASSWD_CREATED=""
 done
 
-# Workarounds - Note we should find better soulutions asap
-## Missing wildfly in OpenShift Adding it manually to cluster Please remove once wildfly is again visible
-#oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/x86_64/community/wildfly/imagestreams/wildfly-centos7.json
+#Clear up the imagestreams out of date
+oc delete is/nodejs -n openshift
+oc delete is/java -n openshift
+oc delete istag/nodejs:10 -n openshift
+oc delete istag/nodejs:12 -n openshift
+oc delete istag/nodejs:latest -n openshift
+oc delete istag/java:11 -n openshift
+oc delete istag/java:8 -n openshift
+oc delete istag/java:latest -n openshift
+
+#Missing required images in OpenShift and Adding it manually to cluster
 oc import-image nodejs --from=registry.redhat.io/rhscl/nodejs-12-rhel7 --confirm -n openshift
 sleep 5
 oc annotate istag/nodejs:latest tags=builder -n openshift --overwrite

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -40,9 +40,7 @@ if [ "${ARCH}" == "s390x" ]; then
     make test-cmd-login-logout
     make test-cmd-project
     # E2e tests
-    make test-e2e-beta
-    make test-e2e-java
-    make test-e2e-source
+    make test-e2e-all
 elif  [ "${ARCH}" == "ppc64le" ]; then
     # Integration tests
     make test-generic

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -5,6 +5,7 @@ package e2escenarios
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -85,15 +86,11 @@ var _ = Describe("odo supported images e2e tests", func() {
 		Expect(cmpLst).To(ContainSubstring("Not Pushed"))
 	}
 
-	Context("odo supported images deployment", func() {
-		It("Should be able to verify the openjdk18-openshift image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("redhat-openjdk-18", "openjdk18-openshift:latest"), "java:8", project)
-			verifySupportedImage(filepath.Join("redhat-openjdk-18", "openjdk18-openshift:latest"), "openjdk", "java:8", project, appName, context)
-		})
-
-		It("Should be able to verify the openjdk-11-rhel7 image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("openjdk", "openjdk-11-rhel7:latest"), "java:8", project)
-			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel7:latest"), "openjdk", "java:8", project, appName, context)
+	Context("odo supported images deployment on amd64", func() {
+		JustBeforeEach(func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skipping test because these images are not supported.")
+			}
 		})
 
 		It("Should be able to verify the nodejs-10 image", func() {
@@ -109,6 +106,18 @@ var _ = Describe("odo supported images e2e tests", func() {
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
 			oc.ImportImageFromRegistry("docker.io", filepath.Join("centos", "nodejs-12-centos7:latest"), "nodejs:latest", project)
 			verifySupportedImage(filepath.Join("centos", "nodejs-12-centos7:latest"), "nodejs", "nodejs:latest", project, appName, context)
+		})
+	})
+
+	Context("odo supported images deployment", func() {
+		It("Should be able to verify the openjdk18-openshift image", func() {
+			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("redhat-openjdk-18", "openjdk18-openshift:latest"), "java:8", project)
+			verifySupportedImage(filepath.Join("redhat-openjdk-18", "openjdk18-openshift:latest"), "openjdk", "java:8", project, appName, context)
+		})
+
+		It("Should be able to verify the openjdk-11-rhel7 image", func() {
+			oc.ImportImageFromRegistry("registry.access.redhat.com", filepath.Join("openjdk", "openjdk-11-rhel7:latest"), "java:8", project)
+			verifySupportedImage(filepath.Join("openjdk", "openjdk-11-rhel7:latest"), "openjdk", "java:8", project, appName, context)
 		})
 
 		It("Should be able to verify the nodejs-10-rhel7 image", func() {


### PR DESCRIPTION
**What type of PR is this?**
 /kind failing-test
**What does does this PR do / why we need it**:
There are some hard code to import S2I images. These images only support amd64 arch which causes failed on s390x arch.

**Which issue(s) this PR fixes**:

Fixes #3670 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
