### PR TITLE
Remove experimental mode from docs

### DIFF
--- a/docs/public/debugging-using-devfile.adoc
+++ b/docs/public/debugging-using-devfile.adoc
@@ -2,7 +2,7 @@
 
 `odo` uses devfiles to build and deploy components. More information on devifles : https://redhat-developer.github.io/devfile/[Introduction to devfile]
 
-To enable debugging mode for the component using devfiles, we need to enable the experimental mode for odo. This can be done by: `odo preference set experimental true`. We also need a devfile with `debugrun` step. Example of a nodejs devfile with a debugrun step:
+In order to use `odo debug` your devfile is required to have a `debugrun` step. Example of a nodejs devfile with a debugrun step:
 
 ```yaml
 apiVersion: 1.0.0

--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -33,8 +33,6 @@ An example deployment scenario:
 
 ==== Prerequisites for an OpenShift Cluster
 
-* Enable experimental mode for odo. This can be done by: `odo preference set experimental true`
-
 * Create a project to keep your source code, tests, and libraries organized in a separate single unit.
 
 . Log in to an OpenShift cluster:
@@ -55,8 +53,6 @@ An example deployment scenario:
 
 
 ==== Prerequisites for a Kubernetes Cluster
-
-* Enable experimental mode for odo. This can be done by: `odo preference set experimental true`
 
 * Before proceeding, you must know your ingress domain name or ingress IP to specify `--host` for `odo url create`.
 +

--- a/docs/public/operator-hub.adoc
+++ b/docs/public/operator-hub.adoc
@@ -13,7 +13,6 @@ Odo utilizes Operators and link:https://operatorhub.io/[Operator Hub] in order t
 ==== Prerequisites
 
 * You must have cluster permissions to install an Operator on either link:https://docs.openshift.com/container-platform/4.3/operators/olm-adding-operators-to-cluster.html[OpenShift] or link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md[Kubernetes].
-* Enable experimental mode for odo. This can be done by: `odo preference set experimental true`
 
 == Creating a project
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

There are outdated portions of our documentation that asks for you to
enable experimental mode before using Devfile or Operator Hub.

Both of those have moved out of experimental mode.

Since our website (https://odo.dev) reflects using the `alpha` release,
we must update the outdated documentation.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [X] Unit test

- [X] Integration test

- [X] Documentation

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>