### PR TITLE
Update the help usage for odo create and odo url create

### DIFF
--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -143,8 +143,8 @@ Alternatively, you can pass in `--starter` to `odo create` to have odo download 
 +
 [source,sh]
 ----
- $ odo url create 
-  ✓  URL myspring-8080.apps-crc.testing created for component: myspring
+ $ odo url create  --host example.com
+  ✓  URL myspring-8080.example.com created for component: myspring
 
  To apply the URL configuration changes, please use odo push
 ----
@@ -164,7 +164,7 @@ NOTE: If deploying on Kubernetes, you need to pass ingress domain name via `--ho
    ✓  Waiting for component to start [5s]
 
   Applying URL changes
-   ✓  URL myspring-8080: http://myspring-8080.apps-crc.testing created
+   ✓  URL myspring-8080: http://myspring-8080.example.com created
 
   Syncing to component myspring
    ✓  Checking files for pushing [2ms]
@@ -185,14 +185,14 @@ NOTE: If deploying on Kubernetes, you need to pass ingress domain name via `--ho
  $ odo url list
  Found the following URLs for component myspring
  NAME              URL                                       PORT     SECURE
- myspring-8080     http://myspring-8080.apps-crc.testing     8080     false
+ myspring-8080     http://myspring-8080.example.com     8080     false
 ----
 
 . View your deployed application using the generated URL:
 +
 [source,sh]
 ----
-  $ curl http://myspring-8080.apps-crc.testing
+  $ curl http://myspring-8080.example.com
 ----
 
 . To delete your deployed application:
@@ -250,8 +250,8 @@ In this example we will be deploying an https://github.com/odo-devfiles/nodejs-e
 +
 [source,sh]
 ----
- $ odo url create 
-  ✓  URL mynodejs-8080.apps-crc.testing created for component: mynodejs
+ $ odo url create --host example.com
+  ✓  URL mynodejs-8080.example.com created for component: mynodejs
 
  To apply the URL configuration changes, please use odo push
 ----
@@ -271,7 +271,7 @@ NOTE: If deploying on Kubernetes, you need to pass ingress domain name via `--ho
    ✓  Waiting for component to start [3s]
 
   Applying URL changes
-   ✓  URL mynodejs-3000: http://mynodejs-3000.apps-crc.testing created
+   ✓  URL mynodejs-3000: http://mynodejs-3000.example.com created
 
   Syncing to component mynodejs
    ✓  Checking files for pushing [2ms]
@@ -292,14 +292,14 @@ NOTE: If deploying on Kubernetes, you need to pass ingress domain name via `--ho
  $ odo url list
      Found the following URLs for component mynodejs
      NAME              URL                                       PORT     SECURE
-     mynodejs-8080     http://mynodejs-8080.apps-crc.testing     8080     false
+     mynodejs-8080     http://mynodejs-8080.example.com     8080     false
 ----
 
 . View your deployed application using the generated URL:
 +
 [source,sh]
 ----
-   $ curl http://mynodejs-8080.apps-crc.testing
+   $ curl http://mynodejs-8080.example.com
 ----
 
 . To delete your deployed application:
@@ -342,8 +342,8 @@ In this example we will be deploying a https://github.com/odo-devfiles/quarkus-e
 +
 [source,sh]
 ----
- $ odo url create 
-  ✓  URL myquarkus-8080.apps-crc.testing created for component: myquarkus
+ $ odo url create  --host example.com
+  ✓  URL myquarkus-8080.example.com created for component: myquarkus
 
  To apply the URL configuration changes, please use odo push
 ----
@@ -385,7 +385,7 @@ Pushing devfile component myquarkus
  $ odo url list
  Found the following URLs for component myspring
  NAME              URL                                       PORT     SECURE
- myquarkus-8080     http://myquarkus-8080.apps-crc.testing     8080     false
+ myquarkus-8080     http://myquarkus-8080.example.com     8080     false
 ----
 
 You can now continue developing your application. Just run `odo push` and refresh your browser to view the latest changes.

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -106,25 +106,24 @@ var EnvFilePath = filepath.Join(LocalDirectoryDefaultLocation, envFile)
 // ConfigFilePath is the path of config.yaml for s2i component
 var ConfigFilePath = filepath.Join(LocalDirectoryDefaultLocation, configFile)
 
