### PR TITLE
Remove need to be connected to a cluster to create a component

### DIFF
--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -337,7 +337,7 @@ func TestList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, fakeClientSet := occlient.FakeNew()
-			client.Namespace = "test"
+			client.SetNamespace("test")
 
 			fakeClientSet.ProjClientset.PrependReactor("get", "projects", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 				if !tt.projectExists {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -458,7 +458,10 @@ func isServerUp(server string) bool {
 }
 
 func (c *Client) GetCurrentProjectName() string {
-	return c.namespace
+	if c.namespace != "" {
+		return c.namespace
+	}
+	return c.kubeClient.Namespace
 }
 
 // GetProjectNames return list of existing projects that user has access to.

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3342,3 +3342,8 @@ func (c *Client) isResourceSupported(apiGroup, apiVersion, resourceName string) 
 	}
 	return supported, nil
 }
+
+func (c *Client) SetNamespace(namespace string) {
+	c.Namespace = namespace
+	c.kubeClient.Namespace = namespace
+}

--- a/pkg/occlient/occlient_test.go
+++ b/pkg/occlient/occlient_test.go
@@ -1528,7 +1528,7 @@ func TestGetExposedPorts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fkclient, _ := FakeNew()
-			fkclient.Namespace = "testing"
+			fkclient.SetNamespace("testing")
 			got, err := fkclient.GetExposedPorts(tt.imageStreamImage)
 
 			// sort result, map is used behind the scene so the ordering might be different
