### PR TITLE
Fixing os.GetWd() usage for getting component name

### DIFF
--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -95,10 +95,10 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	}
 
 	devfileHandler, err := adapters.NewComponentAdapter(componentName, po.componentContext, po.Application, devObj, platformContext)
-
 	if err != nil {
 		return err
 	}
+
 	pushParams := common.PushParameters{
 		Path:            po.sourcePath,
 		IgnoredFiles:    po.ignores,
@@ -187,7 +187,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 	}
 	devfileHandler, err := adapters.NewComponentAdapter(componentName, do.componentContext, do.Application, devObj, kc)
 	if err != nil {
-
+		return err
 	}
 
 	return devfileHandler.Delete(labels, do.show)

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -70,10 +70,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 		return err
 	}
 
-	componentName, err := getComponentName(po.componentContext)
-	if err != nil {
-		return errors.Wrap(err, "unable to get component name")
-	}
+	componentName := po.EnvSpecificInfo.GetName()
 
 	// Set the source path to either the context or current working directory (if context not set)
 	po.sourcePath, err = util.GetAbsPath(po.componentContext)
@@ -140,11 +137,7 @@ func (lo LogOptions) DevfileComponentLog() error {
 	if err != nil {
 		return err
 	}
-
-	componentName, err := getComponentName(lo.componentContext)
-	if err != nil {
-		return errors.Wrap(err, "unable to get component name")
-	}
+	componentName := lo.Context.EnvSpecificInfo.GetName()
 
 	var platformContext interface{}
 	if pushtarget.IsPushTargetDocker() {
@@ -176,27 +169,6 @@ func (lo LogOptions) DevfileComponentLog() error {
 	return util.DisplayLog(lo.logFollow, rd, componentName)
 }
 
-// Get component name from env.yaml file
-func getComponentName(context string) (string, error) {
-	var dir string
-	var err error
-	if context == "" {
-		dir, err = os.Getwd()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		dir = context
-	}
-
-	envInfo, err := envinfo.NewEnvSpecificInfo(dir)
-	if err != nil {
-		return "", err
-	}
-	componentName := envInfo.GetName()
-	return componentName, nil
-}
-
 // DevfileComponentDelete deletes the devfile component
 func (do *DeleteOptions) DevfileComponentDelete() error {
 	// Parse devfile and validate
@@ -204,11 +176,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 	if err != nil {
 		return err
 	}
-
-	componentName, err := getComponentName(do.componentContext)
-	if err != nil {
-		return err
-	}
+	componentName := do.EnvSpecificInfo.GetName()
 
 	kc := kubernetes.KubernetesContext{
 		Namespace: do.namespace,
@@ -219,7 +187,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 	}
 	devfileHandler, err := adapters.NewComponentAdapter(componentName, do.componentContext, do.Application, devObj, kc)
 	if err != nil {
-		return err
+
 	}
 
 	return devfileHandler.Delete(labels, do.show)
@@ -227,10 +195,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 
 // RunTestCommand runs the specific test command in devfile
 func (to *TestOptions) RunTestCommand() error {
-	componentName, err := getComponentName(to.componentContext)
-	if err != nil {
-		return err
-	}
+	componentName := to.Context.EnvSpecificInfo.GetName()
 
 	var platformContext interface{}
 	if pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/util"
 
@@ -34,11 +35,12 @@ type LogOptions struct {
 	componentContext string
 	*ComponentOptions
 	devfilePath string
+	EnvInfo     *envinfo.EnvSpecificInfo
 }
 
 // NewLogOptions returns new instance of LogOptions
 func NewLogOptions() *LogOptions {
-	return &LogOptions{false, false, "", &ComponentOptions{}, ""}
+	return &LogOptions{false, false, "", &ComponentOptions{}, "", nil}
 }
 
 // Complete completes log args
@@ -50,6 +52,10 @@ func (lo *LogOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
 		lo.ComponentOptions.Context = genericclioptions.NewDevfileContext(cmd)
+		lo.EnvInfo, err = envinfo.NewEnvSpecificInfo(lo.componentContext)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/util"
 
@@ -35,12 +34,11 @@ type LogOptions struct {
 	componentContext string
 	*ComponentOptions
 	devfilePath string
-	EnvInfo     *envinfo.EnvSpecificInfo
 }
 
 // NewLogOptions returns new instance of LogOptions
 func NewLogOptions() *LogOptions {
-	return &LogOptions{false, false, "", &ComponentOptions{}, "", nil}
+	return &LogOptions{false, false, "", &ComponentOptions{}, ""}
 }
 
 // Complete completes log args
@@ -52,7 +50,6 @@ func (lo *LogOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
 		lo.ComponentOptions.Context = genericclioptions.NewDevfileContext(cmd)
-		lo.EnvInfo, err = envinfo.NewEnvSpecificInfo(lo.componentContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -50,9 +50,6 @@ func (lo *LogOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	// if experimental mode is enabled and devfile is present
 	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
 		lo.ComponentOptions.Context = genericclioptions.NewDevfileContext(cmd)
-		if err != nil {
-			return err
-		}
 		return nil
 	}
 

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -50,7 +50,9 @@ func NewTestOptions() *TestOptions {
 func (to *TestOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	to.devfilePath = filepath.Join(to.componentContext, DevfilePath)
 	to.Context = genericclioptions.NewDevfileContext(cmd)
-
+	if err != nil {
+		return err
+	}
 	return
 }
 

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -50,9 +50,6 @@ func NewTestOptions() *TestOptions {
 func (to *TestOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	to.devfilePath = filepath.Join(to.componentContext, DevfilePath)
 	to.Context = genericclioptions.NewDevfileContext(cmd)
-	if err != nil {
-		return err
-	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
/kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
See title

**Which issue(s) this PR fixes**:
Fixes #2959 

**PR acceptance criteria**:

- [ ] Existing tests should not break

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
