### PR TITLE
Migrate devfile cmd validation to validate pkg

### DIFF
--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -20,10 +20,6 @@ func TestGetCommand(t *testing.T) {
 
 	commands := [...]string{"ls -la", "pwd"}
 	components := [...]string{"alias1", "alias2"}
-	invalidComponent := "garbagealias"
-	workDir := [...]string{"/", "/root"}
-
-	emptyString := ""
 
 	tests := []struct {
 		name           string
@@ -53,37 +49,7 @@ func TestGetCommand(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Case 4: Invalid devfile with empty component",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   emptyString,
-						WorkingDir:  workDir[0],
-						Group:       &common.Group{Kind: buildGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{buildGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 5: Invalid devfile with empty devbuild command",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: emptyString,
-						Component:   components[0],
-						WorkingDir:  workDir[0],
-						Group:       &common.Group{Kind: buildGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{buildGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 6: Valid devfile with empty workdir",
+			name: "Case 3: Valid devfile with empty workdir",
 			execCommands: []common.DevfileCommand{
 				{
 					Exec: &common.Exec{
@@ -97,21 +63,7 @@ func TestGetCommand(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Case 7: Invalid command referencing an absent component",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   invalidComponent,
-						Group:       &common.Group{Kind: runGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{runGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 8: Mismatched command type",
+			name: "Case 4: Mismatched command type",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
@@ -127,7 +79,7 @@ func TestGetCommand(t *testing.T) {
 			wantErr:        true,
 		},
 		{
-			name: "Case 9: Default command is returned",
+			name: "Case 5: Default command is returned",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultRunCommand",
@@ -151,7 +103,7 @@ func TestGetCommand(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 10: Composite command is returned",
+			name: "Case 6: Composite command is returned",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
@@ -187,9 +139,6 @@ func TestGetCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			components := []common.DevfileComponent{testingutil.GetFakeContainerComponent(tt.execCommands[0].Exec.Component)}
-			if tt.execCommands[0].Exec.Component == invalidComponent {
-				components = []common.DevfileComponent{testingutil.GetFakeContainerComponent("randomComponent")}
-			}
 			devObj := devfileParser.DevfileObj{
 				Data: &testingutil.TestDevfileData{
 					Commands:   append(tt.execCommands, tt.compCommands...),
@@ -219,10 +168,6 @@ func TestGetCommandFromDevfile(t *testing.T) {
 
 	commands := [...]string{"ls -la", "pwd"}
 	components := [...]string{"alias1", "alias2"}
-	invalidComponent := "garbagealias"
-	workDir := [...]string{"/", "/root"}
-
-	emptyString := ""
 
 	tests := []struct {
 		name           string
@@ -251,37 +196,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Case 3: Invalid devfile with empty component",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   emptyString,
-						WorkingDir:  workDir[0],
-						Group:       &common.Group{Kind: buildGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{buildGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 4: Invalid devfile with empty devbuild command",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: emptyString,
-						Component:   components[0],
-						WorkingDir:  workDir[0],
-						Group:       &common.Group{Kind: buildGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{buildGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 5: Valid devfile with empty workdir",
+			name: "Case 3: Valid devfile with empty workdir",
 			execCommands: []common.DevfileCommand{
 				{
 					Exec: &common.Exec{
@@ -295,21 +210,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Case 6: Invalid command referencing an absent component",
-			execCommands: []common.DevfileCommand{
-				{
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   invalidComponent,
-						Group:       &common.Group{Kind: runGroup},
-					},
-				},
-			},
-			requestedType: []common.DevfileCommandGroupType{runGroup},
-			wantErr:       true,
-		},
-		{
-			name: "Case 7: Default command is returned",
+			name: "Case 4: Default command is returned",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
@@ -333,7 +234,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 8: Valid devfile, has composite command",
+			name: "Case 5: Valid devfile, has composite command",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build1",
@@ -374,7 +275,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 9: Default composite command",
+			name: "Case 6: Default composite command",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
@@ -413,46 +314,10 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			requestedType:  []common.DevfileCommandGroupType{buildGroup},
 			wantErr:        false,
 		},
-		{
-			name: "Case 10: Invalid composite command",
-			execCommands: []common.DevfileCommand{
-				{
-					Id: "build",
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   components[0],
-						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
-					},
-				},
-				{
-					Id: "run",
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   components[0],
-						Group:       &common.Group{Kind: runGroup},
-					},
-				},
-			},
-			compCommands: []common.DevfileCommand{
-				{
-					Id: "myComp",
-					Composite: &common.Composite{
-						Commands: []string{"fake"},
-						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
-					},
-				},
-			},
-			retCommandName: "myComp",
-			requestedType:  []common.DevfileCommandGroupType{buildGroup},
-			wantErr:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			components := []common.DevfileComponent{testingutil.GetFakeContainerComponent(tt.execCommands[0].Exec.Component)}
-			if tt.execCommands[0].Exec.Component == invalidComponent {
-				components = []common.DevfileComponent{testingutil.GetFakeContainerComponent("randomComponent")}
-			}
 			devObj := devfileParser.DevfileObj{
 				Data: &testingutil.TestDevfileData{
 					Commands:   append(tt.execCommands, tt.compCommands...),
@@ -483,9 +348,6 @@ func TestGetCommandFromFlag(t *testing.T) {
 	commands := [...]string{"ls -la", "pwd"}
 	components := [...]string{"alias1", "alias2"}
 	invalidComponent := "garbagealias"
-	workDir := [...]string{"/", "/root"}
-
-	emptyString := ""
 
 	tests := []struct {
 		name           string
@@ -508,24 +370,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 2: Invalid devfile with empty component",
-			execCommands: []common.DevfileCommand{
-				{
-					Id: "build command",
-					Exec: &common.Exec{
-						CommandLine: commands[0],
-						Component:   emptyString,
-						WorkingDir:  workDir[0],
-						Group:       &common.Group{Kind: buildGroup},
-					},
-				},
-			},
-			reqCommandName: "build command",
-			requestedType:  buildGroup,
-			wantErr:        true,
-		},
-		{
-			name: "Case 3: Valid devfile with empty workdir",
+			name: "Case 2: Valid devfile with empty workdir",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
@@ -542,7 +387,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 4: Invalid command",
+			name: "Case 3: Invalid command",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
@@ -558,7 +403,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        true,
 		},
 		{
-			name: "Case 5: Mismatched command type",
+			name: "Case 4: Mismatched command type",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
@@ -574,7 +419,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        true,
 		},
 		{
-			name: "Case 6: Multiple default commands but should be with the flag",
+			name: "Case 5: Multiple default commands but should be with the flag",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
@@ -599,7 +444,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 7: No default command but should be with the flag",
+			name: "Case 6: No default command but should be with the flag",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
@@ -624,7 +469,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 8: No Command Group",
+			name: "Case 7: No Command Group",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
@@ -640,7 +485,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 9: Valid devfile with composite commands",
+			name: "Case 8: Valid devfile with composite commands",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
@@ -681,7 +526,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name: "Case 10: Valid devfile with invalid composite commands",
+			name: "Case 9: Valid devfile with invalid composite commands",
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -5,12 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/odo/pkg/util"
-
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
-	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/testingutil"
+	"github.com/openshift/odo/pkg/util"
 )
 
 var buildGroup = common.BuildCommandGroupType
@@ -38,7 +36,7 @@ func TestGetCommand(t *testing.T) {
 	}{
 		{
 			name: "Case 1: Valid devfile",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				getExecCommand("build", buildGroup),
 				getExecCommand("run", runGroup),
 			},
@@ -47,7 +45,7 @@ func TestGetCommand(t *testing.T) {
 		},
 		{
 			name: "Case 2: Valid devfile with devrun and devbuild",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				getExecCommand("build", buildGroup),
 				getExecCommand("run", runGroup),
 			},
@@ -56,13 +54,13 @@ func TestGetCommand(t *testing.T) {
 		},
 		{
 			name: "Case 4: Invalid devfile with empty component",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   emptyString,
 						WorkingDir:  workDir[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -71,13 +69,13 @@ func TestGetCommand(t *testing.T) {
 		},
 		{
 			name: "Case 5: Invalid devfile with empty devbuild command",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: emptyString,
 						Component:   components[0],
 						WorkingDir:  workDir[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -88,10 +86,10 @@ func TestGetCommand(t *testing.T) {
 			name: "Case 6: Valid devfile with empty workdir",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -102,10 +100,10 @@ func TestGetCommand(t *testing.T) {
 			name: "Case 7: Invalid command referencing an absent component",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   invalidComponent,
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -117,10 +115,10 @@ func TestGetCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -133,18 +131,18 @@ func TestGetCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultRunCommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup, IsDefault: true},
+						Group:       &common.Group{Kind: runGroup, IsDefault: true},
 					},
 				},
 				{
 					Id: "runCommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -157,27 +155,27 @@ func TestGetCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "myComposite",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -236,7 +234,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 	}{
 		{
 			name: "Case 1: Valid devfile",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				getExecCommand("", buildGroup),
 				getExecCommand("", runGroup),
 			},
@@ -245,7 +243,7 @@ func TestGetCommandFromDevfile(t *testing.T) {
 		},
 		{
 			name: "Case 2: Valid devfile with devrun and devbuild",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				getExecCommand("", buildGroup),
 				getExecCommand("", runGroup),
 			},
@@ -254,13 +252,13 @@ func TestGetCommandFromDevfile(t *testing.T) {
 		},
 		{
 			name: "Case 3: Invalid devfile with empty component",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   emptyString,
 						WorkingDir:  workDir[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -269,13 +267,13 @@ func TestGetCommandFromDevfile(t *testing.T) {
 		},
 		{
 			name: "Case 4: Invalid devfile with empty devbuild command",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: emptyString,
 						Component:   components[0],
 						WorkingDir:  workDir[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -286,10 +284,10 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			name: "Case 5: Valid devfile with empty workdir",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -300,10 +298,10 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			name: "Case 6: Invalid command referencing an absent component",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   invalidComponent,
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -315,18 +313,18 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup, IsDefault: true},
+						Group:       &common.Group{Kind: runGroup, IsDefault: true},
 					},
 				},
 				{
 					Id: "runcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -339,35 +337,35 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build1",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 				{
 					Id: "build2",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "mycomp",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build1", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -380,34 +378,34 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "mycomp",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 				{
 					Id: "mycomp2",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 			},
@@ -420,27 +418,27 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "myComp",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"fake"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -500,7 +498,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 	}{
 		{
 			name: "Case 1: Valid devfile",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				getExecCommand("a", buildGroup),
 				getExecCommand("b", runGroup),
 			},
@@ -511,14 +509,14 @@ func TestGetCommandFromFlag(t *testing.T) {
 		},
 		{
 			name: "Case 2: Invalid devfile with empty component",
-			execCommands: []versionsCommon.DevfileCommand{
+			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   emptyString,
 						WorkingDir:  workDir[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -531,10 +529,10 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -548,10 +546,10 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   invalidComponent,
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -564,10 +562,10 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -580,18 +578,18 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup, IsDefault: true},
+						Group:       &common.Group{Kind: runGroup, IsDefault: true},
 					},
 				},
 				{
 					Id: "runcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup, IsDefault: true},
+						Group:       &common.Group{Kind: runGroup, IsDefault: true},
 					},
 				},
 			},
@@ -605,18 +603,18 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 				{
 					Id: "runcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -630,7 +628,7 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "defaultruncommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
 					},
@@ -646,34 +644,34 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "mycomp",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 				{
 					Id: "mycomp2",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build", "run"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 			},
@@ -687,27 +685,27 @@ func TestGetCommandFromFlag(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: false},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: false},
 					},
 				},
 				{
 					Id: "run",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: commands[0],
 						Component:   components[0],
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "myComp",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"fake"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -766,11 +764,11 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "run command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							Kind:      runGroup,
 							IsDefault: true,
 						},
@@ -778,11 +776,11 @@ func TestValidateCommandsForGroup(t *testing.T) {
 				},
 				{
 					Id: "customcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							Kind:      runGroup,
 							IsDefault: true,
 						},
@@ -797,20 +795,20 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 				{
 					Id: "build command 2",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -822,11 +820,11 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "test command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: testGroup},
+						Group:       &common.Group{Kind: testGroup},
 					},
 				},
 			},
@@ -838,11 +836,11 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "debug command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							Kind:      debugGroup,
 							IsDefault: true,
 						},
@@ -857,29 +855,29 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 				{
 					Id: "build command 2",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   componentName,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
 			compCommands: []common.DevfileCommand{
 				{
 					Id: "composite1",
-					Composite: &versionsCommon.Composite{
+					Composite: &common.Composite{
 						Commands: []string{"build command", "build command 2"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -891,7 +889,7 @@ func TestValidateCommandsForGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			devObj := devfileParser.DevfileObj{
 				Data: &testingutil.TestDevfileData{
-					Components: []versionsCommon.DevfileComponent{
+					Components: []common.DevfileComponent{
 						testingutil.GetFakeContainerComponent("alias1"),
 					},
 					Commands: append(tt.compCommands, tt.execCommands...),
@@ -901,161 +899,6 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			err := validateCommandsForGroup(devObj.Data, tt.groupType)
 			if !tt.wantErr && err != nil {
 				t.Errorf("TestValidateCommandsForGroup unexpected error: %v", err)
-			}
-		})
-	}
-
-}
-
-func TestValidateCommand(t *testing.T) {
-
-	command := "ls -la"
-	component := "alias1"
-	workDir := "/"
-
-	emptyString := ""
-
-	tests := []struct {
-		name    string
-		exec    []common.DevfileCommand
-		comp    []common.DevfileCommand
-		wantErr bool
-	}{
-		{
-			name: "Case: Valid Exec Command",
-			exec: []common.DevfileCommand{
-				{
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Case: Invalid Exec Command with empty command",
-			exec: []common.DevfileCommand{
-				{
-					Exec: &versionsCommon.Exec{
-						CommandLine: emptyString,
-						Component:   component,
-						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case: Invalid Exec Command with missing component",
-			exec: []common.DevfileCommand{
-				{
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case: valid Exec Command with Group nil",
-			exec: []common.DevfileCommand{
-				{
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Case: valid Composite Command",
-			exec: []common.DevfileCommand{
-				{
-					Id: "somecommand1",
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-				{
-					Id: "somecommand2",
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-			},
-			comp: []common.DevfileCommand{
-				{
-					Id: "composite1",
-					Composite: &versionsCommon.Composite{
-						Commands: []string{"somecommand1", "somecommand2"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Case: Invalid Composite Command",
-			exec: []common.DevfileCommand{
-				{
-					Id: "somecommand1",
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-				{
-					Id: "somecommand2",
-					Exec: &versionsCommon.Exec{
-						CommandLine: command,
-						Component:   component,
-						WorkingDir:  workDir,
-					},
-				},
-			},
-			comp: []common.DevfileCommand{
-				{
-					Id: "composite1",
-					Composite: &versionsCommon.Composite{
-						Commands: []string{"fakecommand"},
-						Group:    &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		devObj := devfileParser.DevfileObj{
-			Data: &testingutil.TestDevfileData{
-				Commands:   append(tt.comp, tt.exec...),
-				Components: []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
-			},
-		}
-		t.Run(tt.name, func(t *testing.T) {
-			var cmd common.DevfileCommand
-			if tt.comp != nil {
-				cmd = tt.comp[0]
-			} else {
-				cmd = tt.exec[0]
-			}
-			err := ValidateCommand(devObj.Data, cmd)
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestValidateAction unexpected error: %v", err)
-				return
 			}
 		})
 	}
@@ -1082,11 +925,11 @@ func TestGetBuildCommand(t *testing.T) {
 			commandName: emptyString,
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup, IsDefault: true},
+						Group:       &common.Group{Kind: buildGroup, IsDefault: true},
 					},
 				},
 			},
@@ -1098,20 +941,20 @@ func TestGetBuildCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "flagcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -1123,11 +966,11 @@ func TestGetBuildCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "build command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -1177,13 +1020,13 @@ func TestGetDebugCommand(t *testing.T) {
 			commandName: emptyString,
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: true,
-							Kind:      versionsCommon.DebugCommandGroupType,
+							Kind:      common.DebugCommandGroupType,
 						},
 					},
 				},
@@ -1196,13 +1039,13 @@ func TestGetDebugCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "customdebugcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: false,
-							Kind:      versionsCommon.DebugCommandGroupType,
+							Kind:      common.DebugCommandGroupType,
 						},
 					},
 				},
@@ -1214,13 +1057,13 @@ func TestGetDebugCommand(t *testing.T) {
 			commandName: "customcommand123",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: true,
-							Kind:      versionsCommon.BuildCommandGroupType,
+							Kind:      common.BuildCommandGroupType,
 						},
 					},
 				},
@@ -1273,13 +1116,13 @@ func TestGetTestCommand(t *testing.T) {
 			commandName: emptyString,
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: true,
-							Kind:      versionsCommon.TestCommandGroupType,
+							Kind:      common.TestCommandGroupType,
 						},
 					},
 				},
@@ -1292,13 +1135,13 @@ func TestGetTestCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "customtestcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: false,
-							Kind:      versionsCommon.TestCommandGroupType,
+							Kind:      common.TestCommandGroupType,
 						},
 					},
 				},
@@ -1310,13 +1153,13 @@ func TestGetTestCommand(t *testing.T) {
 			commandName: "customcommand123",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group: &versionsCommon.Group{
+						Group: &common.Group{
 							IsDefault: true,
-							Kind:      versionsCommon.BuildCommandGroupType,
+							Kind:      common.BuildCommandGroupType,
 						},
 					},
 				},
@@ -1369,11 +1212,11 @@ func TestGetRunCommand(t *testing.T) {
 			commandName: emptyString,
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup, IsDefault: true},
+						Group:       &common.Group{Kind: runGroup, IsDefault: true},
 					},
 				},
 			},
@@ -1385,20 +1228,20 @@ func TestGetRunCommand(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "flagcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 				{
 					Id: "run command",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: runGroup},
+						Group:       &common.Group{Kind: runGroup},
 					},
 				},
 			},
@@ -1409,11 +1252,11 @@ func TestGetRunCommand(t *testing.T) {
 			commandName: "",
 			execCommands: []common.DevfileCommand{
 				{
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
 						WorkingDir:  workDir,
-						Group:       &versionsCommon.Group{Kind: buildGroup},
+						Group:       &common.Group{Kind: buildGroup},
 					},
 				},
 			},
@@ -1451,7 +1294,7 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 
 	execCommands := []common.DevfileCommand{
 		{
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
@@ -1463,7 +1306,7 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 		},
 		{
 			Id: "customdebugcommand",
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
@@ -1490,13 +1333,13 @@ func TestValidateAndGetDebugDevfileCommands(t *testing.T) {
 		{
 			name:          "Case: provided debug Command",
 			debugCommand:  "customdebugcommand",
-			componentType: versionsCommon.ContainerComponentType,
+			componentType: common.ContainerComponentType,
 			wantErr:       false,
 		},
 		{
 			name:          "Case: invalid debug Command",
 			debugCommand:  "invaliddebugcommand",
-			componentType: versionsCommon.ContainerComponentType,
+			componentType: common.ContainerComponentType,
 			wantErr:       true,
 		},
 	}
@@ -1541,11 +1384,11 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 	execCommands := []common.DevfileCommand{
 		{
 			Id: "run command",
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
-				Group: &versionsCommon.Group{
+				Group: &common.Group{
 					Kind:      runGroup,
 					IsDefault: true,
 				},
@@ -1554,21 +1397,21 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 
 		{
 			Id: "build command",
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
-				Group:       &versionsCommon.Group{Kind: buildGroup},
+				Group:       &common.Group{Kind: buildGroup},
 			},
 		},
 
 		{
 			Id: "customcommand",
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
-				Group:       &versionsCommon.Group{Kind: runGroup},
+				Group:       &common.Group{Kind: runGroup},
 			},
 		},
 	}
@@ -1576,11 +1419,11 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 	wrongCompTypeCmd := common.DevfileCommand{
 
 		Id: "wrong",
-		Exec: &versionsCommon.Exec{
+		Exec: &common.Exec{
 			CommandLine: command,
 			Component:   "",
 			WorkingDir:  workDir,
-			Group:       &versionsCommon.Group{Kind: runGroup},
+			Group:       &common.Group{Kind: runGroup},
 		},
 	}
 
@@ -1632,7 +1475,7 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 			execCommands: []common.DevfileCommand{
 				{
 					Id: "customcommand",
-					Exec: &versionsCommon.Exec{
+					Exec: &common.Exec{
 						Group:       &common.Group{Kind: runGroup},
 						Component:   component,
 						CommandLine: command,
@@ -1668,291 +1511,6 @@ func TestValidateAndGetPushDevfileCommands(t *testing.T) {
 
 }
 
-func TestValidateCompositeCommand(t *testing.T) {
-
-	command := []string{"ls -la", "ps", "ls /"}
-	component := "alias1"
-	workDir := []string{"/", "/dev", "/etc"}
-	id := []string{"command1", "command2", "command3", "command4", "command5"}
-
-	tests := []struct {
-		name              string
-		compositeCommands []common.DevfileCommand
-		execCommands      []common.DevfileCommand
-		wantErr           bool
-	}{
-		{
-			name: "Case 1: Valid Composite Command",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &versionsCommon.Composite{
-						Commands: []string{id[0], id[1], id[2]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[1],
-						Component:   component,
-						Group:       &common.Group{Kind: buildGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-				{
-					Id: id[2],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[2],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[2],
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Case 2: Invalid composite command, references non-existent command",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &versionsCommon.Composite{
-						Commands: []string{id[0], "fakecommand", id[2]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[1],
-						Component:   component,
-						Group:       &common.Group{Kind: buildGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-				{
-					Id: id[2],
-					Exec: &versionsCommon.Exec{
-						CommandLine: command[2],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[2],
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case 3: Invalid composite command, references itself",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &common.Composite{
-						Commands: []string{id[0], id[3], id[2]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &common.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &common.Exec{
-						CommandLine: command[1],
-						Component:   component,
-						Group:       &common.Group{Kind: buildGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-				{
-					Id: id[2],
-					Exec: &common.Exec{
-						CommandLine: command[2],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[2],
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case 4: Invalid composite run command",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &common.Composite{
-						Commands: []string{id[0], id[3], id[2]},
-						Group:    &versionsCommon.Group{Kind: runGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &common.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &common.Exec{
-						CommandLine: command[1],
-						Component:   component,
-						Group:       &common.Group{Kind: buildGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-				{
-					Id: id[2],
-					Exec: &common.Exec{
-						CommandLine: command[2],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[2],
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case 5: Invalid composite command, indirectly references itself",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &common.Composite{
-						Commands: []string{id[4], id[3], id[2]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-				{
-					Id: id[4],
-					Composite: &common.Composite{
-						Commands: []string{id[0], id[3], id[2]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &common.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &common.Exec{
-						CommandLine: command[1],
-						Component:   component,
-						Group:       &common.Group{Kind: buildGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-				{
-					Id: id[2],
-					Exec: &common.Exec{
-						CommandLine: command[2],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[2],
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case 6: Invalid composite command, points to invalid exec command",
-			compositeCommands: []common.DevfileCommand{
-				{
-					Id: id[3],
-					Composite: &common.Composite{
-						Commands: []string{id[0], id[1]},
-						Group:    &versionsCommon.Group{Kind: buildGroup},
-					},
-				},
-			},
-			execCommands: []common.DevfileCommand{
-				{
-					Id: id[0],
-					Exec: &common.Exec{
-						CommandLine: command[0],
-						Component:   component,
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[0],
-					},
-				},
-				{
-					Id: id[1],
-					Exec: &common.Exec{
-						CommandLine: command[1],
-						Component:   "some-fake-component",
-						Group:       &common.Group{Kind: runGroup},
-						WorkingDir:  workDir[1],
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		devObj := devfileParser.DevfileObj{
-			Data: &testingutil.TestDevfileData{
-				Commands:   append(tt.execCommands, tt.compositeCommands...),
-				Components: []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
-			},
-		}
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := tt.compositeCommands[0]
-			commandsMap := devObj.Data.GetCommands()
-			parentCommands := make(map[string]string)
-
-			err := validateCompositeCommand(devObj.Data, &cmd, parentCommands, commandsMap)
-			if !tt.wantErr == (err != nil) {
-				t.Errorf("TestValidateAction unexpected error: %v", err)
-				return
-			}
-		})
-	}
-}
-
 func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 
 	command := "ls -la"
@@ -1962,7 +1520,7 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 
 	execCommands := []common.DevfileCommand{
 		{
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
@@ -1974,7 +1532,7 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 		},
 		{
 			Id: "customtestcommand",
-			Exec: &versionsCommon.Exec{
+			Exec: &common.Exec{
 				CommandLine: command,
 				Component:   component,
 				WorkingDir:  workDir,
@@ -2001,13 +1559,13 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 		{
 			name:          "Case: provided test Command",
 			testCommand:   "customtestcommand",
-			componentType: versionsCommon.ContainerComponentType,
+			componentType: common.ContainerComponentType,
 			wantErr:       false,
 		},
 		{
 			name:          "Case: invalid test Command",
 			testCommand:   "invalidtestcommand",
-			componentType: versionsCommon.ContainerComponentType,
+			componentType: common.ContainerComponentType,
 			wantErr:       true,
 		},
 	}
@@ -2042,7 +1600,7 @@ func TestValidateAndGetTestDevfileCommands(t *testing.T) {
 	}
 }
 
-func getExecCommand(id string, group common.DevfileCommandGroupType) versionsCommon.DevfileCommand {
+func getExecCommand(id string, group common.DevfileCommandGroupType) common.DevfileCommand {
 	if len(id) == 0 {
 		id = fmt.Sprintf("%s-%s", "cmd", util.GenerateRandomString(10))
 	}
@@ -2050,9 +1608,9 @@ func getExecCommand(id string, group common.DevfileCommandGroupType) versionsCom
 	components := [...]string{"alias1", "alias2"}
 	workDir := [...]string{"/", "/root"}
 
-	return versionsCommon.DevfileCommand{
+	return common.DevfileCommand{
 		Id: id,
-		Exec: &versionsCommon.Exec{
+		Exec: &common.Exec{
 			CommandLine: commands[0],
 			Component:   components[0],
 			WorkingDir:  workDir[0],

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -61,7 +61,7 @@ const (
 	// BinBash The path to sh executable
 	BinBash = "/bin/sh"
 
-	// Default volume size for volumes defined in a devfile
+	// DefaultVolumeSize Default volume size for volumes defined in a devfile
 	DefaultVolumeSize = "1Gi"
 
 	// EnvProjectsRoot is the env defined for /projects where component mountSources=true
@@ -107,25 +107,6 @@ type CommandNames struct {
 	AdapterName string
 }
 
-// isContainer checks if the component is a container
-func isContainer(component common.DevfileComponent) bool {
-	// Currently odo only uses devfile components of type container, since most of the Che registry devfiles use it
-	if component.Container != nil {
-		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", common.ContainerComponentType, component.Name)
-		return true
-	}
-	return false
-}
-
-// isVolume checks if the component is a volume
-func isVolume(component common.DevfileComponent) bool {
-	if component.Volume != nil {
-		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", common.VolumeComponentType, component.Name)
-		return true
-	}
-	return false
-}
-
 // GetBootstrapperImage returns the odo-init bootstrapper image
 func GetBootstrapperImage() string {
 	if env, ok := os.LookupEnv(bootstrapperImageEnvName); ok {
@@ -139,7 +120,7 @@ func GetDevfileContainerComponents(data data.DevfileData) []common.DevfileCompon
 	var components []common.DevfileComponent
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetAliasedComponents() {
-		if isContainer(comp) {
+		if comp.IsContainer() {
 			components = append(components, comp)
 		}
 	}
@@ -151,7 +132,7 @@ func GetDevfileVolumeComponents(data data.DevfileData) map[string]common.Devfile
 	volumeNameToVolumeComponent := make(map[string]common.DevfileComponent)
 	// Only components with aliases are considered because without an alias commands cannot reference them
 	for _, comp := range data.GetComponents() {
-		if isVolume(comp) {
+		if comp.IsVolume() {
 			volumeNameToVolumeComponent[comp.Name] = comp
 		}
 	}

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -337,67 +337,67 @@ func TestGetBootstrapperImage(t *testing.T) {
 
 }
 
-func TestIsContainer(t *testing.T) {
+// func TestIsContainer(t *testing.T) {
 
-	tests := []struct {
-		name            string
-		component       common.DevfileComponent
-		wantIsSupported bool
-	}{
-		{
-			name:            "Case 1: Container component",
-			component:       testingutil.GetFakeContainerComponent("comp1"),
-			wantIsSupported: true,
-		},
-		{
-			name: "Case 2: Not a container component",
-			component: common.DevfileComponent{
-				Openshift: &versionsCommon.Openshift{},
-			},
-			wantIsSupported: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isSupported := isContainer(tt.component)
-			if isSupported != tt.wantIsSupported {
-				t.Errorf("TestIsContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
-			}
-		})
-	}
+// 	tests := []struct {
+// 		name            string
+// 		component       common.DevfileComponent
+// 		wantIsSupported bool
+// 	}{
+// 		{
+// 			name:            "Case 1: Container component",
+// 			component:       testingutil.GetFakeContainerComponent("comp1"),
+// 			wantIsSupported: true,
+// 		},
+// 		{
+// 			name: "Case 2: Not a container component",
+// 			component: common.DevfileComponent{
+// 				Openshift: &versionsCommon.Openshift{},
+// 			},
+// 			wantIsSupported: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			isSupported := isContainer(tt.component)
+// 			if isSupported != tt.wantIsSupported {
+// 				t.Errorf("TestIsContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+// 			}
+// 		})
+// 	}
 
-}
+// }
 
-func TestIsVolume(t *testing.T) {
+// func TestIsVolume(t *testing.T) {
 
-	tests := []struct {
-		name            string
-		component       common.DevfileComponent
-		wantIsSupported bool
-	}{
-		{
-			name:            "Case 1: Volume component",
-			component:       testingutil.GetFakeVolumeComponent("myvol", "4Gi"),
-			wantIsSupported: true,
-		},
-		{
-			name: "Case 2: Not a volume component",
-			component: common.DevfileComponent{
-				Openshift: &versionsCommon.Openshift{},
-			},
-			wantIsSupported: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isSupported := isVolume(tt.component)
-			if isSupported != tt.wantIsSupported {
-				t.Errorf("TestIsVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
-			}
-		})
-	}
+// 	tests := []struct {
+// 		name            string
+// 		component       common.DevfileComponent
+// 		wantIsSupported bool
+// 	}{
+// 		{
+// 			name:            "Case 1: Volume component",
+// 			component:       testingutil.GetFakeVolumeComponent("myvol", "4Gi"),
+// 			wantIsSupported: true,
+// 		},
+// 		{
+// 			name: "Case 2: Not a volume component",
+// 			component: common.DevfileComponent{
+// 				Openshift: &versionsCommon.Openshift{},
+// 			},
+// 			wantIsSupported: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			isSupported := isVolume(tt.component)
+// 			if isSupported != tt.wantIsSupported {
+// 				t.Errorf("TestIsVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+// 			}
+// 		})
+// 	}
 
-}
+// }
 
 func TestGetCommandsForGroup(t *testing.T) {
 

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -337,68 +337,6 @@ func TestGetBootstrapperImage(t *testing.T) {
 
 }
 
-// func TestIsContainer(t *testing.T) {
-
-// 	tests := []struct {
-// 		name            string
-// 		component       common.DevfileComponent
-// 		wantIsSupported bool
-// 	}{
-// 		{
-// 			name:            "Case 1: Container component",
-// 			component:       testingutil.GetFakeContainerComponent("comp1"),
-// 			wantIsSupported: true,
-// 		},
-// 		{
-// 			name: "Case 2: Not a container component",
-// 			component: common.DevfileComponent{
-// 				Openshift: &versionsCommon.Openshift{},
-// 			},
-// 			wantIsSupported: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			isSupported := isContainer(tt.component)
-// 			if isSupported != tt.wantIsSupported {
-// 				t.Errorf("TestIsContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
-// 			}
-// 		})
-// 	}
-
-// }
-
-// func TestIsVolume(t *testing.T) {
-
-// 	tests := []struct {
-// 		name            string
-// 		component       common.DevfileComponent
-// 		wantIsSupported bool
-// 	}{
-// 		{
-// 			name:            "Case 1: Volume component",
-// 			component:       testingutil.GetFakeVolumeComponent("myvol", "4Gi"),
-// 			wantIsSupported: true,
-// 		},
-// 		{
-// 			name: "Case 2: Not a volume component",
-// 			component: common.DevfileComponent{
-// 				Openshift: &versionsCommon.Openshift{},
-// 			},
-// 			wantIsSupported: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			isSupported := isVolume(tt.component)
-// 			if isSupported != tt.wantIsSupported {
-// 				t.Errorf("TestIsVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
-// 			}
-// 		})
-// 	}
-
-// }
-
 func TestGetCommandsForGroup(t *testing.T) {
 
 	component := []versionsCommon.DevfileComponent{

--- a/pkg/devfile/parse.go
+++ b/pkg/devfile/parse.go
@@ -22,12 +22,8 @@ func ParseFromURLAndValidate(url string) (d parser.DevfileObj, err error) {
 
 	// odo specific validation on devfile content
 	err = validate.ValidateDevfileData(d.Data)
-	if err != nil {
-		return d, err
-	}
 
-	// Successful
-	return d, nil
+	return d, err
 }
 
 // ParseFromDataAndValidate func parses the devfile data
@@ -43,12 +39,8 @@ func ParseFromDataAndValidate(data []byte) (d parser.DevfileObj, err error) {
 
 	// odo specific validation on devfile content
 	err = validate.ValidateDevfileData(d.Data)
-	if err != nil {
-		return d, err
-	}
 
-	// Successful
-	return d, nil
+	return d, err
 }
 
 // ParseAndValidate func parses the devfile data

--- a/pkg/devfile/parse.go
+++ b/pkg/devfile/parse.go
@@ -65,10 +65,6 @@ func ParseAndValidate(path string) (d parser.DevfileObj, err error) {
 
 	// odo specific validation on devfile content
 	err = validate.ValidateDevfileData(d.Data)
-	if err != nil {
-		return d, err
-	}
 
-	// Successful
-	return d, nil
+	return d, err
 }

--- a/pkg/devfile/parser/data/2.0.0/components.go
+++ b/pkg/devfile/parser/data/2.0.0/components.go
@@ -140,7 +140,6 @@ func (d *Devfile200) GetCommands() map[string]common.DevfileCommand {
 		// cases efficiently without being error prone
 		// we also convert the odo push commands from build-command and run-command flags
 		commands[command.SetIDToLower()] = command
-
 	}
 
 	return commands

--- a/pkg/devfile/parser/data/common/component_helper.go
+++ b/pkg/devfile/parser/data/common/component_helper.go
@@ -1,0 +1,22 @@
+package common
+
+import "k8s.io/klog"
+
+// IsContainer checks if the component is a container
+func (component DevfileComponent) IsContainer() bool {
+	// Currently odo only uses devfile components of type container, since most of the Che registry devfiles use it
+	if component.Container != nil {
+		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", ContainerComponentType, component.Name)
+		return true
+	}
+	return false
+}
+
+// IsVolume checks if the component is a volume
+func (component DevfileComponent) IsVolume() bool {
+	if component.Volume != nil {
+		klog.V(2).Infof("Found component \"%v\" with name \"%v\"\n", VolumeComponentType, component.Name)
+		return true
+	}
+	return false
+}

--- a/pkg/devfile/parser/data/common/component_helper_test.go
+++ b/pkg/devfile/parser/data/common/component_helper_test.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestIsContainer(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		component       DevfileComponent
+		wantIsSupported bool
+	}{
+		{
+			name: "Case 1: Container component",
+			component: DevfileComponent{
+				Name:      "name",
+				Container: &Container{}},
+			wantIsSupported: true,
+		},
+		{
+			name: "Case 2: Not a container component",
+			component: DevfileComponent{
+				Openshift: &Openshift{},
+			},
+			wantIsSupported: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isSupported := tt.component.IsContainer()
+			if isSupported != tt.wantIsSupported {
+				t.Errorf("TestIsContainer error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+			}
+		})
+	}
+
+}
+
+func TestIsVolume(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		component       DevfileComponent
+		wantIsSupported bool
+	}{
+		{
+			name: "Case 1: Volume component",
+			component: DevfileComponent{
+				Name: "name",
+				Volume: &Volume{
+					Size: "size",
+				}},
+			wantIsSupported: true,
+		},
+		{
+			name: "Case 2: Not a volume component",
+			component: DevfileComponent{
+				Openshift: &Openshift{},
+			},
+			wantIsSupported: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isSupported := tt.component.IsVolume()
+			if isSupported != tt.wantIsSupported {
+				t.Errorf("TestIsVolume error: component support mismatch, expected: %v got: %v", tt.wantIsSupported, isSupported)
+			}
+		})
+	}
+
+}

--- a/pkg/devfile/validate/commands.go
+++ b/pkg/devfile/validate/commands.go
@@ -1,11 +1,9 @@
 package validate
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
-	"github.com/pkg/errors"
 )
 
 // validateCommands validates all the devfile commands
@@ -16,20 +14,18 @@ func validateCommands(commands map[string]common.DevfileCommand, components []co
 	for _, command := range commands {
 		err = validateCommand(command, commands, components)
 		if err != nil {
-			// return errors.Wrapf(err, "command %s error", command.GetID())
-			// return fmt.Errorf("command %s has validation error: %v", command.GetID(), err)
 			return err
 		}
 	}
 
-	return /* fmt.Errorf("should err out") */
+	return
 }
 
 func validateCommand(command common.DevfileCommand, devfileCommands map[string]common.DevfileCommand, components []common.DevfileComponent) (err error) {
 
 	// type must be exec or composite
 	if command.Exec == nil && command.Composite == nil {
-		return fmt.Errorf("command %q must be of type \"exec\" or \"composite\"", command.GetID())
+		return &UnsupportedOdoCommandError{commandId: command.GetID()}
 	}
 
 	// If the command is a composite command, need to validate that it is valid
@@ -41,17 +37,15 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 
 	// component must be specified
 	if command.Exec.Component == "" {
-		return fmt.Errorf("exec command %q must reference a component", command.GetID())
+		return &ExecCommandMissingComponentError{commandId: command.GetID()}
 	}
 
 	// must specify a command
 	if command.Exec.CommandLine == "" {
-		return fmt.Errorf("exec command %q must have a command", command.GetID())
+		return &ExecCommandMissingCommandLineError{commandId: command.GetID()}
 	}
 
 	// must map to a container component
-	// components := GetDevfileContainerComponents(data)
-
 	isComponentValid := false
 	for _, component := range components {
 		if command.Exec.Component == component.Container.Name {
@@ -59,7 +53,7 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 		}
 	}
 	if !isComponentValid {
-		return fmt.Errorf("the command %q does not map to a supported component", command.GetID())
+		return &ExecCommandInvalidContainerError{commandId: command.GetID()}
 	}
 
 	return
@@ -68,7 +62,7 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 // validateCompositeCommand checks that the specified composite command is valid
 func validateCompositeCommand(compositeCommand *common.Composite, parentCommands map[string]string, devfileCommands map[string]common.DevfileCommand, components []common.DevfileComponent) error {
 	if compositeCommand.Group != nil && compositeCommand.Group.Kind == common.RunCommandGroupType {
-		return fmt.Errorf("composite commands of run Kind are not supported currently")
+		return &CompositeRunKindError{}
 	}
 
 	// Store the command ID in a map of parent commands
@@ -77,18 +71,18 @@ func validateCompositeCommand(compositeCommand *common.Composite, parentCommands
 	// Loop over the commands and validate that each command points to a command that's in the devfile
 	for _, command := range compositeCommand.Commands {
 		if strings.ToLower(command) == compositeCommand.Id {
-			return fmt.Errorf("the composite command %q cannot reference itself", compositeCommand.Id)
+			return &CompositeDirectReferenceError{commandId: compositeCommand.Id}
 		}
 
 		// Don't allow commands to indirectly reference themselves, so check if the command equals any of the parent commands in the command tree
 		_, ok := parentCommands[strings.ToLower(command)]
 		if ok {
-			return fmt.Errorf("the composite command %q cannot indirectly reference itself", compositeCommand.Id)
+			return &CompositeIndirectReferenceError{commandId: compositeCommand.Id}
 		}
 
 		subCommand, ok := devfileCommands[strings.ToLower(command)]
 		if !ok {
-			return fmt.Errorf("the command %q mentioned in the composite command %q does not exist in the devfile", command, compositeCommand.Id)
+			return &CompositeMissingSubCommandError{commandId: compositeCommand.Id, subCommand: command}
 		}
 
 		if subCommand.Composite != nil {
@@ -101,7 +95,7 @@ func validateCompositeCommand(compositeCommand *common.Composite, parentCommands
 		} else {
 			err := validateCommand(subCommand, devfileCommands, components)
 			if err != nil {
-				return errors.Wrapf(err, "the composite command %q references an invalid command %q", compositeCommand.Id, subCommand.GetID())
+				return &CompositeInvalidSubCommandError{commandId: compositeCommand.Id, subCommandId: subCommand.GetID()}
 			}
 		}
 	}

--- a/pkg/devfile/validate/commands.go
+++ b/pkg/devfile/validate/commands.go
@@ -9,8 +9,6 @@ import (
 // validateCommands validates all the devfile commands
 func validateCommands(commands map[string]common.DevfileCommand, components []common.DevfileComponent) (err error) {
 
-	// commandsMap := adapterCommon.GetCommandsMap(commands)
-
 	for _, command := range commands {
 		err = validateCommand(command, commands, components)
 		if err != nil {
@@ -36,7 +34,6 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 	// If the command is a composite command, need to validate that it is valid
 	if command.Composite != nil {
 		parentCommands := make(map[string]string)
-		// commandsMap := adapterCommon.GetCommandsMap(commands)
 		return validateCompositeCommand(&command, parentCommands, devfileCommands, components)
 	}
 

--- a/pkg/devfile/validate/commands.go
+++ b/pkg/devfile/validate/commands.go
@@ -1,0 +1,109 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	adapterCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/pkg/errors"
+)
+
+// validateCommands validates all the devfile commands
+func validateCommands(commands []common.DevfileCommand, components []common.DevfileComponent) (err error) {
+
+	commandsMap := adapterCommon.GetCommandsMap(commands)
+
+	for _, command := range commands {
+		err = validateCommand(command, commandsMap, components)
+		if err != nil {
+			return errors.Wrap(err, "test")
+			// return fmt.Errorf("command %s has validation error: %v", command.GetID(), err)
+		}
+	}
+
+	return /* fmt.Errorf("should err out") */
+}
+
+func validateCommand(command common.DevfileCommand, devfileCommands map[string]common.DevfileCommand, components []common.DevfileComponent) (err error) {
+
+	// type must be exec or composite
+	if command.Exec == nil && command.Composite == nil {
+		return fmt.Errorf("command must be of type \"exec\" or \"composite\"")
+	}
+
+	// If the command is a composite command, need to validate that it is valid
+	if command.Composite != nil {
+		parentCommands := make(map[string]string)
+		// commandsMap := adapterCommon.GetCommandsMap(commands)
+		return validateCompositeCommand(command.Composite, parentCommands, devfileCommands, components)
+	}
+
+	// component must be specified
+	if command.Exec.Component == "" {
+		return fmt.Errorf("exec commands must reference a component")
+	}
+
+	// must specify a command
+	if command.Exec.CommandLine == "" {
+		return fmt.Errorf("exec commands must have a command")
+	}
+
+	// must map to a container component
+	// components := GetDevfileContainerComponents(data)
+
+	isComponentValid := false
+	for _, component := range components {
+		if command.Exec.Component == component.Container.Name {
+			isComponentValid = true
+		}
+	}
+	if !isComponentValid {
+		return fmt.Errorf("the command does not map to a supported component")
+	}
+
+	return
+}
+
+// validateCompositeCommand checks that the specified composite command is valid
+func validateCompositeCommand(compositeCommand *common.Composite, parentCommands map[string]string, devfileCommands map[string]common.DevfileCommand, components []common.DevfileComponent) error {
+	if compositeCommand.Group != nil && compositeCommand.Group.Kind == common.RunCommandGroupType {
+		return fmt.Errorf("composite commands of run Kind are not supported currently")
+	}
+
+	// Store the command ID in a map of parent commands
+	parentCommands[compositeCommand.Id] = compositeCommand.Id
+
+	// Loop over the commands and validate that each command points to a command that's in the devfile
+	for _, command := range compositeCommand.Commands {
+		if strings.ToLower(command) == compositeCommand.Id {
+			return fmt.Errorf("the composite command %q cannot reference itself", compositeCommand.Id)
+		}
+
+		// Don't allow commands to indirectly reference themselves, so check if the command equals any of the parent commands in the command tree
+		_, ok := parentCommands[strings.ToLower(command)]
+		if ok {
+			return fmt.Errorf("the composite command %q cannot indirectly reference itself", compositeCommand.Id)
+		}
+
+		subCommand, ok := devfileCommands[strings.ToLower(command)]
+		if !ok {
+			return fmt.Errorf("the command %q mentioned in the composite command %q does not exist in the devfile", command, compositeCommand.Id)
+		}
+
+		if subCommand.Composite != nil {
+			// Recursively validate the composite subcommand
+			err := validateCompositeCommand(subCommand.Composite, parentCommands, devfileCommands, components)
+			if err != nil {
+				// Don't wrap the error message here to make the error message more readable to the user
+				return err
+			}
+		} else {
+			err := validateCommand(subCommand, devfileCommands, components)
+			if err != nil {
+				return errors.Wrapf(err, "the composite command %q references an invalid command %q", compositeCommand.Id, subCommand.GetID())
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/devfile/validate/commands.go
+++ b/pkg/devfile/validate/commands.go
@@ -97,7 +97,7 @@ func validateCompositeCommand(compositeCommand *common.DevfileCommand, parentCom
 		} else {
 			err := validateCommand(subCommand, devfileCommands, components)
 			if err != nil {
-				return &CompositeInvalidSubCommandError{commandId: compositeCommand.Id, subCommandId: subCommand.GetID()}
+				return &CompositeInvalidSubCommandError{commandId: compositeCommand.Id, subCommandId: subCommand.GetID(), errorMsg: err.Error()}
 			}
 		}
 	}

--- a/pkg/devfile/validate/commands.go
+++ b/pkg/devfile/validate/commands.go
@@ -4,21 +4,21 @@ import (
 	"fmt"
 	"strings"
 
-	adapterCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/pkg/errors"
 )
 
 // validateCommands validates all the devfile commands
-func validateCommands(commands []common.DevfileCommand, components []common.DevfileComponent) (err error) {
+func validateCommands(commands map[string]common.DevfileCommand, components []common.DevfileComponent) (err error) {
 
-	commandsMap := adapterCommon.GetCommandsMap(commands)
+	// commandsMap := adapterCommon.GetCommandsMap(commands)
 
 	for _, command := range commands {
-		err = validateCommand(command, commandsMap, components)
+		err = validateCommand(command, commands, components)
 		if err != nil {
-			return errors.Wrap(err, "test")
+			// return errors.Wrapf(err, "command %s error", command.GetID())
 			// return fmt.Errorf("command %s has validation error: %v", command.GetID(), err)
+			return err
 		}
 	}
 
@@ -29,7 +29,7 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 
 	// type must be exec or composite
 	if command.Exec == nil && command.Composite == nil {
-		return fmt.Errorf("command must be of type \"exec\" or \"composite\"")
+		return fmt.Errorf("command %q must be of type \"exec\" or \"composite\"", command.GetID())
 	}
 
 	// If the command is a composite command, need to validate that it is valid
@@ -41,12 +41,12 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 
 	// component must be specified
 	if command.Exec.Component == "" {
-		return fmt.Errorf("exec commands must reference a component")
+		return fmt.Errorf("exec command %q must reference a component", command.GetID())
 	}
 
 	// must specify a command
 	if command.Exec.CommandLine == "" {
-		return fmt.Errorf("exec commands must have a command")
+		return fmt.Errorf("exec command %q must have a command", command.GetID())
 	}
 
 	// must map to a container component
@@ -59,7 +59,7 @@ func validateCommand(command common.DevfileCommand, devfileCommands map[string]c
 		}
 	}
 	if !isComponentValid {
-		return fmt.Errorf("the command does not map to a supported component")
+		return fmt.Errorf("the command %q does not map to a supported component", command.GetID())
 	}
 
 	return

--- a/pkg/devfile/validate/commands_test.go
+++ b/pkg/devfile/validate/commands_test.go
@@ -1,0 +1,453 @@
+package validate
+
+import (
+	"testing"
+
+	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
+	"github.com/openshift/odo/pkg/testingutil"
+)
+
+var buildGroup = common.BuildCommandGroupType
+var runGroup = common.RunCommandGroupType
+
+func TestValidateCommands(t *testing.T) {
+
+	command := "ls -la"
+	component := "alias1"
+	workDir := "/"
+
+	emptyString := ""
+
+	tests := []struct {
+		name    string
+		exec    []common.DevfileCommand
+		comp    []common.DevfileCommand
+		wantErr bool
+	}{
+		{
+			name: "Case: Valid Exec Command",
+			exec: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+						Group:       &common.Group{Kind: runGroup},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case: Invalid Exec Command with empty command",
+			exec: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						CommandLine: emptyString,
+						Component:   component,
+						WorkingDir:  workDir,
+						Group:       &common.Group{Kind: runGroup},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case: Invalid Exec Command with missing component",
+			exec: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						CommandLine: command,
+						WorkingDir:  workDir,
+						Group:       &common.Group{Kind: runGroup},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case: valid Exec Command with Group nil",
+			exec: []common.DevfileCommand{
+				{
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case: valid Composite Command",
+			exec: []common.DevfileCommand{
+				{
+					Id: "somecommand1",
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+				{
+					Id: "somecommand2",
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+			},
+			comp: []common.DevfileCommand{
+				{
+					Id: "composite1",
+					Composite: &common.Composite{
+						Commands: []string{"somecommand1", "somecommand2"},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case: Invalid Composite Command",
+			exec: []common.DevfileCommand{
+				{
+					Id: "somecommand1",
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+				{
+					Id: "somecommand2",
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+			},
+			comp: []common.DevfileCommand{
+				{
+					Id: "composite1",
+					Composite: &common.Composite{
+						Commands: []string{"fakecommand"},
+						Group:    &common.Group{Kind: buildGroup, IsDefault: true},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		devObj := devfileParser.DevfileObj{
+			Data: &testingutil.TestDevfileData{
+				Commands:   append(tt.comp, tt.exec...),
+				Components: []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
+			},
+		}
+
+		commands := devObj.Data.GetCommands()
+		components := devObj.Data.GetComponents()
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCommands(commands, components)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("TestValidateAction unexpected error: %v", err)
+				return
+			}
+		})
+	}
+
+}
+
+func TestValidateCompositeCommand(t *testing.T) {
+
+	command := []string{"ls -la", "ps", "ls /"}
+	component := "alias1"
+	workDir := []string{"/", "/dev", "/etc"}
+	id := []string{"command1", "command2", "command3", "command4", "command5"}
+
+	tests := []struct {
+		name              string
+		compositeCommands []common.DevfileCommand
+		execCommands      []common.DevfileCommand
+		wantErr           bool
+	}{
+		{
+			name: "Case 1: Valid Composite Command",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[0], id[1], id[2]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   component,
+						Group:       &common.Group{Kind: buildGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+				{
+					Id: id[2],
+					Exec: &common.Exec{
+						CommandLine: command[2],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[2],
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Case 2: Invalid composite command, references non-existent command",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[0], "fakecommand", id[2]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   component,
+						Group:       &common.Group{Kind: buildGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+				{
+					Id: id[2],
+					Exec: &common.Exec{
+						CommandLine: command[2],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[2],
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 3: Invalid composite command, references itself",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[0], id[3], id[2]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   component,
+						Group:       &common.Group{Kind: buildGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+				{
+					Id: id[2],
+					Exec: &common.Exec{
+						CommandLine: command[2],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[2],
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 4: Invalid composite run command",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[0], id[3], id[2]},
+						Group:    &common.Group{Kind: runGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   component,
+						Group:       &common.Group{Kind: buildGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+				{
+					Id: id[2],
+					Exec: &common.Exec{
+						CommandLine: command[2],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[2],
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 5: Invalid composite command, indirectly references itself",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[4], id[3], id[2]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+				{
+					Id: id[4],
+					Composite: &common.Composite{
+						Commands: []string{id[0], id[3], id[2]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   component,
+						Group:       &common.Group{Kind: buildGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+				{
+					Id: id[2],
+					Exec: &common.Exec{
+						CommandLine: command[2],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[2],
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 6: Invalid composite command, points to invalid exec command",
+			compositeCommands: []common.DevfileCommand{
+				{
+					Id: id[3],
+					Composite: &common.Composite{
+						Commands: []string{id[0], id[1]},
+						Group:    &common.Group{Kind: buildGroup},
+					},
+				},
+			},
+			execCommands: []common.DevfileCommand{
+				{
+					Id: id[0],
+					Exec: &common.Exec{
+						CommandLine: command[0],
+						Component:   component,
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[0],
+					},
+				},
+				{
+					Id: id[1],
+					Exec: &common.Exec{
+						CommandLine: command[1],
+						Component:   "some-fake-component",
+						Group:       &common.Group{Kind: runGroup},
+						WorkingDir:  workDir[1],
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		devObj := devfileParser.DevfileObj{
+			Data: &testingutil.TestDevfileData{
+				Commands:   append(tt.execCommands, tt.compositeCommands...),
+				Components: []common.DevfileComponent{testingutil.GetFakeContainerComponent(component)},
+			},
+		}
+
+		commands := devObj.Data.GetCommands()
+		components := devObj.Data.GetComponents()
+
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.compositeCommands[0]
+			parentCommands := make(map[string]string)
+
+			err := validateCompositeCommand(&cmd, parentCommands, commands, components)
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("TestValidateAction unexpected error: %v", err)
+				return
+			}
+		})
+	}
+}

--- a/pkg/devfile/validate/commands_test.go
+++ b/pkg/devfile/validate/commands_test.go
@@ -16,7 +16,7 @@ func TestValidateCommands(t *testing.T) {
 	command := "ls -la"
 	component := "alias1"
 	workDir := "/"
-
+	invalidComponent := "garbagealias"
 	emptyString := ""
 
 	tests := []struct {
@@ -26,9 +26,10 @@ func TestValidateCommands(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Case: Valid Exec Command",
+			name: "Case 1: Valid Exec Command",
 			exec: []common.DevfileCommand{
 				{
+					Id: "somecommand",
 					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
@@ -40,9 +41,10 @@ func TestValidateCommands(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Case: Invalid Exec Command with empty command",
+			name: "Case 2: Invalid Exec Command with empty command",
 			exec: []common.DevfileCommand{
 				{
+					Id: "somecommand",
 					Exec: &common.Exec{
 						CommandLine: emptyString,
 						Component:   component,
@@ -54,9 +56,10 @@ func TestValidateCommands(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Case: Invalid Exec Command with missing component",
+			name: "Case 3: Invalid Exec Command with missing component",
 			exec: []common.DevfileCommand{
 				{
+					Id: "somecommand",
 					Exec: &common.Exec{
 						CommandLine: command,
 						WorkingDir:  workDir,
@@ -67,9 +70,25 @@ func TestValidateCommands(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Case: valid Exec Command with Group nil",
+			name: "Case 4: Valid Exec Command with invalid component",
 			exec: []common.DevfileCommand{
 				{
+					Id: "somecommand",
+					Exec: &common.Exec{
+						CommandLine: command,
+						Component:   invalidComponent,
+						WorkingDir:  workDir,
+						Group:       &common.Group{Kind: runGroup},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 5: valid Exec Command with Group nil",
+			exec: []common.DevfileCommand{
+				{
+					Id: "somecommand",
 					Exec: &common.Exec{
 						CommandLine: command,
 						Component:   component,
@@ -80,7 +99,7 @@ func TestValidateCommands(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Case: valid Composite Command",
+			name: "Case 6: valid Composite Command",
 			exec: []common.DevfileCommand{
 				{
 					Id: "somecommand1",
@@ -111,7 +130,7 @@ func TestValidateCommands(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Case: Invalid Composite Command",
+			name: "Case 7: Invalid Composite Command",
 			exec: []common.DevfileCommand{
 				{
 					Id: "somecommand1",

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -59,3 +59,85 @@ type InvalidEventError struct {
 func (e *InvalidEventError) Error() string {
 	return fmt.Sprintf("%s type events is invalid: %s", e.eventType, e.errorMsg)
 }
+
+// UnsupportedOdoCommandError returns an error if the command is neither exec nor composite
+type UnsupportedOdoCommandError struct {
+	commandId string
+}
+
+func (e *UnsupportedOdoCommandError) Error() string {
+	return fmt.Sprintf("command %q must be of type \"exec\" or \"composite\"", e.commandId)
+}
+
+// ExecCommandMissingComponentError returns an error if the exec command does not have a component
+type ExecCommandMissingComponentError struct {
+	commandId string
+}
+
+func (e *ExecCommandMissingComponentError) Error() string {
+	return fmt.Sprintf("exec command %q must reference a component", e.commandId)
+}
+
+// ExecCommandMissingCommandLineError returns an error if the exec command does not have a command line
+type ExecCommandMissingCommandLineError struct {
+	commandId string
+}
+
+func (e *ExecCommandMissingCommandLineError) Error() string {
+	return fmt.Sprintf("exec command %q must have a command", e.commandId)
+}
+
+// ExecCommandInvalidContainerError returns an error if the exec command references an invalid container component
+type ExecCommandInvalidContainerError struct {
+	commandId string
+}
+
+func (e *ExecCommandInvalidContainerError) Error() string {
+	return fmt.Sprintf("the command %q does not map to a supported component", e.commandId)
+}
+
+// CompositeRunKindError returns an error if the composite command is of kind run
+type CompositeRunKindError struct {
+}
+
+func (e *CompositeRunKindError) Error() string {
+	return "composite commands of run Kind are not supported currently"
+}
+
+// CompositeDirectReferenceError returns an error if the composite command directly references itself
+type CompositeDirectReferenceError struct {
+	commandId string
+}
+
+func (e *CompositeDirectReferenceError) Error() string {
+	return fmt.Sprintf("the composite command %q cannot reference itself", e.commandId)
+}
+
+// CompositeIndirectReferenceError returns an error if the composite command indirectly references itself
+type CompositeIndirectReferenceError struct {
+	commandId string
+}
+
+func (e *CompositeIndirectReferenceError) Error() string {
+	return fmt.Sprintf("the composite command %q cannot indirectly reference itself", e.commandId)
+}
+
+// CompositeMissingSubCommandError returns an error if the composite command has a missing sub command
+type CompositeMissingSubCommandError struct {
+	commandId  string
+	subCommand string
+}
+
+func (e *CompositeMissingSubCommandError) Error() string {
+	return fmt.Sprintf("the command %q mentioned in the composite command %q does not exist in the devfile", e.subCommand, e.commandId)
+}
+
+// CompositeInvalidSubCommandError returns an error if the composite command references an invalid sub command
+type CompositeInvalidSubCommandError struct {
+	commandId    string
+	subCommandId string
+}
+
+func (e *CompositeInvalidSubCommandError) Error() string {
+	return fmt.Sprintf("the composite command %q references an invalid command %q", e.commandId, e.subCommandId)
+}

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -93,7 +93,7 @@ type ExecCommandInvalidContainerError struct {
 }
 
 func (e *ExecCommandInvalidContainerError) Error() string {
-	return fmt.Sprintf("the command %q does not map to a supported component", e.commandId)
+	return fmt.Sprintf("the command %q does not map to a container component", e.commandId)
 }
 
 // CompositeRunKindError returns an error if the composite command is of kind run

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -136,8 +136,9 @@ func (e *CompositeMissingSubCommandError) Error() string {
 type CompositeInvalidSubCommandError struct {
 	commandId    string
 	subCommandId string
+	errorMsg     string
 }
 
 func (e *CompositeInvalidSubCommandError) Error() string {
-	return fmt.Sprintf("the composite command %q references an invalid command %q", e.commandId, e.subCommandId)
+	return fmt.Sprintf("the composite command %q references an invalid command %q: %s", e.commandId, e.subCommandId, e.errorMsg)
 }

--- a/pkg/devfile/validate/events.go
+++ b/pkg/devfile/validate/events.go
@@ -4,39 +4,37 @@ import (
 	"fmt"
 	"strings"
 
-	adapterCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
-	"github.com/openshift/odo/pkg/devfile/parser/data"
+	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"k8s.io/klog"
 )
 
 // validateEvents validates all the devfile events
-func validateEvents(data data.DevfileData) error {
+func validateEvents(events common.DevfileEvents, commands map[string]common.DevfileCommand, components []common.DevfileComponent) error {
 
 	eventErrors := ""
-	events := data.GetEvents()
 
 	switch {
 	case len(events.PreStart) > 0:
 		klog.V(2).Info("Validating preStart events")
-		if preStartErr := isEventValid(data, events.PreStart, "preStart"); preStartErr != nil {
+		if preStartErr := isEventValid(events.PreStart, "preStart", commands, components); preStartErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", preStartErr.Error())
 		}
 		fallthrough
 	case len(events.PostStart) > 0:
 		klog.V(2).Info("Validating postStart events")
-		if postStartErr := isEventValid(data, events.PostStart, "postStart"); postStartErr != nil {
+		if postStartErr := isEventValid(events.PostStart, "postStart", commands, components); postStartErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", postStartErr.Error())
 		}
 		fallthrough
 	case len(events.PreStop) > 0:
 		klog.V(2).Info("Validating preStop events")
-		if preStopErr := isEventValid(data, events.PreStop, "preStop"); preStopErr != nil {
+		if preStopErr := isEventValid(events.PreStop, "preStop", commands, components); preStopErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", preStopErr.Error())
 		}
 		fallthrough
 	case len(events.PostStop) > 0:
 		klog.V(2).Info("Validating postStop events")
-		if postStopErr := isEventValid(data, events.PostStop, "postStop"); postStopErr != nil {
+		if postStopErr := isEventValid(events.PostStop, "postStop", commands, components); postStopErr != nil {
 			eventErrors += fmt.Sprintf("\n%s", postStopErr.Error())
 		}
 	}
@@ -52,10 +50,9 @@ func validateEvents(data data.DevfileData) error {
 // isEventValid checks if events belonging to a specific event type are valid:
 // 1. Event should map to a valid devfile command
 // 2. Event commands should be valid
-func isEventValid(data data.DevfileData, eventNames []string, eventType string) error {
+func isEventValid(eventNames []string, eventType string, commands map[string]common.DevfileCommand, components []common.DevfileComponent) error {
 	eventErrorMsg := make(map[string][]string)
 	eventErrors := ""
-	commands := data.GetCommands()
 
 	for _, eventName := range eventNames {
 		isEventPresent := false
@@ -65,7 +62,7 @@ func isEventValid(data data.DevfileData, eventNames []string, eventType string) 
 				isEventPresent = true
 
 				// Check if the devfile command is valid
-				err := adapterCommon.ValidateCommand(data, command)
+				err := validateCommand(command, commands, components)
 				if err != nil {
 					klog.V(2).Infof("command %s is not valid: %s", command.GetID(), err.Error())
 					eventErrorMsg[strings.ToLower(eventName)] = append(eventErrorMsg[strings.ToLower(eventName)], err.Error())

--- a/pkg/devfile/validate/events_test.go
+++ b/pkg/devfile/validate/events_test.go
@@ -201,7 +201,12 @@ func TestValidateEvents(t *testing.T) {
 					Events:     tt.events,
 				},
 			}
-			err := validateEvents(devObj.Data)
+
+			events := devObj.Data.GetEvents()
+			commands := devObj.Data.GetCommands()
+			components := devObj.Data.GetComponents()
+
+			err := validateEvents(events, commands, components)
 			if err != nil && !tt.wantErr {
 				t.Errorf("TestValidateEvents error - %v", err)
 			}
@@ -346,7 +351,7 @@ func TestIsEventValid(t *testing.T) {
 				"composite1",
 			},
 			wantErr:    true,
-			wantErrMsg: "does not map to a supported component",
+			wantErrMsg: "does not map to a container component",
 		},
 		{
 			name:       "Case 4: Invalid events with wrong child command in composite command",
@@ -395,7 +400,10 @@ func TestIsEventValid(t *testing.T) {
 				},
 			}
 
-			err := isEventValid(devObj.Data, tt.eventNames, tt.eventType)
+			commands := devObj.Data.GetCommands()
+			components := devObj.Data.GetComponents()
+
+			err := isEventValid(tt.eventNames, tt.eventType, commands, components)
 			if err != nil && !tt.wantErr {
 				t.Errorf("TestIsEventValid error: %v", err)
 			} else if err != nil && tt.wantErr {

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -12,14 +12,21 @@ import (
 // ValidateDevfileData validates whether sections of devfile are odo compatible
 func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
+	var commands []common.DevfileCommand
 
 	switch d := data.(type) {
 	case *v200.Devfile200:
 		components = d.GetComponents()
+		commands = d.GetCommands()
 
 		// Validate Events
 		if err := validateEvents(d); err != nil {
 			return err
+		}
+
+		// Validate Commands
+		if err := validateCommands(commands, components); err != nil {
+			return fmt.Errorf("test2: %v", err)
 		}
 	default:
 		return fmt.Errorf("unknown devfile type %T", d)

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -13,28 +13,30 @@ import (
 func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
 	var commands map[string]common.DevfileCommand
+	var events common.DevfileEvents
 
 	switch d := data.(type) {
 	case *v200.Devfile200:
 		components = d.GetComponents()
 		commands = d.GetCommands()
+		events = d.GetEvents()
 
-		// Validate Events
-		if err := validateEvents(d); err != nil {
+		// Validate all the devfile components before validating commands
+		if err := validateComponents(components); err != nil {
 			return err
 		}
 
-		// Validate Commands
+		// Validate all the devfile commands before validating events
 		if err := validateCommands(commands, components); err != nil {
+			return err
+		}
+
+		// Validate all the events
+		if err := validateEvents(events, commands, components); err != nil {
 			return err
 		}
 	default:
 		return fmt.Errorf("unknown devfile type %T", d)
-	}
-
-	// Validate Components
-	if err := validateComponents(components); err != nil {
-		return err
 	}
 
 	// Successful

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -12,7 +12,7 @@ import (
 // ValidateDevfileData validates whether sections of devfile are odo compatible
 func ValidateDevfileData(data interface{}) error {
 	var components []common.DevfileComponent
-	var commands []common.DevfileCommand
+	var commands map[string]common.DevfileCommand
 
 	switch d := data.(type) {
 	case *v200.Devfile200:
@@ -26,7 +26,7 @@ func ValidateDevfileData(data interface{}) error {
 
 		// Validate Commands
 		if err := validateCommands(commands, components); err != nil {
-			return fmt.Errorf("test2: %v", err)
+			return err
 		}
 	default:
 		return fmt.Errorf("unknown devfile type %T", d)

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -50,7 +50,7 @@ commands:
   - id: wrongPostStart
     exec:
       commandLine: echo I am also a PostStart
-      component: wrongruntime
+      component: runtime #wrongruntime #do not delete comment, tests rely on it for search & replace
       workingDir: /
   - id: myPreStop
     exec:
@@ -78,7 +78,7 @@ commands:
     composite:
       label: Build and Mkdir
       commands:
-        - secondPreStopisWrong
+        - secondPreStop #secondPreStopisWrong #do not delete comment, tests rely on it for search & replace
         - thirdPreStop
       parallel: true
   - id: devbuild

--- a/tests/examples/source/devfiles/nodejs/devfileCompositeInvalidComponent.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfileCompositeInvalidComponent.yaml
@@ -17,6 +17,16 @@ components:
         - name: http-3000
           targetPort: 3000
 commands:
+  - id: buildAndMkdir
+    composite:
+         label: Build and Mkdir
+         commands:
+           - mkdir
+           - install
+         parallel: false
+         group: 
+            kind: build
+            isDefault: true
   - id: install
     exec:
       component: runtime
@@ -41,13 +51,3 @@ commands:
       group:
         kind: run
         isDefault: true
-  - id: buildAndMkdir
-    composite:
-         label: Build and Mkdir
-         commands:
-           - mkdir
-           - install
-         parallel: false
-         group: 
-            kind: build
-            isDefault: true

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -254,7 +254,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			// Verify odo push failed
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
-			Expect(output).To(ContainSubstring("references an invalid command"))
+			Expect(output).To(ContainSubstring("does not map to a container component"))
 		})
 
 		It("checks that odo push works outside of the context directory", func() {

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -473,9 +473,10 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			helper.ReplaceString("devfile.yaml", "secondpoststart", "wrongPostStart")
+			helper.ReplaceString("devfile.yaml", "runtime #wrongruntime", "wrongruntime")
 
 			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
-			helper.MatchAllInOutput(output, []string{"the command does not map to a supported component"})
+			helper.MatchAllInOutput(output, []string{"the command \"wrongpoststart\" does not map to a container component"})
 		})
 
 		It("should err out on an event composite command mentioning an invalid child command", func() {
@@ -485,6 +486,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(context, "devfile.yaml"))
 
 			helper.ReplaceString("devfile.yaml", "secondpoststart", "myWrongCompCmd")
+			helper.ReplaceString("devfile.yaml", "secondPreStop #secondPreStopisWrong", "secondPreStopisWrong")
 
 			output := helper.CmdShouldFail("odo", "push", "--namespace", namespace)
 			helper.MatchAllInOutput(output, []string{"does not exist in the devfile"})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind code-refactoring

**What does does this PR do / why we need it**:
- migrates devfile command validation to validate pkg along with other devfile validation
- devfile commands are now validated anytime we parse devfile and not only during odo push when using the command
- cleaned up some code
- updated unit tests

**Which issue(s) this PR fixes**:

Fixes #3703 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
- Make invalid changes to the devfile command and any odo command that parses the devfile should err out