### PR TITLE
Move Operator Hub out of experimental mode

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -214,6 +214,25 @@ func GetComponentLinkedSecretNames(client *occlient.Client, componentName string
 	return secretNames, nil
 }
 
+// GetDevfileComponentLinkedSecretNames
+func GetDevfileComponentLinkedSecretNames(client *kclient.Client, componentName string, applicationName string) (secretNames []string, err error) {
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+
+	dc, err := client.GetOneDeploymentFromSelector(componentSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch deployments for the selector %v", componentSelector)
+	}
+
+	for _, env := range dc.Spec.Template.Spec.Containers[0].EnvFrom {
+		if env.SecretRef != nil {
+			secretNames = append(secretNames, env.SecretRef.Name)
+		}
+	}
+
+	return secretNames, nil
+}
+
 // CreateFromPath create new component with source or binary from the given local path
 // sourceType indicates the source type of the component and can be either local or binary
 // envVars is the array containing the environment variables

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3285,6 +3285,11 @@ func (c *Client) IsSBRSupported() (bool, error) {
 	return c.isResourceSupported("apps.openshift.io", "v1alpha1", "servicebindingrequests")
 }
 
+// IsCSVSupported chekcs if resource of type service binding request present on the cluster
+func (c *Client) IsCSVSupported() (bool, error) {
+	return c.isResourceSupported("operators.coreos.com", "v1alpha1", "clusterserviceversions")
+}
+
 // GenerateOwnerReference genertes an ownerReference which can then be set as
 // owner for various OpenShift objects and ensure that when the owner object is
 // deleted from the cluster, all other objects are automatically removed by

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/secret"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/openshift/odo/pkg/util"
@@ -49,6 +48,8 @@ type commonLinkOptions struct {
 	serviceType string
 	serviceName string
 	*genericclioptions.Context
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 func newCommonLinkOptions() *commonLinkOptions {
@@ -62,15 +63,31 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 	suppliedName := args[0]
 	o.suppliedName = suppliedName
 
-	if experimental.IsExperimentalModeEnabled() {
+	// we need to support both devfile based component and s2i components.
+	// Let's first check if creating a devfile context is possible for the
+	// command provided by the user
+	_, err = genericclioptions.GetValidEnvInfo(cmd)
+	if err != nil {
+		// error means that we can't create a devfile context for the command
+		// and must create s2i context instead
+		o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+	} else {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
+	}
 
-		oclient, err := occlient.New()
-		if err != nil {
-			return err
-		}
+	o.Client, err = occlient.New()
+	if err != nil {
+		return err
+	}
 
-		sboSupport, err := oclient.IsSBRSupported()
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
+
+		// oclient, err := occlient.New()
+		// if err != nil {
+		// 	return err
+		// }
+
+		sboSupport, err := o.Client.IsSBRSupported()
 		if err != nil {
 			return err
 		}
@@ -129,8 +146,6 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 		return nil
 	}
 
-	o.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-
 	svcExists, err := svc.SvcExists(o.Client, suppliedName, o.Application)
 	if err != nil {
 		// we consider this error to be non-terminal since it's entirely possible to use odo without the service catalog
@@ -167,8 +182,7 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 }
 
 func (o *commonLinkOptions) validate(wait bool) (err error) {
-
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
 		// let's validate if the service exists
 		svcFullName := strings.Join([]string{o.serviceType, o.serviceName}, "/")
 		svcExists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
@@ -263,7 +277,7 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 }
 
 func (o *commonLinkOptions) run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
 		if o.operationName == unlink {
 			sbrName := getSBRName(o.EnvSpecificInfo.GetName(), o.serviceType, o.serviceName)
 			svcFullName := getSvcFullName(sbrKind, sbrName)
@@ -319,16 +333,24 @@ func (o *commonLinkOptions) run() (err error) {
 		linkType = "Service"
 	}
 
-	err = o.operation(o.secretName, o.Component(), o.Application)
+	var component string
+	if o.Context.EnvSpecificInfo != nil {
+		component = o.EnvSpecificInfo.GetName()
+		err = o.operation(o.secretName, component, o.Application)
+	} else {
+		component = o.Component()
+		err = o.operation(o.secretName, component, o.Application)
+	}
+
 	if err != nil {
 		return err
 	}
 
 	switch o.operationName {
 	case "link":
-		log.Successf("%s %s has been successfully linked to the component %s\n", linkType, o.suppliedName, o.Component())
+		log.Successf("%s %s has been successfully linked to the component %s\n", linkType, o.suppliedName, component)
 	case "unlink":
-		log.Successf("%s %s has been successfully unlinked from the component %s\n", linkType, o.suppliedName, o.Component())
+		log.Successf("%s %s has been successfully unlinked from the component %s\n", linkType, o.suppliedName, component)
 	default:
 		return fmt.Errorf("unknown operation %s", o.operationName)
 	}
@@ -342,9 +364,9 @@ func (o *commonLinkOptions) run() (err error) {
 		log.Infof("There are no secret environment variables to expose within the %s service", o.suppliedName)
 	} else {
 		if o.operationName == "link" {
-			log.Infof("The below secret environment variables were added to the '%s' component:\n", o.Component())
+			log.Infof("The below secret environment variables were added to the '%s' component:\n", component)
 		} else {
-			log.Infof("The below secret environment variables were removed from the '%s' component:\n", o.Component())
+			log.Infof("The below secret environment variables were removed from the '%s' component:\n", component)
 		}
 
 		// Output the environment variables
@@ -364,7 +386,7 @@ func (o *commonLinkOptions) run() (err error) {
 		if o.operationName == "link" {
 			log.Italicf(`
 You can now access the environment variables from within the component pod, for example:
-$%s is now available as a variable within component %s`, exampleEnv, o.Component())
+$%s is now available as a variable within component %s`, exampleEnv, component)
 		}
 	}
 
@@ -378,7 +400,14 @@ $%s is now available as a variable within component %s`, exampleEnv, o.Component
 }
 
 func (o *commonLinkOptions) waitForLinkToComplete() (err error) {
-	labels := componentlabels.GetLabels(o.Component(), o.Application, true)
+	var component string
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
+		component = o.EnvSpecificInfo.GetName()
+	} else {
+		component = o.Component()
+	}
+
+	labels := componentlabels.GetLabels(component, o.Application, true)
 	selectorLabels, err := util.NamespaceOpenShiftObject(labels[componentlabels.ComponentLabel], labels["app"])
 	if err != nil {
 		return err

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -48,13 +48,27 @@ type UnlinkOptions struct {
 func NewUnlinkOptions() *UnlinkOptions {
 	options := UnlinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
+	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
 	return &options
 }
 
 // Complete completes UnlinkOptions after they've been created
 func (o *UnlinkOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	err = o.complete(name, cmd, args)
-	o.operation = o.Client.UnlinkSecret
+	if err != nil {
+		return err
+	}
+
+	o.csvSupport, err = o.Client.IsCSVSupported()
+	if err != nil {
+		return err
+	}
+
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
+		o.operation = o.KClient.UnlinkSecret
+	} else {
+		o.operation = o.Client.UnlinkSecret
+	}
 	return err
 }
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -13,8 +13,8 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	svc "github.com/openshift/odo/pkg/service"
 
@@ -56,9 +56,9 @@ A --plan must be passed along with the service type. Parameters to configure the
 
 For a full list of service types, use: 'odo catalog list services'`)
 
-	createShortDescExperimental = `Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.`
+	createShortDescOperatorHub = `Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.`
 
-	createLongDescExperimental = ktemplates.LongDesc(`
+	createLongDescOperatorHub = ktemplates.LongDesc(`
 Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.
 
 When creating a service using Operator Hub, provide a service name along with Operator name.
@@ -105,8 +105,9 @@ type ServiceCreateOptions struct {
 	// If set to true, DryRun prints the yaml that will create the service
 	DryRun bool
 	// Location of the file in which yaml specification of CR is stored.
-	// TODO: remove this after service create's interactive mode supports creating operator backed services
 	fromFile string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -132,7 +133,9 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.interactive = true
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.componentContext != "" {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -144,7 +147,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 
 	var class scv1beta1.ClusterServiceClass
 
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport {
 		// we don't support interactive mode for Operator Hub yet
 		o.interactive = false
 
@@ -198,7 +201,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.outputCLI = commonui.Proceed("Output the non-interactive version of the selected options")
 		o.wait = commonui.Proceed("Wait for the service to be ready")
 	} else {
-		if experimental.IsExperimentalModeEnabled() {
+		if o.csvSupport {
 			// split the name provided on CLI and populate servicetype & customresource
 			o.ServiceType, o.CustomResource, err = svc.SplitServiceKindName(args[0])
 			if err != nil {
@@ -208,8 +211,8 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 			o.ServiceType = args[0]
 		}
 		// if only one arg is given, then it is considered as service name and service type both
-		// ONLY if not running in Experimental mode
-		if !experimental.IsExperimentalModeEnabled() {
+		// ONLY if working on a cluster with Service Catalog and not Operator Hub
+		if !o.csvSupport {
 			// This is because an operator with name
 			// "etcdoperator.v0.9.4-clusterwide" would lead to creation of a
 			// serice with name like
@@ -277,7 +280,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 	}
 
 	// we want to find an Operator only if something's passed to the crd flag on CLI
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport {
 		d := NewDynamicCRD()
 		// if the user wants to create service from a file, we check for
 		// existence of file and validate if the requested operator and CR
@@ -430,11 +433,12 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
 	s := &log.Status{}
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport {
 		// in case of an opertor backed service, name of the service is
 		// provided by the yaml specification in alm-examples. It might also
-		// happen that a user spins up Service Catalog based service in
-		// experimental mode but we're taking a bet against that for now, so
+		// happen that a user wants to spin up Service Catalog based service in
+		// spite of having 4.x cluster mode but we're not supporting
+		// interacting with both Operator Hub and Service Catalog on 4.x. So
 		// the user won't get to see service name in the log message
 		if !o.DryRun {
 			log.Infof("Deploying service of type: %s", o.CustomResource)
@@ -445,8 +449,9 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
 	}
 
-	if experimental.IsExperimentalModeEnabled() && o.CustomResource != "" {
-		// if experimental mode is enabled and o.CustomResource is not empty, we're expected to create an Operator backed service
+	if o.csvSupport && o.CustomResource != "" {
+		// if cluster has resources of type CSV and o.CustomResource is not
+		// empty, we're expected to create an Operator backed service
 		if o.DryRun {
 			// if it's dry run, only print the alm-example (o.CustomResourceDefinition) and exit
 			jsonCR, err := json.MarshalIndent(o.CustomResourceDefinition, "", "  ")
@@ -512,10 +517,13 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	// we ignore the error because it doesn't matter at this place to deal with it and the function returns a *cobra.Command
+	csvSupport, _ := cmdutil.IsCSVSupported()
+
+	if csvSupport {
 		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
-		serviceCreateCmd.Short = createShortDescExperimental
-		serviceCreateCmd.Long = createLongDescExperimental
+		serviceCreateCmd.Short = createShortDescOperatorHub
+		serviceCreateCmd.Long = createLongDescOperatorHub
 		serviceCreateCmd.Example += "\n\n" + fmt.Sprintf(createOperatorExample, fullName)
 		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
 		// remove this feature after enabling service create interactive mode for operator backed services

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/odo/cli/ui"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -34,6 +34,8 @@ type ServiceDeleteOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceDeleteOptions creates a new ServiceDeleteOptions instance
@@ -43,7 +45,9 @@ func NewServiceDeleteOptions() *ServiceDeleteOptions {
 
 // Complete completes ServiceDeleteOptions after they've been created
 func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -55,7 +59,7 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport {
 		svcExists, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
 		if err != nil {
 			return err
@@ -79,7 +83,7 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service delete command
 func (o *ServiceDeleteOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport {
 		if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
 
 			s := log.Spinner("Waiting for service to be deleted")

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,6 +33,8 @@ type ServiceListOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -43,7 +44,9 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if o.csvSupport, err = odoutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -53,7 +56,7 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
-	if !experimental.IsExperimentalModeEnabled() {
+	if !o.csvSupport {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
@@ -66,9 +69,9 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		// if experimental mode is enabled, we list only operator hub backed
-		// services and not service catalog ones
+	if o.csvSupport {
+		// if cluster supports Operators, we list only operator backed services
+		// and not service catalog ones
 		var list []unstructured.Unstructured
 		list, err = svc.ListOperatorServices(o.KClient)
 		if err != nil {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -136,6 +136,11 @@ func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
 	return nil
 }
 
+// GetValidEnvInfo is juat a wrapper for getValidEnvInfo
+func GetValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
+	return getValidEnvInfo(command)
+}
+
 // getValidEnvInfo accesses the environment file
 func getValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -304,3 +304,14 @@ func ThrowContextError() error {
 	return errors.Errorf(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
+
+// IsCSVSupported checks if the cluster supports resources of type ClusterServiceVersion
+func IsCSVSupported() (bool, error) {
+
+	oclient, err := occlient.New()
+	if err != nil {
+		return false, err
+	}
+
+	return oclient.IsCSVSupported()
+}

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -41,7 +41,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "link", "-h")
-			Expect(appHelp).To(ContainSubstring("Link component to a service or component"))
+			Expect(appHelp).To(ContainSubstring("Link component to an operator backed service"))
 		})
 	})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -22,7 +22,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		SetDefaultConsistentlyDuration(30 * time.Second)
 		// TODO: remove this when OperatorHub integration is fully baked into odo
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+		// helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
 	preSetup := func() {
@@ -31,7 +31,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		// wait till oc can see the all operators installed by setup script in the namespace
 		ocArgs := []string{"get", "csv"}
-		operators := []string{"etcd", "mongodb"}
+		operators := []string{"etcd"}
 		for _, operator := range operators {
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, operator)
@@ -43,7 +43,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.DeleteProject(project)
 	}
 
-	Context("When experimental mode is enabled", func() {
+	Context("When Operators are installed in the cluster", func() {
 
 		JustBeforeEach(func() {
 			preSetup()
@@ -55,7 +55,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
 		})
 
 		It("should not allow interactive mode command to be executed", func() {
@@ -308,7 +308,7 @@ spec:
 
 		It("listing catalog of services", func() {
 			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
+			helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind code-refactoring

**What does does this PR do / why we need it**:
It moves Operator Hub integration out of experimental mode. We need it for v2.

**Which issue(s) this PR fixes**:

Fixes #3595 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
* Tests should pass.
* If Operators are supported by the cluster (4.x), we ignore service catalog altogether.
* If user's working with 3.x cluster, odo should support Service Catalog (if enabled by the user).