### PR TITLE
Categorizes debugging information

### DIFF
--- a/docs/dev/logging.adoc
+++ b/docs/dev/logging.adoc
@@ -2,6 +2,21 @@
 
 https://github.com/kubernetes/klog[Klog] is used for V style logging in `odo`.
 
+== Logging categories
+
+Each logging output is categorizes into logging levels.
+
+[cols=",",options="header",]
+|===
+|Logging value |Output
+|V(0) |General information
+|V(1) |Experimental debugging output / testing suite
+|V(2) |Devfile debugging output
+|V(3) |Kubernetes and OpenShift client debugging output
+|V(4) |Generic debugging information
+|V(10) |Kubernetes and OpenShift HTTP library debugging output
+|===
+
 == Working
 
 Every `odo` command takes an optional flag `-v` that must be used with an integer log level in the range from 0-9. Any INFO severity log statement that is logged at a level lesser than or equal to the one passed with the command alongside `-v` flag will be logged to STDOUT.
@@ -10,7 +25,7 @@ Alternatively, enviroment variable `ODO_LOG_LEVEL` can be used to set the verbos
 
 All ERROR severity level log messages will always be logged regardless of the values of `v` or `ODO_LOG_LEVEL`.
 
-In order to list multiple log levels, you can provide `--vmodule` to odo. For example: `--vmodule 1,2,3` to list log levels 1, 2 and 3.
+In order to list multiple log levels, you can provide `--vmodule` to odo. `--vmodule` takes a key=value command-deliminated output. For example: `--vmodule "*=1,*=2,*=3"` to list log levels 1, 2 and 3 for all files (`*`), while `--vmodule "occlient=3"` would list all 3 level log messages in the `occlient` folder.
 
 == Usage
 

