### PR TITLE
Sync operators on 4.* cluster

### DIFF
--- a/scripts/setup-operators.sh
+++ b/scripts/setup-operators.sh
@@ -52,7 +52,7 @@ install_service_binding_operator(){
     name: service-binding-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: service-binding-operator.v0.1.1-352
+    startingCSV: service-binding-operator.v0.1.1-364
 EOF
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**What does does this PR do / why we need it**:

Operators are unstable with 4.6 cluster which causing our operator tests to get failed. However there is a common change in start csv version for service binding in all over 4.* cluster. This pr should handle those either by just removing the unstable operators or using workarounds like fetching the operators into the cluster.

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

`make test-operator-hub` should pass.