### PR TITLE
fixed incorrect logging order

### DIFF
--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -118,15 +118,16 @@ func (po *PushOptions) devfilePushInner() (err error) {
 
 	warnIfURLSInvalid(po.EnvSpecificInfo.GetURL())
 
+	log.Infof("\nPushing devfile component %s", componentName)
+
 	// Start or update the component
 	err = devfileHandler.Push(pushParams)
 	if err != nil {
-		err = errors.Errorf("Failed to start component with name %s. Error: %v",
+		err = errors.Errorf("Failed to push component with name %s. Error: %v",
 			componentName,
 			err,
 		)
 	} else {
-		log.Infof("\nPushing devfile component %s", componentName)
 		log.Success("Changes successfully pushed to component")
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does does this PR do / why we need it**:

I found this bit of logging order a bit disinforming. 

"\nPushing devfile component %s" should be logged before the actually `Pushing` logic starts. not after that.