### PR TITLE
Add owners to gh pages

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- dharmit
+- girishramnani
+- cdrage


### PR DESCRIPTION
/kind documentation
[skip ci]

**What does does this PR do / why we need it**:
Add OWNERS file to gh-pages branch, so we can approve PRs

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