@@ -2067,7 +2067,7 @@ func TestGetImageStream(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fkclient, fkclientset := FakeNew()
-			fkclient.Namespace = "testing"
+			fkclient.SetNamespace("testing")
 			openshiftIS := fakeImageStream(tt.imageName, "openshift", []string{"latest", "3.5"})
 			currentNSIS := fakeImageStream(tt.imageName, "testing", []string{"latest"})
 
@@ -5478,7 +5478,7 @@ func TestGetPortsFromBuilderImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fkclient, fkclientset := FakeNew()
-			fkclient.Namespace = "testing"
+			fkclient.SetNamespace("testing")
 			// Fake getting image stream
 			fkclientset.ImageClientset.PrependReactor("get", "imagestreams", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, fakeImageStream(tt.args.componentType, tt.imageNamespace, []string{"latest"}), nil

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -49,7 +49,7 @@ func (o *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string)
 
 // Validate validates the DeleteOptions based on completed values
 func (o *DeleteOptions) Validate() (err error) {
-	if o.Context.Project == "" || o.appName == "" {
+	if o.Context.GetProject() == "" || o.appName == "" {
 		return odoUtil.ThrowContextError()
 	}
 	if !util.CheckOutputFlag(o.OutputFlag) {
@@ -74,17 +74,18 @@ func (o *DeleteOptions) Run() (err error) {
 	}
 
 	// Print App Information which will be deleted
-	err = printDeleteAppInfo(o.Client, o.appName, o.Project)
+	project := o.GetProject()
+	err = printDeleteAppInfo(o.Client, o.appName, project)
 	if err != nil {
 		return err
 	}
 
-	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, o.Project)) {
+	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, project)) {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {
 			return err
 		}
-		log.Infof("Deleted application: %s from project: %v", o.appName, o.Project)
+		log.Infof("Deleted application: %s from project: %v", o.appName, project)
 	} else {
 		log.Infof("Aborting deletion of application: %v", o.appName)
 	}

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -56,7 +56,7 @@ func (o *DeleteOptions) Validate() (err error) {
 		return fmt.Errorf("given output format %s is not supported", o.OutputFlag)
 	}
 
-	exist, err := application.Exists(o.appName, o.Client)
+	exist, err := application.Exists(o.appName, o.GetClient())
 	if !exist {
 		return fmt.Errorf("%s app does not exists", o.appName)
 	}
@@ -65,8 +65,9 @@ func (o *DeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *DeleteOptions) Run() (err error) {
+	client := o.GetClient()
 	if log.IsJSON() {
-		err = application.Delete(o.Client, o.appName)
+		err = application.Delete(client, o.appName)
 		if err != nil {
 			return err
 		}
@@ -75,13 +76,13 @@ func (o *DeleteOptions) Run() (err error) {
 
 	// Print App Information which will be deleted
 	project := o.GetProject()
-	err = printDeleteAppInfo(o.Client, o.appName, project)
+	err = printDeleteAppInfo(client, o.appName, project)
 	if err != nil {
 		return err
 	}
 
 	if o.force || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the application: %v from project: %v", o.appName, project)) {
-		err = application.Delete(o.Client, o.appName)
+		err = application.Delete(client, o.appName)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -47,7 +47,8 @@ func (o *DescribeOptions) Complete(name string, cmd *cobra.Command, args []strin
 
 // Validate validates the DescribeOptions based on completed values
 func (o *DescribeOptions) Validate() (err error) {
-	if o.Context.Project == "" || o.appName == "" {
+	project := o.Context.GetProject()
+	if project == "" || o.appName == "" {
 		return util.ThrowContextError()
 	}
 	err = util.CheckOutputFlag(o.outputFormat)
@@ -55,7 +56,7 @@ func (o *DescribeOptions) Validate() (err error) {
 		return err
 	}
 	if o.appName == "" {
-		return fmt.Errorf("There's no active application in project: %v", o.Project)
+		return fmt.Errorf("There's no active application in project: %v", project)
 	}
 
 	exist, err := application.Exists(o.appName, o.Client)
@@ -68,7 +69,7 @@ func (o *DescribeOptions) Validate() (err error) {
 // Run contains the logic for the odo command
 func (o *DescribeOptions) Run() (err error) {
 	if log.IsJSON() {
-		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.Project)
+		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.GetProject())
 		machineoutput.OutputSuccess(appDef)
 	} else {
 		// List of Component
@@ -85,11 +86,12 @@ func (o *DescribeOptions) Run() (err error) {
 		} else {
 			fmt.Printf("Application Name: %s has %v component(s) and %v service(s):\n--------------------------------------\n",
 				o.appName, len(componentList.Items), len(serviceList.Items))
+			project := o.GetProject()
 			if len(componentList.Items) > 0 {
 				for _, currentComponent := range componentList.Items {
-					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, o.Project)
+					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, project)
 					util.LogErrorAndExit(err, "")
-					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.appName, o.Project)
+					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.appName, project)
 					fmt.Println("--------------------------------------")
 				}
 			}

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -47,7 +47,7 @@ func (o *DescribeOptions) Complete(name string, cmd *cobra.Command, args []strin
 
 // Validate validates the DescribeOptions based on completed values
 func (o *DescribeOptions) Validate() (err error) {
-	project := o.Context.GetProject()
+	project := o.GetProject()
 	if project == "" || o.appName == "" {
 		return util.ThrowContextError()
 	}
@@ -59,7 +59,7 @@ func (o *DescribeOptions) Validate() (err error) {
 		return fmt.Errorf("There's no active application in project: %v", project)
 	}
 
-	exist, err := application.Exists(o.appName, o.Client)
+	exist, err := application.Exists(o.appName, o.GetClient())
 	if !exist {
 		return fmt.Errorf("%s app does not exists", o.appName)
 	}
@@ -68,18 +68,19 @@ func (o *DescribeOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *DescribeOptions) Run() (err error) {
+	client := o.GetClient()
 	if log.IsJSON() {
-		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.GetProject())
+		appDef := application.GetMachineReadableFormat(client, o.appName, o.GetProject())
 		machineoutput.OutputSuccess(appDef)
 	} else {
 		// List of Component
-		componentList, err := component.List(o.Client, o.appName, nil)
+		componentList, err := component.List(client, o.appName, nil)
 		if err != nil {
 			return err
 		}
 
 		//we ignore service errors here because it's entirely possible that the service catalog has not been installed
-		serviceList, _ := service.ListWithDetailedStatus(o.Client, o.appName)
+		serviceList, _ := service.ListWithDetailedStatus(client, o.appName)
 
 		if len(componentList.Items) == 0 && len(serviceList.Items) == 0 {
 			fmt.Printf("Application %s has no components or services deployed.", o.appName)
@@ -89,9 +90,9 @@ func (o *DescribeOptions) Run() (err error) {
 			project := o.GetProject()
 			if len(componentList.Items) > 0 {
 				for _, currentComponent := range componentList.Items {
-					componentDesc, err := component.GetComponent(o.Client, currentComponent.Name, o.appName, project)
+					componentDesc, err := component.GetComponent(client, currentComponent.Name, o.appName, project)
 					util.LogErrorAndExit(err, "")
-					util.PrintComponentInfo(o.Client, currentComponent.Name, componentDesc, o.appName, project)
+					util.PrintComponentInfo(client, currentComponent.Name, componentDesc, o.appName, project)
 					fmt.Println("--------------------------------------")
 				}
 			}

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -45,7 +45,7 @@ func (o *ListOptions) Complete(name string, cmd *cobra.Command, args []string) (
 // Validate validates the ListOptions based on completed values
 func (o *ListOptions) Validate() (err error) {
 	// list doesn't need the app name
-	if o.Context.Project == "" {
+	if o.Context.GetProject() == "" {
 		return util.ThrowContextError()
 	}
 	return util.CheckOutputFlag(o.outputFormat)
@@ -58,12 +58,12 @@ func (o *ListOptions) Run() (err error) {
 		return fmt.Errorf("unable to get list of applications: %v", err)
 	}
 
+	p := o.GetProject()
 	if len(apps) > 0 {
-
 		if log.IsJSON() {
 			var appList []application.App
 			for _, app := range apps {
-				appDef := application.GetMachineReadableFormat(o.Client, app, o.Project)
+				appDef := application.GetMachineReadableFormat(o.Client, app, p)
 				appList = append(appList, appDef)
 			}
 
@@ -71,7 +71,7 @@ func (o *ListOptions) Run() (err error) {
 			machineoutput.OutputSuccess(appListDef)
 
 		} else {
-			log.Infof("The project '%v' has the following applications:", o.Project)
+			log.Infof("The project '%v' has the following applications:", p)
 			tabWriter := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 			_, err := fmt.Fprintln(tabWriter, "NAME")
 			if err != nil {
@@ -90,7 +90,7 @@ func (o *ListOptions) Run() (err error) {
 			apps := application.GetMachineReadableFormatForList([]application.App{})
 			machineoutput.OutputSuccess(apps)
 		} else {
-			log.Infof("There are no applications deployed in the project '%v'", o.Project)
+			log.Infof("There are no applications deployed in the project '%v'", p)
 		}
 	}
 	return

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -53,7 +53,8 @@ func (o *ListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo command
 func (o *ListOptions) Run() (err error) {
-	apps, err := application.List(o.Client)
+	client := o.GetClient()
+	apps, err := application.List(client)
 	if err != nil {
 		return fmt.Errorf("unable to get list of applications: %v", err)
 	}
@@ -63,7 +64,7 @@ func (o *ListOptions) Run() (err error) {
 		if log.IsJSON() {
 			var appList []application.App
 			for _, app := range apps {
-				appDef := application.GetMachineReadableFormat(o.Client, app, p)
+				appDef := application.GetMachineReadableFormat(client, app, p)
 				appList = append(appList, appDef)
 			}
 

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -59,7 +59,7 @@ func (o *DescribeComponentOptions) Complete(name string, cmd *cobra.Command, arg
 		o.Context = genericclioptions.NewContext(cmd, true)
 
 		tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-			catalogList, err := catalog.ListComponents(o.Client)
+			catalogList, err := catalog.ListComponents(o.GetClient())
 			if err != nil {
 				// TODO:
 				// This MAY have to change in the future.. There is no good way to determine whether the user

--- a/pkg/odo/cli/catalog/describe/service.go
+++ b/pkg/odo/cli/catalog/describe/service.go
@@ -49,7 +49,7 @@ func (o *DescribeServiceOptions) Complete(name string, cmd *cobra.Command, args 
 
 // Validate validates the DescribeServiceOptions based on completed values
 func (o *DescribeServiceOptions) Validate() (err error) {
-	o.service, o.plans, err = svc.GetServiceClassAndPlans(o.Client, o.serviceName)
+	o.service, o.plans, err = svc.GetServiceClassAndPlans(o.GetClient(), o.serviceName)
 	return err
 }
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -46,14 +46,15 @@ func (o *ListComponentsOptions) Complete(name string, cmd *cobra.Command, args [
 
 	if !pushtarget.IsPushTargetDocker() {
 		o.Context = genericclioptions.NewContext(cmd)
-		supported, err := o.Client.IsImageStreamSupported()
+		client := o.GetClient()
+		supported, err := client.IsImageStreamSupported()
 		if err != nil {
 			klog.V(4).Info("ignoring error while checking imagestream support:", err.Error())
 		}
 
 		if supported {
 			tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-				o.catalogList, err = catalog.ListComponents(o.Client)
+				o.catalogList, err = catalog.ListComponents(client)
 				if err != nil {
 					errChannel <- err
 				} else {

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -179,9 +179,10 @@ func NewCmdCatalogListComponents(name, fullName string) *cobra.Command {
 }
 
 func (o *ListComponentsOptions) printCatalogList(w io.Writer, catalogList []catalog.ComponentType, supported string) {
+	project := o.GetProject()
 	for _, component := range catalogList {
 		componentName := component.Name
-		if component.Namespace == o.Project {
+		if component.Namespace == project {
 			/*
 				If current namespace is same as the current component namespace,
 				Loop through every other component,

--- a/pkg/odo/cli/catalog/search/component.go
+++ b/pkg/odo/cli/catalog/search/component.go
@@ -32,7 +32,7 @@ func (o *SearchComponentOptions) Complete(name string, cmd *cobra.Command, args 
 	o.Context = genericclioptions.NewContext(cmd)
 	o.searchTerm = args[0]
 
-	o.components, err = catalog.SearchComponent(o.Client, o.searchTerm)
+	o.components, err = catalog.SearchComponent(o.GetClient(), o.searchTerm)
 	return err
 }
 

--- a/pkg/odo/cli/catalog/search/service.go
+++ b/pkg/odo/cli/catalog/search/service.go
@@ -34,7 +34,8 @@ func (o *SearchServiceOptions) Complete(name string, cmd *cobra.Command, args []
 	var noCsvs, noServices bool
 	o.Context = genericclioptions.NewContext(cmd)
 	o.searchTerm = args[0]
-	o.csvs, err = o.KClient.SearchClusterServiceVersionList(o.searchTerm)
+	client := o.GetClient()
+	o.csvs, err = client.GetKubeClient().SearchClusterServiceVersionList(o.searchTerm)
 	if err != nil {
 		// Error only occurs when OperatorHub is not installed/enabled on the
 		// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
@@ -43,7 +44,7 @@ func (o *SearchServiceOptions) Complete(name string, cmd *cobra.Command, args []
 	}
 
 	// Checks service catalog, but if its not available, we do not error.
-	o.services, err = catalog.SearchService(o.Client, o.searchTerm)
+	o.services, err = catalog.SearchService(client, o.searchTerm)
 	if err != nil {
 		// Error occurs if Service Catalog is not enabled on the OpenShift
 		// 3.x/4.x cluster

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -254,7 +254,8 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 	if o.isTargetAService {
 		// if there is a ServiceBinding, then that means there is already a secret (or there will be soon)
 		// which we can link to
-		_, err = o.Client.GetServiceBinding(o.secretName, o.Project)
+		project := o.GetProject()
+		_, err = o.Client.GetServiceBinding(o.secretName, project)
 		if err != nil {
 			return fmt.Errorf("The service was not created via odo. Please delete the service and recreate it using 'odo service create %s'", o.secretName)
 		}
@@ -265,11 +266,11 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 			// service is in running state.
 			// This can take a long time to occur if the image of the service has yet to be downloaded
 			log.Progressf("Waiting for secret of service %s to come up", o.secretName)
-			_, err = o.Client.WaitAndGetSecret(o.secretName, o.Project)
+			_, err = o.Client.WaitAndGetSecret(o.secretName, project)
 		} else {
 			// we also need to check whether there is a secret with the same name as the service
 			// the secret should have been created along with the secret
-			_, err = o.Client.GetSecret(o.secretName, o.Project)
+			_, err = o.Client.GetSecret(o.secretName, project)
 			if err != nil {
 				return fmt.Errorf("The service %s created by 'odo service create' is being provisioned. You may have to wait a few seconds until OpenShift fully provisions it before executing 'odo %s'.", o.secretName, o.operationName)
 			}
@@ -359,7 +360,7 @@ func (o *commonLinkOptions) run() (err error) {
 		return fmt.Errorf("unknown operation %s", o.operationName)
 	}
 
-	secret, err := o.Client.GetSecret(o.secretName, o.Project)
+	secret, err := o.Client.GetSecret(o.secretName, o.GetProject())
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -373,7 +373,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		var catalogList catalog.ComponentTypeList
 		if co.forceS2i {
-			client := co.Client
+			client := co.GetClient()
 			catalogList, err = catalog.ListComponents(client)
 			if err != nil {
 				return err
@@ -643,7 +643,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	// return from here, if it is not an openshift cluster.
 	var openshiftCluster bool
 	if !pushtarget.IsPushTargetDocker() {
-		openshiftCluster, _ = co.Client.IsImageStreamSupported()
+		openshiftCluster, _ = co.GetClient().IsImageStreamSupported()
 	} else {
 		openshiftCluster = false
 	}
@@ -662,7 +662,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	// Below code is for INTERACTIVE mode
 	project := co.Context.GetProject()
 	if co.interactive {
-		client := co.Client
+		client := co.GetClient()
 
 		catalogList, err := catalog.ListComponents(client)
 		if err != nil {
@@ -774,7 +774,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		// if user didn't opt for advanced options, "ports" value remains empty which panics the "odo push"
 		// so we set the ports here
 		if len(ports) == 0 {
-			ports, err = co.Client.GetPortsFromBuilderImage(*co.componentSettings.Type)
+			ports, err = co.GetClient().GetPortsFromBuilderImage(*co.componentSettings.Type)
 			if err != nil {
 				return err
 			}
@@ -798,7 +798,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		if len(co.componentPorts) > 0 {
 			portList = co.componentPorts
 		} else {
-			portList, err = co.Client.GetPortsFromBuilderImage(*co.componentSettings.Type)
+			portList, err = co.GetClient().GetPortsFromBuilderImage(*co.componentSettings.Type)
 			if err != nil {
 				return err
 			}
@@ -852,7 +852,7 @@ func (co *CreateOptions) Validate() (err error) {
 
 	log.Info("Validation")
 
-	supported, err := catalog.IsComponentTypeSupported(co.Context.Client, *co.componentSettings.Type)
+	supported, err := catalog.IsComponentTypeSupported(co.GetClient(), *co.componentSettings.Type)
 	if err != nil {
 		return err
 	}
@@ -863,7 +863,7 @@ func (co *CreateOptions) Validate() (err error) {
 
 	s := log.Spinner("Validating component")
 	defer s.End(false)
-	if err := component.ValidateComponentCreateRequest(co.Context.Client, co.componentSettings, co.componentContext); err != nil {
+	if err := component.ValidateComponentCreateRequest(co.GetClient(), co.componentSettings, co.componentContext); err != nil {
 		return err
 	}
 
@@ -1133,7 +1133,7 @@ func (co *CreateOptions) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		state := component.GetComponentState(co.Client, *co.componentSettings.Name, co.Context.Application)
+		state := component.GetComponentState(co.GetClient(), *co.componentSettings.Name, co.Context.Application)
 
 		if state == component.StateTypeNotPushed || state == component.StateTypeUnknown {
 			componentDesc, err = component.GetComponentFromConfig(co.LocalConfigInfo)
@@ -1142,7 +1142,7 @@ func (co *CreateOptions) Run() (err error) {
 				return err
 			}
 		} else {
-			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.GetProject())
+			componentDesc, err = component.GetComponent(co.GetClient(), *co.componentSettings.Name, co.Context.Application, co.Context.GetProject())
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -660,6 +660,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	co.componentSettings = co.LocalConfigInfo.GetComponentSettings()
 
 	// Below code is for INTERACTIVE mode
+	project := co.Context.GetProject()
 	if co.interactive {
 		client := co.Client
 
@@ -731,7 +732,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		appName := ui.EnterOpenshiftName(co.Context.Application, "Which application do you want the component to be associated with", co.Context)
 		co.componentSettings.Application = &appName
 
-		projectName := ui.EnterOpenshiftName(co.Context.Project, "Which project go you want the component to be created in", co.Context)
+		projectName := ui.EnterOpenshiftName(project, "Which project go you want the component to be created in", co.Context)
 		co.componentSettings.Project = &projectName
 
 		co.componentSettings.Name = &componentName
@@ -806,7 +807,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		co.componentSettings.Ports = &(portList)
 	}
 
-	co.componentSettings.Project = &(co.Context.Project)
+	co.componentSettings.Project = &project
 	envs, err := config.NewEnvVarListFromSlice(co.componentEnvVars)
 	if err != nil {
 		return
@@ -815,7 +816,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	co.ignores = []string{}
 	if co.now {
 		co.ResolveSrcAndConfigFlags()
-		err = co.ResolveProject(co.Context.Project)
+		err = co.ResolveProject(project)
 		if err != nil {
 			return err
 		}
@@ -1141,7 +1142,7 @@ func (co *CreateOptions) Run() (err error) {
 				return err
 			}
 		} else {
-			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.Project)
+			componentDesc, err = component.GetComponent(co.Context.Client, *co.componentSettings.Name, co.Context.Application, co.Context.GetProject())
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -108,7 +108,7 @@ func (do *DeleteOptions) Validate() (err error) {
 		return nil
 	}
 
-	if do.Context.Project == "" || do.Application == "" {
+	if do.Context.GetProject() == "" || do.Application == "" {
 		return odoutil.ThrowContextError()
 	}
 	do.isCmpExists, err = component.Exists(do.Client, do.componentName, do.Application)
@@ -141,7 +141,8 @@ func (do *DeleteOptions) Run() (err error) {
 // s2iRun implements delete Run for s2i components
 func (do *DeleteOptions) s2iRun() (err error) {
 	if do.isCmpExists {
-		err = printDeleteComponentInfo(do.Client, do.componentName, do.Context.Application, do.Context.Project)
+		project := do.Context.GetProject()
+		err = printDeleteComponentInfo(do.Client, do.componentName, do.Context.Application, project)
 		if err != nil {
 			return err
 		}
@@ -157,7 +158,7 @@ func (do *DeleteOptions) s2iRun() (err error) {
 				return err
 			}
 
-			parentComponent, err := component.GetComponent(do.Client, do.componentName, do.Context.Application, do.Context.Project)
+			parentComponent, err := component.GetComponent(do.Client, do.componentName, do.Context.Application, project)
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -47,7 +47,7 @@ func (do *DescribeOptions) Complete(name string, cmd *cobra.Command, args []stri
 
 // Validate validates the describe parameters
 func (do *DescribeOptions) Validate() (err error) {
-	if do.Context.Project == "" || do.Application == "" {
+	if do.Context.GetProject() == "" || do.Application == "" {
 		return odoutil.ThrowContextError()
 	}
 
@@ -56,11 +56,12 @@ func (do *DescribeOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (do *DescribeOptions) Run() (err error) {
-	if (len(do.componentName) <= 0 || len(do.Application) <= 0 || len(do.Project) <= 0) && !do.LocalConfigInfo.Exists() {
+	project := do.GetProject()
+	if (len(do.componentName) <= 0 || len(do.Application) <= 0 || len(project) <= 0) && !do.LocalConfigInfo.Exists() {
 		return fmt.Errorf("Component %v does not exist", do.componentName)
 	}
 
-	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.Context.KClient, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, do.Context.Project)
+	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.Context.KClient, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, project)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -61,7 +61,9 @@ func (do *DescribeOptions) Run() (err error) {
 		return fmt.Errorf("Component %v does not exist", do.componentName)
 	}
 
-	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.Context.KClient, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, project)
+	client := do.GetClient()
+	kClient := client.GetKubeClient()
+	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(client, kClient, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, project)
 	if err != nil {
 		return err
 	}
@@ -69,7 +71,7 @@ func (do *DescribeOptions) Run() (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(cfd)
 	} else {
-		err = cfd.Print(do.Context.Client)
+		err = cfd.Print(client)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -102,7 +102,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 		platformContext = nil
 	} else {
 		kc := kubernetes.KubernetesContext{
-			Namespace: po.KClient.Namespace,
+			Namespace: po.GetClient().GetKubeClient().Namespace,
 		}
 		platformContext = kc
 	}
@@ -156,7 +156,7 @@ func (lo LogOptions) DevfileComponentLog() error {
 		platformContext = nil
 	} else {
 		kc := kubernetes.KubernetesContext{
-			Namespace: lo.KClient.Namespace,
+			Namespace: lo.GetClient().GetKubeClient().Namespace,
 		}
 		platformContext = kc
 	}
@@ -214,7 +214,7 @@ func (to *TestOptions) RunTestCommand() error {
 		platformContext = nil
 	} else {
 		kc := kubernetes.KubernetesContext{
-			Namespace: to.KClient.Namespace,
+			Namespace: to.GetClient().GetKubeClient().Namespace,
 		}
 		platformContext = kc
 	}

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -69,7 +69,7 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 
 		if !pushtarget.IsPushTargetDocker() {
 			// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
-			eo.namespace = eo.componentOptions.KClient.Namespace
+			eo.namespace = eo.componentOptions.GetClient().GetKubeClient().Namespace
 		}
 		return nil
 	}

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -101,15 +101,17 @@ func (o *LinkOptions) Complete(name string, cmd *cobra.Command, args []string) (
 		return err
 	}
 
-	o.csvSupport, err = o.Client.IsCSVSupported()
+	client := o.GetClient()
+	kClient := client.GetKubeClient()
+	o.csvSupport, err = client.IsCSVSupported()
 	if err != nil {
 		return err
 	}
 
 	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
-		o.operation = o.KClient.LinkSecret
+		o.operation = kClient.LinkSecret
 	} else {
-		o.operation = o.Client.LinkSecret
+		o.operation = client.LinkSecret
 	}
 
 	return err
@@ -126,7 +128,7 @@ func (o *LinkOptions) Validate() (err error) {
 		return
 	}
 
-	alreadyLinkedSecretNames, err := component.GetComponentLinkedSecretNames(o.Client, o.Component(), o.Application)
+	alreadyLinkedSecretNames, err := component.GetComponentLinkedSecretNames(o.GetClient(), o.Component(), o.Application)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -88,7 +88,6 @@ type LinkOptions struct {
 func NewLinkOptions() *LinkOptions {
 	options := LinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
-	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
 	options.commonLinkOptions.sbr = &sbo.ServiceBindingRequest{}
 	return &options
 }

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -137,7 +137,7 @@ func (o *LinkOptions) Validate() (err error) {
 			if o.isTargetAService {
 				targetType = "service"
 			}
-			return fmt.Errorf("Component %s has previously been linked to %s %s", o.Project, targetType, o.suppliedName)
+			return fmt.Errorf("Component %s has previously been linked to %s %s", o.GetProject(), targetType, o.suppliedName)
 		}
 	}
 	return

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -13,7 +13,6 @@ import (
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 
-	"github.com/openshift/odo/pkg/odo/util"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -118,7 +118,7 @@ func (lo *ListOptions) Validate() (err error) {
 		app = lo.LocalConfigInfo.GetApplication()
 
 	} else {
-		project = lo.Context.Project
+		project = lo.Context.GetProject()
 		app = lo.Application
 	}
 	if !lo.allAppsFlag && lo.pathFlag == "" && (project == "" || app == "") {

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -208,18 +208,16 @@ func (lo *ListOptions) Run() (err error) {
 	var devfileComponents []component.DevfileComponent
 	currentComponentState := component.StateTypeNotPushed
 
-	if lo.KClient != nil {
-		deploymentList, err = client.GetKubeClient().ListDeployments(selector)
-		if err != nil {
-			return err
-		}
-		devfileComponents = append(devfileComponents, component.DevfileComponentsFromDeployments(deploymentList)...)
-		for _, comp := range devfileComponents {
-			if lo.EnvSpecificInfo != nil {
-				// if we can find a component from the listing from server then the local state is pushed
-				if lo.EnvSpecificInfo.EnvInfo.MatchComponent(comp.Spec.Name, comp.Spec.App, comp.Namespace) {
-					currentComponentState = component.StateTypePushed
-				}
+	deploymentList, err = client.GetKubeClient().ListDeployments(selector)
+	if err != nil {
+		return err
+	}
+	devfileComponents = append(devfileComponents, component.DevfileComponentsFromDeployments(deploymentList)...)
+	for _, comp := range devfileComponents {
+		if lo.EnvSpecificInfo != nil {
+			// if we can find a component from the listing from server then the local state is pushed
+			if lo.EnvSpecificInfo.EnvInfo.MatchComponent(comp.Spec.Name, comp.Spec.App, comp.Namespace) {
+				currentComponentState = component.StateTypePushed
 			}
 		}
 	}

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -69,7 +69,7 @@ func (lo *LogOptions) Run() (err error) {
 		err = lo.DevfileComponentLog()
 	} else {
 		// Retrieve the log
-		err = component.GetLogs(lo.Context.Client, lo.componentName, lo.Context.Application, lo.logFollow, stdout)
+		err = component.GetLogs(lo.GetClient(), lo.componentName, lo.Context.Application, lo.logFollow, stdout)
 	}
 	return
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -139,7 +139,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		// If the push target has been set to Docker, we will have to change the current namespace.
 		// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
 		if !pushtarget.IsPushTargetDocker() {
-			po.namespace = po.KClient.Namespace
+			po.namespace = po.GetClient().GetKubeClient().Namespace
 		}
 
 		return nil
@@ -185,12 +185,13 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Checking component")
 	defer s.End(false)
 
-	po.doesComponentExist, err = component.Exists(po.Context.Client, po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
+	client := po.GetClient()
+	po.doesComponentExist, err = component.Exists(client, po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	}
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
+	if err = component.ValidateComponentCreateRequest(client, po.LocalConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
 		s.End(false)
 		log.Italic("\nRun 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *po.LocalConfigInfo.GetComponentSettings().Type, errors.Cause(err))

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -202,7 +202,7 @@ func createComponentNameValidator(context *genericclioptions.Context) survey.Val
 				return err
 			}
 
-			exists, err := component.Exists(context.Client, s, context.Application)
+			exists, err := component.Exists(context.GetClient(), s, context.Application)
 			if err != nil {
 				klog.V(4).Info(err)
 				return fmt.Errorf("Unable to determine if component '%s' exists or not", s)

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -59,15 +59,17 @@ func (o *UnlinkOptions) Complete(name string, cmd *cobra.Command, args []string)
 		return err
 	}
 
-	o.csvSupport, err = o.Client.IsCSVSupported()
+	client := o.GetClient()
+	kClient := client.GetKubeClient()
+	o.csvSupport, err = client.IsCSVSupported()
 	if err != nil {
 		return err
 	}
 
 	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
-		o.operation = o.KClient.UnlinkSecret
+		o.operation = kClient.UnlinkSecret
 	} else {
-		o.operation = o.Client.UnlinkSecret
+		o.operation = client.UnlinkSecret
 	}
 	return err
 }

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -99,7 +99,7 @@ func (uo *UpdateOptions) Validate() (err error) {
 		return nil
 	}
 
-	uo.doesComponentExist, err = component.Exists(uo.Context.Client, uo.LocalConfigInfo.GetName(), uo.LocalConfigInfo.GetApplication())
+	uo.doesComponentExist, err = component.Exists(uo.GetClient(), uo.LocalConfigInfo.GetName(), uo.LocalConfigInfo.GetApplication())
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", uo.LocalConfigInfo.GetName(), uo.LocalConfigInfo.GetApplication())
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -106,7 +106,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		var platformContext interface{}
 		if !pushtarget.IsPushTargetDocker() {
 			// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
-			wo.namespace = wo.KClient.Namespace
+			wo.namespace = wo.GetClient().GetKubeClient().Namespace
 			platformContext = kubernetes.KubernetesContext{
 				Namespace: wo.namespace,
 			}
@@ -184,7 +184,7 @@ func (wo *WatchOptions) Validate() (err error) {
 		appName = wo.Application
 	}
 
-	exists, err := component.Exists(wo.Client, cmpName, appName)
+	exists, err := component.Exists(wo.GetClient(), cmpName, appName)
 	if err != nil {
 		return
 	}
@@ -223,7 +223,7 @@ func (wo *WatchOptions) Run() (err error) {
 	}
 
 	err = watch.WatchAndPush(
-		wo.Context.Client,
+		wo.Context.GetClient(),
 		os.Stdout,
 		watch.WatchParameters{
 			ComponentName:       wo.LocalConfigInfo.GetName(),

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -65,7 +65,9 @@ func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	}
 
 	// Using Discard streams because nothing important is logged
-	o.PortForwarder = debug.NewDefaultPortForwarder(o.componentName, o.applicationName, o.Namespace, o.Client, o.KClient, k8sgenclioptions.NewTestIOStreamsDiscard())
+	client := o.GetClient()
+	kClient := client.GetKubeClient()
+	o.PortForwarder = debug.NewDefaultPortForwarder(o.componentName, o.applicationName, o.Namespace, client, kClient, k8sgenclioptions.NewTestIOStreamsDiscard())
 
 	return err
 }

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -122,7 +122,9 @@ func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []st
 	o.PortPair = fmt.Sprintf("%d:%d", o.localPort, remotePort)
 
 	// Using Discard streams because nothing important is logged
-	o.PortForwarder = debug.NewDefaultPortForwarder(o.componentName, o.applicationName, o.Namespace, o.Client, o.KClient, k8sgenclioptions.NewTestIOStreamsDiscard())
+	client := o.GetClient()
+	kClient := client.GetKubeClient()
+	o.PortForwarder = debug.NewDefaultPortForwarder(o.componentName, o.applicationName, o.Namespace, client, kClient, k8sgenclioptions.NewTestIOStreamsDiscard())
 
 	o.StopChannel = make(chan struct{}, 1)
 	o.ReadyChannel = make(chan struct{})

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -39,7 +39,7 @@ func (o *LogoutOptions) Validate() (err error) {
 
 // Run contains the logic for the odo logout command
 func (o *LogoutOptions) Run() (err error) {
-	return o.Client.RunLogout(os.Stdout)
+	return o.GetClient().RunLogout(os.Stdout)
 }
 
 // NewCmdLogout implements the logout odo command

--- a/pkg/odo/cli/project/get.go
+++ b/pkg/odo/cli/project/get.go
@@ -53,7 +53,7 @@ func (pgo *ProjectGetOptions) Validate() (err error) {
 
 // Run runs the project get command
 func (pgo *ProjectGetOptions) Run() (err error) {
-	currentProject := pgo.Context.Project
+	currentProject := pgo.Context.GetProject()
 
 	if pgo.projectShortFlag {
 		fmt.Print(currentProject)

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -64,7 +64,7 @@ func (pso *ProjectSetOptions) Validate() (err error) {
 
 // Run runs the project set command
 func (pso *ProjectSetOptions) Run() (err error) {
-	current := pso.Project
+	current := pso.GetProject()
 	err = project.SetCurrent(pso.Context, pso.projectName)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -484,7 +484,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 
 	if o.wait {
 		s = log.Spinner("Waiting for service to come up")
-		_, err = o.Client.WaitAndGetSecret(o.ServiceName, o.Project)
+		_, err = o.Client.WaitAndGetSecret(o.ServiceName, o.GetProject())
 		if err == nil {
 			s.End(true)
 			log.Successf(`Service '%s' is ready for use`, o.ServiceName)

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -33,7 +33,7 @@ const (
 	equivalentTemplate           = "{{.CmdFullName}} {{.ServiceType}}" +
 		"{{if .ServiceName}} {{.ServiceName}}{{end}}" +
 		" --app {{.Application}}" +
-		" --project {{.Project}}" +
+		" --project {{.GetProject}}" +
 		"{{if .Plan}} --plan {{.Plan}}{{end}}" +
 		"{{range $key, $value := .ParametersMap}} -p {{$key}}={{$value}}{{end}}"
 )

--- a/pkg/odo/cli/service/create_test.go
+++ b/pkg/odo/cli/service/create_test.go
@@ -20,7 +20,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "when output is not requested, should return empty string",
 			options: ServiceCreateOptions{
-				Context: genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
 
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   false,
@@ -31,7 +31,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "just service class",
 			options: ServiceCreateOptions{
-				Context: genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
 
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
@@ -42,7 +42,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "just service class and name",
 			options: ServiceCreateOptions{
-				Context: genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
 
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
@@ -54,7 +54,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "service class, name and plan",
 			options: ServiceCreateOptions{
-				Context: genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context: genericclioptions.NewFakeContext("testproject", "app", "", client),
 
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
@@ -67,7 +67,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "service class and plan",
 			options: ServiceCreateOptions{
-				Context:     genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context:     genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName: RecommendedCommandName,
 				outputCLI:   true,
 				ServiceType: "foo",
@@ -78,7 +78,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "service class and empty params",
 			options: ServiceCreateOptions{
-				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",
@@ -89,7 +89,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "service class and params",
 			options: ServiceCreateOptions{
-				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",
@@ -100,7 +100,7 @@ func TestOutputNonInteractiveEquivalent(t *testing.T) {
 		{
 			name: "all",
 			options: ServiceCreateOptions{
-				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client, nil),
+				Context:       genericclioptions.NewFakeContext("testproject", "app", "", client),
 				CmdFullName:   RecommendedCommandName,
 				outputCLI:     true,
 				ServiceType:   "foo",

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -60,7 +60,7 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
 	if o.csvSupport {
-		svcExists, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
+		svcExists, err := svc.OperatorSvcExists(o.GetClient().GetKubeClient(), o.serviceName)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,7 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 		return nil
 	}
 
-	exists, err := svc.SvcExists(o.Client, o.serviceName, o.Application)
+	exists, err := svc.SvcExists(o.GetClient(), o.serviceName, o.Application)
 	if err != nil {
 		return fmt.Errorf("unable to delete service because Service Catalog is not enabled in your cluster:\n%v", err)
 	}
@@ -89,7 +89,7 @@ func (o *ServiceDeleteOptions) Run() (err error) {
 			s := log.Spinner("Waiting for service to be deleted")
 			defer s.End(false)
 
-			err = svc.DeleteOperatorService(o.KClient, o.serviceName)
+			err = svc.DeleteOperatorService(o.GetClient().GetKubeClient(), o.serviceName)
 			if err != nil {
 				return err
 			}
@@ -102,7 +102,7 @@ func (o *ServiceDeleteOptions) Run() (err error) {
 	}
 
 	if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v from %v", o.serviceName, o.Application)) {
-		err = svc.DeleteServiceAndUnlinkComponents(o.Client, o.serviceName, o.Application)
+		err = svc.DeleteServiceAndUnlinkComponents(o.GetClient(), o.serviceName, o.Application)
 		if err != nil {
 			return fmt.Errorf("unable to delete service %s:\n%v", o.serviceName, err)
 		}

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -69,17 +69,19 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
+	client := o.GetClient()
+	kClient := client.GetKubeClient()
 	if o.csvSupport {
 		// if cluster supports Operators, we list only operator backed services
 		// and not service catalog ones
 		var list []unstructured.Unstructured
-		list, err = svc.ListOperatorServices(o.KClient)
+		list, err = svc.ListOperatorServices(kClient)
 		if err != nil {
 			return err
 		}
 
 		if len(list) == 0 {
-			return fmt.Errorf("No operator backed services found in namespace: %s", o.KClient.Namespace)
+			return fmt.Errorf("No operator backed services found in namespace: %s", kClient.Namespace)
 		}
 
 		if log.IsJSON() {
@@ -102,7 +104,7 @@ func (o *ServiceListOptions) Run() (err error) {
 		return err
 	}
 
-	services, err := svc.ListWithDetailedStatus(o.Client, o.Application)
+	services, err := svc.ListWithDetailedStatus(client, o.Application)
 	if err != nil {
 		return fmt.Errorf("Service catalog is not enabled within your cluster: %v", err)
 	}

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -60,7 +60,7 @@ func (o *ServiceListOptions) Validate() (err error) {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
-		if o.Context.Project == "" || o.Context.Application == "" {
+		if o.Context.GetProject() == "" || o.Context.Application == "" {
 			return odoutil.ThrowContextError()
 		}
 	}

--- a/pkg/odo/cli/service/service_test.go
+++ b/pkg/odo/cli/service/service_test.go
@@ -70,7 +70,7 @@ func TestCompletions(t *testing.T) {
 			},
 		}, nil
 	})
-	context := genericclioptions.NewFakeContext("", "", "", client, nil)
+	context := genericclioptions.NewFakeContext("", "", "", client)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := complete.Args{Last: tt.last}

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -75,13 +75,13 @@ func (o *StorageListOptions) Run() (err error) {
 	var componentName string
 	if o.isDevfile {
 		componentName = o.EnvSpecificInfo.GetName()
-		storageList, err = storage.DevfileList(o.KClient, o.DevfileObj.Data, o.EnvSpecificInfo.GetName())
+		storageList, err = storage.DevfileList(o.GetClient().GetKubeClient(), o.DevfileObj.Data, o.EnvSpecificInfo.GetName())
 		if err != nil {
 			return err
 		}
 	} else {
 		componentName = o.LocalConfigInfo.GetName()
-		storageList, err = storage.ListStorageWithState(o.Client, o.LocalConfigInfo, o.Component(), o.Application)
+		storageList, err = storage.ListStorageWithState(o.GetClient(), o.LocalConfigInfo, o.Component(), o.Application)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -41,14 +41,14 @@ func (o *StorageMountOptions) Complete(name string, cmd *cobra.Command, args []s
 
 // Validate validates the StorageMountOptions based on completed values
 func (o *StorageMountOptions) Validate() (err error) {
-	exists, err := storage.Exists(o.Client, o.storageName, o.Application)
+	exists, err := storage.Exists(o.GetClient(), o.storageName, o.Application)
 	if err != nil {
 		return err
 	}
 	if !exists {
 		return fmt.Errorf("the storage %v does not exists in the current application '%v'", o.storageName, o.Application)
 	}
-	isMounted, err := storage.IsMounted(o.Client, o.storageName, o.Component(), o.Application)
+	isMounted, err := storage.IsMounted(o.GetClient(), o.storageName, o.Component(), o.Application)
 	if err != nil {
 		return fmt.Errorf("unable to check if the component is already mounted or not, cause %v", err)
 	}
@@ -60,7 +60,7 @@ func (o *StorageMountOptions) Validate() (err error) {
 
 // Run contains the logic for the odo storage mount command
 func (o *StorageMountOptions) Run() (err error) {
-	err = storage.Mount(o.Client, o.storagePath, o.storageName, o.Component(), o.Application)
+	err = storage.Mount(o.GetClient(), o.storagePath, o.storageName, o.Component(), o.Application)
 	if err != nil {
 		return
 	}

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -55,7 +55,7 @@ func (o *StorageUnMountOptions) Complete(name string, cmd *cobra.Command, args [
 func (o *StorageUnMountOptions) Validate() (err error) {
 	// checking if the first character in the argument is a "/", indicating a path or not, indicating a storage name
 	if len(o.storagePath) > 0 {
-		o.storageName, err = storage.GetStorageNameFromMountPath(o.Client, o.storagePath, o.Component(), o.Application)
+		o.storageName, err = storage.GetStorageNameFromMountPath(o.GetClient(), o.storagePath, o.Component(), o.Application)
 		if err != nil {
 			return fmt.Errorf("unable to get storage name from mount path, cause %v", err)
 		}
@@ -63,7 +63,7 @@ func (o *StorageUnMountOptions) Validate() (err error) {
 			return fmt.Errorf("no storage is mounted to %s in the component %s", o.storagePath, o.Component())
 		}
 	} else {
-		exists, err := storage.IsMounted(o.Client, o.storageName, o.Component(), o.Application)
+		exists, err := storage.IsMounted(o.GetClient(), o.storageName, o.Component(), o.Application)
 		if err != nil {
 			return fmt.Errorf("unable to check if storage is mounted or not, cause %v", err)
 		}
@@ -77,7 +77,7 @@ func (o *StorageUnMountOptions) Validate() (err error) {
 
 // Run contains the logic for the odo storage unmount command
 func (o *StorageUnMountOptions) Run() (err error) {
-	err = storage.Unmount(o.Client, o.storageName, o.Component(), o.Application, true)
+	err = storage.Unmount(o.GetClient(), o.storageName, o.Component(), o.Application, true)
 	if err != nil {
 		return fmt.Errorf("unable to unmount storage %v from component %v", o.storageName, o.Component())
 	}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -117,9 +117,8 @@ func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string)
 
 	if o.isDevfile {
 		if !o.isDocker {
-			o.Client = genericclioptions.Client(cmd)
 
-			o.isRouteSupported, err = o.Client.IsRouteSupported()
+			o.isRouteSupported, err = o.GetClient().IsRouteSupported()
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -10,7 +10,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/envinfo"
-	"github.com/openshift/odo/pkg/occlient"
 	pkgutil "github.com/openshift/odo/pkg/util"
 
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
@@ -123,12 +122,7 @@ func (o *URLListOptions) Run() (err error) {
 			}
 		} else {
 			componentName := o.EnvSpecificInfo.GetName()
-			oclient, err := occlient.New()
-			if err != nil {
-				return err
-			}
-			oclient.Namespace = o.KClient.Namespace
-			routeSupported, err := oclient.IsRouteSupported()
+			routeSupported, err := o.GetClient().IsRouteSupported()
 			if err != nil {
 				return err
 			}
@@ -138,7 +132,7 @@ func (o *URLListOptions) Run() (err error) {
 			}
 
 			containerComponents := adaptersCommon.GetDevfileContainerComponents(devObj.Data)
-			urls, err := url.ListIngressAndRoute(oclient, o.EnvSpecificInfo, containerComponents, componentName, routeSupported)
+			urls, err := url.ListIngressAndRoute(o.GetClient(), o.EnvSpecificInfo, containerComponents, componentName, routeSupported)
 			if err != nil {
 				return err
 			}
@@ -172,7 +166,7 @@ func (o *URLListOptions) Run() (err error) {
 			}
 		}
 	} else {
-		urls, err := url.List(o.Client, o.LocalConfigInfo, o.Component(), o.Application)
+		urls, err := url.List(o.GetClient(), o.LocalConfigInfo, o.Component(), o.Application)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/utils/convert.go
+++ b/pkg/odo/cli/utils/convert.go
@@ -231,7 +231,7 @@ func generateEnvYaml(co *ConvertOptions) (err error) {
 
 	componentSettings := envinfo.ComponentSettings{
 		Name:    co.componentName,
-		Project: co.context.Project,
+		Project: co.context.GetProject(),
 		AppName: application,
 	}
 

--- a/pkg/odo/cli/utils/convert.go
+++ b/pkg/odo/cli/utils/convert.go
@@ -165,7 +165,7 @@ func generateDevfileYaml(co *ConvertOptions) error {
 	// git, local, binary, none
 	sourceType := co.context.LocalConfigInfo.GetSourceType()
 
-	imageStream, imageforDevfile, err := getImageforDevfile(co.context.Client, componentType)
+	imageStream, imageforDevfile, err := getImageforDevfile(co.context.GetClient(), componentType)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get image details")
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -244,7 +244,7 @@ func (o *internalCxt) resolveProject(localConfiguration envinfo.LocalConfigProvi
 	} else {
 		namespace = localConfiguration.GetNamespace()
 		if namespace == "" {
-			namespace = client.Namespace
+			namespace = client.GetCurrentProjectName()
 			if len(namespace) <= 0 {
 				errFormat := "Could not get current project. Please create or set a project\n\t%s project create|set <project_name>"
 				checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command, errFormat)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -261,9 +261,6 @@ func (o *internalCxt) resolveProject(localConfiguration envinfo.LocalConfigProvi
 	}
 	client.SetNamespace(namespace)
 	o.project = &namespace
-	if o.KClient != nil {
-		o.KClient.Namespace = namespace
-	}
 }
 
 // resolveNamespace resolves namespace for devfile component

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -393,7 +393,6 @@ func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingCon
 		KClient:         KClient,
 	}
 
-	internalCxt.resolveProject(localConfiguration)
 	internalCxt.resolveApp(createAppIfNeeded, localConfiguration)
 
 	// Once the component is resolved, add it to the context
@@ -463,12 +462,19 @@ type Context struct {
 	internalCxt
 }
 
+func (c *Context) GetProject() string {
+	if c.project == "" {
+		c.resolveProject(c.LocalConfigInfo)
+	}
+	return c.project
+}
+
 // internalCxt holds the actual context values and is not exported so that it cannot be instantiated outside of this package.
 // This ensures that Context objects are always created properly via NewContext factory functions.
 type internalCxt struct {
 	Client          *occlient.Client
 	command         *cobra.Command
-	Project         string
+	project         string
 	Application     string
 	cmp             string
 	OutputFlag      string

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -274,7 +274,7 @@ func (o *internalCxt) resolveProject(localConfiguration envinfo.LocalConfigProvi
 		}
 	}
 	o.Client.Namespace = namespace
-	o.Project = namespace
+	o.project = &namespace
 	if o.KClient != nil {
 		o.KClient.Namespace = namespace
 	}
@@ -312,7 +312,7 @@ func (o *internalCxt) resolveNamespace(configProvider envinfo.LocalConfigProvide
 		}
 	}
 	o.KClient.Namespace = namespace
-	o.Project = namespace
+	o.project = &namespace
 }
 
 // resolveApp resolves the app
@@ -462,11 +462,11 @@ type Context struct {
 	internalCxt
 }
 
-func (c *Context) GetProject() string {
-	if c.project == "" {
-		c.resolveProject(c.LocalConfigInfo)
+func (o *Context) GetProject() string {
+	if o.project == nil {
+		o.resolveProject(o.LocalConfigInfo)
 	}
-	return c.project
+	return *o.project
 }
 
 // internalCxt holds the actual context values and is not exported so that it cannot be instantiated outside of this package.
@@ -474,7 +474,7 @@ func (c *Context) GetProject() string {
 type internalCxt struct {
 	Client          *occlient.Client
 	command         *cobra.Command
-	project         string
+	project         *string
 	Application     string
 	cmp             string
 	OutputFlag      string

--- a/pkg/odo/genericclioptions/fakecontext.go
+++ b/pkg/odo/genericclioptions/fakecontext.go
@@ -10,7 +10,7 @@ func NewFakeContext(project, application, component string, client *occlient.Cli
 		internalCxt{
 			Client:      client,
 			KClient:     kclient,
-			Project:     project,
+			project:     project,
 			Application: application,
 			cmp:         component,
 		},

--- a/pkg/odo/genericclioptions/fakecontext.go
+++ b/pkg/odo/genericclioptions/fakecontext.go
@@ -6,10 +6,10 @@ import (
 )
 
 func NewFakeContext(project, application, component string, client *occlient.Client, kclient *kclient.Client) *Context {
+	client.SetKubeClient(kclient)
 	return &Context{
 		internalCxt{
-			Client:      client,
-			KClient:     kclient,
+			client:      client,
 			project:     &project,
 			Application: application,
 			cmp:         component,

--- a/pkg/odo/genericclioptions/fakecontext.go
+++ b/pkg/odo/genericclioptions/fakecontext.go
@@ -10,7 +10,7 @@ func NewFakeContext(project, application, component string, client *occlient.Cli
 		internalCxt{
 			Client:      client,
 			KClient:     kclient,
-			project:     project,
+			project:     &project,
 			Application: application,
 			cmp:         component,
 		},

--- a/pkg/odo/genericclioptions/fakecontext.go
+++ b/pkg/odo/genericclioptions/fakecontext.go
@@ -5,8 +5,10 @@ import (
 	"github.com/openshift/odo/pkg/occlient"
 )
 
-func NewFakeContext(project, application, component string, client *occlient.Client, kclient *kclient.Client) *Context {
-	client.SetKubeClient(kclient)
+func NewFakeContext(project, application, component string, client *occlient.Client, kclient ...*kclient.Client) *Context {
+	if len(kclient) == 1 {
+		client.SetKubeClient(kclient[0])
+	}
 	return &Context{
 		internalCxt{
 			client:      client,

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -20,7 +20,7 @@ import (
 var ServiceCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
 
-	services, err := service.List(context.Client, context.Application)
+	services, err := service.List(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -38,7 +38,7 @@ var ServiceCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context
 // ServiceClassCompletionHandler provides catalog service class name completion
 var ServiceClassCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	services, err := context.Client.GetClusterServiceClasses()
+	services, err := context.GetClient().GetClusterServiceClasses()
 	if err != nil {
 		complete.Log("error retrieving services")
 		return completions
@@ -69,13 +69,13 @@ var ServicePlanCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 
 	complete.Log(fmt.Sprintf("Using input: serviceName = %s", inputServiceName))
 
-	clusterServiceClass, err := context.Client.GetClusterServiceClass(inputServiceName)
+	clusterServiceClass, err := context.GetClient().GetClusterServiceClass(inputServiceName)
 	if err != nil {
 		complete.Log("Error retrieving details of service")
 		return completions
 	}
 
-	servicePlans, err := context.Client.GetClusterPlansFromServiceName(clusterServiceClass.Name)
+	servicePlans, err := context.GetClient().GetClusterPlansFromServiceName(clusterServiceClass.Name)
 	if err != nil {
 		complete.Log("Error retrieving details of plans of service")
 		return completions
@@ -101,7 +101,7 @@ var ServiceParameterCompletionHandler = func(cmd *cobra.Command, args parsedArgs
 
 	complete.Log(fmt.Sprintf("Using input: serviceName = %s, servicePlan = %s", inputServiceName, inputPlanName))
 
-	_, servicePlans, err := service.GetServiceClassAndPlans(context.Client, inputServiceName)
+	_, servicePlans, err := service.GetServiceClassAndPlans(context.GetClient(), inputServiceName)
 	if err != nil {
 		complete.Log("Error retrieving details of service")
 		return completions
@@ -142,7 +142,7 @@ var ServiceParameterCompletionHandler = func(cmd *cobra.Command, args parsedArgs
 var AppCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
 
-	applications, err := application.List(context.Client)
+	applications, err := application.List(context.GetClient())
 	if err != nil {
 		return completions
 	}
@@ -165,7 +165,7 @@ var FileCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *g
 // ProjectNameCompletionHandler provides project name completion
 var ProjectNameCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	projects, err := context.Client.GetProjectNames()
+	projects, err := context.GetClient().GetProjectNames()
 	if err != nil {
 		return completions
 	}
@@ -185,7 +185,7 @@ var ProjectNameCompletionHandler = func(cmd *cobra.Command, args parsedArgs, con
 var URLCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
 
-	urls, err := url.ListPushed(context.Client, context.Component(), context.Application)
+	urls, err := url.ListPushed(context.GetClient(), context.Component(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -229,7 +229,7 @@ var StorageDeleteCompletionHandler = func(cmd *cobra.Command, args parsedArgs, c
 // StorageMountCompletionHandler provides storage name completion for storage mount
 var StorageMountCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	storages, err := storage.ListUnmounted(context.Client, context.Application)
+	storages, err := storage.ListUnmounted(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -248,7 +248,7 @@ var StorageMountCompletionHandler = func(cmd *cobra.Command, args parsedArgs, co
 // StorageUnMountCompletionHandler provides storage name completion for storage unmount
 var StorageUnMountCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	storageList, err := storage.ListMounted(context.Client, context.Component(), context.Application)
+	storageList, err := storage.ListMounted(context.GetClient(), context.Component(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -272,7 +272,7 @@ var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 
 	tasks := util.NewConcurrentTasks(2)
 	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-		catalogList, _ := catalog.ListComponents(context.Client)
+		catalogList, _ := catalog.ListComponents(context.GetClient())
 		for _, builder := range catalogList.Items {
 			if args.commands[builder.Name] {
 				found = true
@@ -304,12 +304,12 @@ var CreateCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 // LinkCompletionHandler provides completion for the odo link command
 // The function returns both components and services
 var LinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
-	components, err := component.GetComponentNames(context.Client, context.Application)
+	components, err := component.GetComponentNames(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
 
-	services, err := service.List(context.Client, context.Application)
+	services, err := service.List(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -343,17 +343,17 @@ var LinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *g
 // The function returns both components and services
 var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	// first we need to retrieve the current component
-	comp, err := component.GetPushedComponent(context.Client, context.Component(), context.Application)
+	comp, err := component.GetPushedComponent(context.GetClient(), context.Component(), context.Application)
 	if err != nil {
 		return completions
 	}
 
-	components, err := component.GetComponentNames(context.Client, context.Application)
+	components, err := component.GetComponentNames(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
 
-	services, err := service.List(context.Client, context.Application)
+	services, err := service.List(context.GetClient(), context.Application)
 	if err != nil {
 		return completions
 	}
@@ -397,7 +397,7 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 // ComponentNameCompletionHandler provides component name completion
 var ComponentNameCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context *genericclioptions.Context) (completions []string) {
 	completions = make([]string, 0)
-	components, err := component.List(context.Client, context.Application, nil)
+	components, err := component.List(context.GetClient(), context.Application, nil)
 
 	if err != nil {
 		return completions

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -70,7 +70,7 @@ func TestServicePlanCompletionHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		client, fakeClientSet := occlient.FakeNew()
-		context := genericclioptions.NewFakeContext("project", "app", "component", client, nil)
+		context := genericclioptions.NewFakeContext("testproject", "app", "component", client)
 
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, tt.returnedServiceClass, nil
@@ -192,7 +192,7 @@ func TestServiceParameterCompletionHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		client, fakeClientSet := occlient.FakeNew()
-		context := genericclioptions.NewFakeContext("project", "app", "component", client, nil)
+		context := genericclioptions.NewFakeContext("testproject", "app", "component", client)
 
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, tt.returnedServiceClass, nil
@@ -342,7 +342,7 @@ func TestLinkCompletionHandler(t *testing.T) {
 		parsedArgs := parsedArgs{
 			commands: make(map[string]bool),
 		}
-		context := genericclioptions.NewFakeContext("project", "app", tt.component, client, nil)
+		context := genericclioptions.NewFakeContext("project", "app", tt.component, client)
 
 		fakeClientSet.ProjClientset.PrependReactor("get", "projects", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, &testingutil.FakeOnlyOneExistingProjects().Items[0], nil
@@ -542,7 +542,7 @@ func TestUnlinkCompletionHandler(t *testing.T) {
 		parsedArgs := parsedArgs{
 			commands: make(map[string]bool),
 		}
-		context := genericclioptions.NewFakeContext("project", "app", tt.component, client, client.GetKubeClient())
+		context := genericclioptions.NewFakeContext("project", "app", tt.component, client)
 
 		//fake the services
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -643,7 +643,7 @@ func TestServiceCompletionHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		client, fakeClientSet := occlient.FakeNew()
-		context := genericclioptions.NewFakeContext("project", "app", "component", client, nil)
+		context := genericclioptions.NewFakeContext("testproject", "app", "component", client)
 
 		//fake the services
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -728,7 +728,7 @@ func TestServiceClassCompletionHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		client, fakeClientSet := occlient.FakeNew()
-		context := genericclioptions.NewFakeContext("project", "app", "component", client, nil)
+		context := genericclioptions.NewFakeContext("testproject", "app", "component", client)
 
 		//fake the services
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "clusterserviceclasses", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/odo/util/completion/completionhandlers_test.go
+++ b/pkg/odo/util/completion/completionhandlers_test.go
@@ -542,7 +542,7 @@ func TestUnlinkCompletionHandler(t *testing.T) {
 		parsedArgs := parsedArgs{
 			commands: make(map[string]bool),
 		}
-		context := genericclioptions.NewFakeContext("project", "app", tt.component, client, nil)
+		context := genericclioptions.NewFakeContext("project", "app", tt.component, client, client.GetKubeClient())
 
 		//fake the services
 		fakeClientSet.ServiceCatalogClientSet.PrependReactor("list", "serviceinstances", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -122,7 +122,7 @@ func fakeDeleteClient(namespace string, deleteLast bool) (*occlient.Client, *occ
 	configOverrides := &clientcmd.ConfigOverrides{}
 	client.KubeConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
-	client.Namespace = "testing"
+	client.SetNamespace("testing")
 	fkWatch := watch.NewFake()
 
 	fakeClientSet.ProjClientset.PrependReactor("list", "projects", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -270,7 +270,7 @@ func TestCreate(t *testing.T) {
 
 			// The function we are testing
 			context := genericclioptions.NewFakeContext(tt.projectName, "app", "cmp", client, kubeClient)
-			context.Client.SetDiscoveryInterface(fakeDiscoveryWithProject)
+			context.GetClient().SetDiscoveryInterface(fakeDiscoveryWithProject)
 
 			err := Create(context, tt.projectName, true)
 
@@ -295,7 +295,7 @@ func TestCreate(t *testing.T) {
 
 			// The function we are testing
 			context := genericclioptions.NewFakeContext(tt.projectName, "app", "cmp", client, kclient)
-			context.Client.SetDiscoveryInterface(fakeDiscoveryWithNamespace)
+			context.GetClient().SetDiscoveryInterface(fakeDiscoveryWithNamespace)
 
 			err := Create(context, tt.projectName, true)
 
@@ -363,7 +363,7 @@ func TestDelete(t *testing.T) {
 			kclient, _ := fakeDeleteKClient(tt.projectName, tt.deleteLast)
 
 			context := genericclioptions.NewFakeContext(tt.projectName, "app", "cmp", client, kclient)
-			context.Client.SetDiscoveryInterface(fakeDiscoveryWithProject)
+			context.GetClient().SetDiscoveryInterface(fakeDiscoveryWithProject)
 
 			// The function we are testing
 			err := Delete(context, tt.projectName, tt.wait)
@@ -389,7 +389,7 @@ func TestDelete(t *testing.T) {
 			kubeClient, fakeKClientSet := fakeDeleteKClient(tt.projectName, tt.deleteLast)
 
 			context := genericclioptions.NewFakeContext(tt.projectName, "app", "cmp", client, kubeClient)
-			context.Client.SetDiscoveryInterface(fakeDiscoveryWithNamespace)
+			context.GetClient().SetDiscoveryInterface(fakeDiscoveryWithNamespace)
 
 			// The function we are testing
 			err := Delete(context, tt.projectName, tt.wait)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -32,7 +32,7 @@ func componentTests(args ...string) {
 
 	// Clean up after the test
 	// This is run after every Spec (It)
-	var _ = AfterEach(func() {
+	AfterEach(func() {
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
 		// KUBECONFIG defaults to ~/.kube/config so it can be empty in some cases.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR delays the need to connect to a cluster until it's actually needed. This is accomplished by:
1. delay resolution of project/namespace until needed
1. avoid creating a client (and thus requiring a valid kube config) until needed
1. remove requirement to provide a namespace when creating a devfile component (the namespace is resolved when pushing)
1. update the env file to properly reflect the namespace / name changes when the component is pushed

This is required for `odo create` to work without being connected to a cluster.

**Which issue(s) this PR fixes**:

Fixes #3811

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo create` would fail if not connected to a cluster before this PR. `odo create` should work even when not connected after.