### PR TITLE
[WIP] add verbose to analyse the deployment rollout for odo push

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -371,6 +371,10 @@ spec:
 		})
 
 		JustAfterEach(func() {
+			helper.CmdShouldPass("oc", "describe", "pod", "-n", project)
+			helper.CmdShouldPass("oc", "get", "deployment", "-n", project)
+			helper.CmdShouldPass("oc", "describe", "deployment", "-n", project)
+			helper.CmdShouldPass("oc", "describe", "replicaset", "-n", project)
 			cleanPreSetup()
 			helper.Chdir(currentWorkingDirectory)
 			helper.DeleteDir(context)
@@ -439,7 +443,7 @@ spec:
 
 			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
 			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
-			helper.CmdShouldPass("odo", "push")
+			helper.CmdShouldPass("odo", "push", "--v", "4")
 
 			// verify that sbr is deleted
 			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind flake

What does does this PR do / why we need it:
To analyze flake #3256 as per comment https://github.com/openshift/odo/issues/3256#issuecomment-688243598

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo push` detailed log should be printed for deployment rollout