--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -94,7 +94,7 @@ func getCommandFromDevfile(data data.DevfileData, groupType common.DevfileComman
 	if groupType == common.RunCommandGroupType || groupType == common.TestCommandGroupType {
 		err = fmt.Errorf(msg)
 	} else {
-		klog.V(4).Info(msg)
+		klog.V(2).Info(msg)
 	}
 
 	return
@@ -292,11 +292,11 @@ func ValidateAndGetPushDevfileCommands(data data.DevfileData, devfileInitCmd, de
 	if isInitCmdEmpty && initCmdErr == nil {
 		// If there was no init command specified through odo push and no default init command in the devfile, default validate to true since the init command is optional
 		isInitCommandValid = true
-		klog.V(4).Infof("No init command was provided")
+		klog.V(2).Infof("No init command was provided")
 	} else if !isInitCmdEmpty && initCmdErr == nil {
 		isInitCommandValid = true
 		commandMap[common.InitCommandGroupType] = initCommand
-		klog.V(4).Infof("Init command: %v", initCommand.GetID())
+		klog.V(2).Infof("Init command: %v", initCommand.GetID())
 	}
 
 	buildCommand, buildCmdErr := GetBuildCommand(data, devfileBuildCmd)
@@ -305,18 +305,18 @@ func ValidateAndGetPushDevfileCommands(data data.DevfileData, devfileInitCmd, de
 	if isBuildCmdEmpty && buildCmdErr == nil {
 		// If there was no build command specified through odo push and no default build command in the devfile, default validate to true since the build command is optional
 		isBuildCommandValid = true
-		klog.V(4).Infof("No build command was provided")
+		klog.V(2).Infof("No build command was provided")
 	} else if !reflect.DeepEqual(emptyCommand, buildCommand) && buildCmdErr == nil {
 		isBuildCommandValid = true
 		commandMap[common.BuildCommandGroupType] = buildCommand
-		klog.V(4).Infof("Build command: %v", buildCommand.GetID())
+		klog.V(2).Infof("Build command: %v", buildCommand.GetID())
 	}
 
 	runCommand, runCmdErr := GetRunCommand(data, devfileRunCmd)
 	if runCmdErr == nil && !reflect.DeepEqual(emptyCommand, runCommand) {
 		isRunCommandValid = true
 		commandMap[common.RunCommandGroupType] = runCommand
-		klog.V(4).Infof("Run command: %v", runCommand.GetID())
+		klog.V(2).Infof("Run command: %v", runCommand.GetID())
 	}
 
 	// If either command had a problem, return an empty list of commands and an error
@@ -356,7 +356,7 @@ func ValidateAndGetDebugDevfileCommands(data data.DevfileData, devfileDebugCmd s
 	debugCommand, debugCmdErr := GetDebugCommand(data, devfileDebugCmd)
 	if debugCmdErr == nil && !reflect.DeepEqual(emptyCommand, debugCommand) {
 		isDebugCommandValid = true
-		klog.V(4).Infof("Debug command: %v", debugCommand.Exec.Id)
+		klog.V(2).Infof("Debug command: %v", debugCommand.Exec.Id)
 	}
 
 	if !isDebugCommandValid {
@@ -377,7 +377,7 @@ func ValidateAndGetTestDevfileCommands(data data.DevfileData, devfileTestCmd str
 	testCommand, testCmdErr := GetTestCommand(data, devfileTestCmd)
 	if testCmdErr == nil && !reflect.DeepEqual(emptyCommand, testCommand) {
 		isTestCommandValid = true
-		klog.V(4).Infof("Test command: %v", testCommand.GetID())
+		klog.V(2).Infof("Test command: %v", testCommand.GetID())
 	}
 
 	if !isTestCommandValid && testCmdErr != nil {

--- a/pkg/devfile/adapters/common/exec.go
+++ b/pkg/devfile/adapters/common/exec.go
@@ -24,7 +24,7 @@ func ExecuteCommand(client ExecClient, compInfo ComponentInfo, command []string,
 
 	var cmdOutput string
 
-	klog.V(4).Infof("Executing command %v for pod: %v in container: %v", command, compInfo.PodName, compInfo.ContainerName)
+	klog.V(2).Infof("Executing command %v for pod: %v in container: %v", command, compInfo.PodName, compInfo.ContainerName)
 
 	// Read stdout and stderr, store their output in cmdOutput, and also pass output to consoleOutput Writers (if non-nil)
 	stdoutCompleteChannel := startReaderGoroutine(stdoutReader, show, &cmdOutput, consoleOutputStdout)
@@ -40,7 +40,7 @@ func ExecuteCommand(client ExecClient, compInfo ComponentInfo, command []string,
 
 	if err != nil {
 		// It is safe to read from cmdOutput here, as the goroutines are guaranteed to have terminated at this point.
-		klog.V(4).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
+		klog.V(2).Infof("ExecuteCommand returned an an err: %v. for command '%v'. output: %v", err, command, cmdOutput)
 
 		return errors.Wrapf(err, "unable to exec command %v: \n%v", command, cmdOutput)
 	}
@@ -104,7 +104,7 @@ func CreateConsoleOutputWriterAndChannel() (*io.PipeWriter, chan []string) {
 			line, _, err := bufReader.ReadLine()
 			if err != nil {
 				if err != io.EOF {
-					klog.V(4).Infof("Unexpected error on reading container output reader: %v", err)
+					klog.V(2).Infof("Unexpected error on reading container output reader: %v", err)
 				}
 
 				break

--- a/pkg/devfile/adapters/common/generic.go
+++ b/pkg/devfile/adapters/common/generic.go
@@ -146,7 +146,7 @@ func (a GenericAdapter) ExecDevfile(commandsMap PushCommandsMap, componentExists
 		// we do not need to restart Hot reload capable commands
 		if componentExists {
 			if restart {
-				klog.V(4).Infof("supervisord stop command to restart or start other command")
+				klog.V(2).Infof("supervisord stop command to restart or start other command")
 				if cmd, err := newSupervisorStopCommand(command, a); cmd != nil {
 					if err != nil {
 						return err
@@ -154,7 +154,7 @@ func (a GenericAdapter) ExecDevfile(commandsMap PushCommandsMap, componentExists
 					commands = append(commands, cmd)
 				}
 			} else {
-				klog.V(4).Infof("command is hot reload capable, not restarting %s", defaultCmd)
+				klog.V(2).Infof("command is hot reload capable, not restarting %s", defaultCmd)
 			}
 		}
 

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -110,7 +110,7 @@ type CommandNames struct {
 func isContainer(component common.DevfileComponent) bool {
 	// Currently odo only uses devfile components of type container, since most of the Che registry devfiles use it
 	if component.Container != nil {
-		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.ContainerComponentType, component.Container.Name)
+		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", common.ContainerComponentType, component.Container.Name)
 		return true
 	}
 	return false
@@ -119,7 +119,7 @@ func isContainer(component common.DevfileComponent) bool {
 // isVolume checks if the component is a volume
 func isVolume(component common.DevfileComponent) bool {
 	if component.Volume != nil {
-		klog.V(4).Infof("Found component \"%v\" with name \"%v\"\n", common.VolumeComponentType, component.Volume.Name)
+		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", common.VolumeComponentType, component.Volume.Name)
 		return true
 	}
 	return false

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -293,7 +293,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 	for _, container := range componentContainer {
 
-		klog.V(4).Infof("Deleting container %s for component %s", container.ID, componentName)
+		klog.V(2).Infof("Deleting container %s for component %s", container.ID, componentName)
 		err = a.Client.RemoveContainer(container.ID)
 		if err != nil {
 			return errors.Wrapf(err, "unable to remove container ID %s of component %s", container.ID, componentName)
@@ -313,24 +313,24 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 			// Don't delete any volumes which are mapped into other containers
 			if _, exists := volumesNotToDelete[vol.Name]; exists {
-				klog.V(4).Infof("Skipping volume %s as it is mapped into a non-odo managed container", vol.Name)
+				klog.V(2).Infof("Skipping volume %s as it is mapped into a non-odo managed container", vol.Name)
 				continue
 			}
 
 			// If the volume was found to be attached to the component's container, then add the volume
 			// to the deletion list.
 			if _, ok := volumeNames[vol.Name]; ok {
-				klog.V(4).Infof("Adding volume %s to deletion list", vol.Name)
+				klog.V(2).Infof("Adding volume %s to deletion list", vol.Name)
 				volumesToDelete[vol.Name] = vol.Name
 			} else {
-				klog.V(4).Infof("Skipping volume %s as it was not attached to the component's container", vol.Name)
+				klog.V(2).Infof("Skipping volume %s as it was not attached to the component's container", vol.Name)
 			}
 		}
 	}
 
 	// Finally, delete the volumes we discovered during container deletion.
 	for name := range volumesToDelete {
-		klog.V(4).Infof("Deleting the volume %s for component %s", name, componentName)
+		klog.V(2).Infof("Deleting the volume %s for component %s", name, componentName)
 		err := a.Client.RemoveVolume(name)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to remove volume %s of component %s", name, componentName)

--- a/pkg/devfile/adapters/docker/component/utils.go
+++ b/pkg/devfile/adapters/docker/component/utils.go
@@ -58,13 +58,13 @@ func (a Adapter) createComponent() (err error) {
 			return errors.Wrapf(err, "unable to pull and start container %s for component %s", comp.Container.Name, componentName)
 		}
 	}
-	klog.V(4).Infof("Successfully created all containers for component %s", componentName)
+	klog.V(2).Infof("Successfully created all containers for component %s", componentName)
 
 	return nil
 }
 
 func (a Adapter) updateComponent() (componentExists bool, err error) {
-	klog.V(4).Info("The component already exists, attempting to update it")
+	klog.V(2).Info("The component already exists, attempting to update it")
 	componentExists = true
 	componentName := a.ComponentName
 
@@ -142,7 +142,7 @@ func (a Adapter) updateComponent() (componentExists bool, err error) {
 					return false, errors.Wrapf(err, "unable to start container for devfile component %s", comp.Container.Name)
 				}
 
-				klog.V(4).Infof("Successfully created container %s for component %s", comp.Container.Image, componentName)
+				klog.V(2).Infof("Successfully created container %s for component %s", comp.Container.Image, componentName)
 				s.End(true)
 
 				// Update componentExists so that we re-sync project and initialize supervisord if required
@@ -175,7 +175,7 @@ func (a Adapter) pullAndStartContainer(mounts []mount.Mount, comp versionsCommon
 		return errors.Wrapf(err, "unable to start container for devfile component %s", comp.Container.Name)
 	}
 
-	klog.V(4).Infof("Successfully created container %s for component %s", comp.Container.Image, a.ComponentName)
+	klog.V(2).Infof("Successfully created container %s for component %s", comp.Container.Image, a.ComponentName)
 	return nil
 }
 
@@ -450,7 +450,7 @@ func updateComponentWithSupervisord(comp *versionsCommon.DevfileComponent, runCo
 		utils.AddVolumeToContainer(supervisordVolumeName, common.SupervisordMountPath, hostConfig)
 
 		if len(comp.Container.Command) == 0 && len(comp.Container.Args) == 0 {
-			klog.V(4).Infof("Updating container %v entrypoint with supervisord", comp.Container.Name)
+			klog.V(2).Infof("Updating container %v entrypoint with supervisord", comp.Container.Name)
 			comp.Container.Command = append(comp.Container.Command, common.SupervisordBinaryPath)
 			comp.Container.Args = append(comp.Container.Args, "-c", common.SupervisordConfFile)
 		}

--- a/pkg/devfile/adapters/docker/storage/utils.go
+++ b/pkg/devfile/adapters/docker/storage/utils.go
@@ -27,7 +27,7 @@ func CreateComponentStorage(Client *lclient.Client, storages []common.Storage, c
 		}
 
 		if len(existingDockerVolName) == 0 {
-			klog.V(4).Infof("Creating a Docker volume for %v", volumeName)
+			klog.V(2).Infof("Creating a Docker volume for %v", volumeName)
 			_, err := Create(Client, volumeName, componentName, dockerVolName)
 			if err != nil {
 				return errors.Wrapf(err, "Error creating Docker volume for "+volumeName)
@@ -46,7 +46,7 @@ func Create(Client *lclient.Client, name, componentName, dockerVolName string) (
 		"storage-name": name,
 	}
 
-	klog.V(4).Infof("Creating a Docker volume with name %v and labels %v", dockerVolName, labels)
+	klog.V(2).Infof("Creating a Docker volume with name %v and labels %v", dockerVolName, labels)
 	vol, err := Client.CreateVolume(dockerVolName, labels)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create Docker volume")
@@ -81,14 +81,14 @@ func GetExistingVolume(Client *lclient.Client, volumeName, componentName string)
 		"storage-name": volumeName,
 	}
 
-	klog.V(4).Infof("Checking Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+	klog.V(2).Infof("Checking Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
 
 	vols, err := Client.GetVolumesByLabel(volumeLabels)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to get Docker volume with selectors %v", volumeLabels)
 	}
 	if len(vols) == 1 {
-		klog.V(4).Infof("Found an existing Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
+		klog.V(2).Infof("Found an existing Docker volume for volume %v and labels %v\n", volumeName, volumeLabels)
 		existingVolume := vols[0]
 		return existingVolume.Name, nil
 	} else if len(vols) == 0 {
@@ -116,7 +116,7 @@ func ProcessVolumes(client *lclient.Client, componentName string, containerNameT
 				processedVolumes[vol.Name] = true
 
 				// Generate the volume Names
-				klog.V(4).Infof("Generating Docker volumes name for %v", vol.Name)
+				klog.V(2).Infof("Generating Docker volumes name for %v", vol.Name)
 				generatedDockerVolName, err := GenerateVolName(vol.Name, componentName)
 				if err != nil {
 					return nil, nil, err
@@ -128,7 +128,7 @@ func ProcessVolumes(client *lclient.Client, componentName string, containerNameT
 					return nil, nil, err
 				}
 				if len(existingVolName) > 0 {
-					klog.V(4).Infof("Found an existing Docker volume for %v, volume %v will be re-used", vol.Name, existingVolName)
+					klog.V(2).Infof("Found an existing Docker volume for %v, volume %v will be re-used", vol.Name, existingVolName)
 					generatedDockerVolName = existingVolName
 				}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -305,7 +305,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 				processedVolumes[vol.Name] = true
 
 				// Generate the PVC Names
-				klog.V(4).Infof("Generating PVC name for %v", vol.Name)
+				klog.V(2).Infof("Generating PVC name for %v", vol.Name)
 				generatedPVCName, err := storage.GeneratePVCNameFromDevfileVol(vol.Name, componentName)
 				if err != nil {
 					return err
@@ -317,7 +317,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 					return err
 				}
 				if len(existingPVCName) > 0 {
-					klog.V(4).Infof("Found an existing PVC for %v, PVC %v will be re-used", vol.Name, existingPVCName)
+					klog.V(2).Infof("Found an existing PVC for %v, PVC %v will be re-used", vol.Name, existingPVCName)
 					generatedPVCName = existingPVCName
 				}
 
@@ -363,17 +363,17 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	}
 
 	serviceSpec := kclient.GenerateServiceSpec(objectMeta.Name, containerPorts)
-	klog.V(4).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
-	klog.V(4).Infof("The component name is %v", componentName)
+	klog.V(2).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
+	klog.V(2).Infof("The component name is %v", componentName)
 
 	if componentExists {
 		// If the component already exists, get the resource version of the deploy before updating
-		klog.V(4).Info("The component already exists, attempting to update it")
+		klog.V(2).Info("The component already exists, attempting to update it")
 		deployment, err := a.Client.UpdateDeployment(*deploymentSpec)
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("Successfully updated component %v", componentName)
+		klog.V(2).Infof("Successfully updated component %v", componentName)
 		oldSvc, err := a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Get(componentName, metav1.GetOptions{})
 		objectMetaTemp := objectMeta
 		ownerReference := kclient.GenerateOwnerReference(deployment)
@@ -385,7 +385,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 				if err != nil {
 					return err
 				}
-				klog.V(4).Infof("Successfully created Service for component %s", componentName)
+				klog.V(2).Infof("Successfully created Service for component %s", componentName)
 			}
 		} else {
 			if len(serviceSpec.Ports) > 0 {
@@ -395,7 +395,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 				if err != nil {
 					return err
 				}
-				klog.V(4).Infof("Successfully update Service for component %s", componentName)
+				klog.V(2).Infof("Successfully update Service for component %s", componentName)
 			} else {
 				err = a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Delete(componentName, &metav1.DeleteOptions{})
 				if err != nil {
@@ -408,7 +408,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("Successfully created component %v", componentName)
+		klog.V(2).Infof("Successfully created component %v", componentName)
 		ownerReference := kclient.GenerateOwnerReference(deployment)
 		objectMetaTemp := objectMeta
 		objectMetaTemp.OwnerReferences = append(objectMeta.OwnerReferences, ownerReference)
@@ -417,7 +417,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 			if err != nil {
 				return err
 			}
-			klog.V(4).Infof("Successfully created Service for component %s", componentName)
+			klog.V(2).Infof("Successfully created Service for component %s", componentName)
 		}
 
 	}
@@ -458,7 +458,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 
 	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
 	if kerrors.IsForbidden(err) {
-		klog.V(4).Infof("Resource for %s forbidden", a.ComponentName)
+		klog.V(2).Infof("Resource for %s forbidden", a.ComponentName)
 		// log the error if it failed to determine if the component exists due to insufficient RBACs
 		podSpinner.End(false)
 		log.Warningf("%v", err)

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -30,7 +30,7 @@ func CreateComponentStorage(Client *kclient.Client, storages []common.Storage, c
 		}
 
 		if len(existingPVCName) == 0 {
-			klog.V(4).Infof("Creating a PVC for %v", volumeName)
+			klog.V(2).Infof("Creating a PVC for %v", volumeName)
 			_, err := Create(Client, volumeName, volumeSize, componentName, pvcName)
 			if err != nil {
 				return errors.Wrapf(err, "Error creating PVC for "+volumeName)
@@ -68,7 +68,7 @@ func Create(Client *kclient.Client, name, size, componentName, pvcName string) (
 	objectMeta.OwnerReferences = append(objectMeta.OwnerReferences, ownerReference)
 
 	// Create PVC
-	klog.V(4).Infof("Creating a PVC with name %v and labels %v", pvcName, labels)
+	klog.V(2).Infof("Creating a PVC with name %v and labels %v", pvcName, labels)
 	pvc, err := Client.CreatePVC(objectMeta, *pvcSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create PVC")
@@ -95,14 +95,14 @@ func GetExistingPVC(Client *kclient.Client, volumeName, componentName string) (s
 
 	label := fmt.Sprintf("component=%s,%s=%s", componentName, labels.DevfileStorageLabel, volumeName)
 
-	klog.V(4).Infof("Checking PVC for volume %v and label %v\n", volumeName, label)
+	klog.V(2).Infof("Checking PVC for volume %v and label %v\n", volumeName, label)
 
 	PVCs, err := Client.GetPVCsFromSelector(label)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to get PVC with selectors "+label)
 	}
 	if len(PVCs) == 1 {
-		klog.V(4).Infof("Found an existing PVC for volume %v and label %v\n", volumeName, label)
+		klog.V(2).Infof("Found an existing PVC for volume %v and label %v\n", volumeName, label)
 		existingPVC := &PVCs[0]
 		return existingPVC.Name, nil
 	} else if len(PVCs) == 0 {

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -23,7 +23,7 @@ import (
 func ComponentExists(client kclient.Client, name string) (bool, error) {
 	deployment, err := client.GetDeploymentByName(name)
 	if kerrors.IsNotFound(err) {
-		klog.V(4).Infof("Deployment %s not found", name)
+		klog.V(2).Infof("Deployment %s not found", name)
 		return false, nil
 	}
 	return deployment != nil, err
@@ -170,7 +170,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			}
 
 			// Always mount the supervisord volume in the run component container
-			klog.V(4).Infof("Updating container %v with supervisord volume mounts", container.Name)
+			klog.V(2).Infof("Updating container %v with supervisord volume mounts", container.Name)
 			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 				Name:      adaptersCommon.SupervisordVolumeName,
 				MountPath: adaptersCommon.SupervisordMountPath,
@@ -180,7 +180,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			// only if the env var is not set in the devfile
 			// This is done, so supervisord can use it in it's program
 			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandRun) {
-				klog.V(4).Infof("Updating container %v env with run command", container.Name)
+				klog.V(2).Infof("Updating container %v env with run command", container.Name)
 				var setEnvVariable, command string
 				for _, envVar := range runCommand.Exec.Env {
 					setEnvVariable = setEnvVariable + fmt.Sprintf("%v=\"%v\" ", envVar.Name, envVar.Value)
@@ -198,7 +198,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			}
 
 			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandRunWorkingDir) && runCommand.Exec.WorkingDir != "" {
-				klog.V(4).Infof("Updating container %v env with run command's workdir", container.Name)
+				klog.V(2).Infof("Updating container %v env with run command's workdir", container.Name)
 				container.Env = append(container.Env,
 					corev1.EnvVar{
 						Name:  adaptersCommon.EnvOdoCommandRunWorkingDir,
@@ -223,7 +223,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 
 			if !foundMountPath {
 				// Always mount the supervisord volume in the debug component container
-				klog.V(4).Infof("Updating container %v with supervisord volume mounts", container.Name)
+				klog.V(2).Infof("Updating container %v with supervisord volume mounts", container.Name)
 				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 					Name:      adaptersCommon.SupervisordVolumeName,
 					MountPath: adaptersCommon.SupervisordMountPath,
@@ -234,7 +234,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			// only if the env var is not set in the devfile
 			// This is done, so supervisord can use it in it's program
 			if !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebug) {
-				klog.V(4).Infof("Updating container %v env with debug command", container.Name)
+				klog.V(2).Infof("Updating container %v env with debug command", container.Name)
 				var setEnvVariable, command string
 				for _, envVar := range debugCommand.Exec.Env {
 					setEnvVariable = setEnvVariable + fmt.Sprintf("%v=\"%v\" ", envVar.Name, envVar.Value)
@@ -252,7 +252,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			}
 
 			if debugCommand.Exec.WorkingDir != "" && !isEnvPresent(container.Env, adaptersCommon.EnvOdoCommandDebugWorkingDir) {
-				klog.V(4).Infof("Updating container %v env with debug command's workdir", container.Name)
+				klog.V(2).Infof("Updating container %v env with debug command's workdir", container.Name)
 				container.Env = append(container.Env,
 					corev1.EnvVar{
 						Name:  adaptersCommon.EnvOdoCommandDebugWorkingDir,
@@ -261,7 +261,7 @@ func UpdateContainersWithSupervisord(devfileObj devfileParser.DevfileObj, contai
 			}
 
 			if !isEnvPresent(container.Env, adaptersCommon.EnvDebugPort) {
-				klog.V(4).Infof("Updating container %v env with debug command's debugPort", container.Name)
+				klog.V(2).Infof("Updating container %v env with debug command's debugPort", container.Name)
 				container.Env = append(container.Env,
 					corev1.EnvVar{
 						Name:  adaptersCommon.EnvDebugPort,
@@ -291,7 +291,7 @@ func GetResourceReqs(comp common.DevfileComponent) corev1.ResourceRequirements {
 
 // overrideContainerArgs overrides the container's entrypoint with supervisord
 func overrideContainerArgs(container *corev1.Container) {
-	klog.V(4).Infof("Updating container %v entrypoint with supervisord", container.Name)
+	klog.V(2).Infof("Updating container %v entrypoint with supervisord", container.Name)
 	container.Command = append(container.Command, adaptersCommon.SupervisordBinaryPath)
 	container.Args = append(container.Args, "-c", adaptersCommon.SupervisordConfFile)
 }

--- a/pkg/devfile/parser/context/apiVersion.go
+++ b/pkg/devfile/parser/context/apiVersion.go
@@ -47,7 +47,7 @@ func (d *DevfileCtx) SetDevfileAPIVersion() error {
 
 	// Successful
 	d.apiVersion = apiVer
-	klog.V(4).Infof("devfile apiVersion: '%s'", d.apiVersion)
+	klog.V(2).Infof("devfile apiVersion: '%s'", d.apiVersion)
 	return nil
 }
 

--- a/pkg/devfile/parser/context/content.go
+++ b/pkg/devfile/parser/context/content.go
@@ -30,7 +30,7 @@ func YAMLToJSON(data []byte) ([]byte, error) {
 	}
 
 	// Successful
-	klog.V(4).Infof("converted devfile YAML to JSON")
+	klog.V(2).Infof("converted devfile YAML to JSON")
 	return data, nil
 }
 

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -66,7 +66,7 @@ func (d *DevfileCtx) Populate() (err error) {
 	if d.absPath, err = util.GetAbsPath(d.relPath); err != nil {
 		return err
 	}
-	klog.V(4).Infof("absolute devfile path: '%s'", d.absPath)
+	klog.V(2).Infof("absolute devfile path: '%s'", d.absPath)
 
 	// Read and save devfile content
 	if err := d.SetDevfileContent(); err != nil {

--- a/pkg/devfile/parser/context/schema.go
+++ b/pkg/devfile/parser/context/schema.go
@@ -44,6 +44,6 @@ func (d *DevfileCtx) ValidateDevfileSchema() error {
 	}
 
 	// Sucessful
-	klog.V(4).Info("validated devfile schema")
+	klog.V(2).Info("validated devfile schema")
 	return nil
 }

--- a/pkg/devfile/parser/data/helper.go
+++ b/pkg/devfile/parser/data/helper.go
@@ -32,7 +32,7 @@ func GetDevfileJSONSchema(version string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("unable to find schema for apiVersion '%s'", version)
 	}
-	klog.V(4).Infof("devfile apiVersion '%s' is supported in odo", version)
+	klog.V(2).Infof("devfile apiVersion '%s' is supported in odo", version)
 
 	// Successful
 	return schema, nil

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -82,7 +82,7 @@ func parseParent(d DevfileObj) error {
 		return err
 	}
 
-	klog.V(4).Infof("overriding data of devfile with URI: %v", parent.Uri)
+	klog.V(2).Infof("overriding data of devfile with URI: %v", parent.Uri)
 
 	// override the parent's components, commands, projects and events
 	err = parentData.OverrideComponents(d.Data.GetParent().Components)
@@ -110,7 +110,7 @@ func parseParent(d DevfileObj) error {
 		return err
 	}
 
-	klog.V(4).Infof("adding data of devfile with URI: %v", parent.Uri)
+	klog.V(2).Infof("adding data of devfile with URI: %v", parent.Uri)
 
 	// since the parent's data has been overriden
 	// add the items back to the current devfile

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -25,7 +25,7 @@ func (d *DevfileObj) WriteJsonDevfile() error {
 	}
 
 	// Successful
-	klog.V(4).Infof("devfile json created at: '%s'", OutputDevfileJsonPath)
+	klog.V(2).Infof("devfile json created at: '%s'", OutputDevfileJsonPath)
 	return nil
 }
 
@@ -46,6 +46,6 @@ func (d *DevfileObj) WriteYamlDevfile() error {
 	}
 
 	// Successful
-	klog.V(4).Infof("devfile yaml created at: '%s'", OutputDevfileYamlPath)
+	klog.V(2).Infof("devfile yaml created at: '%s'", OutputDevfileYamlPath)
 	return nil
 }

--- a/pkg/devfile/validate/events.go
+++ b/pkg/devfile/validate/events.go
@@ -17,25 +17,25 @@ func validateEvents(data data.DevfileData) error {
 
 	switch {
 	case len(events.PreStart) > 0:
-		klog.V(4).Info("Validating preStart events")
+		klog.V(2).Info("Validating preStart events")
 		if preStartErr := isEventValid(data, events.PreStart, "preStart"); preStartErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", preStartErr.Error())
 		}
 		fallthrough
 	case len(events.PostStart) > 0:
-		klog.V(4).Info("Validating postStart events")
+		klog.V(2).Info("Validating postStart events")
 		if postStartErr := isEventValid(data, events.PostStart, "postStart"); postStartErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", postStartErr.Error())
 		}
 		fallthrough
 	case len(events.PreStop) > 0:
-		klog.V(4).Info("Validating preStop events")
+		klog.V(2).Info("Validating preStop events")
 		if preStopErr := isEventValid(data, events.PreStop, "preStop"); preStopErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", preStopErr.Error())
 		}
 		fallthrough
 	case len(events.PostStop) > 0:
-		klog.V(4).Info("Validating postStop events")
+		klog.V(2).Info("Validating postStop events")
 		if postStopErr := isEventValid(data, events.PostStop, "postStop"); postStopErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", postStopErr.Error())
 		}
@@ -67,7 +67,7 @@ func isEventValid(data data.DevfileData, eventNames []string, eventType string) 
 				// Check if the devfile command is valid
 				err := adapterCommon.ValidateCommand(data, command)
 				if err != nil {
-					klog.V(4).Infof("command %s is not valid: %s", command.GetID(), err.Error())
+					klog.V(2).Infof("command %s is not valid: %s", command.GetID(), err.Error())
 					eventErrorMsg[strings.ToLower(eventName)] = append(eventErrorMsg[strings.ToLower(eventName)], err.Error())
 				}
 				break
@@ -75,20 +75,20 @@ func isEventValid(data data.DevfileData, eventNames []string, eventType string) 
 		}
 
 		if !isEventPresent {
-			klog.V(4).Infof("%s type event %s does not map to a valid devfile command", eventType, eventName)
+			klog.V(2).Infof("%s type event %s does not map to a valid devfile command", eventType, eventName)
 			eventErrorMsg[strings.ToLower(eventName)] = append(eventErrorMsg[strings.ToLower(eventName)], fmt.Sprintf("event %s does not map to a valid devfile command", eventName))
 		}
 	}
 
 	for eventName, errors := range eventErrorMsg {
 		if len(errors) > 0 {
-			klog.V(4).Infof("errors found for event %s belonging to %s: %s", eventName, eventType, strings.Join(errors, ","))
+			klog.V(2).Infof("errors found for event %s belonging to %s: %s", eventName, eventType, strings.Join(errors, ","))
 			eventErrors += fmt.Sprintf("\n%s is invalid: %s", eventName, strings.Join(errors, ","))
 		}
 	}
 
 	if len(eventErrors) > 0 {
-		klog.V(4).Infof("errors found for event type %s", eventType)
+		klog.V(2).Infof("errors found for event type %s", eventType)
 		return &InvalidEventError{eventType: eventType, errorMsg: eventErrors}
 	}
 

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -34,7 +34,7 @@ func ValidateDevfileData(data interface{}) error {
 	}
 
 	// Successful
-	klog.V(4).Info("Successfully validated devfile sections")
+	klog.V(2).Info("Successfully validated devfile sections")
 	return nil
 
 }

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -53,7 +53,7 @@ func (c *Client) ListDeployments(selector string) (*appsv1.DeploymentList, error
 
 // WaitForDeploymentRollout waits for deployment to finish rollout. Returns the state of the deployment after rollout.
 func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deployment, error) {
-	klog.V(4).Infof("Waiting for %s deployment rollout", deploymentName)
+	klog.V(3).Infof("Waiting for %s deployment rollout", deploymentName)
 	s := log.Spinner("Waiting for component to start")
 	defer s.End(false)
 
@@ -81,25 +81,25 @@ func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deploy
 				for _, cond := range deployment.Status.Conditions {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonCond, _ := json.Marshal(cond)
-					klog.V(4).Infof("Deployment Condition: %s", string(jsonCond))
+					klog.V(3).Infof("Deployment Condition: %s", string(jsonCond))
 				}
 				if deployment.Generation <= deployment.Status.ObservedGeneration {
 					cond := getDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
 					if cond != nil && cond.Reason == timedOutReason {
 						failure <- fmt.Errorf("deployment %q exceeded its progress deadline", deployment.Name)
 					} else if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-						klog.V(4).Infof("Waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+						klog.V(3).Infof("Waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
 					} else if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-						klog.V(4).Infof("Waiting for deployment %q rollout to finish: %d old replicas are pending termination...\n", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
+						klog.V(3).Infof("Waiting for deployment %q rollout to finish: %d old replicas are pending termination...\n", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
 					} else if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-						klog.V(4).Infof("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
+						klog.V(3).Infof("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
 					} else {
 						s.End(true)
-						klog.V(4).Infof("Deployment %q successfully rolled out\n", deployment.Name)
+						klog.V(3).Infof("Deployment %q successfully rolled out\n", deployment.Name)
 						success <- deployment
 					}
 				}
-				klog.V(4).Infof("Waiting for deployment spec update to be observed...\n")
+				klog.V(3).Infof("Waiting for deployment spec update to be observed...\n")
 
 			} else {
 				failure <- errors.New("unable to convert event object to Pod")
@@ -166,10 +166,10 @@ func (c *Client) DeleteDeployment(labels map[string]string) error {
 	}
 	// convert labels to selector
 	selector := util.ConvertLabelsToSelector(labels)
-	klog.V(4).Infof("Selectors used for deletion: %s", selector)
+	klog.V(3).Infof("Selectors used for deletion: %s", selector)
 
 	// Delete Deployment
-	klog.V(4).Info("Deleting Deployment")
+	klog.V(3).Info("Deleting Deployment")
 
 	return c.KubeClient.AppsV1().Deployments(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 }

--- a/pkg/kclient/namespace.go
+++ b/pkg/kclient/namespace.go
@@ -101,10 +101,10 @@ func (c *Client) DeleteNamespace(name string, wait bool) error {
 					watchErrorChannel <- errors.Errorf("watch channel was closed unexpectedly: %+v", val)
 					break
 				}
-				klog.V(4).Infof("Watch event.Type '%s'.", val.Type)
+				klog.V(3).Infof("Watch event.Type '%s'.", val.Type)
 
 				if namespaceStatus, ok := val.Object.(*corev1.Namespace); ok {
-					klog.V(4).Infof("Status of delete of namespace %s is '%s'.", name, namespaceStatus.Status.Phase)
+					klog.V(3).Infof("Status of delete of namespace %s is '%s'.", name, namespaceStatus.Status.Phase)
 					if val.Type == watch.Deleted {
 						namespaceChannel <- namespaceStatus
 						break
@@ -123,7 +123,7 @@ func (c *Client) DeleteNamespace(name string, wait bool) error {
 
 		select {
 		case val := <-namespaceChannel:
-			klog.V(4).Infof("Namespace %s deleted", val.Name)
+			klog.V(3).Infof("Namespace %s deleted", val.Name)
 			return nil
 		case err := <-watchErrorChannel:
 			return err
@@ -178,7 +178,7 @@ func (c *Client) WaitForServiceAccountInNamespace(namespace, serviceAccountName 
 				}
 				if serviceAccount, ok := val.Object.(*corev1.ServiceAccount); ok {
 					if serviceAccount.Name == serviceAccountName {
-						klog.V(4).Infof("Status of creation of service account %s is ready", serviceAccount)
+						klog.V(3).Infof("Status of creation of service account %s is ready", serviceAccount)
 						return nil
 					}
 				}

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -23,7 +23,7 @@ const (
 // GetClusterServiceVersionList returns a list of CSVs in the cluster
 // It is equivalent to doing `oc get csvs` using oc cli
 func (c *Client) GetClusterServiceVersionList() (*olm.ClusterServiceVersionList, error) {
-	klog.V(4).Infof("Fetching list of operators installed in cluster")
+	klog.V(3).Infof("Fetching list of operators installed in cluster")
 	csvs, err := c.OperatorClient.ClusterServiceVersions(c.Namespace).List(v1.ListOptions{})
 	if err != nil {
 		return &olm.ClusterServiceVersionList{}, err

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -29,7 +29,7 @@ const (
 // WaitAndGetPod block and waits until pod matching selector is in the desired phase
 // desiredPhase cannot be PodFailed or PodUnknown
 func (c *Client) WaitAndGetPod(watchOptions metav1.ListOptions, desiredPhase corev1.PodPhase, waitMessage string, hideSpinner bool) (*corev1.Pod, error) {
-	klog.V(4).Infof("Waiting for %s pod", watchOptions.LabelSelector)
+	klog.V(3).Infof("Waiting for %s pod", watchOptions.LabelSelector)
 	var s *log.Status
 	if !hideSpinner {
 		s = log.Spinner(waitMessage)
@@ -55,23 +55,23 @@ func (c *Client) WaitAndGetPod(watchOptions metav1.ListOptions, desiredPhase cor
 				return
 			}
 			if e, ok := val.Object.(*corev1.Pod); ok {
-				klog.V(4).Infof("Status of %s pod is %s", e.Name, e.Status.Phase)
+				klog.V(3).Infof("Status of %s pod is %s", e.Name, e.Status.Phase)
 				for _, cond := range e.Status.Conditions {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonCond, _ := json.Marshal(cond)
-					klog.V(4).Infof("Pod Conditions: %s", string(jsonCond))
+					klog.V(3).Infof("Pod Conditions: %s", string(jsonCond))
 				}
 				for _, status := range e.Status.ContainerStatuses {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonStatus, _ := json.Marshal(status)
-					klog.V(4).Infof("Container Status: %s", string(jsonStatus))
+					klog.V(3).Infof("Container Status: %s", string(jsonStatus))
 				}
 				switch e.Status.Phase {
 				case desiredPhase:
 					if !hideSpinner {
 						s.End(true)
 					}
-					klog.V(4).Infof("Pod %s is %v", e.Name, desiredPhase)
+					klog.V(3).Infof("Pod %s is %v", e.Name, desiredPhase)
 					podChannel <- e
 					return
 				case corev1.PodFailed, corev1.PodUnknown:
@@ -148,7 +148,7 @@ func (c *Client) ExtractProjectToComponent(compInfo common.ComponentInfo, target
 	cmdArr := []string{"tar", "xf", "-", "-C", targetPath}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	klog.V(4).Infof("Executing command %s", strings.Join(cmdArr, " "))
+	klog.V(3).Infof("Executing command %s", strings.Join(cmdArr, " "))
 	err := c.ExecCMDInContainer(compInfo, cmdArr, &stdout, &stderr, stdin, false)
 	if err != nil {
 		log.Errorf("Command '%s' in container failed.\n", strings.Join(cmdArr, " "))

--- a/pkg/lclient/images.go
+++ b/pkg/lclient/images.go
@@ -21,7 +21,7 @@ func (dc *Client) PullImage(image string) error {
 	}
 	defer out.Close()
 
-	if klog.V(4) {
+	if klog.V(1) {
 		_, err := io.Copy(os.Stdout, out)
 		if err != nil {
 			return err

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -448,22 +448,22 @@ func isServerUp(server string) bool {
 	// before proceeding with default timeout
 	cfg, configReadErr := preference.New()
 	if configReadErr != nil {
-		klog.V(4).Info(errors.Wrap(configReadErr, "unable to read config file"))
+		klog.V(3).Info(errors.Wrap(configReadErr, "unable to read config file"))
 	} else {
 		ocRequestTimeout = time.Duration(cfg.GetTimeout()) * time.Second
 	}
 	address, err := util.GetHostWithPort(server)
 	if err != nil {
-		klog.V(4).Infof("Unable to parse url %s (%s)", server, err)
+		klog.V(3).Infof("Unable to parse url %s (%s)", server, err)
 	}
-	klog.V(4).Infof("Trying to connect to server %s", address)
+	klog.V(3).Infof("Trying to connect to server %s", address)
 	_, connectionError := net.DialTimeout("tcp", address, time.Duration(ocRequestTimeout))
 	if connectionError != nil {
-		klog.V(4).Info(errors.Wrap(connectionError, "unable to connect to server"))
+		klog.V(3).Info(errors.Wrap(connectionError, "unable to connect to server"))
 		return false
 	}
 
-	klog.V(4).Infof("Server %v is up", server)
+	klog.V(3).Infof("Server %v is up", server)
 	return true
 }
 
@@ -539,12 +539,12 @@ func (c *Client) CreateNewProject(projectName string, wait bool) error {
 				break
 			}
 			if prj, ok := val.Object.(*projectv1.Project); ok {
-				klog.V(4).Infof("Status of creation of project %s is %s", prj.Name, prj.Status.Phase)
+				klog.V(3).Infof("Status of creation of project %s is %s", prj.Name, prj.Status.Phase)
 				switch prj.Status.Phase {
 				//prj.Status.Phase can only be "Terminating" or "Active" or ""
 				case corev1.NamespaceActive:
 					if val.Type == watch.Added {
-						klog.V(4).Infof("Project %s now exists", prj.Name)
+						klog.V(3).Infof("Project %s now exists", prj.Name)
 						return nil
 					}
 					if val.Type == watch.Error {
@@ -762,7 +762,7 @@ func (c *Client) GetImageStreamImage(imageStream *imagev1.ImageStream, imageTag 
 	for _, tag := range imageStream.Status.Tags {
 		// look for matching tag
 		if tag.Tag == imageTag {
-			klog.V(4).Infof("Found exact image tag match for %s:%s", imageName, imageTag)
+			klog.V(3).Infof("Found exact image tag match for %s:%s", imageName, imageTag)
 
 			if len(tag.Items) > 0 {
 				tagDigest := tag.Items[0].Image
@@ -816,7 +816,7 @@ func getAppRootVolumeName(dcName string) string {
 // inputPorts is the array containing the string port values
 // envVars is the array containing the string env var values
 func (c *Client) NewAppS2I(params CreateArgs, commonObjectMeta metav1.ObjectMeta) error {
-	klog.V(4).Infof("Using BuilderImage: %s", params.ImageName)
+	klog.V(3).Infof("Using BuilderImage: %s", params.ImageName)
 	imageNS, imageName, imageTag, _, err := ParseImageName(params.ImageName)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse image name")
@@ -831,7 +831,7 @@ func (c *Client) NewAppS2I(params CreateArgs, commonObjectMeta metav1.ObjectMeta
 	*/
 
 	imageNS = imageStream.ObjectMeta.Namespace
-	klog.V(4).Infof("Using imageNS: %s", imageNS)
+	klog.V(3).Infof("Using imageNS: %s", imageNS)
 
 	imageStreamImage, err := c.GetImageStreamImage(imageStream, imageTag)
 	if err != nil {
@@ -989,7 +989,7 @@ func GetS2IMetaInfoFromBuilderImg(builderImage *imagev1.ImageStreamImage) (S2IPa
 
 	// If by any chance, labels attribute is nil(although ideally not the case for builder images), return
 	if dimdr.ContainerConfig.Labels == nil {
-		klog.V(4).Infof("No Labels found in %+v in builder image %+v", dimdr, builderImage)
+		klog.V(3).Infof("No Labels found in %+v in builder image %+v", dimdr, builderImage)
 		return S2IPaths{}, nil
 	}
 
@@ -1394,7 +1394,7 @@ func (c *Client) PatchCurrentDC(dc appsv1.DeploymentConfig, prePatchDCHandler dc
 		if errCurrent != nil || errUpdated != nil {
 			return errors.Wrapf(err, "unable to unmarshal dc")
 		}
-		klog.V(4).Infof("going to wait for new deployment roll out because updatedDc Spec.Template: %v doesn't match currentDc Spec.Template: %v", string(updatedDCBytes), string(currentDCBytes))
+		klog.V(3).Infof("going to wait for new deployment roll out because updatedDc Spec.Template: %v doesn't match currentDc Spec.Template: %v", string(updatedDCBytes), string(currentDCBytes))
 
 	}
 
@@ -1692,7 +1692,7 @@ func (c *Client) GetLatestBuildName(buildConfigName string) (string, error) {
 
 // StartBuild starts new build as it is, returns name of the build stat was started
 func (c *Client) StartBuild(name string) (string, error) {
-	klog.V(4).Infof("Build %s started.", name)
+	klog.V(3).Infof("Build %s started.", name)
 	buildRequest := buildv1.BuildRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -1702,7 +1702,7 @@ func (c *Client) StartBuild(name string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to instantiate BuildConfig for %s", name)
 	}
-	klog.V(4).Infof("Build %s for BuildConfig %s triggered.", name, result.Name)
+	klog.V(3).Infof("Build %s for BuildConfig %s triggered.", name, result.Name)
 
 	return result.Name, nil
 }
@@ -1711,7 +1711,7 @@ func (c *Client) StartBuild(name string) (string, error) {
 func (c *Client) WaitForBuildToFinish(buildName string, stdout io.Writer, buildTimeout time.Duration) error {
 	// following indicates if we have already setup the following logic
 	following := false
-	klog.V(4).Infof("Waiting for %s  build to finish", buildName)
+	klog.V(3).Infof("Waiting for %s  build to finish", buildName)
 
 	// start a watch on the build resources and look for the given build name
 	w, err := c.buildClient.Builds(c.Namespace).Watch(metav1.ListOptions{
@@ -1731,11 +1731,11 @@ func (c *Client) WaitForBuildToFinish(buildName string, stdout io.Writer, buildT
 			}
 			// cast the object returned to a build object and check the phase of the build
 			if e, ok := val.Object.(*buildv1.Build); ok {
-				klog.V(4).Infof("Status of %s build is %s", e.Name, e.Status.Phase)
+				klog.V(3).Infof("Status of %s build is %s", e.Name, e.Status.Phase)
 				switch e.Status.Phase {
 				case buildv1.BuildPhaseComplete:
 					// the build is completed thus return
-					klog.V(4).Infof("Build %s completed.", e.Name)
+					klog.V(3).Infof("Build %s completed.", e.Name)
 					return nil
 				case buildv1.BuildPhaseFailed, buildv1.BuildPhaseCancelled, buildv1.BuildPhaseError:
 					// the build failed/got cancelled/error occurred thus return with error
@@ -1796,7 +1796,7 @@ func (c *Client) WaitAndGetDC(name string, desiredRevision int64, timeout time.D
 				for _, cond := range e.Status.Conditions {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonCond, _ := json.Marshal(cond)
-					klog.V(4).Infof("DeploymentConfig Condition: %s", string(jsonCond))
+					klog.V(3).Infof("DeploymentConfig Condition: %s", string(jsonCond))
 				}
 				// If the annotation has been updated, let's exit
 				if waitCond(e, desiredRevision) {
@@ -1824,7 +1824,7 @@ func (c *Client) CollectEvents(selector string, events map[string]corev1.Event, 
 	for {
 		select {
 		case <-quit:
-			klog.V(4).Info("Quitting collect events")
+			klog.V(3).Info("Quitting collect events")
 			return
 		case val, ok := <-eventWatcher.ResultChan():
 			mu.Lock()
@@ -1840,7 +1840,7 @@ func (c *Client) CollectEvents(selector string, events map[string]corev1.Event, 
 					if e.Count >= failedEventCount {
 						newEvent := e
 						(events)[e.Name] = *newEvent
-						klog.V(4).Infof("Warning Event: Count: %d, Reason: %s, Message: %s", e.Count, e.Reason, e.Message)
+						klog.V(3).Infof("Warning Event: Count: %d, Reason: %s, Message: %s", e.Count, e.Reason, e.Message)
 						// Change the spinner message to show the warning
 						spinner.WarningStatus(fmt.Sprintf("WARNING x%d: %s", e.Count, e.Reason))
 					}
@@ -1864,12 +1864,12 @@ func (c *Client) WaitAndGetPod(selector string, desiredPhase corev1.PodPhase, wa
 	pushTimeout := preference.DefaultPushTimeout * time.Second
 	cfg, configReadErr := preference.New()
 	if configReadErr != nil {
-		klog.V(4).Info(errors.Wrap(configReadErr, "unable to read config file"))
+		klog.V(3).Info(errors.Wrap(configReadErr, "unable to read config file"))
 	} else {
 		pushTimeout = time.Duration(cfg.GetPushTimeout()) * time.Second
 	}
 
-	klog.V(4).Infof("Waiting for %s pod", selector)
+	klog.V(3).Infof("Waiting for %s pod", selector)
 	spinner := log.Spinner(waitMessage)
 	defer spinner.End(false)
 
@@ -1893,20 +1893,20 @@ func (c *Client) WaitAndGetPod(selector string, desiredPhase corev1.PodPhase, wa
 				break loop
 			}
 			if e, ok := val.Object.(*corev1.Pod); ok {
-				klog.V(4).Infof("Status of %s pod is %s", e.Name, e.Status.Phase)
+				klog.V(3).Infof("Status of %s pod is %s", e.Name, e.Status.Phase)
 				for _, cond := range e.Status.Conditions {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonCond, _ := json.Marshal(cond)
-					klog.V(4).Infof("Pod Conditions: %s", string(jsonCond))
+					klog.V(3).Infof("Pod Conditions: %s", string(jsonCond))
 				}
 				for _, status := range e.Status.ContainerStatuses {
 					// using this just for debugging message, so ignoring error on purpose
 					jsonStatus, _ := json.Marshal(status)
-					klog.V(4).Infof("Container Status: %#v", jsonStatus)
+					klog.V(3).Infof("Container Status: %#v", jsonStatus)
 				}
 				switch e.Status.Phase {
 				case desiredPhase:
-					klog.V(4).Infof("Pod %s is %v", e.Name, desiredPhase)
+					klog.V(3).Infof("Pod %s is %v", e.Name, desiredPhase)
 					podChannel <- e
 					break loop
 				case corev1.PodFailed, corev1.PodUnknown:
@@ -1972,7 +1972,7 @@ See below for a list of failed events that occured more than %d times during dep
 
 // WaitAndGetSecret blocks and waits until the secret is available
 func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret, error) {
-	klog.V(4).Infof("Waiting for secret %s to become available", name)
+	klog.V(3).Infof("Waiting for secret %s to become available", name)
 
 	w, err := c.kubeClient.CoreV1().Secrets(namespace).Watch(metav1.ListOptions{
 		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
@@ -1987,7 +1987,7 @@ func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret
 			break
 		}
 		if e, ok := val.Object.(*corev1.Secret); ok {
-			klog.V(4).Infof("Secret %s now exists", e.Name)
+			klog.V(3).Infof("Secret %s now exists", e.Name)
 			return e, nil
 		}
 	}
@@ -2060,7 +2060,7 @@ func (c *Client) Delete(labels map[string]string, wait bool) error {
 
 	// convert labels to selector
 	selector := util.ConvertLabelsToSelector(labels)
-	klog.V(4).Infof("Selectors used for deletion: %s", selector)
+	klog.V(3).Infof("Selectors used for deletion: %s", selector)
 
 	var errorList []string
 	var deletionPolicy = metav1.DeletePropagationBackground
@@ -2070,19 +2070,19 @@ func (c *Client) Delete(labels map[string]string, wait bool) error {
 		deletionPolicy = metav1.DeletePropagationForeground
 	}
 	// Delete DeploymentConfig
-	klog.V(4).Info("Deleting DeploymentConfigs")
+	klog.V(3).Info("Deleting DeploymentConfigs")
 	err := c.appsClient.DeploymentConfigs(c.Namespace).DeleteCollection(&metav1.DeleteOptions{PropagationPolicy: &deletionPolicy}, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		errorList = append(errorList, "unable to delete deploymentconfig")
 	}
 	// Delete BuildConfig
-	klog.V(4).Info("Deleting BuildConfigs")
+	klog.V(3).Info("Deleting BuildConfigs")
 	err = c.buildClient.BuildConfigs(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		errorList = append(errorList, "unable to delete buildconfig")
 	}
 	// Delete ImageStream
-	klog.V(4).Info("Deleting ImageStreams")
+	klog.V(3).Info("Deleting ImageStreams")
 	err = c.imageClient.ImageStreams(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		errorList = append(errorList, "unable to delete imagestream")
@@ -2110,7 +2110,7 @@ func (c *Client) Delete(labels map[string]string, wait bool) error {
 // WaitForComponentDeletion waits for component to be deleted
 func (c *Client) WaitForComponentDeletion(selector string) error {
 
-	klog.V(4).Infof("Waiting for component to get deleted")
+	klog.V(3).Infof("Waiting for component to get deleted")
 
 	watcher, err := c.appsClient.DeploymentConfigs(c.Namespace).Watch(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
@@ -2127,14 +2127,14 @@ func (c *Client) WaitForComponentDeletion(selector string) error {
 				return errors.New("Unable to watch deployment config")
 			}
 			if event.Type == watch.Deleted {
-				klog.V(4).Infof("WaitForComponentDeletion, Event Recieved:Deleted")
+				klog.V(3).Infof("WaitForComponentDeletion, Event Recieved:Deleted")
 				return nil
 			} else if event.Type == watch.Error {
-				klog.V(4).Infof("WaitForComponentDeletion, Event Recieved:Deleted ")
+				klog.V(3).Infof("WaitForComponentDeletion, Event Recieved:Deleted ")
 				return errors.New("Unable to watch deployment config")
 			}
 		case <-time.After(waitForComponentDeletionTimeout):
-			klog.V(4).Infof("WaitForComponentDeletion, Timeout")
+			klog.V(3).Infof("WaitForComponentDeletion, Timeout")
 			return errors.New("Time out waiting for component to get deleted")
 		}
 	}
@@ -2142,11 +2142,11 @@ func (c *Client) WaitForComponentDeletion(selector string) error {
 
 // DeleteServiceInstance takes labels as a input and based on it, deletes respective service instance
 func (c *Client) DeleteServiceInstance(labels map[string]string) error {
-	klog.V(4).Infof("Deleting Service Instance")
+	klog.V(3).Infof("Deleting Service Instance")
 
 	// convert labels to selector
 	selector := util.ConvertLabelsToSelector(labels)
-	klog.V(4).Infof("Selectors used for deletion: %s", selector)
+	klog.V(3).Infof("Selectors used for deletion: %s", selector)
 
 	// Listing out serviceInstance because `DeleteCollection` method don't work on serviceInstance
 	serviceInstances, err := c.GetServiceInstanceList(selector)
@@ -2229,7 +2229,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 				// So we depend on val.Type as val.Object.Status.Phase is just empty string and not a mapped value constant
 				if projectStatus, ok := val.Object.(*projectv1.Project); ok {
 
-					klog.V(4).Infof("Status of delete of project %s is '%s'", name, projectStatus.Status.Phase)
+					klog.V(3).Infof("Status of delete of project %s is '%s'", name, projectStatus.Status.Phase)
 
 					switch projectStatus.Status.Phase {
 					//projectStatus.Status.Phase can only be "Terminating" or "Active" or ""
@@ -2256,7 +2256,7 @@ func (c *Client) DeleteProject(name string, wait bool) error {
 
 		select {
 		case val := <-projectChannel:
-			klog.V(4).Infof("Deletion information for project: %+v", val)
+			klog.V(3).Infof("Deletion information for project: %+v", val)
 			return nil
 		case err := <-watchErrorChannel:
 			return err
@@ -2333,7 +2333,7 @@ func (c *Client) GetServiceInstanceList(selector string) ([]scv1beta1.ServiceIns
 
 // GetBuildConfigFromName get BuildConfig by its name
 func (c *Client) GetBuildConfigFromName(name string) (*buildv1.BuildConfig, error) {
-	klog.V(4).Infof("Getting BuildConfig: %s", name)
+	klog.V(3).Infof("Getting BuildConfig: %s", name)
 	bc, err := c.buildClient.BuildConfigs(c.Namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get BuildConfig %s", name)
@@ -2638,7 +2638,7 @@ func (c *Client) DeleteRoute(name string) error {
 
 // ListRoutes lists all the routes based on the given label selector
 func (c *Client) ListRoutes(labelSelector string) ([]routev1.Route, error) {
-	klog.V(4).Infof("Listing routes with label selector: %v", labelSelector)
+	klog.V(3).Infof("Listing routes with label selector: %v", labelSelector)
 	routeList, err := c.routeClient.Routes(c.Namespace).List(metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
@@ -2693,10 +2693,10 @@ func (c *Client) DeleteBuildConfig(commonObjectMeta metav1.ObjectMeta) error {
 
 	// Convert labels to selector
 	selector := util.ConvertLabelsToSelector(commonObjectMeta.Labels)
-	klog.V(4).Infof("DeleteBuildConfig selectors used for deletion: %s", selector)
+	klog.V(3).Infof("DeleteBuildConfig selectors used for deletion: %s", selector)
 
 	// Delete BuildConfig
-	klog.V(4).Info("Deleting BuildConfigs with DeleteBuildConfig")
+	klog.V(3).Info("Deleting BuildConfigs with DeleteBuildConfig")
 	return c.buildClient.BuildConfigs(c.Namespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 }
 
@@ -2726,7 +2726,7 @@ func (c *Client) RemoveVolumeFromDeploymentConfig(pvc string, dcName string) err
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("Found volume: %v in Deployment Config: %v", volumeName, dc.Name)
+		klog.V(3).Infof("Found volume: %v in Deployment Config: %v", volumeName, dc.Name)
 
 		// Remove at max 2 volume mounts if volume mounts exists
 		err = removeVolumeMountsFromDC(volumeName, dc)
@@ -2779,7 +2779,7 @@ func (c *Client) GetServicesFromSelector(selector string) ([]corev1.Service, err
 // GetDeploymentConfigFromName returns the Deployment Config resource given
 // the Deployment Config name
 func (c *Client) GetDeploymentConfigFromName(name string) (*appsv1.DeploymentConfig, error) {
-	klog.V(4).Infof("Getting DeploymentConfig: %s", name)
+	klog.V(3).Infof("Getting DeploymentConfig: %s", name)
 	deploymentConfig, err := c.appsClient.DeploymentConfigs(c.Namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -2926,7 +2926,7 @@ func (c *Client) GetServerVersion() (*ServerInfo, error) {
 	rawOpenShiftVersion, err := c.kubeClient.CoreV1().RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
 	if err != nil {
 		// when using Minishift (or plain 'oc cluster up' for that matter) with OKD 3.11, the version endpoint is missing...
-		klog.V(4).Infof("Unable to get OpenShift Version - endpoint '/version/openshift' doesn't exist")
+		klog.V(3).Infof("Unable to get OpenShift Version - endpoint '/version/openshift' doesn't exist")
 	} else {
 		var openShiftVersion version.Info
 		if err := json.Unmarshal(rawOpenShiftVersion, &openShiftVersion); err != nil {
@@ -3008,7 +3008,7 @@ func (c *Client) ExtractProjectToComponent(compInfo common.ComponentInfo, target
 	cmdArr := []string{"tar", "xf", "-", "-C", targetPath}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	klog.V(4).Infof("Executing command %s", strings.Join(cmdArr, " "))
+	klog.V(3).Infof("Executing command %s", strings.Join(cmdArr, " "))
 	err := c.ExecCMDInContainer(compInfo, cmdArr, &stdout, &stderr, stdin, false)
 	if err != nil {
 		log.Errorf("Command '%s' in container failed.\n", strings.Join(cmdArr, " "))
@@ -3084,7 +3084,7 @@ func (c *Client) CreateBuildConfig(commonObjectMeta metav1.ObjectMeta, builderIm
 	}
 	imageNS = imageStream.ObjectMeta.Namespace
 
-	klog.V(4).Infof("Using namespace: %s for the CreateBuildConfig function", imageNS)
+	klog.V(3).Infof("Using namespace: %s for the CreateBuildConfig function", imageNS)
 
 	// Use BuildConfig to build the container with Git
 	bc := generateBuildConfig(commonObjectMeta, gitURL, gitRef, imageName+":"+imageTag, imageNS)
@@ -3176,7 +3176,7 @@ func (c *Client) PropagateDeletes(targetPodName string, delSrcRelPaths []string,
 			rmPaths = append(rmPaths, filepath.ToSlash(filepath.Join(s2iPath, delRelPath)))
 		}
 	}
-	klog.V(4).Infof("s2ipaths marked for deletion are %+v", rmPaths)
+	klog.V(3).Infof("s2ipaths marked for deletion are %+v", rmPaths)
 	cmdArr := []string{"rm", "-rf"}
 	cmdArr = append(cmdArr, rmPaths...)
 	compInfo := common.ComponentInfo{
@@ -3196,7 +3196,7 @@ func (c *Client) StartDeployment(deploymentName string) (string, error) {
 	if deploymentName == "" {
 		return "", errors.Errorf("deployment name is empty")
 	}
-	klog.V(4).Infof("Deployment %s started.", deploymentName)
+	klog.V(3).Infof("Deployment %s started.", deploymentName)
 	deploymentRequest := appsv1.DeploymentRequest{
 		Name: deploymentName,
 		// latest is set to true to prevent image name resolution issue
@@ -3208,7 +3208,7 @@ func (c *Client) StartDeployment(deploymentName string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to instantiate Deployment for %s", deploymentName)
 	}
-	klog.V(4).Infof("Deployment %s for DeploymentConfig %s triggered.", deploymentName, result.Name)
+	klog.V(3).Infof("Deployment %s for DeploymentConfig %s triggered.", deploymentName, result.Name)
 
 	return result.Name, nil
 }

--- a/pkg/occlient/utils.go
+++ b/pkg/occlient/utils.go
@@ -42,7 +42,7 @@ func IsDCRolledOut(config *appsv1.DeploymentConfig, desiredRevision int64) bool 
 	if latestRevision == 0 {
 		switch {
 		case appsutil.HasImageChangeTrigger(config):
-			klog.V(4).Infof("Deployment config %q waiting on image update", config.Name)
+			klog.V(3).Infof("Deployment config %q waiting on image update", config.Name)
 			return false
 
 		case len(config.Spec.Triggers) == 0:
@@ -53,7 +53,7 @@ func IsDCRolledOut(config *appsv1.DeploymentConfig, desiredRevision int64) bool 
 
 	// We use `<` due to OpenShift at times (in rare cases) updating the DeploymentConfig multiple times via ImageTrigger
 	if desiredRevision > 0 && latestRevision < desiredRevision {
-		klog.V(4).Infof("Desired revision (%d) is different from the running revision (%d)", desiredRevision, latestRevision)
+		klog.V(3).Infof("Desired revision (%d) is different from the running revision (%d)", desiredRevision, latestRevision)
 		return false
 	}
 
@@ -74,15 +74,15 @@ func IsDCRolledOut(config *appsv1.DeploymentConfig, desiredRevision int64) bool 
 			return true
 
 		case config.Status.UpdatedReplicas < config.Spec.Replicas:
-			klog.V(4).Infof("Waiting for rollout to finish: %d out of %d new replicas have been updated...", config.Status.UpdatedReplicas, config.Spec.Replicas)
+			klog.V(3).Infof("Waiting for rollout to finish: %d out of %d new replicas have been updated...", config.Status.UpdatedReplicas, config.Spec.Replicas)
 			return false
 
 		case config.Status.Replicas > config.Status.UpdatedReplicas:
-			klog.V(4).Infof("Waiting for rollout to finish: %d old replicas are pending termination...", config.Status.Replicas-config.Status.UpdatedReplicas)
+			klog.V(3).Infof("Waiting for rollout to finish: %d old replicas are pending termination...", config.Status.Replicas-config.Status.UpdatedReplicas)
 			return false
 
 		case config.Status.AvailableReplicas < config.Status.UpdatedReplicas:
-			klog.V(4).Infof("Waiting for rollout to finish: %d of %d updated replicas are available...", config.Status.AvailableReplicas, config.Status.UpdatedReplicas)
+			klog.V(3).Infof("Waiting for rollout to finish: %d of %d updated replicas are available...", config.Status.AvailableReplicas, config.Status.UpdatedReplicas)
 			return false
 		}
 	}

--- a/pkg/occlient/volumes.go
+++ b/pkg/occlient/volumes.go
@@ -105,7 +105,7 @@ func (c *Client) getVolumeNamesFromPVC(pvc string, dc *appsv1.DeploymentConfig) 
 
 		// If PVC does not exist, we skip (as this is either EmptyDir or "shared-data" from SupervisorD
 		if volume.PersistentVolumeClaim == nil {
-			klog.V(4).Infof("Volume has no PVC, skipping %s", volume.Name)
+			klog.V(3).Infof("Volume has no PVC, skipping %s", volume.Name)
 			continue
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does does this PR do / why we need it**:

This PR updates all debugging information to separate caterogies in
order to make debugging easier.

For example, if we were to want to only output Devfile and experimental debugging
information we would simply do `odo -v 3`.

For fine tuning, one can use `--vmodule "*=3,*=4` to get very specific
debugging outputs.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3007

**PR acceptance criteria**:

- [X] Unit test

N/A

- [X] Integration test

N/A

- [X] Documentation

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

To test:

```sh
odo create nodejs --starter

odo push --vmodule "*=3,*=4" -v 0
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>