### PR TITLE
devfile components should be listed in catalog even if no Kube config exist

### DIFF
--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -57,22 +57,23 @@ func (o *DescribeComponentOptions) Complete(name string, cmd *cobra.Command, arg
 
 	if !pushtarget.IsPushTargetDocker() {
 		o.Context = genericclioptions.NewContext(cmd, true)
-
-		tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
-			catalogList, err := catalog.ListComponents(o.Client)
-			if err != nil {
-				// TODO:
-				// This MAY have to change in the future.. There is no good way to determine whether the user
-				// wants to list OpenShift or Kubernetes components. So we simply just warn in debug V(4) if
-				// we are unable to list anything from OpenShift.
-				klog.V(4).Info("Please log in to an OpenShift cluster to list OpenShift/s2i components")
-			}
-			for _, image := range catalogList.Items {
-				if image.Name == o.componentName {
-					o.component = image.Name
+		if o.Client != nil {
+			tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {
+				catalogList, err := catalog.ListComponents(o.Client)
+				if err != nil {
+					// TODO:
+					// This MAY have to change in the future.. There is no good way to determine whether the user
+					// wants to list OpenShift or Kubernetes components. So we simply just warn in debug V(4) if
+					// we are unable to list anything from OpenShift.
+					klog.V(4).Info("Please log in to an OpenShift cluster to list OpenShift/s2i components")
 				}
-			}
-		}})
+				for _, image := range catalogList.Items {
+					if image.Name == o.componentName {
+						o.component = image.Name
+					}
+				}
+			}})
+		}
 	}
 
 	tasks.Add(util.ConcurrentTask{ToRun: func(errChannel chan error) {

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -250,14 +250,15 @@ func getValidConfig(command *cobra.Command, ignoreMissingConfiguration bool) (*c
 
 // resolveProject resolves project
 func (o *internalCxt) resolveProject(localConfiguration envinfo.LocalConfigProvider) {
-	/*
-		if client == nil {
-			return localConfiguration.GetProject()
-		}*/
-	var namespace string
+
+	var namespace string = "default"
 	command := o.command
 	projectFlag := FlagValueIfSet(command, ProjectFlagName)
-	if len(projectFlag) > 0 {
+	if o.Client == nil {
+		if ns := localConfiguration.GetNamespace(); len(ns) > 0 {
+			namespace = ns
+		}
+	} else if len(projectFlag) > 0 {
 		// if project flag was set, check that the specified project exists and use it
 		project, err := o.Client.GetProject(projectFlag)
 		if err != nil || project == nil {
@@ -283,7 +284,9 @@ func (o *internalCxt) resolveProject(localConfiguration envinfo.LocalConfigProvi
 		}
 
 	}
-	o.Client.Namespace = namespace
+	if o.Client != nil {
+		o.Client.Namespace = namespace
+	}
 	o.Project = namespace
 	if o.KClient != nil {
 		o.KClient.Namespace = namespace

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -2,7 +2,9 @@ package devfile
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
+	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
 
 var _ = Describe("odo devfile catalog command tests", func() {
@@ -77,6 +79,152 @@ var _ = Describe("odo devfile catalog command tests", func() {
 			helper.CmdShouldPass("odo", "registry", "add", registryName, addRegistryURL)
 			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "nodejs")
 			helper.MatchAllInOutput(output, []string{"name: nodejs-starter", "Registry: " + registryName})
+		})
+	})
+	Context("When executing catalog describe component with a component name that does not have a devfile component", func() {
+		It("should print message that there is no Odo devfile component available", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java")
+			helper.MatchAllInOutput(output, []string{"There are no Odo devfile components with the name \"java\""})
+		})
+	})
+	Context("When executing catalog describe component with more than one argument", func() {
+		It("should give an error saying it received too many arguments", func() {
+			output := helper.CmdShouldFail("odo", "catalog", "describe", "component", "too", "many", "args")
+			helper.MatchAllInOutput(output, []string{"accepts 1 arg(s), received 3"})
+		})
+	})
+	Context("When executing catalog describe component with no arguments", func() {
+		It("should give an error saying it expects exactly one argument", func() {
+			output := helper.CmdShouldFail("odo", "catalog", "describe", "component")
+			helper.MatchAllInOutput(output, []string{"accepts 1 arg(s), received 0"})
+		})
+	})
+
+	Context("When executing catalog list components with experimental mode set to true", func() {
+		It("should prove that nodejs is present in both S2I Component list and Devfile Component list", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
+			cmpName := []string{"nodejs"}
+			err := utils.VerifyCatalogListComponent(output, cmpName)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("odo devfile catalog command tests without kubeconfig", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should list all supported devfile components", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
+			wantOutput := []string{
+				"Odo Devfile Components",
+				"NAME",
+				"java-springboot",
+				"java-openliberty",
+				"java-quarkus",
+				"DESCRIPTION",
+				"REGISTRY",
+				"DefaultDevfileRegistry",
+			}
+			helper.MatchAllInOutput(output, wantOutput)
+		})
+
+		It("should list devfile components in json format with -o flag", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
+			wantOutput := []string{
+				"odo.dev/v1alpha1",
+				"devfileItems",
+				"java-openliberty",
+				"java-springboot",
+				"nodejs",
+				"java-quarkus",
+				"java-maven",
+			}
+			helper.MatchAllInOutput(output, wantOutput)
+		})
+	})
+
+	Context("When executing catalog list components with registry that is not set up properly, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should list components from valid registry", func() {
+			helper.CmdShouldPass("odo", "registry", "add", "fake", "http://fake")
+			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
+			helper.MatchAllInOutput(output, []string{
+				"Odo Devfile Components",
+				"java-springboot",
+				"java-quarkus",
+			})
+			helper.CmdShouldPass("odo", "registry", "delete", "fake", "-f")
+		})
+	})
+
+	Context("When executing catalog describe component with a component name with a single project, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should only give information about one project", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java-openliberty")
+			Expect(output).To(MatchRegexp("origin: .+"))
+		})
+	})
+
+	Context("When executing catalog describe component with a component name with no starter projects, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should print message that the component has no starter projects", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java-maven")
+			helper.MatchAllInOutput(output, []string{"The Odo devfile component \"java-maven\" has no starter projects."})
+		})
+	})
+
+	Context("When executing catalog describe component with a component name with multiple components, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should print multiple devfiles from different registries", func() {
+			helper.CmdShouldPass("odo", "registry", "add", registryName, addRegistryURL)
+			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "nodejs")
+			helper.MatchAllInOutput(output, []string{"name: nodejs-starter", "Registry: " + registryName})
+		})
+	})
+
+	Context("When executing catalog describe component with a component name that does not have a devfile component, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should print message that there is no Odo devfile component available", func() {
+			output := helper.CmdShouldPass("odo", "catalog", "describe", "component", "java")
+			helper.MatchAllInOutput(output, []string{"There are no Odo devfile components with the name \"java\""})
+		})
+	})
+
+	Context("When executing catalog describe component with more than one argument, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should give an error saying it received too many arguments", func() {
+			output := helper.CmdShouldFail("odo", "catalog", "describe", "component", "too", "many", "args")
+			helper.MatchAllInOutput(output, []string{"accepts 1 arg(s), received 3"})
+		})
+	})
+
+	Context("When executing catalog describe component with no arguments, without kubeconfig set", func() {
+		JustBeforeEach(func() {
+			helper.LocalKubeconfigSet("")
+		})
+
+		It("should give an error saying it expects exactly one argument", func() {
+			output := helper.CmdShouldFail("odo", "catalog", "describe", "component")
+			helper.MatchAllInOutput(output, []string{"accepts 1 arg(s), received 0"})
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #3779 


**How to verify**:

1.) Make sure the experimental mode is set true.
2.) `mv ~/.kube ~/.kube_backup`
3.) `odo catalog list components` should display all the devfile type components hosted by the defaultDevfileRegistry.
4.) `odo catalog describe component nodejs/java-maven/...` should work fine.
5.) `mv  ~/.kube_backup ~/.kube`