### PR TITLE
Add mandatory file ignores when using --ignore flag

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -513,7 +513,15 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 		*ignores = append(*ignores, rules...)
 	} else {
 		indexFile := pkgUtil.GetIndexFileRelativeToContext()
-		*ignores = append(*ignores, []string{indexFile, gitDirName}...)
+		// check if the ignores flag has the index file
+		if !pkgUtil.In(*ignores, indexFile) {
+			*ignores = append(*ignores, indexFile)
+		}
+
+		// check if the ignores flag has the git dir
+		if !pkgUtil.In(*ignores, gitDirName) {
+			*ignores = append(*ignores, gitDirName)
+		}
 	}
 	return nil
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -19,10 +19,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DefaultAppName is the default name of the application when an application name is not provided
 const (
+	// DefaultAppName is the default name of the application when an application name is not provided
 	DefaultAppName = "app"
-	gitDirName     = ".git"
+
+	// gitDirName is the git dir name in a project
+	gitDirName = ".git"
 )
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
@@ -500,8 +502,8 @@ func (o *Context) checkComponentExistsOrFail(cmp string) {
 	}
 }
 
-// ApplyIgnore will take the current ignores []string and either ignore it (if .odoignore is used)
-// or find the .gitignore file in the directory and use that instead.
+// ApplyIgnore will take the current ignores []string and append the mandatory odo-file-index.json and
+// .git ignores; or find the .odoignore/.gitignore file in the directory and use that instead.
 func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 	if len(*ignores) == 0 {
 		rules, err := pkgUtil.GetIgnoreRulesFromDirectory(sourcePath)

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -20,7 +20,10 @@ import (
 )
 
 // DefaultAppName is the default name of the application when an application name is not provided
-const DefaultAppName = "app"
+const (
+	DefaultAppName = "app"
+	gitDirName     = ".git"
+)
 
 // NewContext creates a new Context struct populated with the current state based on flags specified for the provided command
 func NewContext(command *cobra.Command, ignoreMissingConfiguration ...bool) *Context {
@@ -506,6 +509,9 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 			util.LogErrorAndExit(err, "")
 		}
 		*ignores = append(*ignores, rules...)
+	} else {
+		indexFile := pkgUtil.GetIndexFileRelativeToContext()
+		*ignores = append(*ignores, []string{indexFile, gitDirName}...)
 	}
 	return nil
 }

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -511,18 +511,19 @@ func ApplyIgnore(ignores *[]string, sourcePath string) (err error) {
 			util.LogErrorAndExit(err, "")
 		}
 		*ignores = append(*ignores, rules...)
-	} else {
-		indexFile := pkgUtil.GetIndexFileRelativeToContext()
-		// check if the ignores flag has the index file
-		if !pkgUtil.In(*ignores, indexFile) {
-			*ignores = append(*ignores, indexFile)
-		}
-
-		// check if the ignores flag has the git dir
-		if !pkgUtil.In(*ignores, gitDirName) {
-			*ignores = append(*ignores, gitDirName)
-		}
 	}
+
+	indexFile := pkgUtil.GetIndexFileRelativeToContext()
+	// check if the ignores flag has the index file
+	if !pkgUtil.In(*ignores, indexFile) {
+		*ignores = append(*ignores, indexFile)
+	}
+
+	// check if the ignores flag has the git dir
+	if !pkgUtil.In(*ignores, gitDirName) {
+		*ignores = append(*ignores, gitDirName)
+	}
+
 	return nil
 }
 

--- a/pkg/util/file_indexer.go
+++ b/pkg/util/file_indexer.go
@@ -85,6 +85,11 @@ func ResolveIndexFilePath(directory string) (string, error) {
 	return directory, nil
 }
 
+// GetIndexFileRelativeToContext returns the index file relative to context i.e.; .odo/odo-file-index.json
+func GetIndexFileRelativeToContext() string {
+	return filepath.Join(fileIndexDirectory, fileIndexName)
+}
+
 // AddOdoFileIndex adds odo-file-index.json to .gitignore
 func AddOdoFileIndex(gitIgnoreFile string) error {
 	return addOdoFileIndex(gitIgnoreFile, filesystem.DefaultFs{})

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -219,6 +219,27 @@ var _ = Describe("odo devfile watch command tests", func() {
 		})
 	})
 
