### PR TITLE
Implementing missing --now for component create with devfile

### DIFF
--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -332,6 +332,17 @@ var _ = Describe("odo devfile create command tests", func() {
 		})
 	})
 
+	It("checks that odo push works with a devfile with now flag", func() {
+		originalDir := helper.Getwd()
+		context2 := helper.CreateNewContext()
+		helper.Chdir(context2)
+		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+		output := helper.CmdShouldPass("odo", "create", "--starter", "nodejs", "--now")
+		Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+		helper.Chdir(originalDir)
+		helper.DeleteDir(context2)
+	})
+
 	// Currently these tests need interactive mode in order to set the name of the component.
 	// Once this feature is added we can change these tests.
 	//Context("When executing odo create with devfile component and --downloadSource flag with github type", func() {

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -179,12 +179,6 @@ var _ = Describe("odo devfile create command tests", func() {
 			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(context, "sb.jar"), "--context", context)
 			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when in experimental mode."))
 		})
-
-		It("should fail the create command as --now flag, which is specific to s2i component creation, is used without --s2i flag", func() {
-			componentName := helper.RandString(6)
-			output := helper.CmdShouldFail("odo", "create", "nodejs", componentName, "--now")
-			Expect(output).Should(ContainSubstring("flag --now, requires --s2i flag to be set, when in experimental mode."))
-		})
 	})
 
 	Context("When executing odo create with devfile component type argument and --project flag", func() {


### PR DESCRIPTION
 - --now flag now works with component create with devfiles
 - cleaning up the component create a little bit
 - adding integration tests for implemented functionality

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test

/kind feature

> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
see above

**Which issue(s) this PR fixes**:
Fixes #3469 



**PR acceptance criteria**:

- [x] Integration test 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
❯ odo create nodejs --now
Experimental mode is enabled, use at your own risk

Validation
 ✓  Checking devfile existence [25112ns]
 ✓  Checking devfile compatibility [36832ns]
 ✓  Creating a devfile component from registry: default [41959ns]
 ✓  Validating devfile component [66528ns]

Validation
 ✓  Validating the devfile [31360ns]

Creating Kubernetes resources for component nodejs
 ✓  Waiting for component to start [9s]

Applying URL changes
 ✓  URL http-3000: http://http-3000-nodejs-mzee1000-test.apps.testocp4x.psiodo.net/ created

Syncing to component nodejs
 ✓  Checking files for pushing [552523ns]
 ✓  Syncing files to the component [15s]

Executing devfile commands for component nodejs
 ✓  Executing install command "npm install", if not running [9s]
 ✓  Executing run command "npm start", if not running [5s]

Pushing devfile component nodejs
 ✓  Changes successfully pushed to component


```