### PR TITLE
Prevent v1 devfiles from being used

### DIFF
--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"k8s.io/klog"
 
+	v100 "github.com/openshift/odo/pkg/devfile/parser/data/1.0.0"
 	v200 "github.com/openshift/odo/pkg/devfile/parser/data/2.0.0"
 )
 
@@ -14,6 +15,8 @@ func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
 
 	switch d := data.(type) {
+	case *v100.Devfile100:
+		return fmt.Errorf("unsupported devfile version. Only devfiles with schema version 2.0.0 are supported")
 	case *v200.Devfile200:
 		components = d.GetComponents()
 
@@ -22,7 +25,7 @@ func ValidateDevfileData(data interface{}) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("invalid devfile type %T", d)
+		return fmt.Errorf("unknown devfile type %T", d)
 	}
 
 	// Validate Components

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -6,7 +6,6 @@ import (
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"k8s.io/klog"
 
-	v100 "github.com/openshift/odo/pkg/devfile/parser/data/1.0.0"
 	v200 "github.com/openshift/odo/pkg/devfile/parser/data/2.0.0"
 )
 
@@ -15,8 +14,6 @@ func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
 
 	switch d := data.(type) {
-	case *v100.Devfile100:
-		components = d.GetComponents()
 	case *v200.Devfile200:
 		components = d.GetComponents()
 
@@ -25,7 +22,7 @@ func ValidateDevfileData(data interface{}) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown devfile type %T", d)
+		return fmt.Errorf("invalid devfile type %T", d)
 	}
 
 	// Validate Components

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -583,8 +583,8 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(storageSize).To(ContainSubstring("3Gi"))
 		})
 
-		It("should throw a validation error for composite run commands", func() {
-			helper.CmdShouldPass("odo", "create", "java-springbooot", "--project", namespace, cmpName)
+		It("should throw a validation error for v1 devfiles", func() {
+			helper.CmdShouldPass("odo", "create", "java-springboot", "--project", namespace, cmpName)
 
 			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -583,6 +583,16 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(storageSize).To(ContainSubstring("3Gi"))
 		})
 
+		It("should throw a validation error for composite run commands", func() {
+			helper.CmdShouldPass("odo", "create", "java-springbooot", "--project", namespace, cmpName)
+
+			helper.CopyExampleDevFile(filepath.Join("source", "devfilesV1", "springboot", "devfile-init.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			// Verify odo push failed
+			output := helper.CmdShouldFail("odo", "push", "--context", context)
+			Expect(output).To(ContainSubstring("unsupported devfile version"))
+		})
+
 	})
 
 	Context("when .gitignore file exists", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does does this PR do / why we need it**:
This PR removes the ability to create v1 devfiles in odo, and adds a validation error when a user tries to use one, as most v1 devfiles no long work with odo (and we have feature parity with v2 devfiles)

```
Johns-MacBook-Pro-3:test johncollier$ odo push
 ✗  unsupported devfile version. Only devfiles with schema version 2.0.0 are supported
```
**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3621

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:
