### PR TITLE
Remove unnecessary devfile flag and update tests

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -1225,7 +1225,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.starter, "starter", "", "Download a project specified in the devfile")
 		componentCreateCmd.Flags().Lookup("starter").NoOptDefVal = defaultStarterProjectName //Default value to pass to the flag if one is not specified.
 		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfileRegistry.Name, "registry", "", "Create devfile component from specific registry")
-		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfilePath.value, "devfile", "", "Path to the user specify devfile")
+		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.devfilePath.value, "devfile", "", "Path to the user specified devfile")
 		componentCreateCmd.Flags().StringVar(&co.devfileMetadata.token, "token", "", "Token to be used when downloading devfile from the devfile path that is specified via --devfile")
 		componentCreateCmd.Flags().BoolVar(&co.forceS2i, "s2i", false, "Enforce S2I type components")
 	}

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -61,7 +61,8 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 		return fmt.Errorf("no parameter is expected for the command")
 	}
 
-	eo.devfilePath = filepath.Join(eo.componentContext, eo.devfilePath)
+	eo.devfilePath = filepath.Join(eo.componentContext, devFile)
+
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() {
 		eo.componentOptions.Context = genericclioptions.NewDevfileContext(cmd)
@@ -99,8 +100,6 @@ func NewCmdExec(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-
-	execCmd.Flags().StringVar(&o.devfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
 
 	execCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(execCmd, completion.ComponentNameCompletionHandler)

--- a/pkg/odo/cli/debug/debug.go
+++ b/pkg/odo/cli/debug/debug.go
@@ -5,8 +5,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RecommendedCommandName is the recommended debug command name
-const RecommendedCommandName = "debug"
+const (
+	// RecommendedCommandName is the recommended debug command name
+	RecommendedCommandName = "debug"
+
+	devfile = "devfile.yaml"
+)
 
 var DebugLongDesc = `Warning - Debug is currently in tech preview and hence is subject to change in future.
 

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -2,26 +2,25 @@ package debug
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-// PortForwardOptions contains all the options for running the port-forward cli command.
+// InfoOptions contains all the options for running the info cli command.
 type InfoOptions struct {
 	componentName   string
 	applicationName string
 	Namespace       string
 	PortForwarder   *debug.DefaultPortForwarder
 	*genericclioptions.Context
-	contextDir  string
-	DevfilePath string
+	contextDir string
 }
 
 var (
@@ -46,7 +45,7 @@ func NewInfoOptions() *InfoOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	if experimental.IsExperimentalModeEnabled() {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut
@@ -104,9 +103,6 @@ func NewCmdInfo(name, fullName string) *cobra.Command {
 		},
 	}
 	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
-	if experimental.IsExperimentalModeEnabled() {
-		cmd.Flags().StringVar(&opts.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
-	}
 
 	return cmd
 }

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -2,12 +2,14 @@ package debug
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -45,7 +47,7 @@ func NewInfoOptions() *InfoOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(filepath.Join(o.contextDir, devfile)) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -39,7 +39,6 @@ type PortForwardOptions struct {
 	// ReadChannel is used to receive status of port forwarding ( ready or not ready )
 	ReadyChannel chan struct{}
 	*genericclioptions.Context
-	DevfilePath string
 
 	isExperimental bool
 }
@@ -65,6 +64,7 @@ const (
 	portforwardCommandName = "port-forward"
 )
 
+// NewPortForwardOptions returns the PortForwardOptions struct
 func NewPortForwardOptions() *PortForwardOptions {
 	return &PortForwardOptions{}
 }
@@ -76,7 +76,7 @@ func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []st
 
 	o.isExperimental = experimental.IsExperimentalModeEnabled()
 
-	if o.isExperimental && util.CheckPathExists(o.DevfilePath) {
+	if o.isExperimental {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut
@@ -182,9 +182,6 @@ func NewCmdPortForward(name, fullName string) *cobra.Command {
 		},
 	}
 	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
-	if experimental.IsExperimentalModeEnabled() {
-		cmd.Flags().StringVar(&opts.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
-	}
 	cmd.Flags().IntVarP(&opts.localPort, "local-port", "l", config.DefaultDebugPort, "Set the local port")
 
 	return cmd

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 
@@ -76,7 +77,7 @@ func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []st
 
 	o.isExperimental = experimental.IsExperimentalModeEnabled()
 
-	if o.isExperimental {
+	if o.isExperimental && util.CheckPathExists(filepath.Join(o.contextDir, devfile)) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -48,6 +48,7 @@ func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []stri
 		if err != nil {
 			return err
 		}
+		o.CompleteDevfilePath()
 	} else {
 		if o.now {
 			o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -39,16 +40,15 @@ func NewURLDeleteOptions() *URLDeleteOptions {
 
 // Complete completes URLDeleteOptions after they've been Deleted
 func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.CompleteDevfilePath()
 
-	if experimental.IsExperimentalModeEnabled() {
-
+	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.urlName = args[0]
 		err = o.InitEnvInfoFromContext()
 		if err != nil {
 			return err
 		}
-		o.CompleteDevfilePath()
 	} else {
 		if o.now {
 			o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/experimental"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -41,7 +40,7 @@ func NewURLDeleteOptions() *URLDeleteOptions {
 // Complete completes URLDeleteOptions after they've been Deleted
 func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(o.DevfilePath) {
+	if experimental.IsExperimentalModeEnabled() {
 
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.urlName = args[0]
@@ -49,7 +48,6 @@ func (o *URLDeleteOptions) Complete(name string, cmd *cobra.Command, args []stri
 		if err != nil {
 			return err
 		}
-		o.CompleteDevfilePath()
 	} else {
 		if o.now {
 			o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
@@ -163,7 +161,6 @@ func NewCmdURLDelete(name, fullName string) *cobra.Command {
 	}
 	urlDeleteCmd.Flags().BoolVarP(&o.urlForceDeleteFlag, "force", "f", false, "Delete url without prompting")
 	o.AddContextFlag(urlDeleteCmd)
-	urlDeleteCmd.Flags().StringVar(&o.DevfilePath, "devfile", "./devfile.yaml", "Path to a devfile.yaml")
 	genericclioptions.AddNowFlag(urlDeleteCmd, &o.now)
 	completion.RegisterCommandHandler(urlDeleteCmd, completion.URLCompletionHandler)
 	completion.RegisterCommandFlagHandler(urlDeleteCmd, "context", completion.FileCompletionHandler)

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -63,7 +63,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 		})
 
 		It("check that machine output debug information works", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
 			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
@@ -92,7 +92,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 		})
 
 		It("should expect a ws connection when tried to connect on default debug port locally", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
 			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
@@ -128,7 +128,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 		})
 
 		It("should start a debug session and run debug info on a running debug session", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp-"+namespace, "--project", namespace)
+			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp-"+namespace, "--project", namespace, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
 			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
@@ -153,7 +153,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 		})
 
 		It("should start a debug session and run debug info on a closed debug session", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
 			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -114,6 +114,10 @@ var _ = Describe("odo devfile delete command tests", func() {
 			})
 
 		})
+
+		It("should error out on devfile flag", func() {
+			helper.CmdShouldFail("odo", "delete", "--devfile", "invalid.yaml")
+		})
 	})
 
 	Context("when the project doesn't exist", func() {

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -1,11 +1,12 @@
 package devfile
 
 import (
-	"github.com/openshift/odo/tests/helper"
-	"github.com/openshift/odo/tests/integration/devfile/utils"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/openshift/odo/tests/helper"
+	"github.com/openshift/odo/tests/integration/devfile/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,10 @@ var _ = Describe("odo devfile exec command tests", func() {
 
 		It("should error out when a invalid command is given by the user", func() {
 			utils.ExecWithInvalidCommand(context, cmpName, "kube")
+		})
+
+		It("should error out when a component is not present or when a devfile flag is used", func() {
+			utils.ExecCommandWithoutComponentAndDevfileFlag(context, cmpName)
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -74,6 +74,10 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(output).To(ContainSubstring("Executing devfile commands for component " + name))
 		})
 
+		It("should error out on devfile flag", func() {
+			helper.CmdShouldFail("odo", "push", "--namespace", namespace, "--devfile", "invalid.yaml")
+		})
+
 	})
 
 	Context("Verify devfile push works", func() {

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -106,6 +106,10 @@ var _ = Describe("odo devfile test command tests", func() {
 			output := helper.CmdShouldFail("odo", "test", "--context", context)
 			Expect(output).To(ContainSubstring("there should be exactly one default command for command group test, currently there is more than one default command"))
 		})
+
+		It("should error out on devfile flag", func() {
+			helper.CmdShouldFail("odo", "test", "--devfile", "invalid.yaml")
+		})
 	})
 
 	Context("Should run test command successfully", func() {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -149,7 +149,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
+			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress", "--context", context)
 
 			// check the env for the runMode
 			envOutput, err := helper.ReadFile(filepath.Join(context, ".odo/env/env.yaml"))
@@ -157,7 +157,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			Expect(envOutput).To(ContainSubstring(" RunMode: run"))
 
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
-			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f")
+			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f", "--context", context)
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})
 		})
 

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -234,6 +234,11 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.MatchAllInOutput(stdout, []string{url1, "/testpath", "created"})
 		})
 
+		It("should error out on devfile flag", func() {
+			helper.CmdShouldFail("odo", "url", "create", "mynodejs", "--devfile", "invalid.yaml")
+			helper.CmdShouldFail("odo", "url", "delete", "mynodejs", "--devfile", "invalid.yaml")
+		})
+
 	})
 
 	Context("Describing urls", func() {

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -66,6 +66,10 @@ var _ = Describe("odo devfile watch command tests", func() {
 			output := helper.CmdShouldFail("odo", "watch", "--context", context)
 			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
 		})
+
+		It("should error out on devfile flag", func() {
+			helper.CmdShouldFail("odo", "watch", "--devfile", "invalid.yaml")
+		})
 	})
 
 	Context("when executing odo watch after odo push", func() {

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -541,6 +541,23 @@ func ExecCommand(context, cmpName string) {
 	helper.CmdShouldPass("odo", args...)
 }
 
+// ExecCommandWithoutComponentAndDevfileFlag executes odo exec without a component and with a devfile flag
+func ExecCommandWithoutComponentAndDevfileFlag(context, cmpName string) {
+	args := []string{"create", "nodejs", cmpName, "--context", context}
+	helper.CmdShouldPass("odo", args...)
+
+	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+	args = []string{"exec", "--context", context}
+	args = append(args, []string{"--", "touch", "/projects/blah.js"}...)
+	helper.CmdShouldFail("odo", args...)
+
+	args = []string{"exec", "--context", context, "--devfile", "invalid.yaml"}
+	args = append(args, []string{"--", "touch", "/projects/blah.js"}...)
+	helper.CmdShouldFail("odo", args...)
+}
+
 //ExecWithoutCommand executes odo exec with no user command and fails
 func ExecWithoutCommand(context, cmpName string) {
 	args := []string{"create", "nodejs", cmpName, "--context", context}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

**What type of PR is this?**

/kind bug
/kind cleanup


**What does does this PR do / why we need it**:
- only `odo create` needs the devfile flag to copy contents from the specified flag to project dir/context dir devfile.yaml
- devfile is always devfile.yaml, so no point in having a devfile flag for non create commands
- commands listed in the issue do not require --devfile flag
- there were some bugs when using --context and --devfile flags for the command listed, they have been fixed
- updated integration tests

**Which issue(s) this PR fixes**:

Fixes #3661 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
- Run the commands with the devfile flag; it should err out
- Run the commands with the context flag, it should work