### PR TITLE
Update doc references to spring boot [skip ci]

### DIFF
--- a/docs/dev/experimental-mode.adoc
+++ b/docs/dev/experimental-mode.adoc
@@ -54,7 +54,7 @@ java-springboot      Spring Boot® using IBM Java           YES
 When creating a devfile component with the experimental flag enabled, a local config of the component settings in created at `.odo/env/env.yaml` in the project directory.
 
 ```
-$ odo create java-spring-boot myspring
+$ odo create java-springboot myspring
 Experimental mode is enabled, use at your own risk
 
 Validation

--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -91,7 +91,7 @@ Ingress IP is usually the external IP of ingress controller service, for Minikub
 
 ----
 
-In our example, we will be using `java-spring-boot` to deploy a sample https://spring.io/projects/spring-boot[Springboot] component.
+In our example, we will be using `java-springboot` to deploy a sample https://spring.io/projects/spring-boot[Springboot] component.
 
 == Deploying a Java Spring Boot® component to an OpenShift / Kubernetes cluster
 
@@ -112,11 +112,11 @@ Alternatively, you can pass in `--starter` to `odo create` to have odo download 
  $ cd <directory-name>
 ----
 
-. Create a component configuration using the `java-spring-boot` component-type named `myspring`:
+. Create a component configuration using the `java-springboot` component-type named `myspring`:
 +
 [source,sh]
 ----
-   $ odo create java-spring-boot myspring
+   $ odo create java-springboot myspring
    Experimental mode is enabled, use at your own risk
 
    Validation
@@ -395,7 +395,7 @@ Run `odo delete` to delete the application from cluster.
 [source,sh]
 ----
    $ odo delete
-   ? Are you sure you want to delete the devfile component: java-spring-boot? Yes
-    ✓  Deleting devfile component java-spring-boot [139ms]
+   ? Are you sure you want to delete the devfile component: java-springboot? Yes
+    ✓  Deleting devfile component java-springboot [139ms]
     ✓  Successfully deleted component
 ----


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What type of PR is this?**
/kind documentation
[skip ci]


**What does does this PR do / why we need it**:
A while back, the default devfile stacks were updated to follow a consistent naming scheme (e.g. `java-spring-boot` -> `java-springboot`), but it appears some of the documentation that references the spring boot stack was not updated accordingly.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3863

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)