### PR TITLE
Replace unstable mongodb-enterprise operator subscription with percona-server-mongodb-operator

### DIFF
--- a/scripts/setup-operators.sh
+++ b/scripts/setup-operators.sh
@@ -9,15 +9,15 @@ install_mongo_operator() {
   apiVersion: operators.coreos.com/v1alpha1
   kind: Subscription
   metadata:
-    name: mongodb-enterprise
+    name: percona-server-mongodb-operator-certified
     namespace: openshift-operators
   spec:
     channel: stable
     installPlanApproval: Automatic
-    name: mongodb-enterprise
+    name: percona-server-mongodb-operator-certified
     source: certified-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: mongodb-enterprise.v1.6.0
+    startingCSV: percona-server-mongodb-operator.v1.4.0
 EOF
 }
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "mongodb-enterprise", "etcdoperator"})
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
 		})
 
 		It("should not allow interactive mode command to be executed", func() {
@@ -308,7 +308,7 @@ spec:
 
 		It("listing catalog of services", func() {
 			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"mongodb-enterprise", "etcdoperator"})
+			helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind feature

**What does does this PR do / why we need it**:

There is no `mongodb-enterprise` operator available on 4.6 cluster build released after 2nd Aug. In Spite of just removing mongodb operator, planned to replace it with `percona-server-mongodb-operator` which is available for all the versions.

**Which issue(s) this PR fixes**:

Fixes NA but its blocking pr https://github.com/openshift/release/pull/10346

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

New operator `percona-server-mongodb-operator` should be successfully installed. Also `make test-operator-hub` should pass