### PR TITLE
Updating cross-compile script to produce stripped binaries

### DIFF
--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -14,8 +14,8 @@ fi
 for platform in linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64 windows-amd64 ; do
   echo "Cross compiling $platform and placing binary at dist/bin/$platform/"
   if [ $platform == "windows-amd64" ]; then
-    GOARCH=amd64 GOOS=windows go build -o dist/bin/$platform/odo.exe -ldflags="$COMMON_FLAGS" ./cmd/odo/
+    GOARCH=amd64 GOOS=windows go build -o dist/bin/$platform/odo.exe -ldflags="-s -w $COMMON_FLAGS" ./cmd/odo/
   else
-    GOARCH=${platform#*-} GOOS=${platform%-*} go build -o dist/bin/$platform/odo -ldflags="$COMMON_FLAGS" ./cmd/odo/
+    GOARCH=${platform#*-} GOOS=${platform%-*} go build -o dist/bin/$platform/odo -ldflags="-s -w $COMMON_FLAGS" ./cmd/odo/
   fi
 done


### PR DESCRIPTION
 - This is a soft requirement for downstream releases
   which will need waiver every time, if not done

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>


```
❯ make bin
go build -ldflags="-w -X github.com/openshift/odo/pkg/version.GITCOMMIT=9a32c42a9" cmd/odo/odo.go
❯ objdump --syms ./odo | grep debug
0000000002009460 l     O .rodata	0000000000000014              debugCallFrameTooLarge
000000000045dea0 l     F .text	0000000000000049              debugCall32
000000000045def0 l     F .text	0000000000000049              debugCall64
000000000045df40 l     F .text	000000000000006d              debugCall128
000000000045dfb0 l     F .text	0000000000000070              debugCall256
000000000045e020 l     F .text	0000000000000070              debugCall512
000000000045e090 l     F .text	0000000000000070              debugCall1024
000000000045e100 l     F .text	0000000000000070              debugCall2048
000000000045e170 l     F .text	0000000000000082              debugCall4096
000000000045e200 l     F .text	0000000000000082              debugCall8192
000000000045e290 l     F .text	0000000000000082              debugCall16384
000000000045e320 l     F .text	0000000000000082              debugCall32768
000000000045e3b0 l     F .text	0000000000000082              debugCall65536
...
00000000017b6590 g     F .text	000000000000009b              github.com/openshift/odo/pkg/odo/cli/debug.PortForwardOptions.Component
00000000017b6630 g     F .text	00000000000000aa              github.com/openshift/odo/pkg/odo/cli/debug.PortForwardOptions.ComponentAllowingEmpty


❯ make prepare-release
./scripts/cross-compile.sh '-X github.com/openshift/odo/pkg/version.GITCOMMIT=9a32c42a9'
Cross compiling linux-amd64 and placing binary at dist/bin/linux-amd64/
Cross compiling linux-arm64 and placing binary at dist/bin/linux-arm64/
Cross compiling linux-ppc64le and placing binary at dist/bin/linux-ppc64le/
Cross compiling linux-s390x and placing binary at dist/bin/linux-s390x/
Cross compiling darwin-amd64 and placing binary at dist/bin/darwin-amd64/
Cross compiling windows-amd64 and placing binary at dist/bin/windows-amd64/
./scripts/prepare-release.sh
gzipping binary ./dist/bin/darwin-amd64/odo as ./dist/release/odo-darwin-amd64
odo
copying binary ./dist/bin/darwin-amd64/odo to release directory
gzipping binary ./dist/bin/linux-amd64/odo as ./dist/release/odo-linux-amd64
odo
copying binary ./dist/bin/linux-amd64/odo to release directory
gzipping binary ./dist/bin/linux-arm64/odo as ./dist/release/odo-linux-arm64
odo
copying binary ./dist/bin/linux-arm64/odo to release directory
gzipping binary ./dist/bin/linux-ppc64le/odo as ./dist/release/odo-linux-ppc64le
odo
copying binary ./dist/bin/linux-ppc64le/odo to release directory
gzipping binary ./dist/bin/linux-s390x/odo as ./dist/release/odo-linux-s390x
odo
copying binary ./dist/bin/linux-s390x/odo to release directory
gzipping binary ./dist/bin/windows-amd64/odo.exe as ./dist/release/odo-windows-amd64.exe
odo.exe
copying binary ./dist/bin/windows-amd64/odo.exe to release directory
generating SHA256_SUM for release packages
The SHA256 SUM for the release packages are:
be485165078fd03cd02de676c694a8d4c7810e0f06ad017c8dd91d12adc5113a odo-darwin-amd64.tar.gz
5d2f8679688a660e15dfac7803d2652cafb5f8cfceb5705231465461d637dc65 odo-darwin-amd64
abb8b10c1afba2ed13076b8fe3474a482b2f57cb0a15ede391725fd424577621 odo-linux-s390x.tar.gz
d218e63ca39d91a20c925c9426374bd69a932fc96b6ca9d0f4a3434128639a5c odo-linux-arm64.tar.gz
6a759fed2ed4d8944cdbfefb8e59b6c36f0fdaa39c89b8a15c1beab91a3bb174 odo-windows-amd64.exe.tar.gz
61b8da098ee884669c58651fb9a0d945588a52de3e2c97e5c842f2c8a45dfa8e odo-linux-amd64
515e22205a20585ddc6e9e0b05708447db0ee831a7c06457ccf6f0256137d6e5 odo-linux-ppc64le
77aaf876a3295c7b6ad30effe106ccccfabb94ea1a2d9c3d3cd9bf4332ffaf81 odo-windows-amd64.exe
1f4dad26f524a8ff3b8a9979e9ffdfd0cac6b79d88a107b40e5f0e3b4655adc4 odo-linux-amd64.tar.gz
528746de18060c1db624507ca5484f3132c3ac07665949888bfd00db3a286466 odo-linux-s390x
2f2ad259020719935d20e27dcae0a8368559552d9d433eff3210932ec364bd2a odo-linux-arm64
950edf423fb708114c591aefcd509a3a98dc9dde28af3d1c9c3fc496a85a8d1c odo-linux-ppc64le.tar.gz


## Dumped a few

❯ objdump --syms ./dist/bin/linux-amd64/odo | grep debug
❯ objdump --syms ./dist/bin/linux-ppc64le/odo | grep debug
❯ objdump --syms ./dist/bin/linux-arm64/odo | grep debug
❯ objdump --syms ./dist/bin/linux-s390x/odo | grep debug
❯ objdump --syms ./dist/bin/windows-amd64/odo.exe | grep debug

```