### PR TITLE
not provide %s for namespaces in logs

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -105,6 +105,16 @@ func checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command *cobra.Command, er
 	}
 }
 
+// checkProjectCreateOrDeleteOnlyOnInvalidNamespaceNoFmt errors out if user is trying to create or delete something other than project
+// compare to checkProjectCreateOrDeleteOnlyOnInvalidNamespace, no %s is needed
+func checkProjectCreateOrDeleteOnlyOnInvalidNamespaceNoFmt(command *cobra.Command, errFormatForCommand string) {
+	// do not error out when its odo delete -a, so that we let users delete the local config on missing namespace
+	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || (command.Name() == "delete" && !command.Flags().Changed("all"))) {
+		err := fmt.Errorf(errFormatForCommand)
+		util.LogErrorAndExit(err, "")
+	}
+}
+
 // getFirstChildOfCommand gets the first child command of the root command of command
 func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
 	// If command does not have a parent no point checking
@@ -263,7 +273,7 @@ func resolveNamespace(command *cobra.Command, client *kclient.Client, envSpecifi
 		if err != nil {
 			errFormat := fmt.Sprintf("You don't have permission to create or set namespace '%s' or the namespace doesn't exist. Please create or set a different namespace\n\t", namespace)
 			// errFormat := fmt.Sprint(e1, "%s project create|set <project_name>")
-			checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command, errFormat)
+			checkProjectCreateOrDeleteOnlyOnInvalidNamespaceNoFmt(command, errFormat)
 		}
 	}
 	client.Namespace = namespace


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #3829

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo delete`