### PR TITLE
Fix default registry support

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -216,16 +216,17 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 		Filename:   preferenceFile,
 	}
 
+	// Default devfile registry
+	defaultRegistryList := []Registry{
+		{
+			Name:   DefaultDevfileRegistryName,
+			URL:    DefaultDevfileRegistryURL,
+			Secure: false,
+		},
+	}
+
 	// If the preference file doesn't exist then we return with default preference
 	if _, err = os.Stat(preferenceFile); os.IsNotExist(err) {
-		// Handle user has preference file but doesn't use dynamic registry before
-		defaultRegistryList := []Registry{
-			{
-				Name:   DefaultDevfileRegistryName,
-				URL:    DefaultDevfileRegistryURL,
-				Secure: false,
-			},
-		}
 		c.OdoSettings.RegistryList = &defaultRegistryList
 		return &c, nil
 	}
@@ -233,6 +234,11 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 	err = util.GetFromFile(&c.Preference, c.Filename)
 	if err != nil {
 		return nil, err
+	}
+
+	// Handle user has preference file but doesn't use dynamic registry before
+	if c.OdoSettings.RegistryList == nil {
+		c.OdoSettings.RegistryList = &defaultRegistryList
 	}
 
 	return &c, nil

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNew(t *testing.T) {
@@ -26,8 +28,22 @@ func TestNew(t *testing.T) {
 		{
 			name: "Test filename is being set",
 			output: &PreferenceInfo{
-				Filename:   tempConfigFile.Name(),
-				Preference: NewPreference(),
+				Filename: tempConfigFile.Name(),
+				Preference: Preference{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       preferenceKind,
+						APIVersion: preferenceAPIVersion,
+					},
+					OdoSettings: OdoSettings{
+						RegistryList: &[]Registry{
+							{
+								Name:   DefaultDevfileRegistryName,
+								URL:    DefaultDevfileRegistryURL,
+								Secure: false,
+							},
+						},
+					},
+				},
 			},
 			success: true,
 		},


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Fix the case where default registry is not initialized when user already has a `preference.yaml` file without devfile registries

**Which issue(s) this PR fixes**:

Fixes #3940 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test  

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. Manually remove all devfile registries in `preference.yaml` file
2. Run `odo registry list`, `odo catalog list components` and `odo create <component type>`, all commands should work propertly