### PR TITLE
Fix the make test-coverage for s390x arch

### DIFF
--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -4,11 +4,21 @@
 # go test can't generate code coverage for multiple packages in one command
 
 set -e
+ARCH=$(uname -m)
 echo "" > coverage.txt
-go test -i -race ./cmd/odo
+# The race detector is currently not supported on s390x .
+if [ "${ARCH}" == "s390x" ]; then
+    go test -i ./cmd/odo
+else
+    go test -i -race ./cmd/odo
+fi
+
 for d in $(go list ./... | grep -v vendor | grep -v tests); do
     # For watch related tests, race check causes issue so disabling them here as race is already tested in other tests when used with `-coverprofile=profile.out`
     if [ "$d" = "github.com/openshift/odo/pkg/component" ]; then
+        go test -coverprofile=profile.out -covermode=atomic $d
+    elif [ "${ARCH}" == "s390x" ]; then
+        # The race detector is currently not supported on s390x .
         go test -coverprofile=profile.out -covermode=atomic $d
     else
         go test -race -coverprofile=profile.out -covermode=atomic $d


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does does this PR do / why we need it**:
support `make test-coverage` for s390x arch
**Which issue(s) this PR fixes**:

Fixes #3756 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
