### PR TITLE
3923- url creation with optional port flag

### DIFF
--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -155,55 +155,53 @@ func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string)
 		o.devObj = devObj
 		componentName := o.EnvSpecificInfo.GetName()
 
-		if o.isDocker {
-			var portList []string
-			containers, err := adapterutils.GetContainers(devObj)
-			if err != nil {
-				return err
-			}
-			if len(containers) == 0 {
-				return fmt.Errorf("no valid components found in the devfile")
-			}
-			compWithEndpoint := 0
-			for _, c := range containers {
-				if len(c.Ports) != 0 {
-					compWithEndpoint++
-					for _, port := range c.Ports {
-						portList = append(portList, strconv.FormatInt(int64(port.ContainerPort), 10))
-					}
-				}
-				if compWithEndpoint > 1 {
-					return fmt.Errorf("devfile should only have one component containing endpoint")
+		var portList []string
+		containers, err := adapterutils.GetContainers(devObj)
+		if err != nil {
+			return err
+		}
+		if len(containers) == 0 {
+			return fmt.Errorf("no valid components found in the devfile")
+		}
+		compWithEndpoint := 0
+		for _, c := range containers {
+			if len(c.Ports) != 0 {
+				compWithEndpoint++
+				for _, port := range c.Ports {
+					portList = append(portList, strconv.FormatInt(int64(port.ContainerPort), 10))
 				}
 			}
-			if compWithEndpoint == 0 {
-				return fmt.Errorf("no valid component with an endpoint found in the devfile")
+			if compWithEndpoint > 1 && o.isDocker {
+				return fmt.Errorf("devfile should only have one component containing endpoint")
 			}
+		}
+		if compWithEndpoint == 0 && o.isDocker {
+			return fmt.Errorf("no valid component with an endpoint found in the devfile")
+		}
+		if o.isDocker || o.urlPort == -1 {
 			o.componentPort, err = url.GetValidPortNumber(componentName, o.urlPort, portList)
 			if err != nil {
 				return err
 			}
+		} else {
+			o.componentPort = o.urlPort
+		}
+
+		if len(args) != 0 {
+			o.urlName = args[0]
+		} else {
+			o.urlName = url.GetURLName(componentName, o.componentPort)
+		}
+
+		if o.isDocker {
 			o.exposedPort, err = url.GetValidExposedPortNumber(o.exposedPort)
 			if err != nil {
 				return err
 			}
 			o.urlType = envinfo.DOCKER
 		} else {
-			if o.urlPort == -1 {
-				return fmt.Errorf("port must be provided to create an endpoint entry in devfile")
-			}
-			o.componentPort = o.urlPort
-			if len(args) != 0 {
-				o.urlName = args[0]
-			} else {
-				o.urlName = url.GetURLName(componentName, o.componentPort)
-			}
-
 			foundContainer := false
 			containerComponents := adaptersCommon.GetDevfileContainerComponents(devObj.Data)
-			if len(containerComponents) == 0 {
-				return fmt.Errorf("no valid components found in the devfile")
-			}
 			// map TargetPort with containerName
 			containerPortMap := make(map[int]string)
 			for _, component := range containerComponents {
@@ -219,6 +217,7 @@ func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string)
 					containerPortMap[int(endpoint.TargetPort)] = component.Name
 				}
 			}
+
 			if len(o.container) > 0 && !foundContainer {
 				return fmt.Errorf("the container specified: %v does not exist in devfile", o.container)
 			}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -164,11 +164,13 @@ func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string)
 			return fmt.Errorf("no valid components found in the devfile")
 		}
 		compWithEndpoint := 0
+		portMap := make(map[string]bool)
 		for _, c := range containers {
 			if len(c.Ports) != 0 {
 				compWithEndpoint++
 				for _, port := range c.Ports {
-					portList = append(portList, strconv.FormatInt(int64(port.ContainerPort), 10))
+					// use map to filter out duplicated ports
+					portMap[strconv.FormatInt(int64(port.ContainerPort), 10)] = true
 				}
 			}
 			if compWithEndpoint > 1 && o.isDocker {
@@ -177,6 +179,9 @@ func (o *URLCreateOptions) Complete(_ string, cmd *cobra.Command, args []string)
 		}
 		if compWithEndpoint == 0 && o.isDocker {
 			return fmt.Errorf("no valid component with an endpoint found in the devfile")
+		}
+		for port := range portMap {
+			portList = append(portList, port)
 		}
 		if o.isDocker || o.urlPort == -1 {
 			o.componentPort, err = url.GetValidPortNumber(componentName, o.urlPort, portList)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -124,7 +124,9 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 
-			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--secure", "--ingress")
+			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
+			stdout := helper.CmdShouldPass("odo", "url", "list")
+			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed"})
 		})
 
 		It("should create a secure URL", func() {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -115,6 +115,18 @@ var _ = Describe("odo devfile url command tests", func() {
 	})
 
 	Context("Creating urls", func() {
+		It("should create a URL without port flag if only one port exposed in devfile", func() {
+			url1 := helper.RandString(5)
+			host := helper.RandString(5) + ".com"
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", namespace, componentName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--secure", "--ingress")
+		})
+
 		It("should create a secure URL", func() {
 			url1 := helper.RandString(5)
 			host := helper.RandString(5) + ".com"

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -126,7 +126,7 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
 			stdout := helper.CmdShouldPass("odo", "url", "list")
-			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed"})
+			helper.MatchAllInOutput(stdout, []string{url1, "3000", "Not Pushed"})
 		})
 
 		It("should create a secure URL", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area devfile
/area url


**What does does this PR do / why we need it**:
The `--port` flag should be an optional flag if there is only one port exposed in devfile. 
This PR fixes the regression.

Also created an integration test for the specific case

**Which issue(s) this PR fixes**:

Fixes #3923 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-cmd-devfile-url`


Manual Test: 
`odo url create` should successfully create an endpoint in devfile