### PR TITLE
Enable link unlink target for 311 servicecatalog test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
         - sudo cp odo /usr/bin
         - odo login -u developer
         - travis_wait make test-cmd-service
-        - travis_wait make test-cmd-link-unlink
+        - travis_wait make test-cmd-link-unlink-311-cluster
         - odo logout
 
     - <<: *base-test

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,15 @@ test-generic:
 test-cmd-login-logout:
 	ginkgo $(GINKGO_FLAGS_SERIAL) -focus="odo login and logout command tests" tests/integration/loginlogout/
 
-# Run link and unlink command tests
-.PHONY: test-cmd-link-unlink
-test-cmd-link-unlink:
-	ginkgo $(GINKGO_FLAGS) -focus="odo link and unlink command tests" tests/integration/
+# Run link and unlink commnad tests against 4.x cluster
+.PHONY: test-cmd-link-unlink-4-cluster
+test-cmd-link-unlink-4-cluster:
+	ginkgo $(GINKGO_FLAGS) -focus="odo link and unlink commnad tests" tests/integration/
+
+# Run link and unlink command tests against 3.11 cluster
+.PHONY: test-cmd-link-unlink-311-cluster
+test-cmd-link-unlink-311-cluster:
+	ginkgo $(GINKGO_FLAGS) -focus="odo link and unlink command tests" tests/integration/servicecatalog/
 
 # Run odo service command tests
 .PHONY: test-cmd-service


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup


**What does does this PR do / why we need it**:
link unlink test file target was only for 4.x cluster and there was no test target for same link unlink test file that resides in service- catalog, so I just created seperate target for link unlink service catalog target for 3.11 

**Which issue(s) this PR fixes**:

Fixes N/A

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
make test-cmd-link-unlink-4-cluster
make test-cmd-link-unlink-311-cluster