### PR TITLE
Update odo debug --help screen

### DIFF
--- a/pkg/odo/cli/debug/debug.go
+++ b/pkg/odo/cli/debug/debug.go
@@ -1,8 +1,11 @@
 package debug
 
 import (
+	"fmt"
+
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/spf13/cobra"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
 const (
@@ -12,9 +15,7 @@ const (
 	devfile = "devfile.yaml"
 )
 
-var DebugLongDesc = `Warning - Debug is currently in tech preview and hence is subject to change in future.
-
-Debug allows you to remotely debug your application`
+var debugLongDesc = ktemplates.LongDesc(`Debug allows you to remotely debug your application.`)
 
 func NewCmdDebug(name, fullName string) *cobra.Command {
 
@@ -22,9 +23,12 @@ func NewCmdDebug(name, fullName string) *cobra.Command {
 	infoCmd := NewCmdInfo(infoCommandName, util.GetFullName(fullName, infoCommandName))
 
 	debugCmd := &cobra.Command{
-		Use:     name,
-		Short:   "Debug commands",
-		Long:    DebugLongDesc,
+		Use:   name,
+		Short: "Debug commands",
+		Example: fmt.Sprintf("%s\n\n%s",
+			portforwardCmd.Example,
+			infoCmd.Example),
+		Long:    debugLongDesc,
 		Aliases: []string{"d"},
 	}
 

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -45,10 +45,7 @@ type PortForwardOptions struct {
 }
 
 var (
-	portforwardLong = templates.LongDesc(`
-			Forward a local port to a remote port on the pod where the application is listening for a debugger.
-
-			By default the local port and the remote port will be same. To change the local port you can use --local-port argument and to change the remote port use "odo config set DebugPort <port>"   		  
+	portforwardLong = templates.LongDesc(`Forward a local port to a remote port on the pod where the application is listening for a debugger. By default the local port and the remote port will be same. To change the local port you can use --local-port argument and to change the remote port use "odo env set DebugPort <port>"   		  
 	`)
 
 	portforwardExample = templates.Examples(`


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:

Updates the debug output of `odo debug --help` to the following:

```sh
github.com/openshift/odo  debugging-docs-update ✔                                                                                                                                                                                                                                                                                                                      53m
▶ ./odo debug --help
Debug allows you to remotely debug your application.

Usage:
  odo debug [flags]
  odo debug [command]

Aliases:
  debug, d

Examples:
  # Listen on default port and forwarding to the default port in the pod
  odo debug port-forward

  # Listen on the 5000 port locally, forwarding to default port in the pod
  odo debug port-forward --local-port 5000

  # Get information regarding any debug session of the component
  odo debug info

Available Commands:
  info         Displays debug info of a component
  port-forward Forward one or more local ports to a pod

Flags:
  -h, --help   Help for debug

Additional Flags:
  -v, --v Level              Number for the log level verbosity. Level varies from 0 to 9 (default 0).
      --vmodule moduleSpec   Comma-separated list of pattern=N settings for file-filtered logging

Use "odo debug [command] --help" for more information about a command.
```

**Which issue(s) this PR fixes**:

Closes https://github.com/openshift/odo/issues/3871

**PR acceptance criteria**:

- [ ] Unit test

- [ ] Integration test

- [ ] Documentation

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**: