### PR TITLE
remove showing help twice for incorrect commands

### DIFF
--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -272,6 +272,5 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	_ = cmd.Help()
 	return fmt.Errorf("Invalid command - see available commands/subcommands above")
 }

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -44,6 +45,11 @@ var _ = Describe("odo generic", func() {
 		It("Fail when entering an incorrect name for a component", func() {
 			output := helper.CmdShouldFail("odo", "component", "foobar")
 			Expect(output).To(ContainSubstring("Subcommand not found, use one of the available commands"))
+		})
+
+		It("Fail with showing help only once for incorrect command", func() {
+			output := helper.CmdShouldFail("odo", "hello")
+			Expect(strings.Count(output, "odo [flags]")).Should(Equal(1))
 		})
 
 	})


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3750

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
odo hello 
```
should only print help once