### PR TITLE
Add registry priority to ensure registry/component display order

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -38,7 +38,9 @@ func GetDevfileRegistries(registryName string) ([]Registry, error) {
 
 	hasName := len(registryName) != 0
 	if cfg.OdoSettings.RegistryList != nil {
-		for _, registry := range *cfg.OdoSettings.RegistryList {
+		registryList := *cfg.OdoSettings.RegistryList
+		for i := len(registryList) - 1; i >= 0; i-- {
+			registry := registryList[i]
 			if hasName {
 				if registryName == registry.Name {
 					reg := Registry{

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -39,6 +39,7 @@ func GetDevfileRegistries(registryName string) ([]Registry, error) {
 	hasName := len(registryName) != 0
 	if cfg.OdoSettings.RegistryList != nil {
 		registryList := *cfg.OdoSettings.RegistryList
+		// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
 		for i := len(registryList) - 1; i >= 0; i-- {
 			registry := registryList[i]
 			if hasName {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -183,10 +183,10 @@ apiversion: odo.openshift.io/v1alpha1
 OdoSettings:
   Experimental: true
   RegistryList:
-  - Name: CheDevfileRegistry
-    URL: https://che-devfile-registry.openshift.io/
   - Name: DefaultDevfileRegistry
-    URL: https://github.com/elsony/devfile-registry`,
+    URL: https://github.com/elsony/devfile-registry
+  - Name: CheDevfileRegistry
+    URL: https://che-devfile-registry.openshift.io/`,
 	))
 	if err != nil {
 		t.Error(err)

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -198,29 +198,32 @@ OdoSettings:
 	tests := []struct {
 		name         string
 		registryName string
-		want         map[string]Registry
+		want         []Registry
 	}{
 		{
 			name:         "Case 1: Test get all devfile registries",
 			registryName: "",
-			want: map[string]Registry{
-				"CheDevfileRegistry": {
-					Name: "CheDevfileRegistry",
-					URL:  "https://che-devfile-registry.openshift.io/",
+			want: []Registry{
+				{
+					Name:   "CheDevfileRegistry",
+					URL:    "https://che-devfile-registry.openshift.io/",
+					Secure: false,
 				},
-				"DefaultDevfileRegistry": {
-					Name: "DefaultDevfileRegistry",
-					URL:  "https://github.com/elsony/devfile-registry",
+				{
+					Name:   "DefaultDevfileRegistry",
+					URL:    "https://github.com/elsony/devfile-registry",
+					Secure: false,
 				},
 			},
 		},
 		{
 			name:         "Case 2: Test get specific devfile registry",
 			registryName: "CheDevfileRegistry",
-			want: map[string]Registry{
-				"CheDevfileRegistry": {
-					Name: "CheDevfileRegistry",
-					URL:  "https://che-devfile-registry.openshift.io/",
+			want: []Registry{
+				{
+					Name:   "CheDevfileRegistry",
+					URL:    "https://che-devfile-registry.openshift.io/",
+					Secure: false,
 				},
 			},
 		},

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -14,8 +14,9 @@ type ComponentType struct {
 
 // Registry is the main struct of devfile registry
 type Registry struct {
-	Name string
-	URL  string
+	Name   string
+	URL    string
+	Secure bool
 }
 
 // DevfileComponentType is the main struct for devfile catalog components
@@ -59,7 +60,7 @@ type ComponentTypeList struct {
 
 // DevfileComponentTypeList lists all the DevfileComponentType's
 type DevfileComponentTypeList struct {
-	DevfileRegistries map[string]Registry
+	DevfileRegistries []Registry
 	Items             []DevfileComponentType
 }
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -199,12 +199,12 @@ func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []cata
 }
 
 func (o *ListComponentsOptions) printDevfileCatalogList(w io.Writer, catalogDevfileList []catalog.DevfileComponentType, supported string) {
-	for _, devfileComponent := range catalogDevfileList {
+	for i := len(catalogDevfileList) - 1; i >= 0; i-- {
+		devfileComponent := catalogDevfileList[i]
 		if supported != "" {
 			fmt.Fprintln(w, devfileComponent.Name, "\t", devfileComponent.Description, "\t", devfileComponent.Registry.Name, "\t", supported)
 		} else {
 			fmt.Fprintln(w, devfileComponent.Name, "\t", devfileComponent.Description, "\t", devfileComponent.Registry.Name)
 		}
-
 	}
 }

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -199,8 +199,7 @@ func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []cata
 }
 
 func (o *ListComponentsOptions) printDevfileCatalogList(w io.Writer, catalogDevfileList []catalog.DevfileComponentType, supported string) {
-	for i := len(catalogDevfileList) - 1; i >= 0; i-- {
-		devfileComponent := catalogDevfileList[i]
+	for _, devfileComponent := range catalogDevfileList {
 		if supported != "" {
 			fmt.Fprintln(w, devfileComponent.Name, "\t", devfileComponent.Description, "\t", devfileComponent.Registry.Name, "\t", supported)
 		} else {

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -601,7 +601,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					co.devfileMetadata.devfileSupport = true
 					co.devfileMetadata.devfileLink = devfileComponent.Link
 					co.devfileMetadata.devfileRegistry = devfileComponent.Registry
-					break
 				}
 			}
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -601,6 +601,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					co.devfileMetadata.devfileSupport = true
 					co.devfileMetadata.devfileLink = devfileComponent.Link
 					co.devfileMetadata.devfileRegistry = devfileComponent.Registry
+					break
 				}
 			}
 

--- a/pkg/odo/cli/env/env.go
+++ b/pkg/odo/cli/env/env.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/odo/util"
+	genericUtil "github.com/openshift/odo/pkg/util"
 
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -49,8 +50,8 @@ func NewCmdEnv(name, fullName string) *cobra.Command {
 
 func printSupportedParameters(supportedParameters map[string]string) string {
 	output := "\n\nAvailable parameters:\n"
-	for parameter, parameterDescription := range supportedParameters {
-		output = fmt.Sprintf("%s  %s: %s\n", output, parameter, parameterDescription)
+	for _, parameter := range genericUtil.GetSortedKeys(supportedParameters) {
+		output = fmt.Sprintf("%s  %s: %s\n", output, parameter, supportedParameters[parameter])
 	}
 
 	return output

--- a/pkg/odo/cli/env/env_test.go
+++ b/pkg/odo/cli/env/env_test.go
@@ -14,9 +14,9 @@ func TestPrintSupportedParameters(t *testing.T) {
 	}
 
 	wantSetParameters := `Available parameters:
+  DebugPort: Use this value to set component debug port
   Name: Use this value to set component name
-  Namespace: Use this value to set component namespace
-  DebugPort: Use this value to set component debug port`
+  Namespace: Use this value to set component namespace`
 
 	supportedUnsetParameters := map[string]string{
 		debugportParameter: debugportParameterDescription,

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -79,6 +79,7 @@ func (o *ListOptions) printRegistryList(w io.Writer, registryList *[]preference.
 	}
 
 	regList := *registryList
+	// Loop backwards here to ensure the registry display order is correct (display latest newly added registry firstly)
 	for i := len(regList) - 1; i >= 0; i-- {
 		registry := regList[i]
 		secure := "No"

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -78,7 +78,9 @@ func (o *ListOptions) printRegistryList(w io.Writer, registryList *[]preference.
 		return
 	}
 
-	for _, registry := range *registryList {
+	regList := *registryList
+	for i := len(regList) - 1; i >= 0; i-- {
+		registry := regList[i]
 		secure := "No"
 		if registry.Secure {
 			secure = "Yes"


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug
/area devfile

**What does does this PR do / why we need it**:

Issue: Currently we concurrently retrieve devfile index file from different registries, which means the order of registry and components in the registry is random depends on the speed and load of each concurrent thread.

This PR implements a new algorithm/data structure to add registry priority for all registries by taking advantage of the nature of the array index so that ensure the correctness registry/component display order (the newly added registry/component has highest priority). More specifically, the PR implements:
- Registry has priority (Newly added registry has the highest priority)
- Display order is correct + still use concurrent mechanism for performance

**Which issue(s) this PR fixes**:

Fixes #3693 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
1. Add new registry
2. Run `odo registry list` or `odo catalog list components` to verify the newly added registry/component display at the top of the table row