### PR TITLE
Adding plugin handler test makefile target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "generic, login and component command integration tests"
+      name: "generic, login, component command and plugin handler integration tests"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -73,6 +73,7 @@ jobs:
         - travis_wait make test-generic
         - travis_wait make test-cmd-login-logout
         - travis_wait make test-cmd-cmp
+        - travis_wait make test-plugin-handler
         - odo logout
 
     - <<: *base-test

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,11 @@ test-cmd-pref-config:
 test-cmd-push:
 	ginkgo $(GINKGO_FLAGS) -focus="odo push command tests" tests/integration/
 
+# Run odo plugin handler tests
+.PHONY: test-plugin-handler
+test-plugin-handler:
+	ginkgo $(GINKGO_FLAGS) -focus="odo plugin functionality" tests/integration/
+
 # Run odo catalog devfile command tests
 .PHONY: test-cmd-devfile-catalog
 test-cmd-devfile-catalog:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

$SUBJECT It was missed in the make target. To run the individual target we need it.

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

**How to test changes / Special notes to the reviewer**:

`make test-plugin-handler` as well as `make test-integration` should run
