### PR TITLE
Fix deletion of files and folders created during watch

### DIFF
--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -80,6 +80,10 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 
 		changedFiles = pushParameters.WatchFiles
 		deletedFiles = pushParameters.WatchDeletedFiles
+		deletedFiles, err = util.RemoveRelativePathFromFiles(deletedFiles, pushParameters.Path)
+		if err != nil {
+			return false, errors.Wrap(err, "unable to remove relative path from list of changed/deleted files")
+		}
 		indexRegeneratedByWatch = true
 
 	}

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -326,7 +326,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 
 			deletedPaths = removeDuplicates(deletedPaths)
 
-			for _, file := range changedFiles {
+			for _, file := range removeDuplicates(append(changedFiles, deletedPaths...)) {
 				fmt.Fprintf(out, "File %s changed\n", file)
 			}
 			if len(changedFiles) > 0 || len(deletedPaths) > 0 {

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"index/suffixarray"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -380,11 +381,10 @@ func OdoWatch(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, project, context, fl
 			_, err = os.Create(filepath.Join(context, "a.txt"))
 			Expect(err).To(BeNil())
 
-			helper.DeleteDir(filepath.Join(context, "abcd"))
-
 			if isDevfileTest {
 				helper.ReplaceString(filepath.Join(context, "server.js"), "Hello", "Hello odo")
 			} else {
+				helper.DeleteDir(filepath.Join(context, "abcd"))
 				if odoV1Watch.SrcType == "openjdk" {
 					helper.ReplaceString(filepath.Join(context, "src", "main", "java", "MessageProducer.java"), "Hello", "Hello odo")
 				} else {
@@ -419,10 +419,24 @@ func OdoWatch(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, project, context, fl
 				}
 
 				if stringsMatched {
-					// Verify directory deleted from component pod
-					err := validateContainerExecListDir(odoV1Watch, odoV2Watch, runner, platform, project, isDevfileTest)
-					Expect(err).To(BeNil())
-					return true
+
+					// first push is successful
+					// now delete a folder and check if the deletion is propagated properly
+					// and the file is removed from the cluster
+					index := suffixarray.New([]byte(output))
+					offsets := index.Lookup([]byte(filepath.Join(context, "abcd")+" changed"), -1)
+
+					// the first occurrence of '<target-dir> changed' means the creation of it was pushed to the cluster
+					// and the first push was successful
+					if len(offsets) == 1 {
+						helper.DeleteDir(filepath.Join(context, "abcd"))
+					} else if len(offsets) > 1 {
+						// the occurrence of 'target-directory' more than once indicates that the deletion was propagated too
+						// Verify directory deleted from component pod
+						err := validateContainerExecListDir(odoV1Watch, odoV2Watch, runner, platform, project, isDevfileTest)
+						Expect(err).To(BeNil())
+						return true
+					}
 				}
 			} else {
 				curlURL := helper.CmdShouldPass("curl", odoV1Watch.RouteURL)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

This PR fixes the deletion of files created during watch.

**Which issue(s) this PR fixes**:

Fixes #https://github.com/openshift/odo/issues/3438

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create a odo component and trigger `odo watch`
- Create a file/folder and wait for the push to be completed
- Delete the file/folder and check if the file was removed from the cluster or not.