-var createLongDesc = ktemplates.LongDesc(`Create a configuration describing a component.
+var createLongDesc = ktemplates.LongDesc(`Create a configuration describing a component.`)
 
-If a component name is not provided, it'll be auto-generated.
+var createExample = ktemplates.Examples(`# Create a new Node.JS component with existing sourcecode as well as specifying a name
+%[1]s nodejs mynodejs
 
-A full list of component types that can be deployed is available using: 'odo catalog list components'
-
-By default, builder images (component type) will be used from the current namespace. You can explicitly supply a namespace by using: odo create namespace/name:version
-If version is not specified by default, latest will be chosen as the version.`)
-
-var createExample = ktemplates.Examples(`  # Create new Node.js component with the source in current directory.
-
-Note: When you use odo with experimental mode enabled and create devfile component, if you want to use existing devfile the first argument will be the component name
-# Create new Node.js component with existing devfile
-%[1]s mynodejs (devfile exists in current working directory)
-%[1]s mynodejs --devfile ./devfile.yaml (devfile exists in any other directory)
-%[1]s mynodejs --devfile https://raw.githubusercontent.com/elsony/devfile-registry/master/devfiles/nodejs/devfile.yaml (devfile exists in network)
-
-# Create new Node.js component
+# Name is not required and will be automatically generated if not passed
 %[1]s nodejs
+
+# List all available components before deploying
+odo catalog list components
+%[1]s java-quarkus
+
+# Download an example devfile and application before deploying
+%[1]s nodejs --starter
+
+# Using a specific devfile
+%[1]s mynodejs --devfile ./devfile.yaml
+%[1]s mynodejs --devfile https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/devfile.yaml
 
 # Create new Node.js component named 'frontend' with the source in './frontend' directory
 %[1]s nodejs frontend --context ./frontend
@@ -136,10 +135,7 @@ Note: When you use odo with experimental mode enabled and create devfile compone
 %[1]s nodejs --git https://github.com/openshift/nodejs-ex.git
 
 # Create new Node.js component with custom ports and environment variables
-%[1]s nodejs --port 8080,8100/tcp,9100/udp --env key=value,key1=value1
-
-# Create new Node.js component and download the sample project named nodejs-starter
-%[1]s nodejs --starter=nodejs-starter`)
+%[1]s nodejs --port 8080,8100/tcp,9100/udp --env key=value,key1=value1`)
 
 const defaultStarterProjectName = "devfile-starter-project-name"
 

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -44,20 +44,20 @@ var (
 	%[1]s example --port 8080
 	  `)
 
-	urlCreateExampleExperimental = ktemplates.Examples(`  # Create a URL with a specific host by automatically detecting the port used by the component (using CRC as an exampple)
-	%[1]s example  --host apps-crc.testing
+	urlCreateExampleExperimental = ktemplates.Examples(`  # Create the URL myurl.example.com by automatically detecting the port used by the component
+	%[1]s myurl  --host example.com
   
-	# Create a URL with a specific name and host (using CRC as an example)
-	%[1]s example --host apps-crc.testing
+	# Create a URL with a specific name and host
+	%[1]s myurl --host example.com
 
-	# Create a URL for the current component with a specific port and host (using CRC as an example)
-	%[1]s --port 8080 --host apps-crc.testing
+	# Create a URL for the current component with a specific port and host
+	%[1]s --port 8080 --host example.com
 
-	# Create a URL of ingress kind for the current component with a host (using CRC as an example)
-	%[1]s --host apps-crc.testing --ingress
+	# Create a URL of ingress kind for the current component with a host
+	%[1]s --host example.com --ingress
 
-	# Create a secure URL for the current component with a specific host (using CRC as an example)
-	%[1]s --host apps-crc.testing --secure
+	# Create a secure URL for the current component with a specific host
+	%[1]s --host example.com --secure
 	  `)
 
 	urlCreateExampleDocker = ktemplates.Examples(`  # Create a URL with a specific name by automatically detecting the port used by the component


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup
/kind documentation

**What does does this PR do / why we need it**:

Updates the `--help` in the following way:
 - Changes the `odo create --help` usage to a 1-sentence summary similar
 to every other command
 - Updates our documentation to remove any mention of crc for something
 more neutral (example.com) similar to kubectl / kubernetes
 documentation, for example: https://kubernetes.io/docs/concepts/services-networking/ingress/

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3463

**PR acceptance criteria**:

- [X] Documentation

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

`odo create --help`

and

`odo url create --help`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>