### PR TITLE
Move Operator Hub out of experimental mode [Rebased on top of odo/beta branch]

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -213,6 +213,25 @@ func GetComponentLinkedSecretNames(client *occlient.Client, componentName string
 	return secretNames, nil
 }
 
+// GetDevfileComponentLinkedSecretNames
+func GetDevfileComponentLinkedSecretNames(client *kclient.Client, componentName string, applicationName string) (secretNames []string, err error) {
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+
+	dc, err := client.GetOneDeploymentFromSelector(componentSelector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch deployments for the selector %v", componentSelector)
+	}
+
+	for _, env := range dc.Spec.Template.Spec.Containers[0].EnvFrom {
+		if env.SecretRef != nil {
+			secretNames = append(secretNames, env.SecretRef.Name)
+		}
+	}
+
+	return secretNames, nil
+}
+
 // CreateFromPath create new component with source or binary from the given local path
 // sourceType indicates the source type of the component and can be either local or binary
 // envVars is the array containing the environment variables

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -25,7 +25,6 @@ import (
 	parsercommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/storage"
@@ -565,10 +564,10 @@ func ensureAndLogProperResourceUsage(resourceMin, resourceMax *string, resourceN
 //	envSpecificInfo: Component environment specific information, available if uses devfile
 //  cmpExist: true if components exists in the cluster
 //  endpointMap: value is devfile endpoint entry, key is the TargetPort for each enpoint entry
+//  isS2I: Legacy option. Set as true if you want to use the old S2I method as it differentiates slightly.
 // Returns:
 //	err: Errors if any else nil
-func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool, containerComponents []parsercommon.DevfileComponent) (err error) {
-	isExperimentalModeEnabled := experimental.IsExperimentalModeEnabled()
+func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool, containerComponents []parsercommon.DevfileComponent, isS2I bool) (err error) {
 
 	if client == nil {
 		var err error
@@ -580,7 +579,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 		client.Namespace = kClient.Namespace
 	}
 
-	if !isExperimentalModeEnabled {
+	if isS2I {
 		// if component exist then only call the update function
 		if cmpExist {
 			if err = Update(client, componentConfig, componentConfig.GetSourceLocation(), stdout); err != nil {
@@ -591,7 +590,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 
 	var componentName string
 	var applicationName string
-	if !isExperimentalModeEnabled || kClient == nil {
+	if isS2I || kClient == nil {
 		componentName = componentConfig.GetName()
 		applicationName = componentConfig.GetApplication()
 	} else {
@@ -605,13 +604,13 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 	}
 
 	return urlpkg.Push(client, kClient, urlpkg.PushParameters{
-		ComponentName:             componentName,
-		ApplicationName:           applicationName,
-		ConfigURLs:                componentConfig.GetURL(),
-		EnvURLS:                   envSpecificInfo.GetURL(),
-		IsRouteSupported:          isRouteSupported,
-		IsExperimentalModeEnabled: isExperimentalModeEnabled,
-		ContainerComponents:       containerComponents,
+		ComponentName:       componentName,
+		ApplicationName:     applicationName,
+		ConfigURLs:          componentConfig.GetURL(),
+		EnvURLS:             envSpecificInfo.GetURL(),
+		IsRouteSupported:    isRouteSupported,
+		ContainerComponents: containerComponents,
+		IsS2I:               isS2I,
 	})
 }
 

--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/storage"
 	urlpkg "github.com/openshift/odo/pkg/url"
 	corev1 "k8s.io/api/core/v1"
@@ -192,22 +191,20 @@ func (cfd *ComponentFullDescription) Print(client *occlient.Client) error {
 	if len(cfd.Spec.URL.Items) > 0 {
 		var output string
 
-		if !experimental.IsExperimentalModeEnabled() {
-			// if the component is not pushed
-			for i, componentURL := range cfd.Spec.URL.Items {
-				if componentURL.Status.State == urlpkg.StateTypePushed {
-					output += fmt.Sprintf(" · %v exposed via %v\n", urlpkg.GetURLString(componentURL.Spec.Protocol, componentURL.Spec.Host, "", experimental.IsExperimentalModeEnabled()), componentURL.Spec.Port)
+		for i, componentURL := range cfd.Spec.URL.Items {
+			if componentURL.Status.State == urlpkg.StateTypePushed {
+				output += fmt.Sprintf(" · %v exposed via %v\n", urlpkg.GetURLString(componentURL.Spec.Protocol, componentURL.Spec.Host, "", true), componentURL.Spec.Port)
+			} else {
+				var p string
+				if i >= len(cfd.Spec.Ports) {
+					p = cfd.Spec.Ports[len(cfd.Spec.Ports)-1]
 				} else {
-					var p string
-					if i >= len(cfd.Spec.Ports) {
-						p = cfd.Spec.Ports[len(cfd.Spec.Ports)-1]
-					} else {
-						p = cfd.Spec.Ports[i]
-					}
-					output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL.Name, p)
+					p = cfd.Spec.Ports[i]
 				}
+				output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL.Name, p)
 			}
 		}
+
 		// Cut off the last newline and output
 		if len(output) > 0 {
 			output = output[:len(output)-1]

--- a/pkg/debug/portforward.go
+++ b/pkg/debug/portforward.go
@@ -41,12 +41,12 @@ func NewDefaultPortForwarder(componentName, appName string, projectName string, 
 // portPair is a pair of port in format "localPort:RemotePort" that is to be forwarded
 // stop Chan is used to stop port forwarding
 // ready Chan is used to signal failure to the channel receiver
-func (f *DefaultPortForwarder) ForwardPorts(portPair string, stopChan, readyChan chan struct{}, isExperimental bool) error {
+func (f *DefaultPortForwarder) ForwardPorts(portPair string, stopChan, readyChan chan struct{}, isDevfile bool) error {
 	var pod *corev1.Pod
 	var conf *rest.Config
 	var err error
 
-	if f.kClient != nil && isExperimental {
+	if f.kClient != nil && isDevfile {
 		conf, err = f.kClient.KubeConfig.ClientConfig()
 		if err != nil {
 			return err
@@ -78,7 +78,7 @@ func (f *DefaultPortForwarder) ForwardPorts(portPair string, stopChan, readyChan
 	}
 
 	var req *rest.Request
-	if f.kClient != nil && isExperimental {
+	if f.kClient != nil && isDevfile {
 		req = f.kClient.GeneratePortForwardReq(pod.Name)
 	} else {
 		req = f.client.BuildPortForwardReq(pod.Name)

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -167,7 +167,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
 	}
 
-	err = component.ApplyConfig(nil, &a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists, containerComponents)
+	err = component.ApplyConfig(nil, &a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists, containerComponents, false)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -130,7 +130,7 @@ func TestValidateComponents(t *testing.T) {
 		got := validateComponents(components)
 		want := "size randomgarbage for volume component myvol is invalid"
 
-		if !strings.Contains(got.Error(), want) {
+		if got != nil && !strings.Contains(got.Error(), want) {
 			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
 		}
 	})

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3280,6 +3280,11 @@ func (c *Client) IsSBRSupported() (bool, error) {
 	return c.isResourceSupported("apps.openshift.io", "v1alpha1", "servicebindingrequests")
 }
 
+// IsCSVSupported chekcs if resource of type service binding request present on the cluster
+func (c *Client) IsCSVSupported() (bool, error) {
+	return c.isResourceSupported("operators.coreos.com", "v1alpha1", "clusterserviceversions")
+}
+
 // GenerateOwnerReference genertes an ownerReference which can then be set as
 // owner for various OpenShift objects and ensure that when the owner object is
 // deleted from the cluster, all other objects are automatically removed by

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/util"
 
@@ -719,11 +718,7 @@ func (c *Client) GetImageStream(imageNS string, imageName string, imageTag strin
 			}
 		}
 		if e != nil && err != nil {
-			// Imagestream not found in openshift and current namespaces
-			if experimental.IsExperimentalModeEnabled() {
-				return nil, fmt.Errorf("component type %q not found", imageName)
-			}
-			return nil, err
+			return nil, fmt.Errorf("component type %q not found", imageName)
 		}
 
 		// Required tag not in openshift and current namespaces

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -2,14 +2,14 @@ package list
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/spf13/cobra"
 )
@@ -36,57 +36,41 @@ func NewListServicesOptions() *ListServicesOptions {
 
 // Complete completes ListServicesOptions after they've been created
 func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		var noCsvs, noServices bool
-		o.Context = genericclioptions.NewContext(cmd)
-		o.csvs, err = o.KClient.GetClusterServiceVersionList()
-		if err != nil {
-			// Error only occurs when OperatorHub is not installed/enabled on the
-			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
-			// no operators installed.
-			noCsvs = true
-		}
-
-		o.services, err = catalog.ListServices(o.Client)
-		if err != nil {
-			// Error occurs if Service Catalog is not enabled on the OpenShift
-			// 3.x/4.x cluster
-			noServices = true
-			// But we don't care about the Service Catalog not being enabled if
-			// it's 4.x or k8s cluster
-			if !noCsvs {
-				err = nil
-			}
-		}
-
-		if noCsvs && noServices {
-			// Neither OperatorHub nor Service Catalog is enabled on the cluster
-			return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
-		}
-		o.services = util.FilterHiddenServices(o.services)
-	} else {
-		o.Context = genericclioptions.NewContext(cmd)
-		o.services, err = catalog.ListServices(o.Client)
-		if err != nil {
-			return fmt.Errorf("unable to list services because Service Catalog is not enabled in your cluster: %v", err)
-
-		}
-		o.services = util.FilterHiddenServices(o.services)
+	var noCsvs, noServices bool
+	o.Context = genericclioptions.NewContext(cmd)
+	o.csvs, err = o.KClient.GetClusterServiceVersionList()
+	if err != nil {
+		// Error only occurs when OperatorHub is not installed/enabled on the
+		// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
+		// no operators installed.
+		noCsvs = true
 	}
+
+	o.services, err = catalog.ListServices(o.Client)
+	if err != nil {
+		// Error occurs if Service Catalog is not enabled on the OpenShift
+		// 3.x/4.x cluster
+		noServices = true
+		// But we don't care about the Service Catalog not being enabled if
+		// it's 4.x or k8s cluster
+		if !noCsvs {
+			err = nil
+		}
+	}
+
+	if noCsvs && noServices {
+		// Neither OperatorHub nor Service Catalog is enabled on the cluster
+		return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
+	}
+	o.services = util.FilterHiddenServices(o.services)
 
 	return
 }
 
 // Validate validates the ListServicesOptions based on completed values
 func (o *ListServicesOptions) Validate() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
-			return fmt.Errorf("no deployable services/operators found")
-		}
-	} else {
-		if len(o.services.Items) == 0 {
-			return fmt.Errorf("no deployable services found")
-		}
+	if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
+		return fmt.Errorf("no deployable services/operators found")
 	}
 	return
 }
@@ -96,10 +80,8 @@ func (o *ListServicesOptions) Run() (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(newCatalogListOutput(&o.services, o.csvs))
 	} else {
-		if experimental.IsExperimentalModeEnabled() {
-			if len(o.csvs.Items) > 0 {
-				util.DisplayClusterServiceVersions(o.csvs)
-			}
+		if len(o.csvs.Items) > 0 {
+			util.DisplayClusterServiceVersions(o.csvs)
 		}
 		if len(o.services.Items) > 0 {
 			util.DisplayServices(o.services)

--- a/pkg/odo/cli/catalog/search/service.go
+++ b/pkg/odo/cli/catalog/search/service.go
@@ -6,7 +6,6 @@ import (
 	"github.com/openshift/odo/pkg/catalog"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/spf13/cobra"
 )
@@ -32,69 +31,51 @@ func NewSearchServiceOptions() *SearchServiceOptions {
 
 // Complete completes SearchServiceOptions after they've been created
 func (o *SearchServiceOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		var noCsvs, noServices bool
-		o.Context = genericclioptions.NewContext(cmd)
-		o.searchTerm = args[0]
-		o.csvs, err = o.KClient.SearchClusterServiceVersionList(o.searchTerm)
-		if err != nil {
-			// Error only occurs when OperatorHub is not installed/enabled on the
-			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
-			// no operators installed.
-			noCsvs = true
-		}
-
-		o.services, err = catalog.SearchService(o.Client, o.searchTerm)
-		if err != nil {
-			// Error occurs if Service Catalog is not enabled on the OpenShift
-			// 3.x/4.x cluster
-			noServices = true
-			// But we don't care about the Service Catalog not being enabled if
-			// it's 4.x or k8s cluster
-			if !noCsvs {
-				err = nil
-			}
-		}
-
-		if noCsvs && noServices {
-			// Neither OperatorHub nor Service Catalog is enabled on the cluster
-			return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
-		}
-		o.services = util.FilterHiddenServices(o.services)
-	} else {
-		o.Context = genericclioptions.NewContext(cmd)
-		o.searchTerm = args[0]
-
-		o.services, err = catalog.SearchService(o.Client, o.searchTerm)
-		if err != nil {
-			return fmt.Errorf("unable to list services because Service Catalog is not enabled in your cluster: %v", err)
-		}
-		o.services = util.FilterHiddenServices(o.services)
+	var noCsvs, noServices bool
+	o.Context = genericclioptions.NewContext(cmd)
+	o.searchTerm = args[0]
+	o.csvs, err = o.KClient.SearchClusterServiceVersionList(o.searchTerm)
+	if err != nil {
+		// Error only occurs when OperatorHub is not installed/enabled on the
+		// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are
+		// no operators installed.
+		noCsvs = true
 	}
+
+	// Checks service catalog, but if its not available, we do not error.
+	o.services, err = catalog.SearchService(o.Client, o.searchTerm)
+	if err != nil {
+		// Error occurs if Service Catalog is not enabled on the OpenShift
+		// 3.x/4.x cluster
+		noServices = true
+		// But we don't care about the Service Catalog not being enabled if
+		// it's 4.x or k8s cluster
+		if !noCsvs {
+			err = nil
+		}
+	}
+
+	if noCsvs && noServices {
+		// Neither OperatorHub nor Service Catalog is enabled on the cluster
+		return fmt.Errorf("unable to list services because neither Service Catalog nor Operator Hub is enabled in your cluster: %v", err)
+	}
+	o.services = util.FilterHiddenServices(o.services)
+
 	return err
 }
 
 // Validate validates the SearchServiceOptions based on completed values
 func (o *SearchServiceOptions) Validate() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
-			return fmt.Errorf("no service matched the query: %s", o.searchTerm)
-		}
-	} else {
-		if len(o.services.Items) == 0 {
-			return fmt.Errorf("no service matched the query: %s", o.searchTerm)
-		}
+	if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
+		return fmt.Errorf("no service matched the query: %s", o.searchTerm)
 	}
-
 	return
 }
 
 // Run contains the logic for the command associated with SearchServiceOptions
 func (o *SearchServiceOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
-		if len(o.csvs.Items) > 0 {
-			util.DisplayClusterServiceVersions(o.csvs)
-		}
+	if len(o.csvs.Items) > 0 {
+		util.DisplayClusterServiceVersions(o.csvs)
 	}
 	if len(o.services.Items) > 0 {
 		util.DisplayServices(o.services)

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -205,9 +205,6 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 		debug.NewCmdDebug(debug.RecommendedCommandName, util.GetFullName(fullName, debug.RecommendedCommandName)),
 		registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
 		component.NewCmdTest(component.TestRecommendedCommandName, util.GetFullName(fullName, component.TestRecommendedCommandName)),
-	)
-
-	rootCmd.AddCommand(
 		env.NewCmdEnv(env.RecommendedCommandName, util.GetFullName(fullName, env.RecommendedCommandName)),
 	)
 

--- a/pkg/odo/cli/cli.go
+++ b/pkg/odo/cli/cli.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/version"
 	"github.com/openshift/odo/pkg/odo/util"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -204,15 +203,13 @@ func odoRootCmd(name, fullName string) *cobra.Command {
 		config.NewCmdConfiguration(config.RecommendedCommandName, util.GetFullName(fullName, config.RecommendedCommandName)),
 		preference.NewCmdPreference(preference.RecommendedCommandName, util.GetFullName(fullName, preference.RecommendedCommandName)),
 		debug.NewCmdDebug(debug.RecommendedCommandName, util.GetFullName(fullName, debug.RecommendedCommandName)),
+		registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
+		component.NewCmdTest(component.TestRecommendedCommandName, util.GetFullName(fullName, component.TestRecommendedCommandName)),
 	)
 
-	if experimental.IsExperimentalModeEnabled() {
-		rootCmd.AddCommand(
-			registry.NewCmdRegistry(registry.RecommendedCommandName, util.GetFullName(fullName, registry.RecommendedCommandName)),
-			component.NewCmdTest(component.TestRecommendedCommandName, util.GetFullName(fullName, component.TestRecommendedCommandName)),
-			env.NewCmdEnv(env.RecommendedCommandName, util.GetFullName(fullName, env.RecommendedCommandName)),
-		)
-	}
+	rootCmd.AddCommand(
+		env.NewCmdEnv(env.RecommendedCommandName, util.GetFullName(fullName, env.RecommendedCommandName)),
+	)
 
 	odoutil.VisitCommands(rootCmd, reconfigureCmdWithSubcmd)
 

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/secret"
 	svc "github.com/openshift/odo/pkg/service"
 	"github.com/openshift/odo/pkg/util"
@@ -40,6 +39,8 @@ type commonLinkOptions struct {
 	secretName       string
 	isTargetAService bool
 
+	devfilePath string
+
 	suppliedName  string
 	operation     func(secretName, componentName, applicationName string) error
 	operationName string
@@ -57,12 +58,13 @@ func newCommonLinkOptions() *commonLinkOptions {
 
 // Complete completes LinkOptions after they've been created
 func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []string) (err error) {
+
 	o.operationName = name
 
 	suppliedName := args[0]
 	o.suppliedName = suppliedName
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		oclient, err := occlient.New()
@@ -168,7 +170,7 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 
 func (o *commonLinkOptions) validate(wait bool) (err error) {
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		// let's validate if the service exists
 		svcFullName := strings.Join([]string{o.serviceType, o.serviceName}, "/")
 		svcExists, err := svc.OperatorSvcExists(o.KClient, svcFullName)
@@ -263,7 +265,7 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 }
 
 func (o *commonLinkOptions) run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		if o.operationName == unlink {
 			sbrName := getSBRName(o.EnvSpecificInfo.GetName(), o.serviceType, o.serviceName)
 			svcFullName := getSvcFullName(sbrKind, sbrName)
@@ -282,6 +284,7 @@ func (o *commonLinkOptions) run() (err error) {
 
 			return
 		}
+
 		// convert service binding request into a ma[string]interface{} type so
 		// as to use it with dynamic client
 		sbrMap := make(map[string]interface{})

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -128,7 +128,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		}
 	}
 	// Apply config
-	err := component.ApplyConfig(cpo.Context.Client, nil, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist, []parsercommon.DevfileComponent{})
+	err := component.ApplyConfig(cpo.Context.Client, nil, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist, []parsercommon.DevfileComponent{}, true)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/url"
 	"github.com/pkg/errors"
 
@@ -73,9 +72,7 @@ func NewCmdComponent(name, fullName string) *cobra.Command {
 	componentCmd.Flags().AddFlagSet(componentGetCmd.Flags())
 
 	componentCmd.AddCommand(componentGetCmd, createCmd, deleteCmd, describeCmd, linkCmd, unlinkCmd, listCmd, logCmd, pushCmd, updateCmd, watchCmd, execCmd)
-	if experimental.IsExperimentalModeEnabled() {
-		componentCmd.AddCommand(testCmd)
-	}
+	componentCmd.AddCommand(testCmd)
 
 	// Add a defined annotation in order to appear in the help menu
 	componentCmd.Annotations = map[string]string{"command": "main"}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -1113,15 +1113,19 @@ func (co *CreateOptions) devfileRun() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run() (err error) {
-	if util.CheckPathExists(co.DevfilePath) {
-		if !co.forceS2i && co.devfileMetadata.devfileSupport {
-			return co.devfileRun()
-		}
+
+	// By default we run Devfile
+	if !co.forceS2i && co.devfileMetadata.devfileSupport {
+		return co.devfileRun()
 	}
+
+	// If not, we run s2i (if the --s2i parameter has been passed in).
+	// It's implied that we have passed it in if Devfile did not run above
 	err = co.s2iRun()
 	if err != nil {
 		return err
 	}
+
 	if log.IsJSON() {
 		var componentDesc component.Component
 		co.Context, co.LocalConfigInfo, err = genericclioptions.UpdatedContext(co.Context)

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/odo/pkg/envinfo"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 
 	"github.com/openshift/odo/pkg/util"
@@ -80,7 +79,7 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 	ConfigFilePath = filepath.Join(do.componentContext, configFile)
 
 	// if experimental mode is enabled and devfile is present
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		do.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(do.componentContext)
 		if err != nil {
 			return err
@@ -105,7 +104,7 @@ func (do *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string
 func (do *DeleteOptions) Validate() (err error) {
 
 	// if experimental mode is enabled and devfile is present
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		return nil
 	}
 
@@ -132,7 +131,7 @@ func (do *DeleteOptions) Run() (err error) {
 	klog.V(4).Infof("component delete called")
 	klog.V(4).Infof("args: %#v", do)
 
-	if !do.componentDeleteS2iFlag && experimental.IsExperimentalModeEnabled() && util.CheckPathExists(do.devfilePath) {
+	if !do.componentDeleteS2iFlag && util.CheckPathExists(do.devfilePath) {
 		return do.DevFileRun()
 	}
 
@@ -312,10 +311,7 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteWaitFlag, "wait", "w", false, "Wait for complete deletion of component and its dependent")
 	componentDeleteCmd.Flags().BoolVarP(&do.componentDeleteS2iFlag, "s2i", "", false, "Delete s2i component if devfile and s2i both component present with same name")
 
-	// enable show flag if experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		componentDeleteCmd.Flags().BoolVar(&do.show, "show-log", false, "If enabled, logs will be shown when deleted")
-	}
+	componentDeleteCmd.Flags().BoolVar(&do.show, "show-log", false, "If enabled, logs will be shown when deleted")
 
 	componentDeleteCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	completion.RegisterCommandHandler(componentDeleteCmd, completion.ComponentNameCompletionHandler)

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openshift/odo/pkg/devfile"
@@ -31,6 +32,18 @@ the feature will be available with experimental mode enabled.
 The behaviour of this feature is subject to change as development for this
 feature progresses.
 */
+
+// Constants for devfile component
+const (
+	devFile = "devfile.yaml"
+)
+
+// DevfilePath is the devfile path that is used by odo,
+// which means odo can:
+// 1. Directly use the devfile in DevfilePath
+// 2. Download devfile from registry to DevfilePath then use the devfile in DevfilePath
+// 3. Copy user's own devfile (path is specified via --devfile flag) to DevfilePath then use the devfile in DevfilePath
+var DevfilePath = filepath.Join(LocalDirectoryDefaultLocation, devFile)
 
 // DevfilePush has the logic to perform the required actions for a given devfile
 func (po *PushOptions) DevfilePush() error {

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
+	"github.com/openshift/odo/pkg/util"
 
 	"path/filepath"
 
@@ -64,7 +64,7 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 	eo.devfilePath = filepath.Join(eo.componentContext, devFile)
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(eo.devfilePath) {
 		eo.componentOptions.Context = genericclioptions.NewDevfileContext(cmd)
 
 		if !pushtarget.IsPushTargetDocker() {

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -63,7 +63,7 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 
 	eo.devfilePath = filepath.Join(eo.componentContext, devFile)
 
-	// if experimental mode is enabled and devfile is present
+	// If Devfile is present
 	if util.CheckPathExists(eo.devfilePath) {
 		eo.componentOptions.Context = genericclioptions.NewDevfileContext(cmd)
 
@@ -73,7 +73,9 @@ Please provide a command to execute, odo exec -- <command to be execute>`)
 		}
 		return nil
 	}
-	return
+
+	// If Devfile does not exist, it is implied that we are running s2i
+	return fmt.Errorf("exec command does not work with s2i components")
 }
 
 // Validate validates the exec parameters

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -118,7 +118,7 @@ func (o *LinkOptions) Validate() (err error) {
 		return err
 	}
 
-	// Wat?
+	// Return if we are using Devfile, no need to validate anything else below
 	if util.CheckPathExists(o.commonLinkOptions.devfilePath) {
 		return
 	}

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -2,17 +2,17 @@ package component
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	sbo "github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 
-	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/util"
 
-	"github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
@@ -88,6 +88,7 @@ odo link EtcdCluster/myetcd
 type LinkOptions struct {
 	waitForTarget    bool
 	componentContext string
+
 	*commonLinkOptions
 }
 
@@ -101,8 +102,10 @@ func NewLinkOptions() *LinkOptions {
 
 // Complete completes LinkOptions after they've been created
 func (o *LinkOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.commonLinkOptions.devfilePath = filepath.Join(o.componentContext, DevfilePath)
+
 	err = o.complete(name, cmd, args)
-	if !experimental.IsExperimentalModeEnabled() {
+	if !util.CheckPathExists(o.commonLinkOptions.devfilePath) {
 		o.operation = o.Client.LinkSecret
 	}
 	return err
@@ -115,7 +118,8 @@ func (o *LinkOptions) Validate() (err error) {
 		return err
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	// Wat?
+	if util.CheckPathExists(o.commonLinkOptions.devfilePath) {
 		return
 	}
 
@@ -160,22 +164,19 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 
-	linkCmd.SetUsageTemplate(util.CmdUsageTemplate)
+	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// Modifications for the case when experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		linkCmd.Use = fmt.Sprintf("%s <service-type>/<service-name>", name)
-		linkCmd.Example = fmt.Sprintf(linkExampleExperimental, fullName)
-		linkCmd.Long = linkLongDescExperimental
-	}
+	// Update the use / example / long to the Devfile description
+	linkCmd.Use = fmt.Sprintf("%s <service-type>/<service-name>", name)
+	linkCmd.Example = fmt.Sprintf(linkExampleExperimental, fullName)
+	linkCmd.Long = linkLongDescExperimental
+
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(linkCmd)
-	//Adding `--application` flag
-	if !experimental.IsExperimentalModeEnabled() {
-		appCmd.AddApplicationFlag(linkCmd)
-	}
+
 	//Adding `--component` flag
 	AddComponentFlag(linkCmd)
+
 	//Adding context flag
 	genericclioptions.AddContextFlag(linkCmd, &o.componentContext)
 

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -11,7 +11,6 @@ import (
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
@@ -48,7 +47,7 @@ func (lo *LogOptions) Complete(name string, cmd *cobra.Command, args []string) (
 	lo.devfilePath = filepath.Join(lo.componentContext, lo.devfilePath)
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
+	if util.CheckPathExists(lo.devfilePath) {
 		lo.ComponentOptions.Context = genericclioptions.NewDevfileContext(cmd)
 		return nil
 	}
@@ -66,7 +65,7 @@ func (lo *LogOptions) Run() (err error) {
 	stdout := os.Stdout
 
 	// If experimental mode is enabled, use devfile push
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(lo.devfilePath) {
+	if util.CheckPathExists(lo.devfilePath) {
 		err = lo.DevfileComponentLog()
 	} else {
 		// Retrieve the log

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -172,13 +172,13 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 // Validate validates the push parameters
 func (po *PushOptions) Validate() (err error) {
 
-	// If the experimental flag is set and devfile is present, then we do *not* validate
-	// TODO: We need to clean this section up a bit.. We should also validate Devfile here
-	// too.
+	// If Devfile is present we do not need to validate the below S2I checks
+	// TODO: Perhaps one day move Devfile validation to here instead?
 	if util.CheckPathExists(po.DevfilePath) {
 		return nil
 	}
 
+	// Validation for S2i components
 	log.Info("Validation")
 
 	// First off, we check to see if the component exists. This is ran each time we do `odo push`

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -15,7 +15,6 @@ import (
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -85,7 +84,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 	po.CompleteDevfilePath()
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 
 		po.Devfile, err = devfile.ParseAndValidate(po.DevfilePath)
 		if err != nil {
@@ -176,7 +175,7 @@ func (po *PushOptions) Validate() (err error) {
 	// If the experimental flag is set and devfile is present, then we do *not* validate
 	// TODO: We need to clean this section up a bit.. We should also validate Devfile here
 	// too.
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 		return nil
 	}
 
@@ -208,7 +207,7 @@ func (po *PushOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run() (err error) {
 	// If experimental mode is enabled, use devfile push
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(po.DevfilePath) {
+	if util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push
 		return po.DevfilePush()
 	}
@@ -224,14 +223,8 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	annotations := map[string]string{"command": "component"}
 
 	pushCmdExampleText := pushCmdExample
-
-	if experimental.IsExperimentalModeEnabled() {
-		// The '-o json' option should only appear in help output when experimental mode is enabled.
-		annotations["machineoutput"] = "json"
-
-		// The '-o json' example should likewise only appear in experimental only.
-		pushCmdExampleText += pushCmdExampleExperimentalOnly
-	}
+	annotations["machineoutput"] = "json"
+	pushCmdExampleText += pushCmdExampleExperimentalOnly
 
 	var pushCmd = &cobra.Command{
 		Use:         fmt.Sprintf("%s [component name]", name),
@@ -252,15 +245,12 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	pushCmd.Flags().BoolVar(&po.pushSource, "source", false, "Use source flag to only push latest source on to cluster")
 	pushCmd.Flags().BoolVarP(&po.forceBuild, "force-build", "f", false, "Use force-build flag to force building the component")
 
-	// enable devfile flag if experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		pushCmd.Flags().StringVar(&po.namespace, "namespace", "", "Namespace to push the component to")
-		pushCmd.Flags().StringVar(&po.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
-		pushCmd.Flags().StringVar(&po.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
-		pushCmd.Flags().StringVar(&po.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
-		pushCmd.Flags().BoolVar(&po.debugRun, "debug", false, "Runs the component in debug mode")
-		pushCmd.Flags().StringVar(&po.devfileDebugCommand, "debug-command", "", "Devfile Debug Command to execute")
-	}
+	pushCmd.Flags().StringVar(&po.namespace, "namespace", "", "Namespace to push the component to")
+	pushCmd.Flags().StringVar(&po.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
+	pushCmd.Flags().StringVar(&po.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
+	pushCmd.Flags().StringVar(&po.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
+	pushCmd.Flags().BoolVar(&po.debugRun, "debug", false, "Runs the component in debug mode")
+	pushCmd.Flags().StringVar(&po.devfileDebugCommand, "debug-command", "", "Devfile Debug Command to execute")
 
 	//Adding `--project` flag
 	projectCmd.AddProjectFlag(pushCmd)

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/odo/pkg/devfile"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
+	"github.com/openshift/odo/pkg/util"
 
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
@@ -55,6 +56,11 @@ func (to *TestOptions) Complete(name string, cmd *cobra.Command, args []string) 
 
 // Validate validates the TestOptions based on completed values
 func (to *TestOptions) Validate() (err error) {
+
+	if !util.CheckPathExists(to.devfilePath) {
+		return fmt.Errorf("unable to find devfile, odo test command is only supported by devfile components")
+	}
+
 	devObj, err := devfile.ParseAndValidate(to.devfilePath)
 	if err != nil {
 		return errors.Wrap(err, "fail to parse devfile")

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -48,13 +48,27 @@ type UnlinkOptions struct {
 func NewUnlinkOptions() *UnlinkOptions {
 	options := UnlinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
+	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
 	return &options
 }
 
 // Complete completes UnlinkOptions after they've been created
 func (o *UnlinkOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	err = o.complete(name, cmd, args)
-	o.operation = o.Client.UnlinkSecret
+	if err != nil {
+		return err
+	}
+
+	o.csvSupport, err = o.Client.IsCSVSupported()
+	if err != nil {
+		return err
+	}
+
+	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
+		o.operation = o.KClient.UnlinkSecret
+	} else {
+		o.operation = o.Client.UnlinkSecret
+	}
 	return err
 }
 

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -78,10 +77,7 @@ func NewUpdateOptions() *UpdateOptions {
 func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	uo.devfilePath = filepath.Join(uo.componentContext, DevfilePath)
 
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
-		// Add a disclaimer that we are in *experimental mode*
-		log.Experimental("Experimental mode is enabled, use at your own risk")
-
+	if util.CheckPathExists(uo.devfilePath) {
 		// Configure the devfile context
 		uo.Context = genericclioptions.NewDevfileContext(cmd)
 		return
@@ -99,7 +95,7 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 func (uo *UpdateOptions) Validate() (err error) {
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
+	if util.CheckPathExists(uo.devfilePath) {
 		return nil
 	}
 
@@ -171,8 +167,8 @@ func (uo *UpdateOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (uo *UpdateOptions) Run() (err error) {
 
-	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(uo.devfilePath) {
+	// if devfile is present
+	if util.CheckPathExists(uo.devfilePath) {
 		return errors.New(devfileErrorString)
 	}
 

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/odo/pkg/occlient"
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	"github.com/pkg/errors"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -39,10 +38,6 @@ var watchExampleWithDevfile = ktemplates.Examples(`  # Watch for changes in dire
 
 # Watch source code changes with custom devfile commands using --build-command and --run-command for experimental mode
 %[1]s --build-command="mybuild" --run-command="myrun"
-  `)
-
-var watchExample = ktemplates.Examples(`  # Watch for changes in directory for current component
-%[1]s
   `)
 
 // WatchOptions contains attributes of the watch command
@@ -82,7 +77,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	wo.devfilePath = filepath.Join(wo.componentContext, DevfilePath)
 
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
+	if util.CheckPathExists(wo.devfilePath) {
 		wo.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// Set the source path to either the context or current working directory (if context not set)
@@ -161,7 +156,7 @@ func (wo *WatchOptions) Validate() (err error) {
 	}
 
 	// if experimental mode is enabled and devfile is present, return. The rest of the validation is for non-devfile components
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
+	if util.CheckPathExists(wo.devfilePath) {
 		exists, err := wo.initialDevfileHandler.DoesComponentExist(wo.componentName)
 		if err != nil {
 			return err
@@ -203,7 +198,7 @@ func (wo *WatchOptions) Validate() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (wo *WatchOptions) Run() (err error) {
 	// if experimental mode is enabled and devfile is present
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(wo.devfilePath) {
+	if util.CheckPathExists(wo.devfilePath) {
 
 		err = watch.DevfileWatchAndPush(
 			os.Stdout,
@@ -255,12 +250,10 @@ func (wo *WatchOptions) Run() (err error) {
 func NewCmdWatch(name, fullName string) *cobra.Command {
 	wo := NewWatchOptions()
 
-	example := fmt.Sprintf(watchExample, fullName)
 	usage := name
 
-	if experimental.IsExperimentalModeEnabled() {
-		example = fmt.Sprintf(watchExampleWithDevfile, fullName)
-	}
+	// Add information on Devfile
+	example := fmt.Sprintf(watchExampleWithDevfile, fullName)
 
 	var watchCmd = &cobra.Command{
 		Use:         usage,
@@ -280,12 +273,9 @@ func NewCmdWatch(name, fullName string) *cobra.Command {
 
 	watchCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// enable devfile flag if experimental mode is enabled
-	if experimental.IsExperimentalModeEnabled() {
-		watchCmd.Flags().StringVar(&wo.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
-		watchCmd.Flags().StringVar(&wo.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
-		watchCmd.Flags().StringVar(&wo.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
-	}
+	watchCmd.Flags().StringVar(&wo.devfileInitCommand, "init-command", "", "Devfile Init Command to execute")
+	watchCmd.Flags().StringVar(&wo.devfileBuildCommand, "build-command", "", "Devfile Build Command to execute")
+	watchCmd.Flags().StringVar(&wo.devfileRunCommand, "run-command", "", "Devfile Run Command to execute")
 
 	// Adding context flag
 	genericclioptions.AddContextFlag(watchCmd, &wo.componentContext)

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	k8sgenclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
@@ -47,7 +46,7 @@ func NewInfoOptions() *InfoOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *InfoOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() && util.CheckPathExists(filepath.Join(o.contextDir, devfile)) {
+	if util.CheckPathExists(filepath.Join(o.contextDir, devfile)) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -12,8 +12,8 @@ import (
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/debug"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/util"
 
 	"github.com/spf13/cobra"
@@ -39,9 +39,9 @@ type PortForwardOptions struct {
 	StopChannel chan struct{}
 	// ReadChannel is used to receive status of port forwarding ( ready or not ready )
 	ReadyChannel chan struct{}
-	*genericclioptions.Context
 
-	isExperimental bool
+	*genericclioptions.Context
+	devfilePath string
 }
 
 var (
@@ -72,12 +72,11 @@ func NewPortForwardOptions() *PortForwardOptions {
 
 // Complete completes all the required options for port-forward cmd.
 func (o *PortForwardOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.contextDir, component.DevfilePath)
 
 	var remotePort int
 
-	o.isExperimental = experimental.IsExperimentalModeEnabled()
-
-	if o.isExperimental && util.CheckPathExists(filepath.Join(o.contextDir, devfile)) {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 
 		// a small shortcut
@@ -166,7 +165,7 @@ func (o PortForwardOptions) Run() error {
 		return err
 	}
 
-	return o.PortForwarder.ForwardPorts(o.PortPair, o.StopChannel, o.ReadyChannel, o.isExperimental)
+	return o.PortForwarder.ForwardPorts(o.PortPair, o.StopChannel, o.ReadyChannel, util.CheckPathExists(o.devfilePath))
 }
 
 // NewCmdPortForward implements the port-forward odo command
@@ -182,6 +181,7 @@ func NewCmdPortForward(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(opts, cmd, args)
 		},
 	}
+
 	genericclioptions.AddContextFlag(cmd, &opts.contextDir)
 	cmd.Flags().IntVarP(&opts.localPort, "local-port", "l", config.DefaultDebugPort, "Set the local port")
 

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -57,7 +57,7 @@ func (o *ListOptions) Run() (err error) {
 	}
 
 	registryList := cfg.OdoSettings.RegistryList
-	if len(*registryList) == 0 {
+	if registryList == nil || len(*registryList) == 0 {
 		return fmt.Errorf("No devfile registries added to the configuration. Refer `odo registry add -h` to add one")
 	}
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -6,17 +6,19 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	svc "github.com/openshift/odo/pkg/service"
+	"github.com/openshift/odo/pkg/util"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -107,6 +109,9 @@ type ServiceCreateOptions struct {
 	// Location of the file in which yaml specification of CR is stored.
 	// TODO: remove this after service create's interactive mode supports creating operator backed services
 	fromFile string
+
+	// Devfile
+	devfilePath string
 }
 
 // NewServiceCreateOptions creates a new ServiceCreateOptions instance
@@ -128,11 +133,13 @@ func NewDynamicCRD() *DynamicCRD {
 
 // Complete completes ServiceCreateOptions after they've been created
 func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
+
 	if len(args) == 0 || !cmd.HasFlags() {
 		o.interactive = true
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else if o.componentContext != "" {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -144,8 +151,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 
 	var class scv1beta1.ClusterServiceClass
 
-	if experimental.IsExperimentalModeEnabled() {
-		// we don't support interactive mode for Operator Hub yet
+	if util.CheckPathExists(o.devfilePath) {
 		o.interactive = false
 
 		// if user has just used "odo service create", simply return
@@ -198,18 +204,19 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.outputCLI = commonui.Proceed("Output the non-interactive version of the selected options")
 		o.wait = commonui.Proceed("Wait for the service to be ready")
 	} else {
-		if experimental.IsExperimentalModeEnabled() {
-			// split the name provided on CLI and populate servicetype & customresource
+		// split the name provided on CLI and populate servicetype & customresource
+		if util.CheckPathExists(o.devfilePath) {
 			o.ServiceType, o.CustomResource, err = svc.SplitServiceKindName(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid service name, use the format <operator-type>/<crd-name>")
 			}
+
 		} else {
 			o.ServiceType = args[0]
 		}
 		// if only one arg is given, then it is considered as service name and service type both
 		// ONLY if not running in Experimental mode
-		if !experimental.IsExperimentalModeEnabled() {
+		if !util.CheckPathExists(o.devfilePath) {
 			// This is because an operator with name
 			// "etcdoperator.v0.9.4-clusterwide" would lead to creation of a
 			// serice with name like
@@ -277,7 +284,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 	}
 
 	// we want to find an Operator only if something's passed to the crd flag on CLI
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		d := NewDynamicCRD()
 		// if the user wants to create service from a file, we check for
 		// existence of file and validate if the requested operator and CR
@@ -430,7 +437,7 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 // Run contains the logic for the odo service create command
 func (o *ServiceCreateOptions) Run() (err error) {
 	s := &log.Status{}
-	if experimental.IsExperimentalModeEnabled() {
+	if util.CheckPathExists(o.devfilePath) {
 		// in case of an opertor backed service, name of the service is
 		// provided by the yaml specification in alm-examples. It might also
 		// happen that a user spins up Service Catalog based service in
@@ -445,7 +452,7 @@ func (o *ServiceCreateOptions) Run() (err error) {
 		log.Infof("Deploying service %s of type: %s", o.ServiceName, o.ServiceType)
 	}
 
-	if experimental.IsExperimentalModeEnabled() && o.CustomResource != "" {
+	if util.CheckPathExists(o.devfilePath) && o.CustomResource != "" {
 		// if experimental mode is enabled and o.CustomResource is not empty, we're expected to create an Operator backed service
 		if o.DryRun {
 			// if it's dry run, only print the alm-example (o.CustomResourceDefinition) and exit
@@ -512,15 +519,13 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 		},
 	}
 
-	if experimental.IsExperimentalModeEnabled() {
-		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
-		serviceCreateCmd.Short = createShortDescExperimental
-		serviceCreateCmd.Long = createLongDescExperimental
-		serviceCreateCmd.Example += "\n\n" + fmt.Sprintf(createOperatorExample, fullName)
-		serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
-		// remove this feature after enabling service create interactive mode for operator backed services
-		serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
-	}
+	serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)
+	serviceCreateCmd.Short = createShortDescExperimental
+	serviceCreateCmd.Long = createLongDescExperimental
+	serviceCreateCmd.Example += "\n\n" + fmt.Sprintf(createOperatorExample, fullName)
+	serviceCreateCmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Print the yaml specificiation that will be used to create the service")
+	// remove this feature after enabling service create interactive mode for operator backed services
+	serviceCreateCmd.Flags().StringVar(&o.fromFile, "from-file", "", "Path to the file containing yaml specification to use to start operator backed service")
 
 	serviceCreateCmd.Flags().StringVar(&o.Plan, "plan", "", "The name of the plan of the service to be created")
 	serviceCreateCmd.Flags().StringArrayVarP(&o.parameters, "parameters", "p", []string{}, "Parameters of the plan where a parameter is expressed as <key>=<value")

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -2,12 +2,10 @@ package service
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
-	"github.com/openshift/odo/pkg/util"
+	cmdutil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -36,8 +34,8 @@ type ServiceDeleteOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
-
-	devfilePath string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceDeleteOptions creates a new ServiceDeleteOptions instance
@@ -47,9 +45,9 @@ func NewServiceDeleteOptions() *ServiceDeleteOptions {
 
 // Complete completes ServiceDeleteOptions after they've been created
 func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
-
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -61,7 +59,7 @@ func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []
 
 // Validate validates the ServiceDeleteOptions based on completed values
 func (o *ServiceDeleteOptions) Validate() (err error) {
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		svcExists, err := svc.OperatorSvcExists(o.KClient, o.serviceName)
 		if err != nil {
 			return err
@@ -85,7 +83,7 @@ func (o *ServiceDeleteOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service delete command
 func (o *ServiceDeleteOptions) Run() (err error) {
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport {
 		if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
 
 			s := log.Spinner("Waiting for service to be deleted")

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -3,16 +3,18 @@ package service
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	svc "github.com/openshift/odo/pkg/service"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -34,6 +36,8 @@ type ServiceListOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
+
+	devfilePath string
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -43,7 +47,9 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
+
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -53,7 +59,8 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
-	if !experimental.IsExperimentalModeEnabled() {
+
+	if !util.CheckPathExists(o.devfilePath) {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
@@ -66,7 +73,8 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
-	if experimental.IsExperimentalModeEnabled() {
+
+	if util.CheckPathExists(o.devfilePath) {
 		// if experimental mode is enabled, we list only operator hub backed
 		// services and not service catalog ones
 		var list []unstructured.Unstructured

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -3,18 +3,15 @@ package service
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
-	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 	svc "github.com/openshift/odo/pkg/service"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -36,8 +33,8 @@ type ServiceListOptions struct {
 	*genericclioptions.Context
 	// Context to use when listing service. This will use app and project values from the context
 	componentContext string
-
-	devfilePath string
+	// choose between Operator Hub and Service Catalog. If true, Operator Hub
+	csvSupport bool
 }
 
 // NewServiceListOptions creates a new ServiceListOptions instance
@@ -47,9 +44,9 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
-
-	if util.CheckPathExists(o.devfilePath) {
+	if o.csvSupport, err = odoutil.IsCSVSupported(); err != nil {
+		return err
+	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		o.Context = genericclioptions.NewContext(cmd)
@@ -59,8 +56,7 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the ServiceListOptions based on completed values
 func (o *ServiceListOptions) Validate() (err error) {
-
-	if !util.CheckPathExists(o.devfilePath) {
+	if !o.csvSupport {
 		// Throw error if project and application values are not available.
 		// This will most likely be the case when user does odo service list from outside a component directory and
 		// doesn't provide --app and/or --project flags
@@ -73,10 +69,9 @@ func (o *ServiceListOptions) Validate() (err error) {
 
 // Run contains the logic for the odo service list command
 func (o *ServiceListOptions) Run() (err error) {
-
-	if util.CheckPathExists(o.devfilePath) {
-		// if experimental mode is enabled, we list only operator hub backed
-		// services and not service catalog ones
+	if o.csvSupport {
+		// if cluster supports Operators, we list only operator backed services
+		// and not service catalog ones
 		var list []unstructured.Unstructured
 		list, err = svc.ListOperatorServices(o.KClient)
 		if err != nil {

--- a/pkg/odo/cli/url/describe.go
+++ b/pkg/odo/cli/url/describe.go
@@ -16,14 +16,13 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/occlient"
-	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
+	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/odo/util"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	"github.com/openshift/odo/pkg/url"
-	pkgutil "github.com/openshift/odo/pkg/util"
+	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -53,10 +52,9 @@ func NewURLDescribeOptions() *URLDescribeOptions {
 
 // Complete completes URLDescribeOptions after they've been Listed
 func (o *URLDescribeOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.devfilePath = filepath.Join(o.componentContext, clicomponent.DevfilePath)
+	o.devfilePath = filepath.Join(o.componentContext, component.DevfilePath)
 
-	o.isDevFile = experimental.IsExperimentalModeEnabled() && pkgutil.CheckPathExists(o.devfilePath)
-	if o.isDevFile {
+	if util.CheckPathExists(o.devfilePath) {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(o.componentContext)
 	} else {
@@ -72,12 +70,12 @@ func (o *URLDescribeOptions) Complete(name string, cmd *cobra.Command, args []st
 
 // Validate validates the URLDescribeOptions based on completed values
 func (o *URLDescribeOptions) Validate() (err error) {
-	return util.CheckOutputFlag(o.OutputFlag)
+	return odoutil.CheckOutputFlag(o.OutputFlag)
 }
 
 // Run contains the logic for the odo url describe command
 func (o *URLDescribeOptions) Run() (err error) {
-	if o.isDevFile {
+	if util.CheckPathExists(o.devfilePath) {
 		if pushtarget.IsPushTargetDocker() {
 			client, err := lclient.New()
 			if err != nil {
@@ -142,9 +140,9 @@ func (o *URLDescribeOptions) Run() (err error) {
 				// are there changes between local and cluster states?
 				outOfSync := false
 				if u.Spec.Kind == envinfo.ROUTE {
-					fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", o.isDevFile), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
+					fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", false), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
 				} else {
-					fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, url.ConvertIngressURLToIngress(u, componentName)), "", u.Spec.Host, o.isDevFile), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
+					fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, url.ConvertIngressURLToIngress(u, componentName)), "", u.Spec.Host, false), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
 				}
 				if u.Status.State != url.StateTypePushed {
 					outOfSync = true
@@ -170,7 +168,7 @@ func (o *URLDescribeOptions) Run() (err error) {
 
 			// are there changes between local and cluster states?
 			outOfSync := false
-			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", o.isDevFile), "\t", u.Spec.Port)
+			fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", false), "\t", u.Spec.Port)
 			if u.Status.State != url.StateTypePushed {
 				outOfSync = true
 			}
@@ -198,7 +196,7 @@ func NewCmdURLDescribe(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
-	urlDescribeCmd.SetUsageTemplate(util.CmdUsageTemplate)
+	urlDescribeCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 	genericclioptions.AddContextFlag(urlDescribeCmd, &o.componentContext)
 	completion.RegisterCommandHandler(urlDescribeCmd, completion.URLCompletionHandler)
 	completion.RegisterCommandFlagHandler(urlDescribeCmd, "context", completion.FileCompletionHandler)

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -14,9 +14,9 @@ import (
 	pkgutil "github.com/openshift/odo/pkg/util"
 
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
-	"github.com/openshift/odo/pkg/odo/util/pushtarget"
+	odoutil "github.com/openshift/odo/pkg/odo/util"
 
-	"github.com/openshift/odo/pkg/odo/util/experimental"
+	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 
 	"github.com/openshift/odo/pkg/config"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
@@ -24,7 +24,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	odoutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/url"
 	"github.com/pkg/errors"
@@ -58,7 +57,7 @@ func NewURLListOptions() *URLListOptions {
 // Complete completes URLListOptions after they've been Listed
 func (o *URLListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.devfilePath = filepath.Join(o.componentContext, clicomponent.DevfilePath)
-	o.isDevFile = experimental.IsExperimentalModeEnabled() && pkgutil.CheckPathExists(o.devfilePath)
+	o.isDevFile = pkgutil.CheckPathExists(o.devfilePath)
 	if o.isDevFile {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
 		o.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(o.componentContext)
@@ -158,9 +157,9 @@ func (o *URLListOptions) Run() (err error) {
 				outOfSync := false
 				for _, u := range urls.Items {
 					if u.Spec.Kind == envinfo.ROUTE {
-						fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", o.isDevFile), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
+						fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", false), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
 					} else {
-						fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, url.ConvertIngressURLToIngress(u, o.EnvSpecificInfo.GetName())), "", u.Spec.Host, o.isDevFile), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
+						fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(url.GetProtocol(routev1.Route{}, url.ConvertIngressURLToIngress(u, o.EnvSpecificInfo.GetName())), "", u.Spec.Host, false), "\t", u.Spec.Port, "\t", u.Spec.Secure, "\t", u.Spec.Kind)
 					}
 					if u.Status.State != url.StateTypePushed {
 						outOfSync = true
@@ -191,7 +190,7 @@ func (o *URLListOptions) Run() (err error) {
 			// are there changes between local and cluster states?
 			outOfSync := false
 			for _, u := range urls.Items {
-				fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", o.isDevFile), "\t", u.Spec.Port, "\t", u.Spec.Secure)
+				fmt.Fprintln(tabWriterURL, u.Name, "\t", u.Status.State, "\t", url.GetURLString(u.Spec.Protocol, u.Spec.Host, "", true), "\t", u.Spec.Port, "\t", u.Spec.Secure)
 				if u.Status.State != url.StateTypePushed {
 					outOfSync = true
 				}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -136,6 +136,11 @@ func getFirstChildOfCommand(command *cobra.Command) *cobra.Command {
 	return nil
 }
 
+// GetValidEnvInfo is juat a wrapper for getValidEnvInfo
+func GetValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
+	return getValidEnvInfo(command)
+}
+
 // getValidEnvInfo accesses the environment file
 func getValidEnvInfo(command *cobra.Command) (*envinfo.EnvSpecificInfo, error) {
 

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/openshift/odo/pkg/odo/util/experimental"
 	"github.com/openshift/odo/pkg/storage"
 	urlPkg "github.com/openshift/odo/pkg/url"
 
@@ -137,26 +136,26 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 	if componentDesc.Spec.URL != nil {
 		var output string
 
-		if !experimental.IsExperimentalModeEnabled() {
-			// if the component is not pushed
-			if componentDesc.Status.State == component.StateTypeNotPushed {
-				// Gather the output
-				for i, componentURL := range componentDesc.Spec.URL {
-					output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL, componentDesc.Spec.Ports[i])
-				}
-			} else {
-				// Retrieve the URLs
-				urls, err := urlPkg.ListPushed(client, currentComponentName, applicationName)
-				LogErrorAndExit(err, "")
-
-				// Gather the output
-				for _, componentURL := range componentDesc.Spec.URL {
-					url := urls.Get(componentURL)
-					output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, "", experimental.IsExperimentalModeEnabled()), url.Spec.Port)
-				}
-
+		// S2I Only (odo describe exits by default on Devfile by default anyways..)
+		// if the component is not pushed
+		if componentDesc.Status.State == component.StateTypeNotPushed {
+			// Gather the output
+			for i, componentURL := range componentDesc.Spec.URL {
+				output += fmt.Sprintf(" · URL named %s will be exposed via %v\n", componentURL, componentDesc.Spec.Ports[i])
 			}
+		} else {
+			// Retrieve the URLs
+			urls, err := urlPkg.ListPushed(client, currentComponentName, applicationName)
+			LogErrorAndExit(err, "")
+
+			// Gather the output
+			for _, componentURL := range componentDesc.Spec.URL {
+				url := urls.Get(componentURL)
+				output += fmt.Sprintf(" · %v exposed via %v\n", urlPkg.GetURLString(url.Spec.Protocol, url.Spec.Host, "", true), url.Spec.Port)
+			}
+
 		}
+
 		// Cut off the last newline and output
 		if len(output) > 0 {
 			output = output[:len(output)-1]

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -303,3 +303,14 @@ func ThrowContextError() error {
 	return errors.Errorf(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
+
+// IsCSVSupported checks if the cluster supports resources of type ClusterServiceVersion
+func IsCSVSupported() (bool, error) {
+
+	oclient, err := occlient.New()
+	if err != nil {
+		return false, err
+	}
+
+	return oclient.IsCSVSupported()
+}

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -218,26 +218,21 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 
 	// If the preference file doesn't exist then we return with default preference
 	if _, err = os.Stat(preferenceFile); os.IsNotExist(err) {
+		// Handle user has preference file but doesn't use dynamic registry before
+		defaultRegistryList := []Registry{
+			{
+				Name:   DefaultDevfileRegistryName,
+				URL:    DefaultDevfileRegistryURL,
+				Secure: false,
+			},
+		}
+		c.OdoSettings.RegistryList = &defaultRegistryList
 		return &c, nil
 	}
 
 	err = util.GetFromFile(&c.Preference, c.Filename)
 	if err != nil {
 		return nil, err
-	}
-
-	if c.OdoSettings.Experimental != nil && *c.OdoSettings.Experimental {
-		if c.OdoSettings.RegistryList == nil {
-			// Handle user has preference file but doesn't use dynamic registry before
-			defaultRegistryList := []Registry{
-				{
-					Name:   DefaultDevfileRegistryName,
-					URL:    DefaultDevfileRegistryURL,
-					Secure: false,
-				},
-			}
-			c.OdoSettings.RegistryList = &defaultRegistryList
-		}
 	}
 
 	return &c, nil

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -1423,65 +1423,6 @@ func TestPush(t *testing.T) {
 			},
 		},
 		{
-<<<<<<< HEAD
-=======
-			name:          "env ingress port does not match endpoint defined in devfile",
-			componentName: "nodejs",
-			args:          args{isRouteSupported: true},
-			existingEnvInfoURLs: []envinfo.EnvInfoURL{
-				{
-					Name: "example",
-					Port: 9090,
-					Host: "com",
-					Kind: envinfo.INGRESS,
-				},
-			},
-			endpintMap: map[int32]versionsCommon.Endpoint{
-				8080: versionsCommon.Endpoint{
-					Name:       "example",
-					TargetPort: 8080,
-					Secure:     false,
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:          "env route port does not match endpoint defined in devfile",
-			componentName: "nodejs",
-			args:          args{isRouteSupported: true},
-			existingEnvInfoURLs: []envinfo.EnvInfoURL{
-				{
-					Name: "example",
-					Port: 9090,
-					Kind: envinfo.ROUTE,
-				},
-			},
-			endpintMap: map[int32]versionsCommon.Endpoint{
-				8080: versionsCommon.Endpoint{
-					Name:       "example",
-					TargetPort: 8080,
-					Secure:     false,
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:          "no endpoint defined in devfile",
-			componentName: "nodejs",
-			args:          args{isRouteSupported: true},
-			existingEnvInfoURLs: []envinfo.EnvInfoURL{
-				{
-					Name: "example",
-					Port: 9090,
-					Host: "com",
-					Kind: envinfo.INGRESS,
-				},
-			},
-			endpintMap: map[int32]versionsCommon.Endpoint{},
-			wantErr:    true,
-		},
-		{
->>>>>>> Make Devfile the default deployment mechanism for odo
 			name:          "env has ingress defined with same port, but endpoint port defined in devfile is internally exposed",
 			componentName: "nodejs",
 			args:          args{isRouteSupported: true},
@@ -1523,25 +1464,7 @@ func TestPush(t *testing.T) {
 					Kind: envinfo.INGRESS,
 				},
 			},
-<<<<<<< HEAD
 			containerComponents: []versionsCommon.DevfileComponent{
-=======
-			endpintMap: map[int32]versionsCommon.Endpoint{
-				8080: versionsCommon.Endpoint{
-					Name:       "example",
-					TargetPort: 8080,
-					Secure:     false,
-					Exposure:   "none",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:          "env has route defined with same port, but endpoint port defined in devfile is internally exposed",
-			componentName: "nodejs",
-			args:          args{isRouteSupported: true},
-			existingEnvInfoURLs: []envinfo.EnvInfoURL{
->>>>>>> Make Devfile the default deployment mechanism for odo
 				{
 					Name: "container1",
 					Container: &versionsCommon.Container{
@@ -1844,23 +1767,13 @@ func TestPush(t *testing.T) {
 			})
 
 			if err := Push(fakeClient, fakeKClient, PushParameters{
-<<<<<<< HEAD
-				ComponentName:             tt.componentName,
-				ApplicationName:           tt.applicationName,
-				ConfigURLs:                tt.existingConfigURLs,
-				EnvURLS:                   tt.existingEnvInfoURLs,
-				IsRouteSupported:          tt.args.isRouteSupported,
-				IsExperimentalModeEnabled: tt.args.isExperimentalModeEnabled,
-				ContainerComponents:       tt.containerComponents,
-=======
-				ComponentName:    tt.componentName,
-				ApplicationName:  tt.applicationName,
-				ConfigURLs:       tt.existingConfigURLs,
-				EnvURLS:          tt.existingEnvInfoURLs,
-				IsRouteSupported: tt.args.isRouteSupported,
-				EndpointMap:      tt.endpintMap,
-				IsS2I:            tt.args.isS2I,
->>>>>>> Make Devfile the default deployment mechanism for odo
+				ComponentName:       tt.componentName,
+				ApplicationName:     tt.applicationName,
+				ConfigURLs:          tt.existingConfigURLs,
+				EnvURLS:             tt.existingEnvInfoURLs,
+				IsRouteSupported:    tt.args.isRouteSupported,
+				ContainerComponents: tt.containerComponents,
+				IsS2I:               tt.args.isS2I,
 			}); (err != nil) != tt.wantErr {
 				t.Errorf("Push() error = %v, wantErr %v", err, tt.wantErr)
 			} else {

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -40,16 +40,16 @@ import (
 
 func TestCreate(t *testing.T) {
 	type args struct {
-		componentName             string
-		applicationName           string
-		urlName                   string
-		portNumber                int
-		secure                    bool
-		host                      string
-		urlKind                   envinfo.URLKind
-		isRouteSupported          bool
-		isExperimentalModeEnabled bool
-		tlsSecret                 string
+		componentName    string
+		applicationName  string
+		urlName          string
+		portNumber       int
+		secure           bool
+		host             string
+		urlKind          envinfo.URLKind
+		isRouteSupported bool
+		isS2I            bool
+		tlsSecret        string
 	}
 	tests := []struct {
 		name               string
@@ -69,6 +69,7 @@ func TestCreate(t *testing.T) {
 				urlName:          "nodejs",
 				portNumber:       8080,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -104,6 +105,7 @@ func TestCreate(t *testing.T) {
 				urlName:          "example-url",
 				portNumber:       9100,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -140,6 +142,7 @@ func TestCreate(t *testing.T) {
 				portNumber:       9100,
 				secure:           true,
 				isRouteSupported: true,
+				isS2I:            true,
 				urlKind:          envinfo.ROUTE,
 			},
 			returnedRoute: &routev1.Route{
@@ -175,13 +178,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 4: Create a ingress, with same name as component,instead of route on openshift cluster",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "nodejs",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "nodejs",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress: fake.GetSingleIngress("nodejs-nodejs", "nodejs"),
 			want:            "http://nodejs.com",
@@ -190,13 +192,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 5: Create a ingress, with different name as component,instead of route on openshift cluster",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -227,14 +228,13 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 6: Create a secure ingress, instead of route on openshift cluster, default tls exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:  fake.GetSingleIngress("example-nodejs", "nodejs"),
 			defaultTLSExists: true,
@@ -244,14 +244,13 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 7: Create a secure ingress, instead of route on openshift cluster and default tls doesn't exist",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:  fake.GetSingleIngress("example-nodejs", "nodejs"),
 			defaultTLSExists: false,
@@ -261,15 +260,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 8: Fail when while creating ingress when user given tls secret doesn't exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -280,15 +278,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 9: Create a secure ingress, instead of route on openshift cluster, user tls secret does exists",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   envinfo.INGRESS,
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          envinfo.INGRESS,
 			},
 			returnedIngress:    fake.GetSingleIngress("example-nodejs", "nodejs"),
 			defaultTLSExists:   false,
@@ -300,15 +297,14 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 10: invalid url kind",
 			args: args{
-				componentName:             "nodejs",
-				urlName:                   "example",
-				portNumber:                8080,
-				host:                      "com",
-				isRouteSupported:          true,
-				isExperimentalModeEnabled: true,
-				secure:                    true,
-				tlsSecret:                 "user-secret",
-				urlKind:                   "blah",
+				componentName:    "nodejs",
+				urlName:          "example",
+				portNumber:       8080,
+				host:             "com",
+				isRouteSupported: true,
+				secure:           true,
+				tlsSecret:        "user-secret",
+				urlKind:          "blah",
 			},
 			returnedIngress:    fake.GetSingleIngress("example-nodejs", "nodejs"),
 			defaultTLSExists:   false,
@@ -319,12 +315,11 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 11: route is not supported on the cluster",
 			args: args{
-				componentName:             "nodejs",
-				applicationName:           "app",
-				urlName:                   "example",
-				isRouteSupported:          false,
-				isExperimentalModeEnabled: true,
-				urlKind:                   envinfo.ROUTE,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example",
+				isRouteSupported: false,
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -335,13 +330,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Case 11: secretName used without secure flag",
 			args: args{
-				componentName:             "nodejs",
-				applicationName:           "app",
-				urlName:                   "example",
-				isRouteSupported:          false,
-				isExperimentalModeEnabled: true,
-				tlsSecret:                 "secret",
-				urlKind:                   envinfo.ROUTE,
+				componentName:    "nodejs",
+				applicationName:  "app",
+				urlName:          "example",
+				isRouteSupported: false,
+				tlsSecret:        "secret",
+				urlKind:          envinfo.ROUTE,
 			},
 			returnedIngress:    fake.GetSingleIngress("example", "nodejs"),
 			defaultTLSExists:   false,
@@ -417,7 +411,7 @@ func TestCreate(t *testing.T) {
 				urlKind:         tt.args.urlKind,
 			}
 
-			got, err := Create(client, fakeKClient, urlCreateParameters, tt.args.isRouteSupported, tt.args.isExperimentalModeEnabled)
+			got, err := Create(client, fakeKClient, urlCreateParameters, tt.args.isRouteSupported, tt.args.isS2I)
 
 			if err == nil && !tt.wantErr {
 				if tt.args.urlKind == envinfo.INGRESS {
@@ -746,8 +740,8 @@ func TestGetValidPortNumber(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	type args struct {
-		isRouteSupported          bool
-		isExperimentalModeEnabled bool
+		isRouteSupported bool
+		isS2I            bool
 	}
 	tests := []struct {
 		name                string
@@ -767,6 +761,7 @@ func TestPush(t *testing.T) {
 			name: "no urls on local config and cluster",
 			args: args{
 				isRouteSupported: true,
+				isS2I:            true,
 			},
 			componentName:   "nodejs",
 			applicationName: "app",
@@ -776,7 +771,10 @@ func TestPush(t *testing.T) {
 			name:            "2 urls on local config and 0 on openshift cluster",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args: args{
+				isRouteSupported: true,
+				isS2I:            true,
+			},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example",
@@ -817,7 +815,7 @@ func TestPush(t *testing.T) {
 			name:            "0 url on local config and 2 on openshift cluster",
 			componentName:   "wildfly",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			returnedRoutes:  testingutil.GetRouteListWithMultiple("wildfly", "app"),
 			deletedURLs: []URL{
 				getMachineReadableFormat(testingutil.GetSingleRoute("example-app", 8080, "nodejs", "app")),
@@ -828,7 +826,7 @@ func TestPush(t *testing.T) {
 			name:            "2 url on local config and 2 on openshift cluster, but they are different",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example-local-0",
@@ -873,7 +871,7 @@ func TestPush(t *testing.T) {
 			name:            "2 url on local config and openshift cluster are in sync",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example",
@@ -893,7 +891,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "0 urls on env file and cluster",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			returnedRoutes:      &routev1.RouteList{},
 			returnedIngress:     &extensionsv1.IngressList{},
@@ -901,7 +899,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and 0 on openshift cluster",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -963,7 +961,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "0 urls on env file and 2 on openshift cluster",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			returnedRoutes:      &routev1.RouteList{},
 			returnedIngress:     fake.GetIngressListWithMultiple("nodejs"),
@@ -983,7 +981,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and 2 on openshift cluster, but they are different",
 			componentName: "wildfly",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example-local-0",
@@ -1057,7 +1055,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 urls on env file and openshift cluster are in sync",
 			componentName: "wildfly",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example-0",
@@ -1097,7 +1095,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "2 (1 ingress,1 route) urls on env file and 2 on openshift cluster (1 ingress,1 route), but they are different",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example-local-0",
@@ -1169,7 +1167,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a ingress on a kubernetes cluster",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: false, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: false},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:      "example",
@@ -1212,7 +1210,9 @@ func TestPush(t *testing.T) {
 		{
 			name:          "url with same name exists on env and cluster but with different specs",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args: args{
+				isRouteSupported: true,
+			},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example-local-0",
@@ -1264,7 +1264,7 @@ func TestPush(t *testing.T) {
 			name:            "url with same name exists on config and cluster but with different specs",
 			componentName:   "nodejs",
 			applicationName: "app",
-			args:            args{isRouteSupported: true, isExperimentalModeEnabled: false},
+			args:            args{isRouteSupported: true, isS2I: true},
 			existingConfigURLs: []config.ConfigURL{
 				{
 					Name:   "example-local-0",
@@ -1302,7 +1302,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure route url",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1341,7 +1341,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure ingress url with empty user given tls secret",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1382,7 +1382,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "create a secure ingress url with user given tls secret",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name:      "example",
@@ -1423,9 +1423,68 @@ func TestPush(t *testing.T) {
 			},
 		},
 		{
+<<<<<<< HEAD
+=======
+			name:          "env ingress port does not match endpoint defined in devfile",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name: "example",
+					Port: 9090,
+					Host: "com",
+					Kind: envinfo.INGRESS,
+				},
+			},
+			endpintMap: map[int32]versionsCommon.Endpoint{
+				8080: versionsCommon.Endpoint{
+					Name:       "example",
+					TargetPort: 8080,
+					Secure:     false,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "env route port does not match endpoint defined in devfile",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name: "example",
+					Port: 9090,
+					Kind: envinfo.ROUTE,
+				},
+			},
+			endpintMap: map[int32]versionsCommon.Endpoint{
+				8080: versionsCommon.Endpoint{
+					Name:       "example",
+					TargetPort: 8080,
+					Secure:     false,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "no endpoint defined in devfile",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+				{
+					Name: "example",
+					Port: 9090,
+					Host: "com",
+					Kind: envinfo.INGRESS,
+				},
+			},
+			endpintMap: map[int32]versionsCommon.Endpoint{},
+			wantErr:    true,
+		},
+		{
+>>>>>>> Make Devfile the default deployment mechanism for odo
 			name:          "env has ingress defined with same port, but endpoint port defined in devfile is internally exposed",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1456,7 +1515,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "env has ingress defined with same port, endpoint port defined in devfile is not exposed",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1464,7 +1523,25 @@ func TestPush(t *testing.T) {
 					Kind: envinfo.INGRESS,
 				},
 			},
+<<<<<<< HEAD
 			containerComponents: []versionsCommon.DevfileComponent{
+=======
+			endpintMap: map[int32]versionsCommon.Endpoint{
+				8080: versionsCommon.Endpoint{
+					Name:       "example",
+					TargetPort: 8080,
+					Secure:     false,
+					Exposure:   "none",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "env has route defined with same port, but endpoint port defined in devfile is internally exposed",
+			componentName: "nodejs",
+			args:          args{isRouteSupported: true},
+			existingEnvInfoURLs: []envinfo.EnvInfoURL{
+>>>>>>> Make Devfile the default deployment mechanism for odo
 				{
 					Name: "container1",
 					Container: &versionsCommon.Container{
@@ -1487,7 +1564,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "env has route defined with same port, but endpoint port defined in devfile is internally exposed",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1517,7 +1594,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "env has route defined with same port, but endpoint port defined in devfile is not exposed",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1547,7 +1624,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "no host defined for ingress should not create any URL",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: false, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: false},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			containerComponents: []versionsCommon.DevfileComponent{
 				{
@@ -1571,7 +1648,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "should create route in openshift cluster if endpoint is defined in devfile",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			containerComponents: []versionsCommon.DevfileComponent{
 				{
@@ -1607,7 +1684,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "should create ingress if endpoint is defined in devfile",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1650,7 +1727,7 @@ func TestPush(t *testing.T) {
 		{
 			name:                "should create route in openshift cluster with path defined in devfile",
 			componentName:       "nodejs",
-			args:                args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:                args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{},
 			containerComponents: []versionsCommon.DevfileComponent{
 				{
@@ -1687,7 +1764,7 @@ func TestPush(t *testing.T) {
 		{
 			name:          "should create ingress with path defined in devfile",
 			componentName: "nodejs",
-			args:          args{isRouteSupported: true, isExperimentalModeEnabled: true},
+			args:          args{isRouteSupported: true},
 			existingEnvInfoURLs: []envinfo.EnvInfoURL{
 				{
 					Name: "example",
@@ -1767,6 +1844,7 @@ func TestPush(t *testing.T) {
 			})
 
 			if err := Push(fakeClient, fakeKClient, PushParameters{
+<<<<<<< HEAD
 				ComponentName:             tt.componentName,
 				ApplicationName:           tt.applicationName,
 				ConfigURLs:                tt.existingConfigURLs,
@@ -1774,6 +1852,15 @@ func TestPush(t *testing.T) {
 				IsRouteSupported:          tt.args.isRouteSupported,
 				IsExperimentalModeEnabled: tt.args.isExperimentalModeEnabled,
 				ContainerComponents:       tt.containerComponents,
+=======
+				ComponentName:    tt.componentName,
+				ApplicationName:  tt.applicationName,
+				ConfigURLs:       tt.existingConfigURLs,
+				EnvURLS:          tt.existingEnvInfoURLs,
+				IsRouteSupported: tt.args.isRouteSupported,
+				EndpointMap:      tt.endpintMap,
+				IsS2I:            tt.args.isS2I,
+>>>>>>> Make Devfile the default deployment mechanism for odo
 			}); (err != nil) != tt.wantErr {
 				t.Errorf("Push() error = %v, wantErr %v", err, tt.wantErr)
 			} else {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ Changing these values will change the versioning information when releasing odo.
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v1.2.6"
+	VERSION = "v2.0.0"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/tests/e2escenarios/e2e_beta_test.go
+++ b/tests/e2escenarios/e2e_beta_test.go
@@ -46,7 +46,7 @@ var _ = Describe("odo core beta flow", func() {
 
 	// abstract main test to the function, to allow running the same test in a different context (slightly different arguments)
 	TestBasicCreateConfigPush := func(extraArgs ...string) {
-		createSession := helper.CmdShouldPass(odo, append([]string{"component", "create", "java:8", "mycomponent", "--app", "myapp", "--project", project}, extraArgs...)...)
+		createSession := helper.CmdShouldPass(odo, append([]string{"component", "create", "--s2i", "java:8", "mycomponent", "--app", "myapp", "--project", project}, extraArgs...)...)
 		// output of the commands should point user to running "odo push"
 		Expect(createSession).Should(ContainSubstring("odo push"))
 		configFile := filepath.Join(context, ".odo", "config.yaml")
@@ -106,8 +106,8 @@ var _ = Describe("odo core beta flow", func() {
 		})
 
 		It("'odo component' should fail if there already is .odo dir", func() {
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--project", project)
-			helper.CmdShouldFail("odo", "component", "create", "nodejs", "--project", project)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "--project", project)
+			helper.CmdShouldFail("odo", "component", "create", "--s2i", "nodejs", "--project", project)
 		})
 
 		It("'odo config' should fail if there is no .odo dir", func() {
@@ -123,8 +123,8 @@ var _ = Describe("odo core beta flow", func() {
 
 	Context("when --context flag is used", func() {
 		It("odo component should fail if there already is .odo dir", func() {
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--context", context, "--project", project)
-			helper.CmdShouldFail("odo", "component", "create", "nodejs", "--context", context, "--project", project)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "--context", context, "--project", project)
+			helper.CmdShouldFail("odo", "component", "create", "--s2i", "nodejs", "--context", context, "--project", project)
 		})
 
 		It("odo config should fail if there is no .odo dir", func() {

--- a/tests/e2escenarios/e2e_java_test.go
+++ b/tests/e2escenarios/e2e_java_test.go
@@ -47,7 +47,7 @@ var _ = Describe("odo java e2e tests", func() {
 		})
 
 		It("Should be able to deploy a git repo that contains a wildfly application without wait flag", func() {
-			helper.CmdShouldPass("odo", "create", "wildfly", "wo-wait-javaee-git-test", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "wildfly", "wo-wait-javaee-git-test", "--project",
 				project, "--ref", "master", "--git", warGitRepo, "--context", context)
 
 			// Create a URL
@@ -66,7 +66,7 @@ var _ = Describe("odo java e2e tests", func() {
 	Context("odo component creation", func() {
 		It("Should be able to deploy a .war file using wildfly", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "wildfly"), context)
-			helper.CmdShouldPass("odo", "create", "wildfly", "javaee-war-test", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "wildfly", "javaee-war-test", "--project",
 				project, "--binary", filepath.Join(context, "ROOT.war"), "--context", context)
 
 			// Create a URL
@@ -85,7 +85,7 @@ var _ = Describe("odo java e2e tests", func() {
 			oc.ImportJavaIS(project)
 
 			// Deploy the git repo / wildfly example
-			helper.CmdShouldPass("odo", "create", "java:8", "uberjar-git-test", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "uberjar-git-test", "--project",
 				project, "--ref", "master", "--git", jarGitRepo, "--context", context)
 
 			// Create a URL
@@ -104,7 +104,7 @@ var _ = Describe("odo java e2e tests", func() {
 			oc.ImportJavaIS(project)
 			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
 
-			helper.CmdShouldPass("odo", "create", "java:8", "sb-jar-test", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(context, "sb.jar"), "--context", context)
 
 			// Create a URL

--- a/tests/e2escenarios/e2e_source_test.go
+++ b/tests/e2escenarios/e2e_source_test.go
@@ -39,7 +39,7 @@ var _ = Describe("odo source e2e tests", func() {
 
 		It("Should be able to deploy a wildfly source application", func() {
 			helper.CopyExample(filepath.Join("source", "wildfly"), context)
-			helper.CmdShouldPass("odo", "create", "wildfly", "wildfly-app", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "wildfly", "wildfly-app", "--project",
 				project, "--context", context)
 
 			// Push changes
@@ -62,7 +62,7 @@ var _ = Describe("odo source e2e tests", func() {
 		It("Should be able to deploy a dotnet source application", func() {
 			oc.ImportDotnet20IS(project)
 			helper.CopyExample(filepath.Join("source", "dotnet"), context)
-			helper.CmdShouldPass("odo", "create", "dotnet:2.0", "dotnet-app", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "dotnet:2.0", "dotnet-app", "--project",
 				project, "--context", context)
 
 			// Push changes
@@ -87,7 +87,7 @@ var _ = Describe("odo source e2e tests", func() {
 
 		It("Should be able to deploy a python source application", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", "create", "python", "python-app", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "python-app", "--project",
 				project, "--context", context)
 
 			// Push changes
@@ -110,7 +110,7 @@ var _ = Describe("odo source e2e tests", func() {
 		It("Should be able to deploy an openjdk source application", func() {
 			oc.ImportJavaIS(project)
 			helper.CopyExample(filepath.Join("source", "openjdk"), context)
-			helper.CmdShouldPass("odo", "create", "java:8", "openjdk-app", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "openjdk-app", "--project",
 				project, "--context", context)
 
 			// Push changes
@@ -132,7 +132,7 @@ var _ = Describe("odo source e2e tests", func() {
 
 		It("Should be able to deploy a nodejs source application", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-app", "--project",
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs-app", "--project",
 				project, "--context", context)
 
 			// Push changes

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -69,7 +69,7 @@ var _ = Describe("odo app command tests", func() {
 
 		It("should successfully execute list, describe and delete along with machine readable output", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			// changing directory to the context directory
@@ -93,7 +93,7 @@ var _ = Describe("odo app command tests", func() {
 	Context("when running app command without app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should fail without app parameter (except the list command)", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			// list should pass as the project exists
@@ -107,7 +107,7 @@ var _ = Describe("odo app command tests", func() {
 	Context("when running app command app parameter in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute list, describe and delete along with machine readable output", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			appListOutput := helper.CmdShouldPass("odo", "app", "list", "--project", project)
@@ -130,7 +130,7 @@ var _ = Describe("odo app command tests", func() {
 	Context("When running app describe with storage added in component in directory that doesn't contain .odo config directory", func() {
 		It("should successfully execute describe", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "storage", "create", "storage-one", "--context", context, "--path", mountPath, "--size", size)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			helper.CmdShouldPass("odo", "app", "describe", appName, "--project", project)

--- a/tests/integration/cmd_debug_test.go
+++ b/tests/integration/cmd_debug_test.go
@@ -42,7 +42,7 @@ var _ = Describe("odo debug command tests", func() {
 	Context("odo debug on a nodejs:latest component", func() {
 		It("check that machine output debug information works", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			httpPort, err := util.HTTPGetFreePort()
@@ -69,7 +69,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should expect a ws connection when tried to connect on different debug port locally and remotely", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--force", "DebugPort", "9292", "--context", context)
 			dbgPort := helper.GetConfigValueWithContext("DebugPort", context)
 			Expect(dbgPort).To(Equal("9292"))
@@ -88,7 +88,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should expect a ws connection when tried to connect on default debug port locally", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			stopChannel := make(chan bool)
@@ -107,7 +107,7 @@ var _ = Describe("odo debug command tests", func() {
 	Context("odo debug info should work on a odo component", func() {
 		It("should start a debug session and run debug info on a running debug session", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			httpPort, err := util.HTTPGetFreePort()
@@ -130,7 +130,7 @@ var _ = Describe("odo debug command tests", func() {
 
 		It("should start a debug session and run debug info on a closed debug session", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "nodejs-cmp-"+project, "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			httpPort, err := util.HTTPGetFreePort()

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -41,14 +41,16 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "link", "-h")
-			Expect(appHelp).To(ContainSubstring("Link component to a service or component"))
+			// Check for -vmodule moduleSpec output which is in additional flags
+			Expect(appHelp).To(ContainSubstring("--vmodule moduleSpec"))
 		})
 	})
 
 	Context("when running help for unlink command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "unlink", "-h")
-			Expect(appHelp).To(ContainSubstring("Unlink component or service from a component"))
+			// Check for -vmodule moduleSpec output which is in additional flags
+			Expect(appHelp).To(ContainSubstring("--vmodule moduleSpec"))
 		})
 	})
 
@@ -63,10 +65,10 @@ var _ = Describe("odo link and unlink command tests", func() {
 		})
 		It("should fail", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), frontendContext)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", frontendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--context", frontendContext, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", frontendContext)
 			helper.CopyExample(filepath.Join("source", "python"), backendContext)
-			helper.CmdShouldPass("odo", "create", "python", "backend", "--context", backendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "backend", "--context", backendContext, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", backendContext)
 			stdErr := helper.CmdShouldFail("odo", "link", "backend", "--context", frontendContext, "--port", "1234")
 			Expect(stdErr).To(ContainSubstring("Unable to properly link to component backend using port 1234"))
@@ -84,13 +86,13 @@ var _ = Describe("odo link and unlink command tests", func() {
 		})
 		It("should link the frontend application to the backend and then unlink successfully", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), frontendContext)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", frontendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--context", frontendContext, "--project", project)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", frontendContext)
 			helper.CmdShouldPass("odo", "push", "--context", frontendContext)
 			frontendURL := helper.DetermineRouteURL(frontendContext)
 			oc.ImportJavaIS(project)
 			helper.CopyExample(filepath.Join("source", "openjdk"), backendContext)
-			helper.CmdShouldPass("odo", "create", "java:8", "backend", "--project", project, "--context", backendContext)
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "backend", "--project", project, "--context", backendContext)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", backendContext)
 			helper.CmdShouldPass("odo", "push", "--context", backendContext)
 
@@ -113,14 +115,14 @@ var _ = Describe("odo link and unlink command tests", func() {
 		It("Wait till frontend dc rollout properly after linking the frontend application to the backend", func() {
 			appName := helper.RandString(7)
 			helper.CopyExample(filepath.Join("source", "nodejs"), frontendContext)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--app", appName, "--context", frontendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--app", appName, "--context", frontendContext, "--project", project)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", frontendContext)
 			helper.CmdShouldPass("odo", "push", "--context", frontendContext)
 			frontendURL := helper.DetermineRouteURL(frontendContext)
 
 			oc.ImportJavaIS(project)
 			helper.CopyExample(filepath.Join("source", "openjdk"), backendContext)
-			helper.CmdShouldPass("odo", "create", "java:8", "backend", "--app", appName, "--project", project, "--context", backendContext)
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "backend", "--app", appName, "--project", project, "--context", backendContext)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", backendContext)
 			helper.CmdShouldPass("odo", "push", "--context", backendContext)
 
@@ -138,10 +140,10 @@ var _ = Describe("odo link and unlink command tests", func() {
 		It("should successfully delete component after linked component is deleted", func() {
 			// first create the two components
 			helper.CopyExample(filepath.Join("source", "nodejs"), frontendContext)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", frontendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--context", frontendContext, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", frontendContext)
 			helper.CopyExample(filepath.Join("source", "nodejs"), backendContext)
-			helper.CmdShouldPass("odo", "create", "nodejs", "backend", "--context", backendContext, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "backend", "--context", backendContext, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", backendContext)
 
 			// now link frontend to the backend component

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -41,8 +41,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "link", "-h")
-			// Check for -vmodule moduleSpec output which is in additional flags
-			Expect(appHelp).To(ContainSubstring("--vmodule moduleSpec"))
+			Expect(appHelp).To(ContainSubstring("Link component to an operator backed service"))
 		})
 	})
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -190,7 +190,7 @@ var _ = Describe("odo preference and config command tests", func() {
 					paramValue: "https://github.com/sclorg/nodejs-ex",
 				},
 			}
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project)
 			for _, testCase := range cases {
 				helper.CmdShouldPass("odo", "config", "set", testCase.paramName, testCase.paramValue, "-f")
 				setValue := helper.GetConfigValue(testCase.paramName)
@@ -269,7 +269,7 @@ var _ = Describe("odo preference and config command tests", func() {
 					paramValue: "https://github.com/sclorg/nodejs-ex",
 				},
 			}
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			for _, testCase := range cases {
 
 				helper.CmdShouldPass("odo", "config", "set", "-f", "--context", context, testCase.paramName, testCase.paramValue)
@@ -293,7 +293,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.DeleteDir(context)
 		})
 		It("should set and unset env variables", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
 			configPort := helper.GetConfigValueWithContext("PORT", context)
 			Expect(configPort).To(ContainSubstring("1234"))
@@ -306,7 +306,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.DontMatchAllInOutput(configValue, []string{"PORT", "SECRET_KEY"})
 		})
 		It("should check for existence of environment variable in config before unsetting it", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "PORT=4000", "--env", "PORT=1234", "--context", context)
 
 			// unset a valid env var
@@ -330,7 +330,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.DeleteDir(context)
 		})
 		It("should list config successfully", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--env", "hello=world", "--context", context)
 			kubeconfigOld := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
@@ -340,7 +340,7 @@ var _ = Describe("odo preference and config command tests", func() {
 		})
 
 		It("should set config variable without logging in", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			kubeconfigOld := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
 			helper.CmdShouldPass("odo", "config", "set", "--force", "--context", context, "Name", "foobar")
@@ -366,7 +366,7 @@ var _ = Describe("odo preference and config command tests", func() {
 		It("should successfully set and unset variables", func() {
 			//set env var
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "config", "set", "--now", "--env", "hello=world", "--context", context)
 			//*Check config
 			configValue1 := helper.CmdShouldPass("odo", "config", "view", "--context", context)

--- a/tests/integration/cmd_push_test.go
+++ b/tests/integration/cmd_push_test.go
@@ -45,7 +45,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("Check that pod timeout works and we time out immediately..", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "preference", "set", "PushTimeout", "1")
 			output := helper.CmdShouldFail("odo", "push", "--context", context+"/nodejs-ex")
 			Expect(output).To(ContainSubstring("waited 1s but couldn't find running pod matching selector"))
@@ -58,7 +58,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "Memory", "300Mi", "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -68,7 +68,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "minmemory", "100Mi", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
@@ -79,7 +79,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "maxmemory", "400Mi", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
@@ -90,7 +90,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "cpu", "0.4", "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -100,7 +100,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "mincpu", "0.4", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
@@ -111,7 +111,7 @@ var _ = Describe("odo push command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			helper.CmdShouldPass("odo", "config", "set", "maxcpu", "0.5", "--context", context)
 			output := helper.CmdShouldFail("odo", "push", "--context", context)
@@ -123,7 +123,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("Check for labels", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			// Check for all the labels
@@ -154,7 +154,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("Push, modify a file and then push outside of the working directory", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			// Create a new file to test propagating changes
@@ -178,7 +178,7 @@ var _ = Describe("odo push command tests", func() {
 	Context("when push command is executed", func() {
 		It("should not build when no changes are detected in the directory and build when a file change is detected", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
 			output := helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
@@ -194,7 +194,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should be able to create a file, push, delete, then push again propagating the deletions and build", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			output := helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			Expect(output).To(ContainSubstring("No file changes detected, skipping build"))
@@ -233,7 +233,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should build when a file and a folder is renamed in the directory", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			output := helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
@@ -272,7 +272,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should build when no changes are detected in the directory and force flag is enabled", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
 
@@ -283,7 +283,7 @@ var _ = Describe("odo push command tests", func() {
 
 		It("should push only the modified files", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
@@ -355,7 +355,7 @@ var _ = Describe("odo push command tests", func() {
 			oc.ImportJavaIS(project)
 			cmpName := "backend"
 			helper.CopyExample(filepath.Join("source", "openjdk"), context)
-			helper.CmdShouldPass("odo", "create", "java:8", "backend", "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "backend", "--project", project, "--context", context, "--app", appName)
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080", "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
@@ -404,7 +404,7 @@ var _ = Describe("odo push command tests", func() {
 				fmt.Printf("the .odoignore file was not created, reason %v", err.Error())
 			}
 
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--context", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 
 			// get the name of running pod
@@ -435,7 +435,7 @@ var _ = Describe("odo push command tests", func() {
 	Context("when .gitignore file exists", func() {
 		It("should create and push the contents of a named component and include odo-file-index.json path to .gitignore file to exclude the contents", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context+"/nodejs-ex", "--app", appName)
 
 			// push and include the odo-file-index.json path to .gitignore file
 			helper.CmdShouldPass("odo", "push", "--context", filepath.Join(context, "nodejs-ex"))
@@ -447,7 +447,7 @@ var _ = Describe("odo push command tests", func() {
 	Context("when .gitignore file does not exist", func() {
 		It("should create and push the contents of a named component and also create .gitignore then include odo-file-index.json path to .gitignore file to exclude the contents", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
 
 			// push and include the odo-file-index.json path to .gitignore file
 			helper.CmdShouldPass("odo", "push", "--context", context)
@@ -459,9 +459,7 @@ var _ = Describe("odo push command tests", func() {
 	Context("when running odo push with flag --show-log", func() {
 		It("should be able to execute odo push consecutively without breaking anything", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--context", context+"/nodejs-ex")
-
-			// Run odo push in consecutive iteration
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--context", context+"/nodejs-ex")
 			output := helper.CmdShouldPass("odo", "push", "--show-log", "--context", context+"/nodejs-ex")
 			Expect(output).To(Not(ContainSubstring("No file changes detected, skipping build")))
 

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -43,7 +43,7 @@ var _ = Describe("odo storage command tests", func() {
 	Context("when running storage command without required flag(s)", func() {
 		It("should fail", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
 			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1", "--context", context)
 			Expect(stdErr).To(ContainSubstring("required flag"))
 			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--path", "/data", "--context", context)
@@ -56,7 +56,7 @@ var _ = Describe("odo storage command tests", func() {
 		It("should add a storage, list and delete it", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
 			// Default flag value
 			// --app string         Application, defaults to active application
 			// --component string   Component, defaults to active component.
@@ -94,7 +94,7 @@ var _ = Describe("odo storage command tests", func() {
 	Context("when using storage command with specified flag values", func() {
 		It("should add a storage, list and delete it", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", "component", "create", "python", "python", "--app", "pyapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "python", "python", "--app", "pyapp", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			storAdd := helper.CmdShouldPass("odo", "storage", "create", "pv1", "--path", "/mnt/pv1", "--size", "1Gi", "--context", context)
 			Expect(storAdd).To(ContainSubstring("python"))
@@ -130,7 +130,7 @@ var _ = Describe("odo storage command tests", func() {
 	Context("when using storage command with -o json", func() {
 		It("should create and list output in json format", func() {
 			helper.CopyExample(filepath.Join("source", "wildfly"), context)
-			helper.CmdShouldPass("odo", "component", "create", "wildfly", "wildfly", "--app", "wildflyapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "wildfly", "wildfly", "--app", "wildflyapp", "--project", project, "--context", context)
 			actualJSONStorage := helper.CmdShouldPass("odo", "storage", "create", "mystorage", "--path=/opt/app-root/src/storage/", "--size=1Gi", "--context", context, "-o", "json")
 			desiredJSONStorage := `{"kind":"storage","apiVersion":"odo.dev/v1alpha1","metadata":{"name":"mystorage","creationTimestamp":null},"spec":{"size":"1Gi","path":"/opt/app-root/src/storage/"}}`
 			Expect(desiredJSONStorage).Should(MatchJSON(actualJSONStorage))
@@ -147,7 +147,7 @@ var _ = Describe("odo storage command tests", func() {
 		It("should list storage with correct state", func() {
 
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "nodejs", "--app", "nodeapp", "--project", project, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 
 			// create storage, list storage should have state "Not Pushed"

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -44,7 +44,7 @@ var _ = Describe("odo url command tests", func() {
 			url1 := helper.RandString(5)
 			url2 := helper.RandString(5)
 			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			stdout = helper.CmdShouldFail("odo", "url", "list", "--context", context)
 			Expect(stdout).To(ContainSubstring("no URLs found"))
@@ -75,7 +75,7 @@ var _ = Describe("odo url command tests", func() {
 			url1 := helper.RandString(5)
 			componentName := helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context, "--project", project, componentName)
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context, "--secure")
 
@@ -100,7 +100,7 @@ var _ = Describe("odo url command tests", func() {
 			var stdout string
 			url1 := helper.RandString(5)
 			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", context)
 			stdout = helper.CmdShouldPass("odo", "url", "describe", url1, "--context", context)
@@ -117,7 +117,7 @@ var _ = Describe("odo url command tests", func() {
 		})
 
 		It("should be able to describe a url in CLI format and machine readable json format for a secure url", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context)
 			helper.CmdShouldPass("odo", "url", "create", "myurl", "--secure", "--context", context)
 
 			actualURLDescribeJSON := helper.CmdShouldPass("odo", "url", "describe", "myurl", "-o", "json", "--context", context)
@@ -146,7 +146,7 @@ var _ = Describe("odo url command tests", func() {
 			helper.Chdir(originalDir)
 		})
 		It("should be able to list url in machine readable json format", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex")
 			helper.CmdShouldPass("odo", "url", "create", "myurl")
 			helper.CmdShouldPass("odo", "push")
 
@@ -159,7 +159,7 @@ var _ = Describe("odo url command tests", func() {
 		})
 
 		It("should be able to list url in machine readable json format for a secure url", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--app", "myapp", "--project", project, "--git", "https://github.com/openshift/nodejs-ex")
 			helper.CmdShouldPass("odo", "url", "create", "myurl", "--secure")
 			actualURLListJSON := helper.CmdShouldPass("odo", "url", "list", "-o", "json")
 			desiredURLListJSON := `{"kind":"List","apiVersion":"odo.dev/v1alpha1","metadata":{},"items":[{"kind":"url","apiVersion":"odo.dev/v1alpha1","metadata":{"name":"myurl","creationTimestamp":null},"spec":{"port":8080,"secure":true,"path": "/","kind": "route"},"status":{"state": "Not Pushed"}}]}`
@@ -181,7 +181,7 @@ var _ = Describe("odo url command tests", func() {
 			url1 := helper.RandString(5)
 			componentName := helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context, "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex", "--port", "8080,8000")
 			helper.CmdShouldPass("odo", "url", "create", url1, "--context", context, "--port", "8080", "--now")
 			out1 := helper.CmdShouldPass("odo", "url", "list", "--context", context)
 			helper.MatchAllInOutput(out1, []string{url1, "Pushed", url1})

--- a/tests/integration/cmd_watch_test.go
+++ b/tests/integration/cmd_watch_test.go
@@ -45,7 +45,7 @@ var _ = Describe("odo watch command tests", func() {
 	Context("when executing watch without pushing the component", func() {
 		It("should fail", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "--project", project, "--context", context)
 			output := helper.CmdShouldFail("odo", "watch", "--context", context)
 			Expect(output).To(ContainSubstring("component does not exist. Please use `odo push` to create your component"))
 		})
@@ -61,7 +61,7 @@ var _ = Describe("odo watch command tests", func() {
 		})
 		It("should fail with proper error", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "nodejs", "--project", project)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "--project", project)
 			output := helper.CmdShouldFail("odo", "watch", "--app", "dummy")
 			Expect(output).To(ContainSubstring("component does not exist"))
 		})
@@ -69,7 +69,7 @@ var _ = Describe("odo watch command tests", func() {
 
 	Context("when executing watch on a git source type component", func() {
 		It("should fail", func() {
-			helper.CmdShouldPass("odo", "create", "--context", context, "nodejs", "--git", "https://github.com/openshift/nodejs-ex.git")
+			helper.CmdShouldPass("odo", "create", "--s2i", "--context", context, "nodejs", "--git", "https://github.com/openshift/nodejs-ex.git")
 			output := helper.CmdShouldFail("odo", "watch", "--context", context)
 			Expect(output).To(ContainSubstring("Watch is supported by binary and local components only"))
 		})

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -61,7 +61,7 @@ func componentTests(args ...string) {
 		})
 
 		It("should create component even in new project", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v4")...)
 			oc.SwitchProject(project)
@@ -70,7 +70,7 @@ func componentTests(args ...string) {
 		})
 
 		It("shouldn't error when creating a component with --project and --context at the same time", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v4")...)
 			oc.SwitchProject(project)
 			projectList := helper.CmdShouldPass("odo", "project", "list")
@@ -78,13 +78,13 @@ func componentTests(args ...string) {
 		})
 
 		It("should error when listing components (basically anything other then creating) with --project and --context ", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
 			helper.CmdShouldFail("odo", "list", "--project", project, "--context", context)
 		})
 
 		It("Without an application should create one", func() {
 			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", project, componentName, "--ref", "master", "--git", "https://github.com/openshift/nodejs-ex")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+componentName, "Application,app")
 			helper.CmdShouldPass("odo", append(args, "push")...)
 			appName := helper.CmdShouldPass("odo", "app", "list")
@@ -104,30 +104,30 @@ func componentTests(args ...string) {
 		It("should create default named component when passed same context differently", func() {
 			dir := filepath.Base(context)
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", ".", "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "--context", ".", "--app", "testing")...)
 			componentName := helper.GetConfigValueWithContext("Name", context)
 			Expect(componentName).To(ContainSubstring("nodejs-" + dir))
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+componentName, "Application,testing")
 			helper.DeleteDir(filepath.Join(context, ".odo"))
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "--context", context, "--app", "testing")...)
 			newComponentName := helper.GetConfigValueWithContext("Name", context)
 			Expect(newComponentName).To(ContainSubstring("nodejs-" + dir))
 		})
 
 		It("should show an error when ref flag is provided with sources except git", func() {
-			outputErr := helper.CmdShouldFail("odo", append(args, "create", "nodejs", "--project", project, "cmp-git", "--ref", "test")...)
+			outputErr := helper.CmdShouldFail("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "cmp-git", "--ref", "test")...)
 			Expect(outputErr).To(ContainSubstring("the --ref flag is only valid for --git flag"))
 		})
 
 		It("create component twice fails from same directory", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "nodejs", "--project", project)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "nodejs", "--project", project)...)
 			output := helper.CmdShouldFail("odo", append(args, "create", "nodejs", "nodejs", "--project", project)...)
 			Expect(output).To(ContainSubstring("this directory already contains a component"))
 		})
 
 		It("should list out component in json format along with path flag", func() {
 			var contextPath string
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "nodejs", "--project", project)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "nodejs", "--project", project)...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,nodejs", "Application,app")
 			if runtime.GOOS == "windows" {
 				contextPath = strings.Replace(strings.TrimSpace(context), "\\", "\\\\", -1)
@@ -149,7 +149,7 @@ func componentTests(args ...string) {
 			var contextPath string
 			var contextPath2 string
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "nodejs", "--project", project)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "nodejs", "--project", project)...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,nodejs", "Application,app")
 			helper.CmdShouldPass("odo", append(args, "push")...)
 
@@ -157,7 +157,7 @@ func componentTests(args ...string) {
 			context2 := helper.CreateNewContext()
 			helper.Chdir(context2)
 			helper.CopyExample(filepath.Join("source", "python"), context2)
-			helper.CmdShouldPass("odo", append(args, "create", "python", "python", "--project", project2)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "python", "python", "--project", project2)...)
 			helper.ValidateLocalCmpExist(context2, "Type,python", "Name,python", "Application,app")
 			helper.CmdShouldPass("odo", append(args, "push")...)
 
@@ -186,7 +186,7 @@ func componentTests(args ...string) {
 		})
 
 		It("should list the component", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
@@ -201,14 +201,14 @@ func componentTests(args ...string) {
 		})
 
 		It("should list the component when it is not pushed", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context)...)
 			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "Not Pushed"})
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", context)...)
 		})
 		It("should list the state as unknown for disconnected cluster", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			kubeconfigOrig := os.Getenv("KUBECONFIG")
 			os.Setenv("KUBECONFIG", "/no/such/path")
@@ -225,7 +225,7 @@ func componentTests(args ...string) {
 		})
 
 		It("should describe the component when it is not pushed", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", "url", "create", "url-1", "--context", context)
 			helper.CmdShouldPass("odo", "url", "create", "url-2", "--context", context)
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
@@ -255,7 +255,7 @@ func componentTests(args ...string) {
 
 		It("should describe not pushed component when it is created with json output", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json")...))
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json")...))
 			Expect(err).Should(BeNil())
 			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.dev/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","source": "file://./","sourceType": "local","ports": ["8080/TCP"]}, "status": {"state": "Not Pushed"}}`)
 			Expect(err).Should(BeNil())
@@ -265,7 +265,7 @@ func componentTests(args ...string) {
 
 		It("should describe pushed component when it is created with json output", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
+			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing", "-o", "json", "--now")...))
 			Expect(err).Should(BeNil())
 			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.dev/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + project + `","creationTimestamp": null},"spec":{"app": "testing","type":"nodejs","sourceType": "local","env": [{"name": "DEBUG_PORT","value": "5858"}],"ports": ["8080/TCP"]}, "status": {"state": "Pushed"}}`)
 			Expect(err).Should(BeNil())
@@ -275,12 +275,12 @@ func componentTests(args ...string) {
 
 		It("should list the component in the same app when one is pushed and the other one is not pushed", func() {
 			helper.Chdir(originalDir)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			context2 := helper.CreateNewContext()
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git-2", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context2, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git-2", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context2, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context2, "Type,nodejs", "Name,cmp-git-2", "Application,testing")
 			cmpList := helper.CmdShouldPass("odo", append(args, "list", "--context", context2)...)
 			helper.MatchAllInOutput(cmpList, []string{"cmp-git", "cmp-git-2", "Not Pushed", "Pushed"})
@@ -291,18 +291,15 @@ func componentTests(args ...string) {
 		})
 
 		It("should succeed listing catalog components", func() {
-
 			// Since components catalog is constantly changing, we simply check to see if this command passes.. rather than checking the JSON each time.
-			output := helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
-			helper.MatchAllInOutput(output, []string{"List", "supportedTags"})
-			Expect(output).ToNot(ContainSubstring("devfileItems"))
+			helper.CmdShouldPass("odo", "catalog", "list", "components", "-o", "json")
 		})
 
 		It("binary component should not fail when --context is not set", func() {
 			oc.ImportJavaIS(project)
 			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
 			// Was failing due to https://github.com/openshift/odo/issues/1969
-			helper.CmdShouldPass("odo", append(args, "create", "java:8", "sb-jar-test", "--project",
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(context, "sb.jar"))...)
 			helper.ValidateLocalCmpExist(context, "Type,java:8", "Name,sb-jar-test")
 		})
@@ -314,7 +311,7 @@ func componentTests(args ...string) {
 			newContext := helper.CreateNewContext()
 			defer helper.DeleteDir(newContext)
 
-			output := helper.CmdShouldFail("odo", append(args, "create", "java:8", "sb-jar-test", "--project",
+			output := helper.CmdShouldFail("odo", append(args, "create", "--s2i", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(context, "sb.jar"), "--context", newContext)...)
 			Expect(output).To(ContainSubstring("inside of the context directory"))
 		})
@@ -326,7 +323,7 @@ func componentTests(args ...string) {
 			relativeContext := fmt.Sprintf("..%c%s", filepath.Separator, filepath.Base(context))
 			fmt.Printf("relativeContext = %#v\n", relativeContext)
 
-			helper.CmdShouldPass("odo", append(args, "create", "java:8", "sb-jar-test", "--project",
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(context, "sb.jar"), "--context", relativeContext)...)
 			helper.ValidateLocalCmpExist(relativeContext, "Type,java:8", "Name,sb-jar-test")
 		})
@@ -349,7 +346,7 @@ func componentTests(args ...string) {
 				cmpName := "nodejs"
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project)...)
+				helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project)...)
 				helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 
 				// component doesn't exist yet so attempt to only push source should fail
@@ -379,7 +376,7 @@ func componentTests(args ...string) {
 				cmpName := "nodejs-push-atonce"
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project)...)
+				helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project)...)
 				helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 				// Push only config and see that the component is created but wothout any source copied
 				helper.CmdShouldPass("odo", append(args, "push")...)
@@ -405,7 +402,7 @@ func componentTests(args ...string) {
 				cmpName := "nodejs"
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--context", context, "--app", appName, "--project", project)...)
+				helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--context", context, "--app", appName, "--project", project)...)
 				helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 
 				// component doesn't exist yet so attempt to only push source should fail
@@ -435,7 +432,7 @@ func componentTests(args ...string) {
 				cmpName := "nodejs-push-atonce"
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
 
-				helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--context", context, "--project", project)...)
+				helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--context", context, "--project", project)...)
 				helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 
 				// Push both config and source
@@ -465,7 +462,7 @@ func componentTests(args ...string) {
 			helper.DeleteProject(project)
 		})
 		It("should create component", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--project", project, "--context", context, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,cmp-git", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context, "-v4")...)
 			oc.SwitchProject(project)
@@ -488,7 +485,7 @@ func componentTests(args ...string) {
 			appName := "nodejs-create-now-test"
 			cmpName := "nodejs-push-atonce"
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--now")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 
 			oc.VerifyCmpExists(cmpName, appName, project)
@@ -523,14 +520,14 @@ func componentTests(args ...string) {
 
 		It("create local nodejs component twice and fail", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
-			output := helper.CmdShouldFail("odo", append(args, "create", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
+			output := helper.CmdShouldFail("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "--env", "key=value,key1=value1")...)
 			Expect(output).To(ContainSubstring("this directory already contains a component"))
 		})
 
 		It("creates and pushes local nodejs component and then deletes --all", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", componentName, "--app", appName, "--project", project, "--env", "key=value,key1=value1")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", componentName, "--app", appName, "--project", project, "--env", "key=value,key1=value1")...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+componentName, "Application,"+appName)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--context", context, "-f", "--all")...)
@@ -542,7 +539,7 @@ func componentTests(args ...string) {
 
 		It("creates a local python component, pushes it and then deletes it using --all flag", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
 			helper.ValidateLocalCmpExist(context, "Type,python", "Name,"+componentName, "Application,"+appName)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--context", context, "-f")...)
@@ -555,7 +552,7 @@ func componentTests(args ...string) {
 
 		It("creates a local python component, pushes it and then deletes it using --all flag in local directory", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "python", componentName, "--app", appName, "--project", project)...)
 			helper.ValidateLocalCmpExist(context, "Type,python", "Name,"+componentName, "Application,"+appName)
 			helper.CmdShouldPass("odo", append(args, "push")...)
 			helper.CmdShouldPass("odo", append(args, "delete", "--all", "-f")...)
@@ -568,19 +565,19 @@ func componentTests(args ...string) {
 
 		It("creates a local python component and check for unsupported warning", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
+			output := helper.CmdShouldPass("odo", append(args, "create", "--s2i", "python", componentName, "--app", appName, "--project", project, "--context", context)...)
 			Expect(output).To(ContainSubstring("Warning: python is not fully supported by odo, and it is not guaranteed to work"))
 		})
 
 		It("creates a local nodejs component and check unsupported warning hasn't occured", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "nodejs:latest", componentName, "--app", appName, "--project", project, "--context", context)...)
+			output := helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs:latest", componentName, "--app", appName, "--project", project, "--context", context)...)
 			Expect(output).NotTo(ContainSubstring("Warning"))
 		})
 
 		It("creates a local java component and check unsupported warning hasn't occured", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
-			output := helper.CmdShouldPass("odo", append(args, "create", "java:latest", componentName, "--project", project, "--context", context)...)
+			output := helper.CmdShouldPass("odo", append(args, "create", "--s2i", "java:latest", componentName, "--project", project, "--context", context)...)
 			Expect(output).NotTo(ContainSubstring("Warning"))
 		})
 	})
@@ -596,7 +593,7 @@ func componentTests(args ...string) {
 
 		It("should be able to create a git component and update it from local to git", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			helper.CmdShouldPass("odo", "update", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", context)
@@ -608,7 +605,7 @@ func componentTests(args ...string) {
 		})
 
 		It("should be able to update a component from git to local", func() {
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", project, "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			// update the component config according to the git component
@@ -640,7 +637,7 @@ func componentTests(args ...string) {
 
 		It("should pass inside a odo directory without component name as parameter", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
 			helper.CmdShouldPass("odo", "url", "create", "example", "--context", context)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName, "URL,0,Name,example")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
@@ -660,7 +657,7 @@ func componentTests(args ...string) {
 
 		It("should fail outside a odo directory without component name as parameter", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
@@ -673,7 +670,7 @@ func componentTests(args ...string) {
 
 		It("should pass outside a odo directory with component name as parameter", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
 			helper.ValidateLocalCmpExist(context, "Type,nodejs", "Name,"+cmpName, "Application,"+appName)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
@@ -704,7 +701,7 @@ func componentTests(args ...string) {
 			componentName := helper.RandString(6)
 			appName := helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", componentName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", componentName, "--app", appName, "--project", project, "--context", context)...)
 			helper.CmdShouldPass("odo", append(args, "push", "--context", context)...)
 
 			helper.Chdir(context)
@@ -739,7 +736,7 @@ func componentTests(args ...string) {
 
 		It("should create default named component in a directory with numeric name", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), contextNumeric)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", "--project", project, "--context", contextNumeric, "--app", "testing")...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", project, "--context", contextNumeric, "--app", "testing")...)
 			helper.ValidateLocalCmpExist(contextNumeric, "Type,nodejs", "Application,testing")
 			helper.CmdShouldPass("odo", append(args, "push", "--context", contextNumeric, "-v4")...)
 		})
@@ -775,7 +772,7 @@ func componentTests(args ...string) {
 			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
 
 			// create the component using symlink
-			helper.CmdShouldPass("odo", append(args, "create", "java:8", "sb-jar-test", "--project",
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "java:8", "sb-jar-test", "--project",
 				project, "--binary", filepath.Join(symLinkPath, "sb.jar"), "--context", symLinkPath)...)
 
 			// Create a URL and push without using the symlink
@@ -793,7 +790,7 @@ func componentTests(args ...string) {
 
 		It("Should be able to deploy a wildfly war file using symlinks in some odo commands", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "wildfly"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "wildfly", "javaee-war-test", "--project",
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "wildfly", "javaee-war-test", "--project",
 				project, "--binary", filepath.Join(symLinkPath, "ROOT.war"), "--context", symLinkPath)...)
 
 			// Create a URL
@@ -824,7 +821,7 @@ func componentTests(args ...string) {
 
 		It("should delete the component and the owned resources", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
 			helper.CmdShouldPass("odo", "url", "create", "example-1", "--context", context)
 
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)
@@ -847,7 +844,7 @@ func componentTests(args ...string) {
 
 		It("should delete the component and the owned resources with wait flag", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", append(args, "create", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", cmpName, "--app", appName, "--project", project, "--context", context)...)
 			helper.CmdShouldPass("odo", "url", "create", "example-1", "--context", context)
 
 			helper.CmdShouldPass("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", context)

--- a/tests/integration/debug/cmd_debug_test.go
+++ b/tests/integration/debug/cmd_debug_test.go
@@ -48,7 +48,7 @@ var _ = Describe("odo debug command serial tests", func() {
 
 	It("should auto-select a local debug port when the given local port is occupied", func() {
 		helper.CopyExample(filepath.Join("source", "nodejs"), context)
-		helper.CmdShouldPass("odo", "component", "create", "nodejs:latest", "nodejs-cmp-"+namespace, "--project", namespace, "--context", context)
+		helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs:latest", "nodejs-cmp-"+namespace, "--project", namespace, "--context", context)
 		helper.CmdShouldPass("odo", "push", "--context", context)
 
 		stopChannel := make(chan bool)

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -24,13 +24,17 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		project = cliRunner.CreateRandNamespaceProject()
 		currentWorkingDirectory = helper.Getwd()
 		helper.Chdir(context)
+
+		// For some reason on TravisCI, there are flakes with regards to registrycachetime and doing
+		// odo catalog list components.
+		// TODO: Investigate this more.
+		helper.CmdShouldPass("odo", "preference", "set", "registrycachetime", "0")
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -25,7 +25,6 @@ var _ = Describe("odo devfile create command tests", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()
@@ -42,49 +41,6 @@ var _ = Describe("odo devfile create command tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
-	})
-
-	Context("Enabling experimental preference should show a disclaimer", func() {
-		It("checks that the experimental warning appears for create", func() {
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-			// Check that it will contain the experimental mode output
-			experimentalOutputMsg := "Experimental mode is enabled, use at your own risk"
-			Expect(helper.CmdShouldPass("odo", "create", "nodejs")).To(ContainSubstring(experimentalOutputMsg))
-
-		})
-	})
-
-	Context("Disabling experimental preference should show a disclaimer", func() {
-		JustBeforeEach(func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("Skipping test because s2i image is not supported on Kubernetes cluster")
-			}
-		})
-		It("checks that the experimental warning does *not* appear when Experimental is set to false for create", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "false", "-f")
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-			// Check that it will contain the experimental mode output
-			experimentalOutputMsg := "Experimental mode is enabled, use at your own risk"
-			Expect(helper.CmdShouldPass("odo", "create", "nodejs")).To(Not(ContainSubstring(experimentalOutputMsg)))
-		})
-	})
-
-	Context("Disabling experimental preference should error out on providing --s2i flag", func() {
-		JustBeforeEach(func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("Skipping test because s2i image is not supported on Kubernetes cluster")
-			}
-		})
-		It("checks that the --s2i flag is unrecognised when Experimental is set to false for create", func() {
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "false", "-f")
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-
-			// Check that it will contain the experimental mode output
-			s2iFlagUnknownMsg := "Error: unknown flag: --s2i"
-			Expect(helper.CmdShouldFail("odo", "create", "nodejs", "--s2i")).To(ContainSubstring(s2iFlagUnknownMsg))
-		})
 	})
 
 	Context("When executing odo create with devfile component type argument", func() {
@@ -170,14 +126,20 @@ var _ = Describe("odo devfile create command tests", func() {
 
 		It("should fail the create command as --git flag, which is specific to s2i component creation, is used without --s2i flag", func() {
 			output := helper.CmdShouldFail("odo", "create", "nodejs", "cmp-git", "--git", "https://github.com/openshift/nodejs-ex", "--context", context, "--app", "testing")
-			Expect(output).Should(ContainSubstring("flag --git, requires --s2i flag to be set, when in experimental mode."))
+			Expect(output).Should(ContainSubstring("flag --git, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
 		})
 
 		It("should fail the create command as --binary flag, which is specific to s2i component creation, is used without --s2i flag", func() {
 			helper.CopyExample(filepath.Join("binary", "java", "openjdk"), context)
 
 			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(context, "sb.jar"), "--context", context)
-			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when in experimental mode."))
+			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
+		})
+
+		It("should fail the create command as --now flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			componentName := helper.RandString(6)
+			output := helper.CmdShouldFail("odo", "create", "nodejs", componentName, "--now")
+			Expect(output).Should(ContainSubstring("flag --now, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -135,12 +135,6 @@ var _ = Describe("odo devfile create command tests", func() {
 			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(context, "sb.jar"), "--context", context)
 			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
 		})
-
-		It("should fail the create command as --now flag, which is specific to s2i component creation, is used without --s2i flag", func() {
-			componentName := helper.RandString(6)
-			output := helper.CmdShouldFail("odo", "create", "nodejs", componentName, "--now")
-			Expect(output).Should(ContainSubstring("flag --now, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
-		})
 	})
 
 	Context("When executing odo create with devfile component type argument and --project flag", func() {

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -29,9 +29,6 @@ var _ = Describe("odo devfile debug command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -25,9 +25,6 @@ var _ = Describe("odo devfile delete command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile commands require experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -28,7 +28,6 @@ var _ = Describe("odo devfile env command tests", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 var _ = Describe("odo devfile exec command tests", func() {
-	var project, namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
-
-	appName := "app"
+	var namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
 
 	// Using program command according to cliRunner in devfile
 	cliRunner := helper.GetCliRunner()
@@ -24,7 +22,6 @@ var _ = Describe("odo devfile exec command tests", func() {
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
-		project = helper.CreateRandProject()
 		currentWorkingDirectory = helper.Getwd()
 		cmpName = helper.RandString(6)
 
@@ -46,16 +43,6 @@ var _ = Describe("odo devfile exec command tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
-	})
-
-	Context("Should fail when running against s2i", func() {
-
-		It("Fail when running against s2i", func() {
-			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
-			helper.CmdShouldFail("odo", "exec", "--context", context, "--", "ls")
-		})
-
 	})
 
 	Context("When devfile exec command is executed", func() {

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 var _ = Describe("odo devfile exec command tests", func() {
-	var namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
+	var project, namespace, context, cmpName, currentWorkingDirectory, originalKubeconfig string
+
+	appName := "app"
 
 	// Using program command according to cliRunner in devfile
 	cliRunner := helper.GetCliRunner()
@@ -22,6 +24,7 @@ var _ = Describe("odo devfile exec command tests", func() {
 	var _ = BeforeEach(func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
+		project = helper.CreateRandProject()
 		currentWorkingDirectory = helper.Getwd()
 		cmpName = helper.RandString(6)
 
@@ -43,6 +46,16 @@ var _ = Describe("odo devfile exec command tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		helper.DeleteDir(context)
 		os.Unsetenv("GLOBALODOCONFIG")
+	})
+
+	Context("Should fail when running against s2i", func() {
+
+		It("Fail when running against s2i", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), context)
+			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--app", appName)
+			helper.CmdShouldFail("odo", "exec", "--context", context, "--", "ls")
+		})
+
 	})
 
 	Context("When devfile exec command is executed", func() {

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -29,9 +29,6 @@ var _ = Describe("odo devfile exec command tests", func() {
 
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -23,9 +23,6 @@ var _ = Describe("odo devfile log command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -31,9 +31,6 @@ var _ = Describe("odo devfile push command tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()
@@ -897,7 +894,6 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(output).To(ContainSubstring(cmpName))
 			Expect(output).To(ContainSubstring(cmpName2))
 
-			helper.CmdShouldPass("odo", "preference", "set", "Experimental", "false")
 			helper.DeleteDir(context2)
 
 		})
@@ -923,14 +919,11 @@ var _ = Describe("odo devfile push command tests", func() {
 			context2 := helper.CreateNewContext()
 			cmpName2 := helper.RandString(6)
 			appName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "preference", "set", "--force", "Experimental", "false")
 			helper.CopyExample(filepath.Join("source", "nodejs"), context2)
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, "--app", appName, "--context", context2, cmpName2)
 
 			output2 := helper.CmdShouldPass("odo", "push", "--context", context2)
 			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
-
-			helper.CmdShouldPass("odo", "preference", "set", "--force", "Experimental", "true")
 
 			output = helper.CmdShouldPass("odo", "list", "--all-apps", "--project", namespace)
 

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -25,8 +25,6 @@ var _ = Describe("odo devfile registry command tests", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		project = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -27,9 +27,6 @@ var _ = Describe("odo devfile storage command tests", func() {
 
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -22,8 +22,6 @@ var _ = Describe("odo devfile test command tests", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -31,9 +31,6 @@ var _ = Describe("odo devfile url command tests", func() {
 		currentWorkingDirectory = helper.Getwd()
 		componentName = helper.RandString(6)
 		helper.Chdir(context)
-
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
 	// Clean up after the test

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -36,9 +36,6 @@ var _ = Describe("odo devfile watch command tests", func() {
 		currentWorkingDirectory = helper.Getwd()
 		cmpName = helper.RandString(6)
 		helper.Chdir(context)
-
-		// Set experimental mode to true
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
 	// Clean up after the test

--- a/tests/integration/devfile/debug/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/debug/cmd_devfile_debug_test.go
@@ -38,9 +38,6 @@ var _ = Describe("odo devfile debug command serial tests", func() {
 		context = helper.CreateNewContext()
 		os.Setenv("GLOBALODOCONFIG", filepath.Join(context, "config.yaml"))
 
-		// Devfile push requires experimental mode to be set
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
-
 		originalKubeconfig = os.Getenv("KUBECONFIG")
 		helper.LocalKubeconfigSet(context)
 		namespace = cliRunner.CreateRandNamespaceProject()

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -137,7 +137,7 @@ var _ = Describe("odo generic", func() {
 			os.Unsetenv("GLOBALODOCONFIG")
 		})
 		It("should create the component in default application", func() {
-			helper.CmdShouldPass("odo", "create", "php", "testcmp", "--app", "e2e-xyzk", "--project", project, "--git", testPHPGitURL)
+			helper.CmdShouldPass("odo", "create", "--s2i", "php", "testcmp", "--app", "e2e-xyzk", "--project", project, "--git", testPHPGitURL)
 			helper.CmdShouldPass("odo", "config", "set", "Ports", "8080/TCP", "-f")
 			helper.CmdShouldPass("odo", "push")
 			oc.VerifyCmpName("testcmp", project)
@@ -162,7 +162,7 @@ var _ = Describe("odo generic", func() {
 			os.Unsetenv("GLOBALODOCONFIG")
 		})
 		It("should pass to build component if the given build timeout is more than the default(300s) value", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--git", testNodejsGitURL)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--git", testNodejsGitURL)
 			helper.CmdShouldPass("odo", "preference", "set", "BuildTimeout", "600")
 			buildTimeout := helper.GetPreferenceValue("BuildTimeout")
 			helper.MatchAllInOutput(buildTimeout, []string{"600"})
@@ -170,7 +170,7 @@ var _ = Describe("odo generic", func() {
 		})
 
 		It("should fail to build component if the given build timeout is pretty less(2s)", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--git", testNodejsGitURL)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--git", testNodejsGitURL)
 			helper.CmdShouldPass("odo", "preference", "set", "BuildTimeout", "2")
 			buildTimeout := helper.GetPreferenceValue("BuildTimeout")
 			helper.MatchAllInOutput(buildTimeout, []string{"2"})
@@ -192,7 +192,7 @@ var _ = Describe("odo generic", func() {
 			os.Unsetenv("GLOBALODOCONFIG")
 		})
 		It("should be able to create a php component with application created", func() {
-			helper.CmdShouldPass("odo", "create", "php", "testcmp", "--app", "testing", "--project", project, "--ref", "master", "--git", testPHPGitURL, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "php", "testcmp", "--app", "testing", "--project", project, "--ref", "master", "--git", testPHPGitURL, "--context", context)
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			currentProject := helper.CreateRandProject()
 			currentAppNames := helper.CmdShouldPass("odo", "app", "list", "--project", currentProject)
@@ -217,7 +217,7 @@ var _ = Describe("odo generic", func() {
 		})
 		It("should be able to push changes", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs", "--project", project, "--context", context)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "nodejs", "--project", project, "--context", context)
 
 			// Push the changes with --show-log
 			getLogging := helper.CmdShouldPass("odo", "push", "--show-log", "--context", context)
@@ -239,7 +239,7 @@ var _ = Describe("odo generic", func() {
 		})
 		It("should deploy the component", func() {
 			helper.CmdShouldPass("git", "clone", "https://github.com/openshift/nodejs-ex", context+"/nodejs-ex")
-			helper.CmdShouldPass("odo", "create", "nodejs:latest", "testversioncmp", "--project", project, "--context", context+"/nodejs-ex")
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs:latest", "testversioncmp", "--project", project, "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "push", "--context", context+"/nodejs-ex")
 			helper.CmdShouldPass("odo", "delete", "-f", "--context", context+"/nodejs-ex")
 		})
@@ -316,7 +316,7 @@ var _ = Describe("odo generic", func() {
 			os.Unsetenv("GLOBALODOCONFIG")
 		})
 		It("should not allow creating a URL with long name", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--project", project)
 			stdOut := helper.CmdShouldFail("odo", "url", "create", testLongURLName, "--port", "8080")
 			Expect(stdOut).To(ContainSubstring("must be shorter than 63 characters"))
 		})
@@ -342,7 +342,7 @@ var _ = Describe("odo generic", func() {
 		})
 		It("should delete all OpenShift objects except the component's imagestream", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", componentRandomName, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", componentRandomName, "--project", project)
 			helper.CmdShouldPass("odo", "push")
 
 			// Delete the deployment config using oc delete
@@ -416,7 +416,7 @@ var _ = Describe("odo generic", func() {
 			}
 			for _, testCase := range cases {
 				helper.CopyExample(filepath.Join("source", "nodejs"), context)
-				output := helper.CmdShouldFail("odo", "component", "create", "nodejs", cmpName, "--project", project, "--context", context, "--"+testCase.paramName, testCase.paramValue)
+				output := helper.CmdShouldFail("odo", "component", "create", "--s2i", "nodejs", cmpName, "--project", project, "--context", context, "--"+testCase.paramName, testCase.paramValue)
 				Expect(output).To(ContainSubstring("unknown flag: --" + testCase.paramName))
 			}
 		})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -1,7 +1,5 @@
 package integration
 
-/*
-
 import (
 	"fmt"
 	"io/ioutil"
@@ -24,436 +22,440 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		SetDefaultEventuallyTimeout(10 * time.Minute)
 		SetDefaultConsistentlyDuration(30 * time.Second)
 		// TODO: remove this when OperatorHub integration is fully baked into odo
-		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
+		// helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
-		preSetup := func() {
-			project = helper.CreateRandProject()
-			helper.CmdShouldPass("odo", "project", "set", project)
+	preSetup := func() {
+		project = helper.CreateRandProject()
+		helper.CmdShouldPass("odo", "project", "set", project)
 
-			// wait till oc can see the all operators installed by setup script in the namespace
-			ocArgs := []string{"get", "csv"}
-			operators := []string{"etcd", "mongodb"}
-			for _, operator := range operators {
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, operator)
-				})
+		// wait till oc can see the all operators installed by setup script in the namespace
+		ocArgs := []string{"get", "csv"}
+		operators := []string{"etcd"}
+		for _, operator := range operators {
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, operator)
+			})
+		}
+	}
+
+	cleanPreSetup := func() {
+		helper.DeleteProject(project)
+	}
+
+	Context("When Operators are installed in the cluster", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should list operators installed in the namespace", func() {
+			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
+		})
+
+		It("should list operators installed in the namespace", func() {
+			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
+		})
+
+		It("should not allow interactive mode command to be executed", func() {
+			stdOut := helper.CmdShouldFail("odo", "service", "create")
+			Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
+		})
+	})
+
+	Context("When creating and deleting an operator backed service", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", project)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// now test listing of the service using odo
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
+
+			// now test the deletion of the service using odo
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+			// now try deleting the same service again. It should fail with error message
+			stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
+			Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
+		})
+
+		It("should be able to create service with name passed on CLI", func() {
+			name := helper.RandString(6)
+			svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", project)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with custom name because that's the name etcd will give to the pods.
+			compileString := name + `-.[a-z0-9]*`
+			etcdPod := regexp.MustCompile(compileString).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			// now try creating service with same name again. it should fail
+			stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", project)
+			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
+
+			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
+		})
+	})
+
+	Context("When deleting an invalid operator backed service", func() {
+		It("should correctly detect invalid service names", func() {
+			names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+
+			for _, name := range names {
+				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
+				Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
 			}
-		}
+		})
+	})
 
-		cleanPreSetup := func() {
-			helper.DeleteProject(project)
-		}
+	Context("When using dry-run option to create operator backed service", func() {
 
-		Context("When experimental mode is enabled", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should list operators installed in the namespace", func() {
-				stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
-			})
-
-			It("should not allow interactive mode command to be executed", func() {
-				stdOut := helper.CmdShouldFail("odo", "service", "create")
-				Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
-			})
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When creating and deleting an operator backed service", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				// now test listing of the service using odo
-				stdOut := helper.CmdShouldPass("odo", "service", "list")
-				Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
-
-				// now test the deletion of the service using odo
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-				// now try deleting the same service again. It should fail with error message
-				stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
-				Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
-			})
-
-			It("should be able to create service with name passed on CLI", func() {
-				name := helper.RandString(6)
-				svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with custom name because that's the name etcd will give to the pods.
-				compileString := name + `-.[a-z0-9]*`
-				etcdPod := regexp.MustCompile(compileString).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				// now try creating service with same name again. it should fail
-				stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
-
-				helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When deleting an invalid operator backed service", func() {
-			It("should correctly detect invalid service names", func() {
-				names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+		It("should only output the definition of the CR that will be used to start service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-				for _, name := range names {
-					stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
-					Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
-				}
-			})
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", project)
+			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
+		})
+	})
+
+	Context("Should be able to search from catalog", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When using dry-run option to create operator backed service", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should only output the definition of the CR that will be used to start service", func() {
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-				helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("Should be able to search from catalog", func() {
+		It("should only output the definition of the CR that will be used to start service", func() {
+			stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
+			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			JustBeforeEach(func() {
-				preSetup()
-			})
+			stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
+			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
+			stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
+			Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
+		})
+	})
 
-			It("should only output the definition of the CR that will be used to start service", func() {
-				stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
-				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
+	Context("When using from-file option", func() {
 
-				stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
-				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-				stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
-				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
-			})
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When using from-file option", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should be able to create a service", func() {
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-				// stdOut contains the yaml specification. Store it to a file
-				randomFileName := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join(os.TempDir(), randomFileName)
-				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-			})
-
-			It("should be able to create a service with name passed on CLI", func() {
-				name := helper.RandString(6)
-				// First let's grab the etcd operator's name from "odo catalog list services" output
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-				// stdOut contains the yaml specification. Store it to a file
-				randomFileName := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join(os.TempDir(), randomFileName)
-				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name)
-
-				// Attempting to create service with same name should fail
-				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
-				Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When using from-file option", func() {
+		It("should be able to create a service", func() {
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			JustBeforeEach(func() {
-				preSetup()
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", project)
+
+			// stdOut contains the yaml specification. Store it to a file
+			randomFileName := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join(os.TempDir(), randomFileName)
+			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
+
+			// now create operator backed service
+			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, "--project", project)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
 			})
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should fail to create service if metadata doesn't exist or is invalid", func() {
-				noMetadata := `
-	apiVersion: etcd.database.coreos.com/v1beta2
-	kind: EtcdCluster
-	spec:
-	  size: 3
-	  version: 3.2.13
-	`
-
-				invalidMetadata := `
-	apiVersion: etcd.database.coreos.com/v1beta2
-	kind: EtcdCluster
-	metadata:
-	  noname: noname
-	spec:
-	  size: 3
-	  version: 3.2.13
-	`
-
-				noMetaFile := helper.RandString(6) + ".yaml"
-				fileName := filepath.Join("/tmp", noMetaFile)
-				if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-				Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
-
-				invalidMetaFile := helper.RandString(6) + ".yaml"
-				fileName = filepath.Join("/tmp", invalidMetaFile)
-				if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
-					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-				}
-
-				// now create operator backed service
-				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-				Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
-
-			})
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
 		})
 
-		Context("JSON output", func() {
+		It("should be able to create a service with name passed on CLI", func() {
+			name := helper.RandString(6)
+			// First let's grab the etcd operator's name from "odo catalog list services" output
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 
-			JustBeforeEach(func() {
-				preSetup()
-			})
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", project)
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
+			// stdOut contains the yaml specification. Store it to a file
+			randomFileName := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join(os.TempDir(), randomFileName)
+			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-			It("listing catalog of services", func() {
-				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-				helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
-			})
+			// now create operator backed service
+			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name, "--project", project)
+
+			// Attempting to create service with same name should fail
+			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name, "--project", project)
+			Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
+		})
+	})
+
+	Context("When using from-file option", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
 		})
 
-		Context("When operator backed services are created", func() {
-
-			JustBeforeEach(func() {
-				preSetup()
-			})
-
-			JustAfterEach(func() {
-				cleanPreSetup()
-			})
-
-			It("should list the services if they exist", func() {
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				stdOut := helper.CmdShouldPass("odo", "service", "list")
-				helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
-
-				// now check for json output
-				jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-				helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
-
-				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-				// Now let's check the output again to ensure expected behaviour
-				stdOut = helper.CmdShouldFail("odo", "service", "list")
-				jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
-
-				msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
-				msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
-				Expect(stdOut).To(ContainSubstring(msg))
-				helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
-			})
+		JustAfterEach(func() {
+			cleanPreSetup()
 		})
 
-		Context("When linking devfile component with Operator backed service", func() {
-			var context, currentWorkingDirectory, devfilePath string
-			const devfile = "devfile.yaml"
+		It("should fail to create service if metadata doesn't exist or is invalid", func() {
+			noMetadata := `
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+spec:
+  size: 3
+  version: 3.2.13
+`
 
-			JustBeforeEach(func() {
-				preSetup()
-				context = helper.CreateNewContext()
-				devfilePath = filepath.Join(context, devfile)
-				currentWorkingDirectory = helper.Getwd()
-				helper.Chdir(context)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
-			})
+			invalidMetadata := `
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  noname: noname
+spec:
+  size: 3
+  version: 3.2.13
+`
 
-			JustAfterEach(func() {
-				cleanPreSetup()
-				helper.Chdir(currentWorkingDirectory)
-				helper.DeleteDir(context)
-			})
+			noMetaFile := helper.RandString(6) + ".yaml"
+			fileName := filepath.Join("/tmp", noMetaFile)
+			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-			It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
+			// now create operator backed service
+			stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
 
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
+			invalidMetaFile := helper.RandString(6) + ".yaml"
+			fileName = filepath.Join("/tmp", invalidMetaFile)
+			if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
+				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+			}
 
-				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			// now create operator backed service
+			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+			Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
 
-				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
-
-				stdOut = helper.CmdShouldFail("odo", "link", "/example")
-				Expect(stdOut).To(ContainSubstring("Invalid service name"))
-			})
-
-			It("should fail if the provided service doesn't exist in the namespace", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
-
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
-				helper.CmdShouldPass("odo", "push")
-
-				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
-			})
-
-			It("should successfully connect and disconnect a component with an existing service", func() {
-				if os.Getenv("KUBERNETES") == "true" {
-					Skip("This is a OpenShift specific scenario, skipping")
-				}
-
-				componentName := helper.RandString(6)
-				helper.CmdShouldPass("odo", "create", componentName)
-				helper.CmdShouldPass("odo", "push")
-
-				// start the Operator backed service first
-				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-				// now verify if the pods for the operator have started
-				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-				// Look for pod with example name because that's the name etcd will give to the pods.
-				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, "Running")
-				})
-
-				stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
-				helper.CmdShouldPass("odo", "push")
-				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("already linked with the service"))
-
-				stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
-				helper.CmdShouldPass("odo", "push")
-
-				// verify that sbr is deleted
-				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-				Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
-
-				// next, delete a link outside of odo (using oc) and ensure that it throws an error
-				helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-				sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
-				helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
-				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-				helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
-			})
 		})
+	})
+
+	Context("JSON output", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("listing catalog of services", func() {
+			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+			helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
+		})
+	})
+
+	Context("When operator backed services are created", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+		})
+
+		It("should list the services if they exist", func() {
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", project)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
+
+			// now check for json output
+			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
+
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+			// Now let's check the output again to ensure expected behaviour
+			stdOut = helper.CmdShouldFail("odo", "service", "list")
+			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
+
+			msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
+			msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
+			Expect(stdOut).To(ContainSubstring(msg))
+			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
+		})
+	})
+
+	Context("When linking devfile component with Operator backed service", func() {
+		var context, currentWorkingDirectory, devfilePath string
+		const devfile = "devfile.yaml"
+
+		JustBeforeEach(func() {
+			preSetup()
+			context = helper.CreateNewContext()
+			devfilePath = filepath.Join(context, devfile)
+			currentWorkingDirectory = helper.Getwd()
+			helper.Chdir(context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
+		})
+
+		JustAfterEach(func() {
+			cleanPreSetup()
+			helper.Chdir(currentWorkingDirectory)
+			helper.DeleteDir(context)
+		})
+
+		It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+
+			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+			stdOut = helper.CmdShouldFail("odo", "link", "/example")
+			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+		})
+
+		It("should fail if the provided service doesn't exist in the namespace", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+			helper.CmdShouldPass("odo", "push")
+
+			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
+		})
+
+		It("should successfully connect and disconnect a component with an existing service", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			componentName := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", componentName)
+			helper.CmdShouldPass("odo", "push")
+
+			// start the Operator backed service first
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", project)
+
+			// now verify if the pods for the operator have started
+			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+			// Look for pod with example name because that's the name etcd will give to the pods.
+			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "Running")
+			})
+
+			stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
+			helper.CmdShouldPass("odo", "push")
+			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("already linked with the service"))
+
+			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+			helper.CmdShouldPass("odo", "push")
+
+			// verify that sbr is deleted
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+
+			// next, delete a link outside of odo (using oc) and ensure that it throws an error
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+			sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
+			helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
+			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+			helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
+		})
+	})
 })
-*/

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -1,5 +1,7 @@
 package integration
 
+/*
+
 import (
 	"fmt"
 	"io/ioutil"
@@ -25,432 +27,433 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.CmdShouldPass("odo", "preference", "set", "Experimental", "true")
 	})
 
-	preSetup := func() {
-		project = helper.CreateRandProject()
-		helper.CmdShouldPass("odo", "project", "set", project)
+		preSetup := func() {
+			project = helper.CreateRandProject()
+			helper.CmdShouldPass("odo", "project", "set", project)
 
-		// wait till oc can see the all operators installed by setup script in the namespace
-		ocArgs := []string{"get", "csv"}
-		operators := []string{"etcd", "mongodb"}
-		for _, operator := range operators {
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, operator)
-			})
+			// wait till oc can see the all operators installed by setup script in the namespace
+			ocArgs := []string{"get", "csv"}
+			operators := []string{"etcd", "mongodb"}
+			for _, operator := range operators {
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, operator)
+				})
+			}
 		}
-	}
 
-	cleanPreSetup := func() {
-		helper.DeleteProject(project)
-	}
+		cleanPreSetup := func() {
+			helper.DeleteProject(project)
+		}
 
-	Context("When experimental mode is enabled", func() {
+		Context("When experimental mode is enabled", func() {
 
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should list operators installed in the namespace", func() {
-			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
-		})
-
-		It("should not allow interactive mode command to be executed", func() {
-			stdOut := helper.CmdShouldFail("odo", "service", "create")
-			Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
-		})
-	})
-
-	Context("When creating and deleting an operator backed service", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustBeforeEach(func() {
+				preSetup()
 			})
 
-			// now test listing of the service using odo
-			stdOut := helper.CmdShouldPass("odo", "service", "list")
-			Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
-
-			// now test the deletion of the service using odo
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-			// now try deleting the same service again. It should fail with error message
-			stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
-			Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
-		})
-
-		It("should be able to create service with name passed on CLI", func() {
-			name := helper.RandString(6)
-			svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with custom name because that's the name etcd will give to the pods.
-			compileString := name + `-.[a-z0-9]*`
-			etcdPod := regexp.MustCompile(compileString).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustAfterEach(func() {
+				cleanPreSetup()
 			})
 
-			// now try creating service with same name again. it should fail
-			stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
-			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
-
-			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
-		})
-	})
-
-	Context("When deleting an invalid operator backed service", func() {
-		It("should correctly detect invalid service names", func() {
-			names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
-
-			for _, name := range names {
-				stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
-				Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
-			}
-		})
-	})
-
-	Context("When using dry-run option to create operator backed service", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should only output the definition of the CR that will be used to start service", func() {
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
-		})
-	})
-
-	Context("Should be able to search from catalog", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should only output the definition of the CR that will be used to start service", func() {
-			stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
-			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-			stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
-			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-			stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
-			Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
-		})
-	})
-
-	Context("When using from-file option", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should be able to create a service", func() {
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-			// stdOut contains the yaml specification. Store it to a file
-			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join(os.TempDir(), randomFileName)
-			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			It("should list operators installed in the namespace", func() {
+				stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "percona-server-mongodb-operator", "etcdoperator"})
 			})
 
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+			It("should not allow interactive mode command to be executed", func() {
+				stdOut := helper.CmdShouldFail("odo", "service", "create")
+				Expect(stdOut).To(ContainSubstring("please use a valid command to start an Operator backed service"))
+			})
 		})
 
-		It("should be able to create a service with name passed on CLI", func() {
-			name := helper.RandString(6)
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+		Context("When creating and deleting an operator backed service", func() {
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
-
-			// stdOut contains the yaml specification. Store it to a file
-			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join(os.TempDir(), randomFileName)
-			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name)
-
-			// Attempting to create service with same name should fail
-			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
-			Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
-		})
-	})
-
-	Context("When using from-file option", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should fail to create service if metadata doesn't exist or is invalid", func() {
-			noMetadata := `
-apiVersion: etcd.database.coreos.com/v1beta2
-kind: EtcdCluster
-spec:
-  size: 3
-  version: 3.2.13
-`
-
-			invalidMetadata := `
-apiVersion: etcd.database.coreos.com/v1beta2
-kind: EtcdCluster
-metadata:
-  noname: noname
-spec:
-  size: 3
-  version: 3.2.13
-`
-
-			noMetaFile := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join("/tmp", noMetaFile)
-			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
-
-			invalidMetaFile := helper.RandString(6) + ".yaml"
-			fileName = filepath.Join("/tmp", invalidMetaFile)
-			if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
-			Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
-
-		})
-	})
-
-	Context("JSON output", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("listing catalog of services", func() {
-			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
-		})
-	})
-
-	Context("When operator backed services are created", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should list the services if they exist", func() {
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustBeforeEach(func() {
+				preSetup()
 			})
 
-			stdOut := helper.CmdShouldPass("odo", "service", "list")
-			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
-
-			// now check for json output
-			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
-
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-			// Now let's check the output again to ensure expected behaviour
-			stdOut = helper.CmdShouldFail("odo", "service", "list")
-			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
-
-			msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
-			msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
-			Expect(stdOut).To(ContainSubstring(msg))
-			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
-		})
-	})
-
-	Context("When linking devfile component with Operator backed service", func() {
-		var context, currentWorkingDirectory, devfilePath string
-		const devfile = "devfile.yaml"
-
-		JustBeforeEach(func() {
-			preSetup()
-			context = helper.CreateNewContext()
-			devfilePath = filepath.Join(context, devfile)
-			currentWorkingDirectory = helper.Getwd()
-			helper.Chdir(context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-			helper.Chdir(currentWorkingDirectory)
-			helper.DeleteDir(context)
-		})
-
-		It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", componentName)
-
-			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
-
-			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
-
-			stdOut = helper.CmdShouldFail("odo", "link", "/example")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
-		})
-
-		It("should fail if the provided service doesn't exist in the namespace", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", componentName)
-			helper.CmdShouldPass("odo", "push")
-
-			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
-		})
-
-		It("should successfully connect and disconnect a component with an existing service", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", componentName)
-			helper.CmdShouldPass("odo", "push")
-
-			// start the Operator backed service first
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
-
-			// now verify if the pods for the operator have started
-			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustAfterEach(func() {
+				cleanPreSetup()
 			})
 
-			stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
-			helper.CmdShouldPass("odo", "push")
-			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("already linked with the service"))
+			It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
 
-			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
-			helper.CmdShouldPass("odo", "push")
+				// now verify if the pods for the operator have started
+				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+				// Look for pod with example name because that's the name etcd will give to the pods.
+				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
 
-			// verify that sbr is deleted
-			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, "Running")
+				})
 
-			// next, delete a link outside of odo (using oc) and ensure that it throws an error
-			helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-			sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
-			helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
-			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-			helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
+				// now test listing of the service using odo
+				stdOut := helper.CmdShouldPass("odo", "service", "list")
+				Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
+
+				// now test the deletion of the service using odo
+				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+				// now try deleting the same service again. It should fail with error message
+				stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
+				Expect(stdOut).To(ContainSubstring("Couldn't find service named"))
+			})
+
+			It("should be able to create service with name passed on CLI", func() {
+				name := helper.RandString(6)
+				svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
+
+				// now verify if the pods for the operator have started
+				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+				// Look for pod with custom name because that's the name etcd will give to the pods.
+				compileString := name + `-.[a-z0-9]*`
+				etcdPod := regexp.MustCompile(compileString).FindString(pods)
+
+				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, "Running")
+				})
+
+				// now try creating service with same name again. it should fail
+				stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name)
+				Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
+
+				helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
+			})
 		})
-	})
+
+		Context("When deleting an invalid operator backed service", func() {
+			It("should correctly detect invalid service names", func() {
+				names := []string{"EtcdCluster", "EtcdCluster/", "/example"}
+
+				for _, name := range names {
+					stdOut := helper.CmdShouldFail("odo", "service", "delete", name, "-f")
+					Expect(stdOut).To(ContainSubstring("couldn't split %q into exactly two", name))
+				}
+			})
+		})
+
+		Context("When using dry-run option to create operator backed service", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("should only output the definition of the CR that will be used to start service", func() {
+				// First let's grab the etcd operator's name from "odo catalog list services" output
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+
+				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
+				helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
+			})
+		})
+
+		Context("Should be able to search from catalog", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("should only output the definition of the CR that will be used to start service", func() {
+				stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
+				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
+
+				stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
+				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
+
+				stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
+				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
+			})
+		})
+
+		Context("When using from-file option", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("should be able to create a service", func() {
+				// First let's grab the etcd operator's name from "odo catalog list services" output
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+
+				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
+
+				// stdOut contains the yaml specification. Store it to a file
+				randomFileName := helper.RandString(6) + ".yaml"
+				fileName := filepath.Join(os.TempDir(), randomFileName)
+				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+				}
+
+				// now create operator backed service
+				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName)
+
+				// now verify if the pods for the operator have started
+				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+				// Look for pod with example name because that's the name etcd will give to the pods.
+				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, "Running")
+				})
+
+				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+			})
+
+			It("should be able to create a service with name passed on CLI", func() {
+				name := helper.RandString(6)
+				// First let's grab the etcd operator's name from "odo catalog list services" output
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+
+				stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run")
+
+				// stdOut contains the yaml specification. Store it to a file
+				randomFileName := helper.RandString(6) + ".yaml"
+				fileName := filepath.Join(os.TempDir(), randomFileName)
+				if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+				}
+
+				// now create operator backed service
+				helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name)
+
+				// Attempting to create service with same name should fail
+				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name)
+				Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
+			})
+		})
+
+		Context("When using from-file option", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("should fail to create service if metadata doesn't exist or is invalid", func() {
+				noMetadata := `
+	apiVersion: etcd.database.coreos.com/v1beta2
+	kind: EtcdCluster
+	spec:
+	  size: 3
+	  version: 3.2.13
+	`
+
+				invalidMetadata := `
+	apiVersion: etcd.database.coreos.com/v1beta2
+	kind: EtcdCluster
+	metadata:
+	  noname: noname
+	spec:
+	  size: 3
+	  version: 3.2.13
+	`
+
+				noMetaFile := helper.RandString(6) + ".yaml"
+				fileName := filepath.Join("/tmp", noMetaFile)
+				if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
+					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+				}
+
+				// now create operator backed service
+				stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+				Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
+
+				invalidMetaFile := helper.RandString(6) + ".yaml"
+				fileName = filepath.Join("/tmp", invalidMetaFile)
+				if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
+					fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+				}
+
+				// now create operator backed service
+				stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName)
+				Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
+
+			})
+		})
+
+		Context("JSON output", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("listing catalog of services", func() {
+				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+				helper.MatchAllInOutput(jsonOut, []string{"percona-server-mongodb-operator", "etcdoperator"})
+			})
+		})
+
+		Context("When operator backed services are created", func() {
+
+			JustBeforeEach(func() {
+				preSetup()
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+			})
+
+			It("should list the services if they exist", func() {
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
+
+				// now verify if the pods for the operator have started
+				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+				// Look for pod with example name because that's the name etcd will give to the pods.
+				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, "Running")
+				})
+
+				stdOut := helper.CmdShouldPass("odo", "service", "list")
+				helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
+
+				// now check for json output
+				jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+				helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
+
+				helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+
+				// Now let's check the output again to ensure expected behaviour
+				stdOut = helper.CmdShouldFail("odo", "service", "list")
+				jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
+
+				msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
+				msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
+				Expect(stdOut).To(ContainSubstring(msg))
+				helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
+			})
+		})
+
+		Context("When linking devfile component with Operator backed service", func() {
+			var context, currentWorkingDirectory, devfilePath string
+			const devfile = "devfile.yaml"
+
+			JustBeforeEach(func() {
+				preSetup()
+				context = helper.CreateNewContext()
+				devfilePath = filepath.Join(context, devfile)
+				currentWorkingDirectory = helper.Getwd()
+				helper.Chdir(context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
+			})
+
+			JustAfterEach(func() {
+				cleanPreSetup()
+				helper.Chdir(currentWorkingDirectory)
+				helper.DeleteDir(context)
+			})
+
+			It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+
+				componentName := helper.RandString(6)
+				helper.CmdShouldPass("odo", "create", componentName)
+
+				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
+				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
+				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+
+				stdOut = helper.CmdShouldFail("odo", "link", "/example")
+				Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			})
+
+			It("should fail if the provided service doesn't exist in the namespace", func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+
+				componentName := helper.RandString(6)
+				helper.CmdShouldPass("odo", "create", componentName)
+				helper.CmdShouldPass("odo", "push")
+
+				stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+				Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
+			})
+
+			It("should successfully connect and disconnect a component with an existing service", func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+
+				componentName := helper.RandString(6)
+				helper.CmdShouldPass("odo", "create", componentName)
+				helper.CmdShouldPass("odo", "push")
+
+				// start the Operator backed service first
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator))
+
+				// now verify if the pods for the operator have started
+				pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
+				// Look for pod with example name because that's the name etcd will give to the pods.
+				etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+				ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+					return strings.Contains(output, "Running")
+				})
+
+				stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+				Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
+				helper.CmdShouldPass("odo", "push")
+				stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+				Expect(stdOut).To(ContainSubstring("already linked with the service"))
+
+				stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
+				Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+				helper.CmdShouldPass("odo", "push")
+
+				// verify that sbr is deleted
+				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+				Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+
+				// next, delete a link outside of odo (using oc) and ensure that it throws an error
+				helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+				sbrName := strings.Join([]string{componentName, "etcdcluster", "example"}, "-")
+				helper.CmdShouldPass("oc", "delete", fmt.Sprintf("ServiceBindingRequest/%s", sbrName))
+				stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+				helper.MatchAllInOutput(stdOut, []string{"component's link with", "has been deleted outside odo"})
+			})
+		})
 })
+*/

--- a/tests/integration/servicecatalog/cmd_service_test.go
+++ b/tests/integration/servicecatalog/cmd_service_test.go
@@ -148,7 +148,7 @@ var _ = Describe("odo service command tests", func() {
 			helper.CopyExample(filepath.Join("source", "openjdk-sb-postgresql"), context)
 
 			// Local config needs to be present in order to create service https://github.com/openshift/odo/issues/1602
-			helper.CmdShouldPass("odo", "create", "java:8", "sb-app", "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "java:8", "sb-app", "--project", project)
 
 			// Create a URL
 			helper.CmdShouldPass("odo", "url", "create", "--port", "8080")
@@ -213,7 +213,7 @@ var _ = Describe("odo service command tests", func() {
 		It("should be able to create, list and delete a service using a given value for --context", func() {
 			// create a component by copying the example
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", "create", "python", "--app", app, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "--app", app, "--project", project)
 
 			// cd to the originalDir to create service using --context
 			helper.Chdir(originalDir)
@@ -239,7 +239,7 @@ var _ = Describe("odo service command tests", func() {
 		It("should be able to list services, as well as json list in a given app and project combination", func() {
 			// create a component by copying the example
 			helper.CopyExample(filepath.Join("source", "nodejs"), context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--app", app, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--app", app, "--project", project)
 
 			// create a service from within a component directory
 			helper.CmdShouldPass("odo", "service", "create", "dh-prometheus-apb", "--plan", "ephemeral",
@@ -304,10 +304,10 @@ var _ = Describe("odo service command tests", func() {
 		})
 		It("should link backend to service successfully", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context1)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", context1, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--context", context1, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context1)
 			helper.CopyExample(filepath.Join("source", "python"), context2)
-			helper.CmdShouldPass("odo", "create", "python", "backend", "--context", context2, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "backend", "--context", context2, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context2)
 			helper.CmdShouldPass("odo", "link", "backend", "--context", context1)
 			// Switching to context2 dir because --context flag is not supported with service command
@@ -336,10 +336,10 @@ var _ = Describe("odo service command tests", func() {
 		})
 		It("should pass", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), context1)
-			helper.CmdShouldPass("odo", "create", "nodejs", "frontend", "--context", context1, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "frontend", "--context", context1, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context1)
 			helper.CopyExample(filepath.Join("source", "python"), context2)
-			helper.CmdShouldPass("odo", "create", "python", "backend", "--context", context2, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "backend", "--context", context2, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context2)
 			helper.CmdShouldPass("odo", "link", "backend", "--context", context1)
 			helper.Chdir(context2)
@@ -373,10 +373,10 @@ var _ = Describe("odo service command tests", func() {
 
 		It("should print the environment variables being linked/unlinked", func() {
 			helper.CopyExample(filepath.Join("source", "python"), context1)
-			helper.CmdShouldPass("odo", "create", "python", "component1", "--context", context1, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "component1", "--context", context1, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context1)
 			helper.CopyExample(filepath.Join("source", "nodejs"), context2)
-			helper.CmdShouldPass("odo", "create", "nodejs", "component2", "--context", context2, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "component2", "--context", context2, "--project", project)
 			helper.CmdShouldPass("odo", "push", "--context", context2)
 
 			// tests for linking a component to a component
@@ -417,7 +417,7 @@ var _ = Describe("odo service command tests", func() {
 		It("should succeed when we're describing service that could have integer value for default field", func() {
 			// https://github.com/openshift/odo/issues/2488
 			helper.CopyExample(filepath.Join("source", "python"), context)
-			helper.CmdShouldPass("odo", "create", "python", "component1", "--context", context, "--project", project)
+			helper.CmdShouldPass("odo", "create", "--s2i", "python", "component1", "--context", context, "--project", project)
 			helper.Chdir(context)
 
 			helper.CmdShouldPass("odo", "catalog", "describe", "service", "dh-es-apb")


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind code-refactoring

**What does does this PR do / why we need it**:
It moves Operator Hub integration out of experimental mode. We need it for v2.

**Which issue(s) this PR fixes**:

Fixes #3595 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
* Tests should pass.
* If Operators are supported by the cluster (4.x), we ignore service catalog altogether.
* If user's working with 3.x cluster, odo should support Service Catalog (if enabled by the user).