### PR TITLE
Cleaning up odo rpm spec and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ configure-supported-311-is:
 
 .PHONY: test
 test:
-	go test $(BUILD_FLAGS) $(UNIT_TEST_ARGS) -race $(PKGS)
+	go test $(UNIT_TEST_ARGS) -race $(PKGS)
 
 # Run generic integration tests
 .PHONY: test-generic

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ configure-supported-311-is:
 
 .PHONY: test
 test:
-	go test $(UNIT_TEST_ARGS) -race $(PKGS)
+	go test $(BUILD_FLAGS) $(UNIT_TEST_ARGS) -race $(PKGS)
 
 # Run generic integration tests
 .PHONY: test-generic

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -23,8 +23,8 @@ URL:            https://github.com/openshift/odo/tree/%{odo_cli_version}
 Source0:        %{source_tar}
 BuildRequires:  gcc
 BuildRequires:  golang >= %{golang_version}
-Provides:       %{package_name}
-Obsoletes:      %{package_name}
+Provides:       %{package_name} = %{odo_version}
+Obsoletes:      %{package_name} <= %{odo_version}
 
 %description
 odo is a fast, iterative, and straightforward CLI tool for developers who write, build, and deploy applications on OpenShift.
@@ -69,8 +69,8 @@ cp -avrf dist/release/SHA256_SUM %{buildroot}%{_datadir}/%{name}-redistributable
 Summary:        %{product_name} client CLI binaries for Linux, macOS and Windows
 BuildRequires:  gcc
 BuildRequires:  golang >= %{golang_version}
-Provides:       %{package_name}-redistributable
-Obsoletes:      %{package_name}-redistributable
+Provides:       %{package_name}-redistributable = %{odo_version}
+Obsoletes:      %{package_name}-redistributable <= %{odo_version}
 
 %description redistributable
 %{product_name} client odo cross platform binaries for Linux, macOS and Windows.

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -44,6 +44,7 @@ cd %{gopath}/src/github.com/openshift/odo
 GOFLAGS='-mod=vendor' make test
 %endif
 make prepare-release
+echo "%{odo_version}" > dist/release/VERSION
 unlink %{gopath}/src/github.com/openshift/odo
 
 %install
@@ -59,7 +60,7 @@ install -p -m 755 dist/release/odo-darwin-amd64 %{buildroot}%{_datadir}/%{name}-
 install -p -m 755 dist/release/odo-windows-amd64.exe %{buildroot}%{_datadir}/%{name}-redistributable/odo-windows-amd64.exe
 cp -avrf dist/release/odo*.tar.gz %{buildroot}%{_datadir}/%{name}-redistributable
 cp -avrf dist/release/SHA256_SUM %{buildroot}%{_datadir}/%{name}-redistributable
-
+cp -avrf dist/release/VERSION %{buildroot}%{_datadir}/%{name}-redistributable
 
 %files
 %license LICENSE
@@ -91,3 +92,4 @@ Obsoletes:      %{package_name}-redistributable <= %{odo_version}
 %{_datadir}/%{name}-redistributable/odo-windows-amd64.exe
 %{_datadir}/%{name}-redistributable/odo-windows-amd64.exe.tar.gz
 %{_datadir}/%{name}-redistributable/SHA256_SUM
+%{_datadir}/%{name}-redistributable/VERSION

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -45,7 +45,6 @@ make test
 %endif
 make prepare-release
 unlink %{gopath}/src/github.com/openshift/odo
-rm -rf %{gopath}
 
 %install
 mkdir -p %{buildroot}/%{_bindir}

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -41,7 +41,7 @@ export GOPATH=%{gopath}
 cd %{gopath}/src/github.com/openshift/odo
 %ifarch x86_64
 # go test -race is not supported on all arches
-make test
+GOFLAGS='-mod=vendor' make test
 %endif
 make prepare-release
 unlink %{gopath}/src/github.com/openshift/odo

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -12,6 +12,7 @@
 %global source_dir openshift-odo-%{odo_version}-%{odo_release}
 %global source_tar %{source_dir}.tar.gz
 %global gopath  %{_builddir}/gocode
+%global _missing_build_ids_terminate_build 0
 
 Name:           %{package_name}
 Version:        %{odo_version}
@@ -40,7 +41,7 @@ export GOPATH=%{gopath}
 cd %{gopath}/src/github.com/openshift/odo
 %ifarch x86_64
 # go test -race is not supported on all arches
-make test
+GOFLAGS=-mod=vendor make test
 %endif
 make prepare-release
 unlink %{gopath}/src/github.com/openshift/odo

--- a/rpms/openshift-odo.spec
+++ b/rpms/openshift-odo.spec
@@ -41,7 +41,7 @@ export GOPATH=%{gopath}
 cd %{gopath}/src/github.com/openshift/odo
 %ifarch x86_64
 # go test -race is not supported on all arches
-GOFLAGS=-mod=vendor make test
+make test
 %endif
 make prepare-release
 unlink %{gopath}/src/github.com/openshift/odo

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -19,3 +19,7 @@ GOFLAGS='' make test
 # crosscompile and publish artifacts
 make cross
 cp -r dist $ARTIFACTS_DIR
+
+# RPM Tests
+GOFLAGS='' scripts/rpm-x86_64-test.sh
+

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -22,4 +22,3 @@ cp -r dist $ARTIFACTS_DIR
 
 # RPM Tests
 scripts/rpm-x86_64-test.sh
