### PR TITLE
Update s2i image from library for ppc64le

### DIFF
--- a/scripts/configure-installer-tests-cluster-ppc64le.sh
+++ b/scripts/configure-installer-tests-cluster-ppc64le.sh
@@ -105,7 +105,7 @@ oc annotate istag/wildfly:latest --namespace=openshift tags=builder --overwrite
 oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/nginx/imagestreams/nginx-rhel.json
 sleep 15
 oc annotate istag/nginx:latest --namespace=openshift tags=builder --overwrite
-oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/community/dotnet/imagestreams/dotnet-centos7.json
+oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/community/dotnet/imagestreams/dotnet-centos.json
 sleep 15
 oc annotate istag/dotnet:latest --namespace=openshift tags=builder --overwrite
 oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/php/imagestreams/php-rhel.json


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Similar to PR #3873 . The upstream library updated the link for s2i imagestreams. There are errors when running odo ci script on OCP/P. Errors of following types are observed.
```
++ oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/community/dotnet/imagestreams/dotnet-centos7.json
error: unable to read URL "https://raw.githubusercontent.com/openshift/library/master/community/dotnet/imagestreams/dotnet-centos7.json", server reported 404 Not Found, status code=404
++ sleep 15
++ oc annotate istag/dotnet:latest --namespace=openshift tags=builder --overwrite
Error from server (NotFound): imagestreamtags.image.openshift.io "dotnet" not found
```
**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
