### PR TITLE
s2i component fix: use Config instead of ContainerConfig for port detection

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -602,10 +602,16 @@ func getExposedPortsFromISI(image *imagev1.ImageStreamImage) ([]corev1.Container
 	var ports []corev1.ContainerPort
 
 	var exposedPorts = image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).ContainerConfig.ExposedPorts
-	if len(exposedPorts) == 0 {
-		// if ContainerConfig is empty use ExposedPorts from Config struct
-		if image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config != nil {
-			exposedPorts = image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config.ExposedPorts
+
+	if image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config != nil {
+		if exposedPorts == nil {
+			exposedPorts = make(map[string]struct{})
+		}
+
+		// add ports from Config
+		for exposedPort := range image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config.ExposedPorts {
+			var emptyStruct struct{}
+			exposedPorts[exposedPort] = emptyStruct
 		}
 	}
 

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -601,7 +601,15 @@ func getExposedPortsFromISI(image *imagev1.ImageStreamImage) ([]corev1.Container
 
 	var ports []corev1.ContainerPort
 
-	for exposedPort := range image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config.ExposedPorts {
+	var exposedPorts = image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).ContainerConfig.ExposedPorts
+	if len(exposedPorts) == 0 {
+		// if ContainerConfig is empty use ExposedPorts from Config struct
+		if image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config != nil {
+			exposedPorts = image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config.ExposedPorts
+		}
+	}
+
+	for exposedPort := range exposedPorts {
 		splits := strings.Split(exposedPort, "/")
 		if len(splits) != 2 {
 			return nil, fmt.Errorf("invalid port %s", exposedPort)

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -601,7 +601,7 @@ func getExposedPortsFromISI(image *imagev1.ImageStreamImage) ([]corev1.Container
 
 	var ports []corev1.ContainerPort
 
-	for exposedPort := range image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).ContainerConfig.ExposedPorts {
+	for exposedPort := range image.Image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage).Config.ExposedPorts {
 		splits := strings.Split(exposedPort, "/")
 		if len(splits) != 2 {
 			return nil, fmt.Errorf("invalid port %s", exposedPort)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug


**What does does this PR do / why we need it**:

s2i builder images available on OCP 4.6 has metadata where exposed ports are listed only in `Config` section.
Previously we were incorrectly using Exposed ports from `ContainerConfig`.  

**Which issue(s) this PR fixes**:

fixes https://github.com/openshift/odo/issues/3882


**How to test changes / Special notes to the reviewer**:

`odo create nodejs --s2i` on OCP 4.6 used to fail, now it should work. you can check issue for more info
