### PR TITLE
Add devfile registry on preferences init when ODO_EXPERIMENTAL=true

### DIFF
--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -57,7 +57,7 @@ func (o *ListOptions) Run() (err error) {
 	}
 
 	registryList := cfg.OdoSettings.RegistryList
-	if len(*registryList) == 0 {
+	if registryList == nil || len(*registryList) == 0 {
 		return fmt.Errorf("No devfile registries added to the configuration. Refer `odo registry add -h` to add one")
 	}
 

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -218,6 +218,15 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 
 	// If the preference file doesn't exist then we return with default preference
 	if _, err = os.Stat(preferenceFile); os.IsNotExist(err) {
+		// If initializing a new preferences file, make sure we add the default devfile registry to it
+		defaultRegistryList := []Registry{
+			{
+				Name:   DefaultDevfileRegistryName,
+				URL:    DefaultDevfileRegistryURL,
+				Secure: false,
+			},
+		}
+		c.OdoSettings.RegistryList = &defaultRegistryList
 		return &c, nil
 	}
 

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -218,15 +218,20 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 
 	// If the preference file doesn't exist then we return with default preference
 	if _, err = os.Stat(preferenceFile); os.IsNotExist(err) {
-		// If initializing a new preferences file, make sure we add the default devfile registry to it
-		defaultRegistryList := []Registry{
-			{
-				Name:   DefaultDevfileRegistryName,
-				URL:    DefaultDevfileRegistryURL,
-				Secure: false,
-			},
+		// Add the default devfile registry if "ODO_EXPERIMENTAL" env variable is true
+		// We specifically need to check for the experimental mode env, as `odo preferences set experimental true` already properly
+		// initializes the default devfile registries.
+		experimentalEnvStr, _ := os.LookupEnv("ODO_EXPERIMENTAL")
+		if experimentalEnvStr == "true" {
+			defaultRegistryList := []Registry{
+				{
+					Name:   DefaultDevfileRegistryName,
+					URL:    DefaultDevfileRegistryURL,
+					Secure: false,
+				},
+			}
+			c.OdoSettings.RegistryList = &defaultRegistryList
 		}
-		c.OdoSettings.RegistryList = &defaultRegistryList
 		return &c, nil
 	}
 

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -61,11 +61,12 @@ var _ = Describe("odo devfile registry command tests", func() {
 		})
 
 		It("Should list all default registries when experimental mode is set via env", func() {
-			helper.CmdShouldPass("odo", "preference", "unset", "Experimental")
-			os.Setenv("ODO_EXPERIMENTAL", "true")
-			output := helper.CmdShouldPass("odo", "registry", "list")
+			// Point to an alternative global odo config for this test case (want to test without any preferences file)
+			// And set experimental mode via env
+			fakeConfig := filepath.Join(context, "fakeconfig.yaml")
+			env := []string{"GLOBALODOCONFIG=" + fakeConfig, "ODO_EXPERIMENTAL=true"}
+			output := helper.CmdShouldPassWithEnv(env, "odo", "registry", "list")
 			helper.MatchAllInOutput(output, []string{"DefaultDevfileRegistry"})
-			os.Unsetenv("ODO_EXPERIMENTAL")
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 	// Using program commmand according to cliRunner in devfile
 	cliRunner := helper.GetCliRunner()
 
-	// This is run after every Spec (It)
+	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
@@ -58,6 +58,14 @@ var _ = Describe("odo devfile registry command tests", func() {
 			output := helper.CmdShouldFail("odo", "registry", "list")
 			helper.MatchAllInOutput(output, []string{"No devfile registries added to the configuration. Refer `odo registry add -h` to add one"})
 
+		})
+
+		It("Should list all default registries when experimental mode is set via env", func() {
+			helper.CmdShouldPass("odo", "preference", "unset", "Experimental")
+			os.Setenv("ODO_EXPERIMENTAL", "true")
+			output := helper.CmdShouldPass("odo", "registry", "list")
+			helper.MatchAllInOutput(output, []string{"DefaultDevfileRegistry"})
+			os.Unsetenv("ODO_EXPERIMENTAL")
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
This PR is mostly a backport of https://github.com/johnmcollier/odo/commit/274acb72db1fb3ac4ec06104dae639856d6602f2, which was delivered into the odov2 alpha release

This PR fixes a panic that can be seen when `odo registry list` is called but the preferences file does not yet exist (and experimental mode is set via `ODO_EXPERIMENTAL=true`). What was happening was that when retrieve a preferences file, we only add the default devfile registry if the preferences file already exists, if we have to create and initialize the preferences file, we don't add the registry.  So a simple solution is to make sure we add the devfile registries when we create and initialize the preferences file.

I also added an integration test case to verify this scenario. As this bug was specific to when `ODO_EXPERIMENTAL` was set, I had to add some wrapper functions that allow us to pass in env variables to commands in the test framework.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3842

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. Delete `~/.odo/preference.yaml`
2. Run `export ODO_EXPERIMENTAL=true`
3. Run `odo registry list`, verify the default registry is listed and noo panic occurs.