### PR TITLE
Fix #3841 - odo watch redeploys component during first push 

### DIFF
--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -209,6 +209,7 @@ func (wo *WatchOptions) Run() (err error) {
 			os.Stdout,
 			watch.WatchParameters{
 				ComponentName:       wo.componentName,
+				ApplicationName:     wo.Context.Application,
 				Path:                wo.sourcePath,
 				FileIgnores:         util.GetAbsGlobExps(wo.sourcePath, wo.ignores),
 				PushDiffDelay:       wo.delay,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:

As per the linked issue, `odo watch` is redeploying the application on first use, but shouldn't be. This is because the application name is not set properly in the watch parameters of `pkg/odo/cli/component/watch.go`, which causes the `"app.kubernetes.io/part-of"` label to be incorrectly set to `""` on the watch-initiated deployment.

Since the `part-of` label has (incorrectly) changed (to `""` from `"app"`, for example), the push logic detects this as a deployment change, and performs a redeploy.  This is why the redeploy is occurring. Fixing the application name at the source (`watch.go`) resolves the issue.

Application name is not being set on the watch parameters, which causes the push code to detect

**Which issue(s) this PR fixes**:

Fixes #3841

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

See reproduction steps on https://github.com/openshift/odo/issues/3841