### PR TITLE
Implement clonePath, update source code sync location

### DIFF
--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -452,3 +452,130 @@ func TestUpdateIndexWithWatchChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSyncFolder(t *testing.T) {
+	projectNames := []string{"some-name", "another-name"}
+	projectRepos := []string{"https://github.com/some/repo.git", "https://github.com/another/repo.git"}
+	projectClonePath := "src/github.com/golang/example/"
+	invalidClonePaths := []string{"/var", "../var", "pkg/../../var"}
+	sourceVolumePath := "/projects/app"
+
+	tests := []struct {
+		name     string
+		projects []versionsCommon.DevfileProject
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "Case 1: No projects",
+			projects: []versionsCommon.DevfileProject{},
+			want:     sourceVolumePath,
+			wantErr:  false,
+		},
+		{
+			name: "Case 2: One project",
+			projects: []versionsCommon.DevfileProject{
+				{
+					Name: projectNames[0],
+					Git: &versionsCommon.Git{
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    filepath.ToSlash(filepath.Join(sourceVolumePath, projectNames[0])),
+			wantErr: false,
+		},
+		{
+			name: "Case 3: Multiple projects",
+			projects: []versionsCommon.DevfileProject{
+				{
+					Name: projectNames[0],
+					Git: &versionsCommon.Git{
+						Location: projectRepos[0],
+					},
+				},
+				{
+					Name: projectNames[1],
+					Github: &versionsCommon.Github{
+						Location: projectRepos[1],
+					},
+				},
+				{
+					Name: projectNames[1],
+					Zip: &versionsCommon.Zip{
+						Location: projectRepos[1],
+					},
+				},
+			},
+			want:    sourceVolumePath,
+			wantErr: false,
+		},
+		{
+			name: "Case 4: Clone path set",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: projectClonePath,
+					Name:      projectNames[0],
+					Zip: &versionsCommon.Zip{
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    filepath.ToSlash(filepath.Join(sourceVolumePath, projectClonePath)),
+			wantErr: false,
+		},
+		{
+			name: "Case 5: Invalid clone path, set with absolute path",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: invalidClonePaths[0],
+					Name:      projectNames[0],
+					Github: &versionsCommon.Github{
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Case 6: Invalid clone path, starts with ..",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: invalidClonePaths[1],
+					Name:      projectNames[0],
+					Git: &versionsCommon.Git{
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Case 7: Invalid clone path, contains ..",
+			projects: []versionsCommon.DevfileProject{
+				{
+					ClonePath: invalidClonePaths[2],
+					Name:      projectNames[0],
+					Zip: &versionsCommon.Zip{
+						Location: projectRepos[0],
+					},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		syncFolder, err := getSyncFolder(sourceVolumePath, tt.projects)
+
+		if !tt.wantErr == (err != nil) {
+			t.Errorf("expected %v, actual %v", tt.wantErr, err)
+		}
+
+		if syncFolder != tt.want {
+			t.Errorf("expected %s, actual %s", tt.want, syncFolder)
+		}
+	}
+}

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -478,7 +478,9 @@ func TestGetSyncFolder(t *testing.T) {
 				{
 					Name: projectNames[0],
 					Git: &versionsCommon.Git{
-						Location: projectRepos[0],
+						GitLikeProjectSource: versionsCommon.GitLikeProjectSource{
+							Remotes: map[string]string{"origin": projectRepos[0]},
+						},
 					},
 				},
 			},
@@ -491,13 +493,17 @@ func TestGetSyncFolder(t *testing.T) {
 				{
 					Name: projectNames[0],
 					Git: &versionsCommon.Git{
-						Location: projectRepos[0],
+						GitLikeProjectSource: versionsCommon.GitLikeProjectSource{
+							Remotes: map[string]string{"origin": projectRepos[0]},
+						},
 					},
 				},
 				{
 					Name: projectNames[1],
 					Github: &versionsCommon.Github{
-						Location: projectRepos[1],
+						GitLikeProjectSource: versionsCommon.GitLikeProjectSource{
+							Remotes: map[string]string{"origin": projectRepos[1]},
+						},
 					},
 				},
 				{
@@ -531,7 +537,9 @@ func TestGetSyncFolder(t *testing.T) {
 					ClonePath: invalidClonePaths[0],
 					Name:      projectNames[0],
 					Github: &versionsCommon.Github{
-						Location: projectRepos[0],
+						GitLikeProjectSource: versionsCommon.GitLikeProjectSource{
+							Remotes: map[string]string{"origin": projectRepos[0]},
+						},
 					},
 				},
 			},
@@ -545,7 +553,9 @@ func TestGetSyncFolder(t *testing.T) {
 					ClonePath: invalidClonePaths[1],
 					Name:      projectNames[0],
 					Git: &versionsCommon.Git{
-						Location: projectRepos[0],
+						GitLikeProjectSource: versionsCommon.GitLikeProjectSource{
+							Remotes: map[string]string{"origin": projectRepos[0]},
+						},
 					},
 				},
 			},

--- a/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
@@ -5,17 +5,20 @@ projects:
   - name: nodeshift
     clonePath: webapp/
     git:
-      location: "https://github.com/nodeshift/nodeshift"
+      remotes:
+        origin: "https://github.com/nodeshift/nodeshift"
   - name: nodejs-health-check
     git:
-      location: "https://github.com/nodeshift-starters/nodejs-health-check"
+      remotes: 
+        origin: "https://github.com/nodeshift-starters/nodejs-health-check" 
 starterProjects:
   - name: nodejs-starter
     git:
-      location: "https://github.com/odo-devfiles/nodejs-ex.git"
+      remotes: 
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
 components:
-  - container:
-      name: runtime
+  - name: runtime
+    container:
       image: registry.access.redhat.com/ubi8/nodejs-12:1-36
       memoryLimit: 1024Mi
       endpoints:
@@ -23,16 +26,16 @@ components:
           targetPort: 3000
       mountSources: true
 commands:
-  - exec:
-      id: devbuild
+  - id: devbuild
+    exec:
       component: runtime
       commandLine: npm install
       workingDir: ${PROJECTS_ROOT}
       group:
         kind: build
         isDefault: true
-  - exec:
-      id: devrun
+  - id: devrun
+    exec:
       component: runtime
       commandLine: npm start
       workingDir: ${PROJECTS_ROOT}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+projects:
+  - name: nodeshift
+    clonePath: webapp/
+    git:
+      location: "https://github.com/nodeshift/nodeshift"
+  - name: nodejs-health-check
+    git:
+      location: "https://github.com/nodeshift-starters/nodejs-health-check"
+starterProjects:
+  - name: nodejs-starter
+    git:
+      location: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - container:
+      name: runtime
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      endpoints:
+        - name: "3000/tcp"
+          targetPort: 3000
+      mountSources: true
+commands:
+  - exec:
+      id: devbuild
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - exec:
+      id: devrun
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true

--- a/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
@@ -17,7 +17,7 @@ components:
     container:
       image: registry.access.redhat.com/ubi8/nodejs-12:1-36
       memoryLimit: 1024Mi
-      sourceMapping: apps/
+      sourceMapping: /apps
       endpoints:
         - name: "3000/tcp"
           targetPort: 3000

--- a/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
@@ -5,14 +5,16 @@ projects:
   - name: nodeshift
     clonePath: webapp/
     git:
-      location: "https://github.com/nodeshift/nodeshift"
+      remotes: 
+        origin: "https://github.com/nodeshift/nodeshift"
 starterProjects:
   - name: nodejs-starter
     git:
-      location: "https://github.com/odo-devfiles/nodejs-ex.git"
+      remotes: 
+        origin: "https://github.com/odo-devfiles/nodejs-ex.git"
 components:
-  - container:
-      name: runtime
+  - name: runtime
+    container:
       image: registry.access.redhat.com/ubi8/nodejs-12:1-36
       memoryLimit: 1024Mi
       sourceMapping: apps/
@@ -21,16 +23,16 @@ components:
           targetPort: 3000
       mountSources: true
 commands:
-  - exec:
-      id: devbuild
+  - id: devbuild
+    exec:
       component: runtime
       commandLine: npm install
       workingDir: ${PROJECTS_ROOT}/webapp
       group:
         kind: build
         isDefault: true
-  - exec:
-      id: devrun
+  - id: devrun
+    exec:
       component: runtime
       commandLine: npm start
       workingDir: ${PROJECTS_ROOT}/webapp

--- a/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+projects:
+  - name: nodeshift
+    clonePath: webapp/
+    git:
+      location: "https://github.com/nodeshift/nodeshift"
+starterProjects:
+  - name: nodejs-starter
+    git:
+      location: "https://github.com/odo-devfiles/nodejs-ex.git"
+components:
+  - container:
+      name: runtime
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 1024Mi
+      sourceMapping: apps/
+      endpoints:
+        - name: "3000/tcp"
+          targetPort: 3000
+      mountSources: true
+commands:
+  - exec:
+      id: devbuild
+      component: runtime
+      commandLine: npm install
+      workingDir: ${PROJECTS_ROOT}/webapp
+      group:
+        kind: build
+        isDefault: true
+  - exec:
+      id: devrun
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}/webapp
+      group:
+        kind: run
+        isDefault: true

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -857,22 +857,37 @@ var _ = Describe("odo devfile push command tests", func() {
 	})
 	Context("Verify source code sync location", func() {
 
-		It("Should sync to the correct dir in container if project is present", func() {
+		It("Should sync to the correct dir in container if project and clonePath is present", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 
 			// devfile with clonePath set in project field
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(context, "devfile.yaml"))
-			// we do not need to check source code location inside the container, as the expected workingDir
-			// is already set in devfile.yaml, odo push would fail if it is not synced to correct location
-			// so we are only checking odo push should pass to verify location.
+
 			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context, "--v", "5")
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+			// source code is synced to $PROJECTS_ROOT/clonePath
+			// $PROJECTS_ROOT is /projects by default, if sourceMapping is set it is same as sourceMapping
+			// for devfile-with-projects.yaml, sourceMapping is apps and clonePath is webapp
+			// so source code would be synced to /apps/webapp
+			output := cliRunner.ExecListDir(podName, namespace, "/apps/webapp")
+			helper.MatchAllInOutput(output, []string{"package.json"})
+		})
+
+		It("Should sync to the correct dir in container if project present", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			// reset clonePath and change the workdir accordingly, it should sync to project name
-			helper.ReplaceString("devfile.yaml", "clonePath: webapp/ ", "clonepath: ")
-			helper.ReplaceString("devfile.yaml", "${PROJECTS_ROOT}/webapp ", "${PROJECTS_ROOT}/nodeshift")
+			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "clonePath: webapp/", "# clonePath: webapp/")
+			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "workingDir: ${PROJECTS_ROOT}/webapp", "workingDir: ${PROJECTS_ROOT}/nodeshift")
 
 			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+			output := cliRunner.ExecListDir(podName, namespace, "/apps/nodeshift")
+			helper.MatchAllInOutput(output, []string{"package.json"})
 		})
 
 		It("Should sync to the correct dir in container if multiple project is present", func() {
@@ -881,6 +896,11 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"), filepath.Join(context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+			// for devfile-with-multiple-projects.yaml source mapping is not set so $PROJECTS_ROOT is /projects
+			// multiple projects, so source code would sync to /projects
+			output := cliRunner.ExecListDir(podName, namespace, "/projects")
+			helper.MatchAllInOutput(output, []string{"package.json"})
 		})
 
 		It("Should sync to the correct dir in container if no project is present", func() {
@@ -889,6 +909,9 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+			output := cliRunner.ExecListDir(podName, namespace, "/projects")
+			helper.MatchAllInOutput(output, []string{"package.json"})
 		})
 
 	})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -855,6 +855,43 @@ var _ = Describe("odo devfile push command tests", func() {
 
 		})
 	})
+	Context("Verify source code sync location", func() {
+
+		It("Should sync to the correct dir in container if project is present", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+
+			// devfile with clonePath set in project field
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(context, "devfile.yaml"))
+			// we do not need to check source code location inside the container, as the expected workingDir
+			// is already set in devfile.yaml, odo push would fail if it is not synced to correct location
+			// so we are only checking odo push should pass to verify location.
+			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context, "--v", "5")
+
+			// reset clonePath and change the workdir accordingly, it should sync to project name
+			helper.ReplaceString("devfile.yaml", "clonePath: webapp/ ", "clonepath: ")
+			helper.ReplaceString("devfile.yaml", "${PROJECTS_ROOT}/webapp ", "${PROJECTS_ROOT}/nodeshift")
+
+			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+		})
+
+		It("Should sync to the correct dir in container if multiple project is present", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+		})
+
+		It("Should sync to the correct dir in container if no project is present", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+			helper.CmdShouldPass("odo", "push", "--namespace", namespace, "--context", context)
+		})
+
+	})
 
 	Context("push with listing the devfile component", func() {
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
If a single project is present in devfile:
- if project.clonePath is present sync to $PROJECTS_ROOT/clonePath
- if clonePath not set sync to $PROJECTS_ROOT/projectName

if no project or multiple project present in devfile 
- sync to $PROJECTS_ROOT

The value of $PROJECTS_ROOT is determined by `sourceMapping` field in devfile or `PROJECTS_ROOT` env variable. if both are unset default is `/projects`. 

**Which issue(s) this PR fixes**:

Fixes #3729 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
* create nodejs component from file https://github.com/openshift/odo/pull/3907/files#diff-233e1a3be07da905fb5e3d944f1e3398
* verify the source code sync location with `kubectl exec -it <pod-name>  -- ls  $PROJECTS_ROOT/<clonePathValue>`