-

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -14,12 +14,12 @@ export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
 make goget-tools
 make validate
-GOFLAGS='' make test
+make test
 
 # crosscompile and publish artifacts
 make cross
 cp -r dist $ARTIFACTS_DIR
 
 # RPM Tests
-GOFLAGS='' scripts/rpm-x86_64-test.sh
+scripts/rpm-x86_64-test.sh
 

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -14,7 +14,7 @@ export GOLANGCI_LINT_CACHE="/tmp/.cache"
 
 make goget-tools
 make validate
-make test
+GOFLAGS='' make test
 
 # crosscompile and publish artifacts
 make cross

--- a/scripts/rpm-local-build.sh
+++ b/scripts/rpm-local-build.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set +x
 
 if [[ ! -d dist/rpmbuild  ]]; then
 	echo "Cannot build as artifacts are not generated. Run scrips/rpm-prepare.sh first"

--- a/scripts/rpm-local-build.sh
+++ b/scripts/rpm-local-build.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 set -e
+set +x
 
 if [[ ! -d dist/rpmbuild  ]]; then
 	echo "Cannot build as artifacts are not generated. Run scrips/rpm-prepare.sh first"
 	exit 1
 fi
 
-echo "Cleaning up old rpmcontent"
-rm -f ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-
-echo "Copying content to local rpmbuild"
-cp -avrf dist/rpmbuild/SOURCES/* $HOME/rpmbuild/SOURCES/
-cp -avrf dist/rpmbuild/SPECS/* $HOME/rpmbuild/SPECS/
-
+top_dir="`pwd`/dist/rpmbuild"
 echo "Building locally"
-rpmbuild -ba $HOME/rpmbuild/SPECS/openshift-odo.spec
+rpmbuild --define "_topdir `echo $top_dir`" -ba dist/rpmbuild/SPECS/openshift-odo.spec

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -37,17 +37,11 @@ NAME="openshift-odo-$ODO_RPM_VERSION-$ODO_RELEASE"
 echo "Making release for $NAME, git commit $GIT_COMMIT"
 
 echo "Cleaning up old content"
-if [[ -d $DIST_DIR ]]; then
-    rm -rf $DIST_DIR
-fi
-if [[ -d $FINAL_OUT_DIR ]]; then
-    rm -rf $FINAL_OUT_DIR
-fi
+rm -rf $DIST_DIR
+rm -rf $FINAL_OUT_DIR
 
 echo "Configuring output directory $OUT_DIR"
-if [[ -d $OUT_DIR  ]]; then
-    rm -rf $OUT_DIR
-fi
+rm -rf $OUT_DIR
 mkdir -p $SPEC_DIR
 mkdir -p $SOURCES_DIR/$NAME
 mkdir -p $FINAL_OUT_DIR
@@ -61,17 +55,13 @@ cp -arf ./* $SOURCES_DIR/$NAME
 pushd $SOURCES_DIR
 pushd $NAME
 # Remove bin if it exists, we dont need it in tarball
-if [[ -f ./odo  ]]; then
-    rm -rf ./odo
-fi
+rm -rf ./odo
 popd
 
 # Create tarball
 tar -czf $NAME.tar.gz $NAME
 # Removed copied content
-if [[ -d $NAME ]]; then
-    rm -rf $NAME
-fi
+rm -rf $NAME
 popd
 
 echo "Finalizing..."

--- a/scripts/rpm-x86_64-test.sh
+++ b/scripts/rpm-x86_64-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Preping rpm"
+scripts/rpm-prepare.sh
+
+echo "Building rpm"
+scripts/rpm-local-build.sh
+
+rm -rf dist/rpmtest
+mkdir -p dist/rpmtest/{odo,redistributable}
+
+echo "Validating odo rpm"
+rpm2cpio dist/rpmbuild/RPMS/x86_64/`ls dist/rpmbuild/RPMS/x86_64/ | grep -v redistributable` > dist/rpmtest/odo/odo.cpio
+pushd dist/rpmtest/odo
+cpio -idv < odo.cpio
+ls ./usr/bin | grep odo
+./usr/bin/odo version
+popd
+
+RL="odo-darwin-amd64 odo-linux-ppc64le odo-linux-arm64 odo-windows-amd64.exe odo-linux-amd64 odo-linux-s390x"
+echo "Validating odo-redistributable rpm"
+rpm2cpio dist/rpmbuild/RPMS/x86_64/`ls dist/rpmbuild/RPMS/x86_64/ | grep redistributable` > dist/rpmtest/redistributable/odo-redistribuable.cpio
+pushd dist/rpmtest/redistributable
+cpio -idv < odo-redistribuable.cpio
+for i in $RL; do
+	ls ./usr/share/odo-redistributable | grep $i
+done
+./usr/share/odo-redistributable/odo-linux-amd64 version
+popd


### PR DESCRIPTION
/kind cleanup

**What does this PR do / why we need it**:
- downloading deps in rpm build is a big no
- some cleanup

**Changes**:
- rpmspec `Provides` and `Obsoletes` is more specific (this removes warnings as well)
- rpm local build script now uses dist/rpmbuild as topdir
- explicit `GOFLAGS=-mod-vendor` for `make test` in rpm spec (see https://gist.github.com/mohammedzee1000/81382df2c2a0c67411966e55aa5c1dd2) we cannot have deps being pulled in release
- Added rpm testing