### PR TITLE
Makefile docker target clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,40 +296,41 @@ test-cmd-devfile-env:
 test-cmd-devfile-config:
 	ginkgo $(GINKGO_FLAGS) -focus="odo devfile config command tests" tests/integration/devfile/
 
-# Run odo push docker devfile command tests
-.PHONY: test-cmd-docker-devfile-push
-test-cmd-docker-devfile-push:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile push command tests" tests/integration/devfile/docker/
+# Fix https://github.com/openshift/odo/issues/3714 to uncomment docker make target
+# # Run odo push docker devfile command tests
+# .PHONY: test-cmd-docker-devfile-push
+# test-cmd-docker-devfile-push:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile push command tests" tests/integration/devfile/docker/
 
-# Run odo watch docker devfile command tests
-.PHONY: test-cmd-docker-devfile-watch
-test-cmd-docker-devfile-watch:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile watch command tests" tests/integration/devfile/docker/
+# # Run odo watch docker devfile command tests
+# .PHONY: test-cmd-docker-devfile-watch
+# test-cmd-docker-devfile-watch:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile watch command tests" tests/integration/devfile/docker/
 
-# Run odo url docker devfile command tests
-.PHONY: test-cmd-docker-devfile-url
-test-cmd-docker-devfile-url:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url command tests" tests/integration/devfile/docker/
+# # Run odo url docker devfile command tests
+# .PHONY: test-cmd-docker-devfile-url
+# test-cmd-docker-devfile-url:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url command tests" tests/integration/devfile/docker/
 
-# Run odo docker devfile delete command tests
-.PHONY: test-cmd-docker-devfile-delete
-test-cmd-docker-devfile-delete:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile delete command tests" tests/integration/devfile/docker/
+# # Run odo docker devfile delete command tests
+# .PHONY: test-cmd-docker-devfile-delete
+# test-cmd-docker-devfile-delete:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile delete command tests" tests/integration/devfile/docker/
 
-# Run odo catalog devfile command tests
-.PHONY: test-cmd-docker-devfile-catalog
-test-cmd-docker-devfile-catalog:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile catalog command tests" tests/integration/devfile/docker/
+# # Run odo catalog devfile command tests
+# .PHONY: test-cmd-docker-devfile-catalog
+# test-cmd-docker-devfile-catalog:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile catalog command tests" tests/integration/devfile/docker/
 
-# Run odo url docker devfile command tests
-.PHONY: test-cmd-docker-devfile-url-pushtarget
-test-cmd-docker-devfile-url-pushtarget:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url pushtarget command tests" tests/integration/devfile/docker/
+# # Run odo url docker devfile command tests
+# .PHONY: test-cmd-docker-devfile-url-pushtarget
+# test-cmd-docker-devfile-url-pushtarget:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile url pushtarget command tests" tests/integration/devfile/docker/
 
-# Run odo test docker devfile command tests
-.PHONY: test-cmd-docker-devfile-test
-test-cmd-docker-devfile-test:
-	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile test command tests" tests/integration/devfile/docker/
+# # Run odo test docker devfile command tests
+# .PHONY: test-cmd-docker-devfile-test
+# test-cmd-docker-devfile-test:
+# 	ginkgo $(GINKGO_FLAGS) -focus="odo docker devfile test command tests" tests/integration/devfile/docker/
 
 # Run odo watch command tests
 .PHONY: test-cmd-watch


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:

There is a regression failure with docker tests which has been tracked https://github.com/openshift/odo/issues/3714 . So just commented out the targets from Makefile. 

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
