### PR TITLE
Updates test for printSupportedParameters to fix flake

### DIFF
--- a/pkg/odo/cli/env/env_test.go
+++ b/pkg/odo/cli/env/env_test.go
@@ -45,8 +45,20 @@ func TestPrintSupportedParameters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := strings.TrimSpace(printSupportedParameters(tt.supportedParameters))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Got %s, want %s", got, tt.want)
+
+			gotStrings := strings.Split(got, "\n")
+			wantStrings := strings.Split(tt.want, "\n")
+
+			gotStringMap := make(map[string]bool)
+			for _, gotString := range gotStrings {
+				gotStringMap[gotString] = true
+			}
+
+			for _, wantString := range wantStrings {
+				_, found := gotStringMap[wantString]
+				if !found {
+					t.Errorf("String %s not found in output %s", wantString, got)
+				}
 			}
 		})
 	}

--- a/pkg/odo/cli/env/env_test.go
+++ b/pkg/odo/cli/env/env_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -49,16 +50,11 @@ func TestPrintSupportedParameters(t *testing.T) {
 			gotStrings := strings.Split(got, "\n")
 			wantStrings := strings.Split(tt.want, "\n")
 
-			gotStringMap := make(map[string]bool)
-			for _, gotString := range gotStrings {
-				gotStringMap[gotString] = true
-			}
+			sort.Strings(gotStrings)
+			sort.Strings(wantStrings)
 
-			for _, wantString := range wantStrings {
-				_, found := gotStringMap[wantString]
-				if !found {
-					t.Errorf("String %s not found in output %s", wantString, got)
-				}
+			if !reflect.DeepEqual(wantStrings, gotStrings) {
+				t.Errorf("\nGot: %s\nWant: %s", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

The printing order in printSupportedParameters() is dependent on a for loop over a map which is random in nature. Thus the unit test should not check for a complete match.

**Which issue(s) this PR fixes**:

Fixes #3755

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

- Unit test for printSupportedParameters() should pass without flakes.