### PR TITLE
add caching to version check

### DIFF
--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -1,11 +1,10 @@
 package notify
 
 import (
-	"io/ioutil"
-	"net/http"
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 )
 
@@ -18,12 +17,12 @@ const (
 // tag of the latest release
 func getLatestReleaseTag() (string, error) {
 
-	resp, err := http.Get(VersionFetchURL)
-	if err != nil {
-		return "", errors.Wrap(err, "error getting latest release")
+	request := util.HTTPRequestParams{
+		URL: VersionFetchURL,
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+
+	// Make request and cache response for 60 minutes
+	body, err := util.HTTPGetRequest(request, 60)
 	if err != nil {
 		return "", errors.Wrap(err, "error getting latest release")
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


 /kind cleanup

>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

Add HTTP response caching to version notifier to reduce the number of requests that odo does to github.com

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
