### PR TITLE
Fix odo describe for component with linked services

### DIFF
--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -126,6 +126,7 @@ func NewComponentFullDescriptionFromClientAndLocalConfig(client *occlient.Client
 		cfd.Spec.Type = componentDescFromCluster.Spec.Type
 		cfd.Spec.SourceType = componentDescFromCluster.Spec.SourceType
 		cfd.Status.LinkedComponents = componentDescFromCluster.Status.LinkedComponents
+		cfd.Status.LinkedServices = componentDescFromCluster.Status.LinkedServices
 	}
 
 	cfd.fillEmptyFields(componentDesc, componentName, applicationName, projectName)


### PR DESCRIPTION
Signed-off-by: Denis Golovin <dgolovin@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

Fix odo describe for components with linked services. Adds linked services information to human/machine readable output.
Similar to #3766.
