### PR TITLE
Remove references to Docker support

### DIFF
--- a/docs/public/community.adoc
+++ b/docs/public/community.adoc
@@ -55,8 +55,7 @@ https://groups.google.com/forum/#!forum/odo-dev[odo-dev Google group].
 
 === Where do I start?
 
-odo is a complex project that touches both Kubernetes, OpenShift and
-Docker. We have a list of
+odo is a complex project that touches both Kubernetes and OpenShift. We have a list of
 https://github.com/openshift/odo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22[good
 first issues] to help start.
 

--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -10,7 +10,7 @@ With a devfile you can describe:
 * A list of pre-defined commands that can be run
 * Projects to initially clone
 
-odo takes this devfile and transforms it into a workspace of multiple containers running on OpenShift, Kubernetes or Docker.
+odo takes this devfile and transforms it into a workspace of multiple containers running on Kubernetes or OpenShift.
 
 Devfiles are YAML files with a defined https://devfile.github.io/devfile/_attachments/api-reference.html[schema].
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Removes references to deploying via Docker

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Unit test

- [ ] Integration test

- [X] Documentation

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>