### PR TITLE
Improve URL format validation

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1141,8 +1141,15 @@ func ValidateURL(sourceURL string) error {
 	if err != nil {
 		return err
 	}
+	scheme := u.Scheme
+	user := u.User.Username()
+	host := u.Host
 
-	if len(u.Host) == 0 || len(u.Scheme) == 0 {
+	// Valid URL needs to satisfy the following requirements:
+	// 1. URL has scheme and host components
+	// 2. Scheme, host and user (if applicable) components of the URL shouldn't contain reserved character
+	re := regexp.MustCompile(`[\/;?:@&=+$,]`)
+	if scheme == "" || host == "" || re.MatchString(scheme) || re.MatchString(host) || re.MatchString(user) {
 		return errors.New("URL is invalid")
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1137,19 +1137,17 @@ func CheckKubeConfigExist() bool {
 
 // ValidateURL validates the URL
 func ValidateURL(sourceURL string) error {
-	u, err := url.Parse(sourceURL)
+	// Valid URL needs to satisfy the following requirements:
+	// 1. URL has scheme and host components
+	// 2. Scheme, host of the URL shouldn't contain reserved character
+	url, err := url.ParseRequestURI(sourceURL)
 	if err != nil {
 		return err
 	}
-	scheme := u.Scheme
-	user := u.User.Username()
-	host := u.Host
+	host := url.Host
 
-	// Valid URL needs to satisfy the following requirements:
-	// 1. URL has scheme and host components
-	// 2. Scheme, host and user (if applicable) components of the URL shouldn't contain reserved character
-	re := regexp.MustCompile(`[\/;?:@&=+$,]`)
-	if scheme == "" || host == "" || re.MatchString(scheme) || re.MatchString(host) || re.MatchString(user) {
+	re := regexp.MustCompile(`[:\/\?#\[\]@]`)
+	if host == "" || re.MatchString(host) {
 		return errors.New("URL is invalid")
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1766,17 +1766,12 @@ func TestValidateURL(t *testing.T) {
 		},
 		{
 			name:    "Case 4: Invalid URL - Host contains reserved character",
-			url:     "http://$$,,",
+			url:     "http://??##",
 			wantErr: true,
 		},
 		{
 			name:    "Case 5: Invalid URL - Scheme contains reserved character",
 			url:     "$$$,,://www.example.com",
-			wantErr: true,
-		},
-		{
-			name:    "Case 6: Invalid URL - User contains reserved character",
-			url:     "http://$$$,,@server.com",
 			wantErr: true,
 		},
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1764,6 +1764,21 @@ func TestValidateURL(t *testing.T) {
 			url:     "://www.example.com/",
 			wantErr: true,
 		},
+		{
+			name:    "Case 4: Invalid URL - Host contains reserved character",
+			url:     "http://$$,,",
+			wantErr: true,
+		},
+		{
+			name:    "Case 5: Invalid URL - Scheme contains reserved character",
+			url:     "$$$,,://www.example.com",
+			wantErr: true,
+		},
+		{
+			name:    "Case 6: Invalid URL - User contains reserved character",
+			url:     "http://$$$,,@server.com",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug
/area devfile

**What does does this PR do / why we need it**:
This PR adds more requirements to URL format validation so that gate more invalid registry URLs

**Which issue(s) this PR fixes**:

Fixes #3451 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test  

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Run `odo registry add test <invalid URL>`, for example run `odo registry add test http://$$$$,,,,,@hdjh.hcgcyd `