### PR TITLE
Alpha and move Operator Hub out of experimental

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,25 @@ language: go
 
 jobs:
   include:
-    # YAML alias, for settings shared across the tests
     - &base-test
       stage: test
+      name: "Unit test on Linux"
       go_import_path: github.com/openshift/odo
       go: "1.13.x"
       install:
         - make goget-tools
       script:
         - lsb_release -a
-        - free -m
-        - dmesg
         - export PATH="$PATH:$GOPATH/bin"
         - make bin
         - make validate
         - make test-coverage
       after_success:
-        # submit coverage.txt to codecov.io
         - bash <(curl -s https://codecov.io/bash)
       
-    # YAML alias, for settings shared across the tests on windows
     - &windows-test
       stage: Test
-      name: "Unit test on windows"
+      name: "Unit test on Windows"
       os: 
         - windows
       init:
@@ -45,10 +41,9 @@ jobs:
         - make test
       after_success: skip
 
-    # YAML alias, for settings shared across the tests on macOS
     - &osx-test
       stage: Test
-      name: "Unit test on OSX"
+      name: "Unit test on macOS"
       os:
         - osx
       go_import_path: github.com/openshift/odo
@@ -65,7 +60,7 @@ jobs:
 
     - <<: *base-test
       stage: test
-      name: "generic, login, component command and plugin handler integration tests"
+      name: "Generic test"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -73,14 +68,49 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-generic
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Login / Logout"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-cmd-login-logout
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Component"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-cmd-cmp
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Plugin"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-plugin-handler
         - odo logout
 
     - <<: *base-test
       stage: test
-      name: "preference, config, component sub-commands and debug command integration tests"
+      name: "Preference"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -88,14 +118,37 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-cmd-pref-config
-        - travis_wait make test-cmd-cmp-sub
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "URL"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-url
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Debug"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-cmd-debug
         - odo logout
 
-    # Run service-catalog e2e tests
     - <<: *base-test
       stage: test
-      name: "service, link and component sub-commands command integration tests"
+      name: "Service"
       script:
         - ./scripts/oc-cluster.sh service-catalog
         - make configure-supported-311-is
@@ -103,12 +156,35 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-cmd-service
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Link / Unlink"
+      script:
+        - ./scripts/oc-cluster.sh service-catalog
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-cmd-link-unlink
         - odo logout
 
     - <<: *base-test
       stage: test
-      name: "watch, storage, app, project, URL and push command integration tests"
+      name: "Subcommands"
+      script:
+        - ./scripts/oc-cluster.sh service-catalog
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-cmp-sub
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Watch"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -116,38 +192,230 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-cmd-watch
-        - travis_wait make test-cmd-storage
-        - travis_wait make test-cmd-app
-        - travis_wait make test-cmd-push
-        - travis_wait make test-cmd-project
-        - travis_wait make test-cmd-url
         - odo logout
 
     - <<: *base-test
       stage: test
-      # Docker push target test command does not need a running cluster at all, however few test
-      # scenario of docker devfile url testing needs only Kube config file. So the test has been
-      # added here just to make sure docker devfile url command test gets a proper kube config file.
-      # without creating a separate OpenShift cluster.
-      name: "devfile catalog, create, push, watch, delete, registry, exec, test, env, config, debug and log command integration tests"
+      name: "Storage"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
-        - free -m
-        - dmesg
         - make bin
         - sudo cp odo /usr/bin
-        # Commenting out the docker test target (though test-cmd-docker-devfile-url-pushtarget is not broken)
-        # to avoid regression failure due to https://github.com/openshift/odo/issues/3714
-        # - travis_wait make test-cmd-docker-devfile-url-pushtarget
-        # These tests need cluster login as they will be interacting with a Kube environment
         - odo login -u developer
-        - travis_wait 60 make test-integration-devfile
+        - travis_wait make test-cmd-storage
         - odo logout
 
     - <<: *base-test
       stage: test
-      name: "core beta, java, source e2e tests"
+      name: "Application"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-app
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Push"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-push
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Project"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-project
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Config"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-config
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Debug"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-debug
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Storage"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-storage
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: URL"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-url
+        - odo logout
+
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Catalog"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-catalog
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Create"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-create
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Push"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-push
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Watch"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-watch
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Delete"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-delete
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Registry"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-registry
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Test"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-test
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Log"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-log
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Exec"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-exec
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "Devfile: Env"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
+        - travis_wait make test-cmd-devfile-env
+        - odo logout
+
+    - <<: *base-test
+      stage: test
+      name: "End-to-End: Beta Test"
       script:
         - ./scripts/oc-cluster.sh
         - make configure-supported-311-is
@@ -155,30 +423,47 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-e2e-beta
+        - odo logout
+    
+    - <<: *base-test
+      stage: test
+      name: "End-to-End: Java Test"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-e2e-java
+        - odo logout
+    
+    - <<: *base-test
+      stage: test
+      name: "End-to-End: Source Test"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-e2e-source
+        - odo logout
+    
+    - <<: *base-test
+      stage: test
+      name: "End-to-End: Image Test"
+      script:
+        - ./scripts/oc-cluster.sh
+        - make configure-supported-311-is
+        - make bin
+        - sudo cp odo /usr/bin
+        - odo login -u developer
         - travis_wait make test-e2e-images
         - odo logout
     
-    # Fix https://github.com/openshift/odo/issues/3714 to uncomment tests
-    # - <<: *base-test
-    #   stage: test
-    #   name: "docker devfile push, watch, url, test, catalog, exec and delete command integration tests"
-    #   script:
-    #     - make bin
-    #     - sudo cp odo /usr/bin
-    #     - travis_wait make test-cmd-docker-devfile-push
-    #     - travis_wait make test-cmd-docker-devfile-watch
-    #     - travis_wait make test-cmd-docker-devfile-catalog
-    #     - travis_wait make test-cmd-docker-devfile-delete
-    #     - travis_wait make test-cmd-docker-devfile-url
-    #     - travis_wait make test-cmd-docker-devfile-test
-    #     - travis_wait make test-cmd-docker-devfile-exec
-
-    # Run devfile integration test on Kubernetes cluster    
     - <<: *base-test
       stage: test
-      name: "devfile catalog,url, watch, push, debug, delete, exec, test, log, storage and create command integration tests on kubernetes cluster"
+      name: "Kubernetes - Project"
       env:
         - MINIKUBE_WANTUPDATENOTIFICATION=false
         - MINIKUBE_WANTREPORTERRORPROMPT=false
@@ -186,9 +471,7 @@ jobs:
         - CHANGE_MINIKUBE_NONE_USER=true
         - KUBECONFIG=$HOME/.kube/config
       before_script:
-        # Download kubectl, a cli tool for accessing Kubernetes cluster
         - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        # Download minikube and set up Kubernetes single node cluster
         - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
         - mkdir -p $HOME/.kube $HOME/.minikube
         - touch $KUBECONFIG
@@ -198,10 +481,282 @@ jobs:
         - sudo apt-get install -y socat
       script:
         - kubectl cluster-info
-        - free -m
-        - dmesg
         - make bin
         - sudo cp odo /usr/bin
         - export KUBERNETES=true
         - travis_wait make test-cmd-project
-        - travis_wait 60 make test-integration-devfile
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Catalog"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-catalog
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Watch"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-watch
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Push"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-push
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Debug"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-debug
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Exec"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-exec
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Delete"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-delete
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Create"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-create
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: URL"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-url
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Test"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-test
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Log"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-log
+    
+    - <<: *base-test
+      stage: test
+      name: "Kubernetes - Devfile: Storage"
+      env:
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+      before_script:
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.11.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - mkdir -p $HOME/.kube $HOME/.minikube
+        - touch $KUBECONFIG
+        - sudo minikube start --vm-driver=none --kubernetes-version=v1.16.1
+        - "sudo chown -R travis: /home/travis/.minikube/"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y socat
+      script:
+        - kubectl cluster-info
+        - make bin
+        - sudo cp odo /usr/bin
+        - export KUBERNETES=true
+        - travis_wait make test-cmd-devfile-storage

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -213,6 +213,25 @@ func GetComponentLinkedSecretNames(client *occlient.Client, componentName string
 	return secretNames, nil
 }
 
+// GetDevfileComponentLinkedSecretNames
+func GetDevfileComponentLinkedSecretNames(client *kclient.Client, componentName string, applicationName string) (secretNames []string, err error) {
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+
+	dc, err := client.GetOneDeploymentFromSelector(componentSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch deployments for the selector %v", componentSelector)
+	}
+
+	for _, env := range dc.Spec.Template.Spec.Containers[0].EnvFrom {
+		if env.SecretRef != nil {
+			secretNames = append(secretNames, env.SecretRef.Name)
+		}
+	}
+
+	return secretNames, nil
+}
+
 // CreateFromPath create new component with source or binary from the given local path
 // sourceType indicates the source type of the component and can be either local or binary
 // envVars is the array containing the environment variables

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3280,6 +3280,11 @@ func (c *Client) IsSBRSupported() (bool, error) {
 	return c.isResourceSupported("apps.openshift.io", "v1alpha1", "servicebindingrequests")
 }
 
+// IsCSVSupported chekcs if resource of type service binding request present on the cluster
+func (c *Client) IsCSVSupported() (bool, error) {
+	return c.isResourceSupported("operators.coreos.com", "v1alpha1", "clusterserviceversions")
+}
+
 // GenerateOwnerReference genertes an ownerReference which can then be set as
 // owner for various OpenShift objects and ensure that when the owner object is
 // deleted from the cluster, all other objects are automatically removed by

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,8 @@ type ListServicesOptions struct {
 	csvs *olm.ClusterServiceVersionList
 	// generic context options common to all commands
 	*genericclioptions.Context
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewListServicesOptions creates a new ListServicesOptions instance
@@ -36,41 +39,58 @@ func NewListServicesOptions() *ListServicesOptions {
 
 // Complete completes ListServicesOptions after they've been created
 func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	var noCsvs, noServices bool
-	o.Context = genericclioptions.NewContext(cmd)
-	o.csvs, err = o.KClient.GetClusterServiceVersionList()
-	if err != nil {
-		// Error only occurs when OperatorHub is not installed/enabled on the
-		// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
-		// no operators installed.
-		noCsvs = true
-	}
-
-	o.services, err = catalog.ListServices(o.Client)
-	if err != nil {
-		// Error occurs if Service Catalog is not enabled on the OpenShift
-		// 3.x/4.x cluster
-		noServices = true
-		// But we don't care about the Service Catalog not being enabled if
-		// it's 4.x or k8s cluster
-		if !noCsvs {
-			err = nil
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
+		var noCsvs, noServices bool
+		o.Context = genericclioptions.NewContext(cmd)
+		o.csvs, err = o.KClient.GetClusterServiceVersionList()
+		if err != nil {
+			// Error only occurs when OperatorHub is not installed/enabled on the
+			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
+			// no operators installed.
+			noCsvs = true
 		}
-	}
 
-	if noCsvs && noServices {
-		// Neither OperatorHub nor Service Catalog is enabled on the cluster
-		return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
-	}
-	o.services = util.FilterHiddenServices(o.services)
+		o.services, err = catalog.ListServices(o.Client)
+		if err != nil {
+			// Error occurs if Service Catalog is not enabled on the OpenShift
+			// 3.x/4.x cluster
+			noServices = true
+			// But we don't care about the Service Catalog not being enabled if
+			// it's 4.x or k8s cluster
+			if !noCsvs {
+				err = nil
+			}
+		}
 
+		if noCsvs && noServices {
+			// Neither OperatorHub nor Service Catalog is enabled on the cluster
+			return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
+		}
+		o.services = util.FilterHiddenServices(o.services)
+	} else {
+		o.Context = genericclioptions.NewContext(cmd)
+		o.services, err = catalog.ListServices(o.Client)
+		if err != nil {
+			return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
+		}
+
+		o.services = util.FilterHiddenServices(o.services)
+	}
 	return
 }
 
 // Validate validates the ListServicesOptions based on completed values
 func (o *ListServicesOptions) Validate() (err error) {
-	if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
-		return fmt.Errorf("no deployable services/operators found")
+	if o.csvSupport {
+		if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
+			return fmt.Errorf("no deployable services/operators found")
+		}
+	} else {
+		if len(o.services.Items) == 0 {
+			return fmt.Errorf("no deployable services found")
+		}
 	}
 	return
 }
@@ -80,8 +100,10 @@ func (o *ListServicesOptions) Run() (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(newCatalogListOutput(&o.services, o.csvs))
 	} else {
-		if len(o.csvs.Items) > 0 {
-			util.DisplayClusterServiceVersions(o.csvs)
+		if o.csvSupport {
+			if len(o.csvs.Items) > 0 {
+				util.DisplayClusterServiceVersions(o.csvs)
+			}
 		}
 		if len(o.services.Items) > 0 {
 			util.DisplayServices(o.services)

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -48,13 +48,27 @@ type UnlinkOptions struct {
 func NewUnlinkOptions() *UnlinkOptions {
 	options := UnlinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
+	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
 	return &options
 }
 
 // Complete completes UnlinkOptions after they've been created
 func (o *UnlinkOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	err = o.complete(name, cmd, args)
-	o.operation = o.Client.UnlinkSecret
+	if err != nil {
+		return err
+	}
+
+	o.csvSupport, err = o.Client.IsCSVSupported()
+	if err != nil {
+		return err
+	}
+
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
+		o.operation = o.KClient.UnlinkSecret
+	} else {
+		o.operation = o.Client.UnlinkSecret
+	}
 	return err
 }
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -6,19 +6,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	svc "github.com/openshift/odo/pkg/service"
-	"github.com/openshift/odo/pkg/util"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -58,9 +56,9 @@ A --plan must be passed along with the service type. Parameters to configure the
 
 For a full list of service types, use: 'odo catalog list services'`)
 
-	createShortDescExperimental = `Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.`
+	createShortDescOperatorHub = `Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.`
 
-	createLongDescExperimental = ktemplates.LongDesc(`
+	createLongDescOperatorHub = ktemplates.LongDesc(`
 Create a new service from Operator Hub or Service Catalog and deploy it on OpenShift.
 
 When creating a service using Operator Hub, provide a service name along with Operator name.
@@ -107,11 +105,9 @@ type ServiceCreateOptions struct {
 	// If set to true, DryRun prints the yaml that will create the service
 	DryRun bool
 	// Location of the file in which yaml specification of CR is stored.
-	// TODO: remove this after service create's interactive mode supports creating operator backed services
 	fromFile string
-
-	// Devfile
-	devfilePath string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -133,13 +129,14 @@ func NewDynamicCRD() *DynamicCRD {
 
 // Complete completes ServiceCreateOptions after they've been created
 func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
 
 	if len(args) == 0 || !cmd.HasFlags() {
 		o.interactive = true
 	}
 
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.componentContext != "" {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -151,7 +148,8 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 
 	var class scv1beta1.ClusterServiceClass
 
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
+		// we don't support interactive mode for Operator Hub yet
 		o.interactive = false
 
 		// if user has just used "odo service create", simply return
@@ -204,8 +202,8 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.outputCLI = commonui.Proceed("Output the non-interactive version of the selected options")
 		o.wait = commonui.Proceed("Wait for the service to be ready")
 	} else {
-		// split the name provided on CLI and populate servicetype & customresource
-		if util.CheckPathExists(o.devfilePath) {
+		if o.csvSupport {
+			// split the name provided on CLI and populate servicetype & customresource
 			o.ServiceType, o.CustomResource, err = svc.SplitServiceKindName(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid service name, use the format <operator-type>/<crd-name>")
@@ -215,8 +213,8 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 			o.ServiceType = args[0]
 		}
 		// if only one arg is given, then it is considered as service name and service type both
-		// ONLY if not running in Experimental mode
-		if !util.CheckPathExists(o.devfilePath) {
+		// ONLY if working on a cluster with Service Catalog and not Operator Hub
+		if !o.csvSupport {
 			// This is because an operator with name
 			// "etcdoperator.v0.9.4-clusterwide" would lead to creation of a
 			// serice with name like
@@ -284,7 +282,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 	}
 
 	// we want to find an Operator only if something's passed to the crd flag on CLI
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		d := NewDynamicCRD()
 		// if the user wants to create service from a file, we check for
 		// existence of file and validate if the requested operator and CR
@@ -437,11 +435,12 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
 	s := &log.Status{}
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		// in case of an opertor backed service, name of the service is
 		// provided by the yaml specification in alm-examples. It might also
-		// happen that a user spins up Service Catalog based service in
-		// experimental mode but we're taking a bet against that for now, so
+		// happen that a user wants to spin up Service Catalog based service in
+		// spite of having 4.x cluster mode but we're not supporting
+		// interacting with both Operator Hub and Service Catalog on 4.x. So
 		// the user won't get to see service name in the log message
 		if !o.DryRun {
 			log.Infof("Deploying service of type: %s", o.CustomResource)
@@ -452,8 +451,9 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
 	}
 
-	if util.CheckPathExists(o.devfilePath) && o.CustomResource != "" {
-		// if experimental mode is enabled and o.CustomResource is not empty, we're expected to create an Operator backed service
+	if o.csvSupport && o.CustomResource != "" {
+		// if cluster has resources of type CSV and o.CustomResource is not
+		// empty, we're expected to create an Operator backed service
 		if o.DryRun {
 			// if it's dry run, only print the alm-example (o.CustomResourceDefinition) and exit
 			jsonCR, err := json.MarshalIndent(o.CustomResourceDefinition, "", "  ")
@@ -519,13 +519,18 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
-	serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
-	serviceCreateCmd.Short = createShortDescExperimental
-	serviceCreateCmd.Long = createLongDescExperimental
-	serviceCreateCmd.Example += "\n\n" + fmt.Sprintf(createOperatorExample, fullName)
-	serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
-	// remove this feature after enabling service create interactive mode for operator backed services
-	serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
+	// we ignore the error because it doesn't matter at this place to deal with it and the function returns a *cobra.Command
+	csvSupport, _ := cmdutil.IsCSVSupported()
+
+	if csvSupport {
+		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
+		serviceCreateCmd.Short = createShortDescOperatorHub
+		serviceCreateCmd.Long = createLongDescOperatorHub
+		serviceCreateCmd.Example += "\n\n" + fmt.Sprintf(createOperatorExample, fullName)
+		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
+		// remove this feature after enabling service create interactive mode for operator backed services
+		serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
+	}
 
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringArrayVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -2,12 +2,10 @@ package service
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
-	"github.com/openshift/odo/pkg/util"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -36,8 +34,8 @@ type ServiceDeleteOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
-
-	devfilePath string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceDeleteOptions creates a new ServiceDeleteOptions instance
@@ -47,9 +45,9 @@ func NewServiceDeleteOptions() *ServiceDeleteOptions {
 
 // Complete completes ServiceDeleteOptions after they've been created
 func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
-
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -61,7 +59,7 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		svcExists, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
 		if err != nil {
 			return err
@@ -85,7 +83,7 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service delete command
 func (o *ServiceDeleteOptions) Run() (err error) {
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
 
 			s := log.Spinner("Waiting for service to be deleted")

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -3,18 +3,15 @@ package service
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
-	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	svc "github.com/openshift/odo/pkg/service"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -36,8 +33,8 @@ type ServiceListOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
-
-	devfilePath string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -47,9 +44,9 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
-
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport, err = odoutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -59,8 +56,7 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
-
-	if !util.CheckPathExists(o.devfilePath) {
+	if !o.csvSupport {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
@@ -73,10 +69,9 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
-
-	if util.CheckPathExists(o.devfilePath) {
-		// if experimental mode is enabled, we list only operator hub backed
-		// services and not service catalog ones
+	if o.csvSupport {
+		// if cluster supports Operators, we list only operator backed services
+		// and not service catalog ones
 		var list []unstructured.Unstructured
 		list, err = svc.ListOperatorServices(o.KClient)
 		if err != nil {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -136,6 +136,11 @@ func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
 	return nil
 }
 
+// GetValidEnvInfo is juat a wrapper for getValidEnvInfo
+func GetValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
+	return getValidEnvInfo(command)
+}
+
 // getValidEnvInfo accesses the environment file
 func getValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -303,3 +303,14 @@ func ThrowContextError() error {
 	return errors.Errorf(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
+
+// IsCSVSupported checks if the cluster supports resources of type ClusterServiceVersion
+func IsCSVSupported() (bool, error) {
+
+	oclient, err := occlient.New()
+	if err != nil {
+		return false, err
+	}
+
+	return oclient.IsCSVSupported()
+}

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -41,8 +41,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "link", "-h")
-			// Check for -vmodule moduleSpec output which is in additional flags
-			Expect(appHelp).To(ContainSubstring("--vmodule moduleSpec"))
+			Expect(appHelp).To(ContainSubstring("Link component to an operator backed service"))
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 var _ = Describe("odo devfile exec command tests", func() {
-	var namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
+	var project, namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
+
+	appName := "app"
 
 	// Using program command according to cliRunner in devfile
 	cliRunner := helper.GetCliRunner()
@@ -22,6 +24,7 @@ var _ = Describe("odo devfile exec command tests", func() {
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
+		project = helper.CreateRandProject()
 		currentWorkingDirectory = helper.Getwd()
 		cmpName = helper.RandString(6)
 
@@ -43,6 +46,16 @@ var _ = Describe("odo devfile exec command tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	Context("Should fail when running against s2i", func() {
+
+		It("Fail when running against s2i", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldFail("odo", "exec", "--context", context, "--", "ls")
+		})
+
 	})
 
 	Context("When devfile exec command is executed", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -22,7 +22,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		SetDefaultConsistentlyDuration(30 * time.Second)
 		// TODO: remove this when OperatorHub integration is fully baked into odo
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+		// helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
 	preSetup := func() {
@@ -31,7 +31,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		// wait till oc can see the all operators installed by setup script in the namespace
 		ocArgs := []string{"get", "csv"}
-		operators := []string{"etcd", "mongodb"}
+		operators := []string{"etcd"}
 		for _, operator := range operators {
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, operator)
@@ -43,7 +43,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.DeleteProject(project)
 	}
 
-	Context("When experimental mode is enabled", func() {
+	Context("When Operators are installed in the cluster", func() {
 
 		JustBeforeEach(func() {
 			preSetup()
@@ -55,7 +55,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
 		})
 
 		It("should not allow interactive mode command to be executed", func() {
@@ -308,7 +308,7 @@ spec:
 
 		It("listing catalog of services", func() {
 			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
+			helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
 		})
 	})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -1,7 +1,5 @@
 package integration
 
-/*
-
 import (
 	"fmt"
 	"io/ioutil"
@@ -27,433 +25,432 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
-		preSetup := func() {
-			project = helper.CreateRandProject()
-			helper.CmdShouldPass("odo", "project", "set", project)
+	preSetup := func() {
+		project = helper.CreateRandProject()
+		helper.CmdShouldPass("odo", "project", "set", project)
 
-			// wait till oc can see the all operators installed by setup script in the namespace
-			ocArgs := []string{"get", "csv"}
-			operators := []string{"etcd", "mongodb"}
-			for _, operator := range operators {
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, operator)
-				})
+		// wait till oc can see the all operators installed by setup script in the namespace
+		ocArgs := []string{"get", "csv"}
+		operators := []string{"etcd", "mongodb"}
+		for _, operator := range operators {
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, operator)
+			})
+		}
+	}
+
+	cleanPreSetup := func() {
+		helper.DeleteProject(project)
+	}
+
+	Context("When experimental mode is enabled", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should list operators installed in the namespace", func() {
+			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
+		})
+
+		It("should not allow interactive mode command to be executed", func() {
+			stdOut := helper.CmdShouldFail("odo", "service", "create")
+			Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
+		})
+	})
+
+	Context("When creating and deleting an operator backed service", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// now test listing of the service using odo
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
+
+			// now test the deletion of the service using odo
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+			// now try deleting the same service again. It should fail with error message
+			stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
+			Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
+		})
+
+		It("should be able to create service with name passed on CLI", func() {
+			name := helper.RandString(6)
+			svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with custom name because that's the name etcd will give to the pods.
+			compileString := name + `-.[a-z0-9]*`
+			etcdPod := regexp.MustCompile(compileString).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// now try creating service with same name again. it should fail
+			stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
+			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
+
+			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
+		})
+	})
+
+	Context("When deleting an invalid operator backed service", func() {
+		It("should correctly detect invalid service names", func() {
+			names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+
+			for _, name := range names {
+				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
+				Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
 			}
-		}
+		})
+	})
 
-		cleanPreSetup := func() {
-			helper.DeleteProject(project)
-		}
+	Context("When using dry-run option to create operator backed service", func() {
 
-		Context("When experimental mode is enabled", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should list operators installed in the namespace", func() {
-				stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
-			})
-
-			It("should not allow interactive mode command to be executed", func() {
-				stdOut := helper.CmdShouldFail("odo", "service", "create")
-				Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
-			})
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When creating and deleting an operator backed service", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				// now test listing of the service using odo
-				stdOut := helper.CmdShouldPass("odo", "service", "list")
-				Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
-
-				// now test the deletion of the service using odo
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-				// now try deleting the same service again. It should fail with error message
-				stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
-				Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
-			})
-
-			It("should be able to create service with name passed on CLI", func() {
-				name := helper.RandString(6)
-				svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with custom name because that's the name etcd will give to the pods.
-				compileString := name + `-.[a-z0-9]*`
-				etcdPod := regexp.MustCompile(compileString).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				// now try creating service with same name again. it should fail
-				stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
-
-				helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When deleting an invalid operator backed service", func() {
-			It("should correctly detect invalid service names", func() {
-				names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+		It("should only output the definition of the CR that will be used to start service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-				for _, name := range names {
-					stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
-					Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
-				}
-			})
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
+			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
+		})
+	})
+
+	Context("Should be able to search from catalog", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When using dry-run option to create operator backed service", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should only output the definition of the CR that will be used to start service", func() {
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-				helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("Should be able to search from catalog", func() {
+		It("should only output the definition of the CR that will be used to start service", func() {
+			stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
+			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			JustBeforeEach(func() {
-				preSetup()
-			})
+			stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
+			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
+			stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
+			Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
+		})
+	})
 
-			It("should only output the definition of the CR that will be used to start service", func() {
-				stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
-				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
+	Context("When using from-file option", func() {
 
-				stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
-				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-				stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
-				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
-			})
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When using from-file option", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should be able to create a service", func() {
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-				// stdOut contains the yaml specification. Store it to a file
-				randomFileName := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join(os.TempDir(), randomFileName)
-				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-			})
-
-			It("should be able to create a service with name passed on CLI", func() {
-				name := helper.RandString(6)
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-				// stdOut contains the yaml specification. Store it to a file
-				randomFileName := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join(os.TempDir(), randomFileName)
-				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name)
-
-				// Attempting to create service with same name should fail
-				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
-				Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When using from-file option", func() {
+		It("should be able to create a service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			JustBeforeEach(func() {
-				preSetup()
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
+
+			// stdOut contains the yaml specification. Store it to a file
+			randomFileName := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join(os.TempDir(), randomFileName)
+			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
+
+			// now create operator backed service
+			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
 			})
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should fail to create service if metadata doesn't exist or is invalid", func() {
-				noMetadata := `
-	apiVersion: etcd.database.coreos.com/v1beta2
-	kind: EtcdCluster
-	spec:
-	  size: 3
-	  version: 3.2.13
-	`
-
-				invalidMetadata := `
-	apiVersion: etcd.database.coreos.com/v1beta2
-	kind: EtcdCluster
-	metadata:
-	  noname: noname
-	spec:
-	  size: 3
-	  version: 3.2.13
-	`
-
-				noMetaFile := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join("/tmp", noMetaFile)
-				if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-				Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
-
-				invalidMetaFile := helper.RandString(6) + ".yaml"
-				fileName = filepath.Join("/tmp", invalidMetaFile)
-				if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-				Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
-
-			})
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
 		})
 
-		Context("JSON output", func() {
+		It("should be able to create a service with name passed on CLI", func() {
+			name := helper.RandString(6)
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			JustBeforeEach(func() {
-				preSetup()
-			})
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
+			// stdOut contains the yaml specification. Store it to a file
+			randomFileName := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join(os.TempDir(), randomFileName)
+			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-			It("listing catalog of services", func() {
-				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-				helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
-			})
+			// now create operator backed service
+			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name)
+
+			// Attempting to create service with same name should fail
+			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
+			Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
+		})
+	})
+
+	Context("When using from-file option", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When operator backed services are created", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should list the services if they exist", func() {
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				stdOut := helper.CmdShouldPass("odo", "service", "list")
-				helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
-
-				// now check for json output
-				jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-				helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
-
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-				// Now let's check the output again to ensure expected behaviour
-				stdOut = helper.CmdShouldFail("odo", "service", "list")
-				jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
-
-				msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
-				msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
-				Expect(stdOut).To(ContainSubstring(msg))
-				helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When linking devfile component with Operator backed service", func() {
-			var context, currentWorkingDirectory, devfilePath string
-			const devfile = "devfile.yaml"
+		It("should fail to create service if metadata doesn't exist or is invalid", func() {
+			noMetadata := `
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+spec:
+  size: 3
+  version: 3.2.13
+`
 
-			JustBeforeEach(func() {
-				preSetup()
-				context = helper.CreateNewContext()
-				devfilePath = filepath.Join(context, devfile)
-				currentWorkingDirectory = helper.Getwd()
-				helper.Chdir(context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
-			})
+			invalidMetadata := `
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  noname: noname
+spec:
+  size: 3
+  version: 3.2.13
+`
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-				helper.Chdir(currentWorkingDirectory)
-				helper.DeleteDir(context)
-			})
+			noMetaFile := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join("/tmp", noMetaFile)
+			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-			It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
+			// now create operator backed service
+			stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
 
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
+			invalidMetaFile := helper.RandString(6) + ".yaml"
+			fileName = filepath.Join("/tmp", invalidMetaFile)
+			if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			// now create operator backed service
+			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+			Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
 
-				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
-
-				stdOut = helper.CmdShouldFail("odo", "link", "/example")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
-			})
-
-			It("should fail if the provided service doesn't exist in the namespace", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
-
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
-				helper.CmdShouldPass("odo", "push")
-
-				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
-			})
-
-			It("should successfully connect and disconnect a component with an existing service", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
-
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
-				helper.CmdShouldPass("odo", "push")
-
-				// start the Operator backed service first
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
-				helper.CmdShouldPass("odo", "push")
-				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("already linked with the service"))
-
-				stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
-				helper.CmdShouldPass("odo", "push")
-
-				// verify that sbr is deleted
-				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
-
-				// next, delete a link outside of odo (using oc) and ensure that it throws an error
-				helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-				sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
-				helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
-				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-				helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
-			})
 		})
+	})
+
+	Context("JSON output", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("listing catalog of services", func() {
+			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+			helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
+		})
+	})
+
+	Context("When operator backed services are created", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should list the services if they exist", func() {
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
+
+			// now check for json output
+			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
+
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+			// Now let's check the output again to ensure expected behaviour
+			stdOut = helper.CmdShouldFail("odo", "service", "list")
+			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
+
+			msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
+			msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
+			Expect(stdOut).To(ContainSubstring(msg))
+			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
+		})
+	})
+
+	Context("When linking devfile component with Operator backed service", func() {
+		var context, currentWorkingDirectory, devfilePath string
+		const devfile = "devfile.yaml"
+
+		JustBeforeEach(func() {
+			preSetup()
+			context = helper.CreateNewContext()
+			devfilePath = filepath.Join(context, devfile)
+			currentWorkingDirectory = helper.Getwd()
+			helper.Chdir(context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+			helper.Chdir(currentWorkingDirectory)
+			helper.DeleteDir(context)
+		})
+
+		It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+
+			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+			stdOut = helper.CmdShouldFail("odo", "link", "/example")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+		})
+
+		It("should fail if the provided service doesn't exist in the namespace", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+			helper.CmdShouldPass("odo", "push")
+
+			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
+		})
+
+		It("should successfully connect and disconnect a component with an existing service", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+			helper.CmdShouldPass("odo", "push")
+
+			// start the Operator backed service first
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
+			helper.CmdShouldPass("odo", "push")
+			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("already linked with the service"))
+
+			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+			helper.CmdShouldPass("odo", "push")
+
+			// verify that sbr is deleted
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+
+			// next, delete a link outside of odo (using oc) and ensure that it throws an error
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+			sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
+			helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
+		})
+	})
 })
-*/


### PR DESCRIPTION
## NOTE1: 
### This PR is rebased on top of @cdrage's work on alpha release under [alpha-testing branch](https://github.com/cdrage/odo/tree/alpha-testing).
------
**What type of PR is this?**
/kind feature
/kind code-refactoring

**What does does this PR do / why we need it**:
 It moves Operator Hub integration out of experimental mode. We need it for v2.

**Which issue(s) this PR fixes**:

Fixes #3595 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

* Tests should pass.
* If Operators are supported by the cluster (4.x), we ignore service catalog altogether.
* If user's working with 3.x cluster, odo should support Service Catalog (if enabled by the user).