+	Context("when executing odo watch after odo push with ignores flag", func() {
+		It("should be able to ignore the specified file, .git and odo-file-index.json ", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run", "--project", namespace)
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			watchFlag := "--ignore doignoreme.txt"
+			odoV2Watch := utils.OdoV2Watch{
+				CmpName:               cmpName,
+				StringsToBeMatched:    []string{"donotignoreme.txt changed", "Executing devbuild command", "Executing devrun command"},
+				StringsNotToBeMatched: []string{"doignoreme.txt changed", "odo-file-index.json changed", ".git/index changed"},
+			}
+			// odo watch and validate
+			utils.OdoWatchWithIgnore(odoV2Watch, context, watchFlag)
+		})
+	})
+
 	Context("when executing odo watch", func() {
 		It("ensure that index information is updated by watch", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, cmpName)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -347,8 +347,9 @@ type OdoV1Watch struct {
 }
 
 type OdoV2Watch struct {
-	CmpName            string
-	StringsToBeMatched []string
+	CmpName               string
+	StringsToBeMatched    []string
+	StringsNotToBeMatched []string
 }
 
 // OdoWatch creates files, dir in the context and watches for the changes to be pushed
@@ -491,6 +492,56 @@ func OdoWatchWithDebug(odoV2Watch OdoV2Watch, context, flag string) {
 				// We are just using this to validate if nodejs agent is listening on the other side
 				helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
 
+				return true
+			}
+
+			return false
+		},
+		startSimulationCh,
+		func(output string) bool {
+			return strings.Contains(output, "Waiting for something to change")
+		})
+
+	Expect(success).To(Equal(true))
+	Expect(err).To(BeNil())
+}
+
+// OdoWatchWithIgnore checks if odo watch ignores the specified files and
+// it also checks if odo-file-index.json and .git are ignored
+// when --ignores is used
+func OdoWatchWithIgnore(odoV2Watch OdoV2Watch, context, flag string) {
+
+	startSimulationCh := make(chan bool)
+	go func() {
+		startMsg := <-startSimulationCh
+		if startMsg {
+			_, err := os.Create(filepath.Join(context, "doignoreme.txt"))
+			Expect(err).To(BeNil())
+
+			_, err = os.Create(filepath.Join(context, "donotignoreme.txt"))
+			Expect(err).To(BeNil())
+		}
+	}()
+
+	success, err := helper.WatchNonRetCmdStdOut(
+		("odo watch " + flag + " --context " + context),
+		time.Duration(5)*time.Minute,
+		func(output string) bool {
+			stringsMatched := true
+			for _, stringToBeMatched := range odoV2Watch.StringsToBeMatched {
+				if !strings.Contains(output, stringToBeMatched) {
+					stringsMatched = false
+				}
+			}
+
+			stringsNotMatched := true
+			for _, stringNotToBeMatched := range odoV2Watch.StringsNotToBeMatched {
+				if strings.Contains(output, stringNotToBeMatched) {
+					stringsNotMatched = false
+				}
+			}
+
+			if stringsMatched && stringsNotMatched {
 				return true
 			}
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

**What type of PR is this?**
/kind bug


**What does does this PR do / why we need it**:
- previously when we used `--ignore`, `.odoignore`/`.gitignore` was overwritten. Hence if odo index file `.odo/odo-file-index.json` changed due to a file change, it got stuck in an infinite loop
- Similarly, if the local project was a git project, it would build more than once for `.git` changes
- This PR adds `.odo/odo-file-index.json` & `.git` to the list of ignored files when `--ignores` is used

**Which issue(s) this PR fixes**:

Fixes #3819 
Fixes #3961

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo watch --ignore some.txt` and create a file in the component directory. It should only build once.