### PR TITLE
Save PROJECT_SOURCE for containers mounting source

### DIFF
--- a/docs/file-reference/index.md
+++ b/docs/file-reference/index.md
@@ -380,7 +380,7 @@ components:
 | image          | string                                  | yes      | Image version                                                                                               |
 | memoryLimit    | string                                  | no       | Memory limit to be used with your container                                                                 |
 | mountSources   | boolean                                 | no       | Mount the source or not                                                                                     |
-| sourceMapping  | string                                  | no       | Path in the container where project sources should be transferred / mounted when mountSource is set to true |
+| sourceMapping  | string                                  | no       | Path in the container where project sources should be transferred / mounted when mountSource is set to true, `/projects` if absent. This is available in the container via env `PROJECTS_ROOT` |
 | endpoints[]    | [endpointObject](#endpointobject)       | no       | List of endpoints to use                                                                                    |
 | volumeMounts[] | [volumeMountsObject](#volumemountsobject) | no       | List of volumes to mount                                                                                    |
 | env[]          | [envObject](#envobject)                 | no       | List of environment variables to use                                                                        |
@@ -610,7 +610,7 @@ Please refer to the below table for a list of features which are *not yet* imple
 | Key                                | Key Description                                | Status      | Description                                                                                     |
 |------------------------------------|------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------|
 | starterProjects[].clonePath        | [starterProjectObject](#starterproject-object) | IN PROGRESS | Refer to issue: https://github.com/openshift/odo/issues/3729                                     |
-| projects[]                         | [projectObject](#projectobject)                        | IN PROGRESS | Entire object not yet implemented. Refer to issue: https://github.com/openshift/odo/issues/3798 |
+| projects[]                         | [projectObject](#projectobject)                        | IN PROGRESS | Entire object not yet implemented. Refer to issue: https://github.com/openshift/odo/issues/3798. Project source path in the container is available via ENV `PROJECT_SOURCE`. If there are multiple projects, `PROJECT_SOURCE` would point to the first project |
 | parent                             | [parentObject](#parent-object)                 | IN PROGRESS | Refer to issue: https://github.com/openshift/odo/issues/2936                                    |
 | events                             | [eventObject](#event-object)                   | IN PROGRESS | Refer to postStop issue: https://github.com/openshift/odo/issues/3577                                    |
 | component[].kubernetes             | [kubernetesObject](#kubernetesobject)          | IN PROGRESS |                                                                                                 |

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -64,8 +64,11 @@ const (
 	// DefaultVolumeSize Default volume size for volumes defined in a devfile
 	DefaultVolumeSize = "1Gi"
 
-	// EnvProjectsRoot is the env defined for /projects where component mountSources=true
+	// EnvProjectsRoot is the env defined for project mount in a component container when component's mountSources=true
 	EnvProjectsRoot = "PROJECTS_ROOT"
+
+	// EnvProjectsSrc is the env defined for path to the project source in a component container
+	EnvProjectsSrc = "PROJECT_SOURCE"
 
 	// EnvOdoCommandRunWorkingDir is the env defined in the runtime component container which holds the work dir for the run command
 	EnvOdoCommandRunWorkingDir = "ODO_COMMAND_RUN_WORKING_DIR"

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -129,6 +129,8 @@ func GetContainers(devfileObj devfileParser.DevfileObj) ([]corev1.Container, err
 						Name:  adaptersCommon.EnvProjectsSrc,
 						Value: syncFolder,
 					})
+			} else {
+				return nil, fmt.Errorf("env variable %s is reserved and cannot be customized in component %s", adaptersCommon.EnvProjectsSrc, comp.Name)
 			}
 
 		}

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -8,7 +8,6 @@ import (
 
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
-	devData "github.com/openshift/odo/pkg/devfile/parser/data"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	versionsCommon "github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/kclient"
@@ -660,12 +659,261 @@ func TestUpdateContainersWithSupervisord(t *testing.T) {
 	}
 }
 
+func TestGetContainers(t *testing.T) {
+
+	containerNames := []string{"testcontainer1", "testcontainer2"}
+	containerImages := []string{"image1", "image2"}
+
+	tests := []struct {
+		name                  string
+		containerComponents   []common.DevfileComponent
+		wantContainerName     string
+		wantContainerImage    string
+		wantContainerEnv      []corev1.EnvVar
+		wantContainerVolMount []corev1.VolumeMount
+		wantErr               bool
+	}{
+		{
+			name: "Case 1: Container with default project root",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image:        containerImages[0],
+						MountSources: true,
+					},
+				},
+			},
+			wantContainerName:  containerNames[0],
+			wantContainerImage: containerImages[0],
+			wantContainerEnv: []corev1.EnvVar{
+
+				{
+					Name:  "PROJECTS_ROOT",
+					Value: "/projects",
+				},
+				{
+					Name:  "PROJECT_SOURCE",
+					Value: "/projects/test-project",
+				},
+			},
+			wantContainerVolMount: []corev1.VolumeMount{
+				{
+					Name:      "odo-projects",
+					MountPath: "/projects",
+				},
+			},
+		},
+		{
+			name: "Case 2: Container with source mapping",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image:         containerImages[0],
+						MountSources:  true,
+						SourceMapping: "/myroot",
+					},
+				},
+			},
+			wantContainerName:  containerNames[0],
+			wantContainerImage: containerImages[0],
+			wantContainerEnv: []corev1.EnvVar{
+
+				{
+					Name:  "PROJECTS_ROOT",
+					Value: "/myroot",
+				},
+				{
+					Name:  "PROJECT_SOURCE",
+					Value: "/myroot/test-project",
+				},
+			},
+			wantContainerVolMount: []corev1.VolumeMount{
+				{
+					Name:      "odo-projects",
+					MountPath: "/myroot",
+				},
+			},
+		},
+		{
+			name: "Case 3: Container with custom PROJECTS_ROOT env",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image:        containerImages[0],
+						MountSources: true,
+						Env: []common.Env{
+							{
+								Name:  "PROJECTS_ROOT",
+								Value: "/my/custom/path",
+							},
+						},
+					},
+				},
+			},
+			wantContainerName:  containerNames[0],
+			wantContainerImage: containerImages[0],
+			wantContainerEnv: []corev1.EnvVar{
+
+				{
+					Name:  "PROJECTS_ROOT",
+					Value: "/my/custom/path",
+				},
+				{
+					Name:  "PROJECT_SOURCE",
+					Value: "/my/custom/path/test-project",
+				},
+			},
+			wantContainerVolMount: []corev1.VolumeMount{
+				{
+					Name:      "odo-projects",
+					MountPath: "/my/custom/path",
+				},
+			},
+		},
+		{
+			name: "Case 4: Invalid container with custom PROJECT_SOURCE env",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image:        containerImages[0],
+						MountSources: true,
+						Env: []common.Env{
+							{
+								Name:  "PROJECTS_ROOT",
+								Value: "/my/custom/path",
+							},
+							{
+								Name:  "PROJECT_SOURCE",
+								Value: "/my/invalid/path",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 5: Container with no mount source",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image: containerImages[0],
+					},
+				},
+			},
+			wantContainerName:  containerNames[0],
+			wantContainerImage: containerImages[0],
+		},
+		{
+			name: "Case 6: Invalid container with same endpoint names",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image:        containerImages[0],
+						MountSources: true,
+						Endpoints: []common.Endpoint{
+							{
+								Name:       "url1",
+								TargetPort: 8080,
+								Exposure:   common.Public,
+							},
+						},
+					},
+				},
+				{
+					Name: containerNames[1],
+					Container: &common.Container{
+						Image:        containerImages[1],
+						MountSources: true,
+						Endpoints: []common.Endpoint{
+							{
+								Name:       "url1",
+								TargetPort: 8081,
+								Exposure:   common.Public,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Case 7: Invalid container with same endpoint target ports",
+			containerComponents: []common.DevfileComponent{
+				{
+					Name: containerNames[0],
+					Container: &common.Container{
+						Image: containerImages[0],
+						Endpoints: []common.Endpoint{
+							{
+								Name:       "url1",
+								TargetPort: 8080,
+							},
+						},
+					},
+				},
+				{
+					Name: containerNames[1],
+					Container: &common.Container{
+						Image: containerImages[1],
+						Endpoints: []common.Endpoint{
+							{
+								Name:       "url2",
+								TargetPort: 8080,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			devObj := devfileParser.DevfileObj{
+				Data: &testingutil.TestDevfileData{
+					Components: tt.containerComponents,
+				},
+			}
+
+			containers, err := GetContainers(devObj)
+			if err != nil && !tt.wantErr {
+				t.Errorf("TestGetContainers unexpected error: %v", err)
+			} else if err == nil && tt.wantErr {
+				t.Errorf("TestGetContainers unexpected test failure: want err but got no err")
+			} else {
+				for _, container := range containers {
+					if container.Name != tt.wantContainerName {
+						t.Errorf("TestGetContainers error: Name mismatch - got: %s, wanted: %s", container.Name, tt.wantContainerName)
+					}
+					if container.Image != tt.wantContainerImage {
+						t.Errorf("TestGetContainers error: Image mismatch - got: %s, wanted: %s", container.Image, tt.wantContainerImage)
+					}
+					if len(container.Env) > 0 && !reflect.DeepEqual(container.Env, tt.wantContainerEnv) {
+						t.Errorf("TestGetContainers error: Env mismatch - got: %+v, wanted: %+v", container.Env, tt.wantContainerEnv)
+					}
+					if len(container.VolumeMounts) > 0 && !reflect.DeepEqual(container.VolumeMounts, tt.wantContainerVolMount) {
+						t.Errorf("TestGetContainers error: Vol Mount mismatch - got: %+v, wanted: %+v", container.VolumeMounts, tt.wantContainerVolMount)
+					}
+				}
+			}
+		})
+	}
+
+}
+
 func TestGetPortExposure(t *testing.T) {
 	urlName := "testurl"
 	urlName2 := "testurl2"
 	tests := []struct {
 		name                string
-		devfileData         devData.DevfileData
 		containerComponents []common.DevfileComponent
 		wantMap             map[int32]common.ExposureType
 		wantErr             bool

--- a/pkg/devfile/adapters/kubernetes/utils/utils_test.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils_test.go
@@ -737,67 +737,7 @@ func TestGetContainers(t *testing.T) {
 			},
 		},
 		{
-			name: "Case 3: Container with custom PROJECTS_ROOT env",
-			containerComponents: []common.DevfileComponent{
-				{
-					Name: containerNames[0],
-					Container: &common.Container{
-						Image:        containerImages[0],
-						MountSources: true,
-						Env: []common.Env{
-							{
-								Name:  "PROJECTS_ROOT",
-								Value: "/my/custom/path",
-							},
-						},
-					},
-				},
-			},
-			wantContainerName:  containerNames[0],
-			wantContainerImage: containerImages[0],
-			wantContainerEnv: []corev1.EnvVar{
-
-				{
-					Name:  "PROJECTS_ROOT",
-					Value: "/my/custom/path",
-				},
-				{
-					Name:  "PROJECT_SOURCE",
-					Value: "/my/custom/path/test-project",
-				},
-			},
-			wantContainerVolMount: []corev1.VolumeMount{
-				{
-					Name:      "odo-projects",
-					MountPath: "/my/custom/path",
-				},
-			},
-		},
-		{
-			name: "Case 4: Invalid container with custom PROJECT_SOURCE env",
-			containerComponents: []common.DevfileComponent{
-				{
-					Name: containerNames[0],
-					Container: &common.Container{
-						Image:        containerImages[0],
-						MountSources: true,
-						Env: []common.Env{
-							{
-								Name:  "PROJECTS_ROOT",
-								Value: "/my/custom/path",
-							},
-							{
-								Name:  "PROJECT_SOURCE",
-								Value: "/my/invalid/path",
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Case 5: Container with no mount source",
+			name: "Case 3: Container with no mount source",
 			containerComponents: []common.DevfileComponent{
 				{
 					Name: containerNames[0],
@@ -810,7 +750,7 @@ func TestGetContainers(t *testing.T) {
 			wantContainerImage: containerImages[0],
 		},
 		{
-			name: "Case 6: Invalid container with same endpoint names",
+			name: "Case 4: Invalid container with same endpoint names",
 			containerComponents: []common.DevfileComponent{
 				{
 					Name: containerNames[0],
@@ -844,7 +784,7 @@ func TestGetContainers(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Case 7: Invalid container with same endpoint target ports",
+			name: "Case 5: Invalid container with same endpoint target ports",
 			containerComponents: []common.DevfileComponent{
 				{
 					Name: containerNames[0],

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -33,10 +33,12 @@ func validateComponents(components []common.DevfileComponent) error {
 				}
 			}
 
-			// Check if any containers are customizing the reserved PROJECT_SOURCE env
+			// Check if any containers are customizing the reserved PROJECT_SOURCE or PROJECTS_ROOT env
 			for _, env := range component.Container.Env {
 				if env.Name == adaptersCommon.EnvProjectsSrc {
 					return &ReservedEnvError{envName: adaptersCommon.EnvProjectsSrc, componentName: component.Name}
+				} else if env.Name == adaptersCommon.EnvProjectsRoot {
+					return &ReservedEnvError{envName: adaptersCommon.EnvProjectsRoot, componentName: component.Name}
 				}
 			}
 		}

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"strings"
 
+	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +30,13 @@ func validateComponents(components []common.DevfileComponent) error {
 			for _, volumeMount := range component.Container.VolumeMounts {
 				if _, ok := processedVolumeMounts[volumeMount.Name]; !ok {
 					processedVolumeMounts[volumeMount.Name] = true
+				}
+			}
+
+			// Check if any containers are customizing the reserved PROJECT_SOURCE env
+			for _, env := range component.Container.Env {
+				if env.Name == adaptersCommon.EnvProjectsSrc {
+					return &ReservedEnvError{envName: adaptersCommon.EnvProjectsSrc, componentName: component.Name}
 				}
 			}
 		}

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -1,10 +1,12 @@
 package validate
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 )
 
@@ -102,6 +104,32 @@ func TestValidateComponents(t *testing.T) {
 
 		if got != nil {
 			t.Errorf("TestValidateComponents error - got: '%v'", got)
+		}
+	})
+
+	t.Run("Invalid container using reserved env", func(t *testing.T) {
+
+		envName := adaptersCommon.EnvProjectsSrc
+
+		components := []common.DevfileComponent{
+			{
+				Name: "container",
+				Container: &common.Container{
+					Env: []common.Env{
+						{
+							Name:  envName,
+							Value: "/some/path/",
+						},
+					},
+				},
+			},
+		}
+
+		got := validateComponents(components)
+		want := fmt.Sprintf("env variable %s is reserved and cannot be customized in component container", envName)
+
+		if got != nil && !strings.Contains(got.Error(), want) {
+			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
 		}
 	})
 

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -109,27 +109,29 @@ func TestValidateComponents(t *testing.T) {
 
 	t.Run("Invalid container using reserved env", func(t *testing.T) {
 
-		envName := adaptersCommon.EnvProjectsSrc
+		envName := []string{adaptersCommon.EnvProjectsSrc, adaptersCommon.EnvProjectsRoot}
 
-		components := []common.DevfileComponent{
-			{
-				Name: "container",
-				Container: &common.Container{
-					Env: []common.Env{
-						{
-							Name:  envName,
-							Value: "/some/path/",
+		for _, env := range envName {
+			components := []common.DevfileComponent{
+				{
+					Name: "container",
+					Container: &common.Container{
+						Env: []common.Env{
+							{
+								Name:  env,
+								Value: "/some/path/",
+							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		got := validateComponents(components)
-		want := fmt.Sprintf("env variable %s is reserved and cannot be customized in component container", envName)
+			got := validateComponents(components)
+			want := fmt.Sprintf("env variable %s is reserved and cannot be customized in component container", env)
 
-		if got != nil && !strings.Contains(got.Error(), want) {
-			t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
+			if got != nil && !strings.Contains(got.Error(), want) {
+				t.Errorf("TestValidateComponents error - got: '%v', want substring: '%v'", got.Error(), want)
+			}
 		}
 	})
 

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -41,6 +41,16 @@ func (e *InvalidVolumeSizeError) Error() string {
 	return fmt.Sprintf("size %s for volume component %s is invalid: %v. Example - 2Gi, 1024Mi", e.size, e.componentName, e.validationError)
 }
 
+// ReservedEnvError returns an error if the user attempts to customize a reserved ENV in a container
+type ReservedEnvError struct {
+	componentName string
+	envName       string
+}
+
+func (e *ReservedEnvError) Error() string {
+	return fmt.Sprintf("env variable %s is reserved and cannot be customized in component %s", e.envName, e.componentName)
+}
+
 // MissingVolumeMountError returns an error if the container volume mount does not reference a valid volume component
 type MissingVolumeMountError struct {
 	volumeName string

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -248,16 +248,16 @@ func GetSyncFolder(sourceVolumePath string, projects []parserCommon.DevfileProje
 
 	if project.ClonePath != "" {
 		if strings.HasPrefix(project.ClonePath, "/") {
-			return "", fmt.Errorf("the clonePath in the devfile must be a relative path")
+			return "", fmt.Errorf("the clonePath %s in the devfile project %s must be a relative path", project.ClonePath, project.Name)
 		}
 		if strings.Contains(project.ClonePath, "..") {
-			return "", fmt.Errorf("the clonePath in the devfile cannot escape the projects root. Don't use .. to try and do that")
+			return "", fmt.Errorf("the clonePath %s in the devfile project %s cannot escape the value defined by $PROJECTS_ROOT. Please avoid using \"..\" in clonePath", project.ClonePath, project.Name)
 		}
 		// If clonepath exist source would be synced to $PROJECTS_ROOT/clonePath
 		return filepath.ToSlash(filepath.Join(sourceVolumePath, project.ClonePath)), nil
 	}
 	// If clonepath does not exist source would be synced to $PROJECTS_ROOT/projectName
-	return filepath.ToSlash(filepath.Join(sourceVolumePath, projects[0].Name)), nil
+	return filepath.ToSlash(filepath.Join(sourceVolumePath, project.Name)), nil
 
 }
 

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -188,7 +188,7 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	s := log.Spinner("Syncing files to the component")
 	defer s.End(false)
 
-	syncFolder, err := getSyncFolder(compInfo.SourceMount, a.Devfile.Data.GetProjects())
+	syncFolder, err := GetSyncFolder(compInfo.SourceMount, a.Devfile.Data.GetProjects())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get sync folder")
 	}
@@ -234,15 +234,16 @@ func (a Adapter) pushLocal(path string, files []string, delFiles []string, isFor
 	return nil
 }
 
+// GetSyncFolder gets the sync folder path for source code.
 // sourceVolumePath: mount path of the empty dir volume the odo uses to sync source code
 // projects: list of projects from devfile
-// getSyncFolder gets the sync folder path for source code.
-func getSyncFolder(sourceVolumePath string, projects []parserCommon.DevfileProject) (string, error) {
-	// if there are no projects in devfile or multiple projects source would be synced to $PROJECTS_ROOT
-	if len(projects) != 1 {
+func GetSyncFolder(sourceVolumePath string, projects []parserCommon.DevfileProject) (string, error) {
+	// if there are no projects in the devfile, source would be synced to $PROJECTS_ROOT
+	if len(projects) == 0 {
 		return sourceVolumePath, nil
 	}
 
+	// if there is one or more projects in the devfile, get the first project and check its clonepath
 	project := projects[0]
 
 	if project.ClonePath != "" {

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -578,7 +578,7 @@ func TestGetSyncFolder(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		syncFolder, err := getSyncFolder(sourceVolumePath, tt.projects)
+		syncFolder, err := GetSyncFolder(sourceVolumePath, tt.projects)
 
 		if !tt.wantErr == (err != nil) {
 			t.Errorf("expected %v, actual %v", tt.wantErr, err)

--- a/pkg/sync/adapter_test.go
+++ b/pkg/sync/adapter_test.go
@@ -513,7 +513,7 @@ func TestGetSyncFolder(t *testing.T) {
 					},
 				},
 			},
-			want:    sourceVolumePath,
+			want:    filepath.ToSlash(filepath.Join(sourceVolumePath, projectNames[0])),
 			wantErr: false,
 		},
 		{
@@ -578,14 +578,16 @@ func TestGetSyncFolder(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		syncFolder, err := GetSyncFolder(sourceVolumePath, tt.projects)
+		t.Run(tt.name, func(t *testing.T) {
+			syncFolder, err := GetSyncFolder(sourceVolumePath, tt.projects)
 
-		if !tt.wantErr == (err != nil) {
-			t.Errorf("expected %v, actual %v", tt.wantErr, err)
-		}
+			if !tt.wantErr == (err != nil) {
+				t.Errorf("expected %v, actual %v", tt.wantErr, err)
+			}
 
-		if syncFolder != tt.want {
-			t.Errorf("expected %s, actual %s", tt.want, syncFolder)
-		}
+			if syncFolder != tt.want {
+				t.Errorf("expected %s, actual %s", tt.want, syncFolder)
+			}
+		})
 	}
 }

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -50,7 +50,7 @@ func (d TestDevfileData) GetAliasedComponents() []versionsCommon.DevfileComponen
 // GetProjects is a mock function to get the components that have an alias from a devfile
 func (d TestDevfileData) GetProjects() []versionsCommon.DevfileProject {
 	projectName := [...]string{"test-project", "anotherproject"}
-	clonePath := [...]string{"/test-project", "/anotherproject"}
+	clonePath := [...]string{"test-project/", "anotherproject/"}
 	sourceLocation := [...]string{"https://github.com/someproject/test-project.git", "https://github.com/another/project.git"}
 
 	project1 := versionsCommon.DevfileProject{

--- a/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-multiple-projects.yaml
@@ -30,7 +30,7 @@ commands:
     exec:
       component: runtime
       commandLine: npm install
-      workingDir: ${PROJECTS_ROOT}
+      workingDir: ${PROJECTS_ROOT}/webapp
       group:
         kind: build
         isDefault: true
@@ -38,7 +38,7 @@ commands:
     exec:
       component: runtime
       commandLine: npm start
-      workingDir: ${PROJECTS_ROOT}
+      workingDir: ${PROJECT_SOURCE}
       group:
         kind: run
         isDefault: true

--- a/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-projects.yaml
@@ -27,7 +27,7 @@ commands:
     exec:
       component: runtime
       commandLine: npm install
-      workingDir: ${PROJECTS_ROOT}/webapp
+      workingDir: ${PROJECT_SOURCE}
       group:
         kind: build
         isDefault: true
@@ -35,7 +35,7 @@ commands:
     exec:
       component: runtime
       commandLine: npm start
-      workingDir: ${PROJECTS_ROOT}/webapp
+      workingDir: ${PROJECT_SOURCE}
       group:
         kind: run
         isDefault: true

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -19,4 +19,5 @@ type CliRunner interface {
 	GetPVCSize(compName, storageName, namespace string) string
 	GetAllPVCNames(namespace string) []string
 	GetPodInitContainers(compName, namespace string) []string
+	GetContainerEnv(podName, containerName, namespace string) string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -96,6 +96,16 @@ func (kubectl KubectlRunner) GetVolumeMountNamesandPathsFromContainer(deployName
 	return strings.TrimSpace(volumeName)
 }
 
+// GetContainerEnv returns the container env in the format name:value\n
+func (kubectl KubectlRunner) GetContainerEnv(podName, containerName, namespace string) string {
+	volumeName := CmdShouldPass(kubectl.path, "get", "po", podName, "--namespace", namespace,
+		"-o", "go-template="+
+			"{{range .spec.containers}}{{if eq .name \""+containerName+
+			"\"}}{{range .env}}{{.name}}{{\":\"}}{{.value}}{{\"\\n\"}}{{end}}{{end}}{{end}}")
+
+	return strings.TrimSpace(volumeName)
+}
+
 // WaitAndCheckForExistence wait for the given and checks if the given resource type gets deleted on the cluster
 func (kubectl KubectlRunner) WaitAndCheckForExistence(resourceType, namespace string, timeoutMinutes int) bool {
 	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -98,12 +98,12 @@ func (kubectl KubectlRunner) GetVolumeMountNamesandPathsFromContainer(deployName
 
 // GetContainerEnv returns the container env in the format name:value\n
 func (kubectl KubectlRunner) GetContainerEnv(podName, containerName, namespace string) string {
-	volumeName := CmdShouldPass(kubectl.path, "get", "po", podName, "--namespace", namespace,
+	containerEnv := CmdShouldPass(kubectl.path, "get", "po", podName, "--namespace", namespace,
 		"-o", "go-template="+
 			"{{range .spec.containers}}{{if eq .name \""+containerName+
 			"\"}}{{range .env}}{{.name}}{{\":\"}}{{.value}}{{\"\\n\"}}{{end}}{{end}}{{end}}")
 
-	return strings.TrimSpace(volumeName)
+	return strings.TrimSpace(containerEnv)
 }
 
 // WaitAndCheckForExistence wait for the given and checks if the given resource type gets deleted on the cluster

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -450,12 +450,12 @@ func (oc OcRunner) GetVolumeMountNamesandPathsFromContainer(deployName string, c
 
 // GetContainerEnv returns the container env in the format name:value\n
 func (oc OcRunner) GetContainerEnv(podName, containerName, namespace string) string {
-	volumeName := CmdShouldPass(oc.path, "get", "po", podName, "--namespace", namespace,
+	containerEnv := CmdShouldPass(oc.path, "get", "po", podName, "--namespace", namespace,
 		"-o", "go-template="+
 			"{{range .spec.containers}}{{if eq .name \""+containerName+
 			"\"}}{{range .env}}{{.name}}{{\":\"}}{{.value}}{{\"\\n\"}}{{end}}{{end}}{{end}}")
 
-	return strings.TrimSpace(volumeName)
+	return strings.TrimSpace(containerEnv)
 }
 
 // GetVolumeMountName returns the name of the volume

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -448,6 +448,16 @@ func (oc OcRunner) GetVolumeMountNamesandPathsFromContainer(deployName string, c
 	return strings.TrimSpace(volumeName)
 }
 
+// GetContainerEnv returns the container env in the format name:value\n
+func (oc OcRunner) GetContainerEnv(podName, containerName, namespace string) string {
+	volumeName := CmdShouldPass(oc.path, "get", "po", podName, "--namespace", namespace,
+		"-o", "go-template="+
+			"{{range .spec.containers}}{{if eq .name \""+containerName+
+			"\"}}{{range .env}}{{.name}}{{\":\"}}{{.value}}{{\"\\n\"}}{{end}}{{end}}{{end}}")
+
+	return strings.TrimSpace(volumeName)
+}
+
 // GetVolumeMountName returns the name of the volume
 func (oc OcRunner) GetVolumeMountName(dcName string, namespace string) string {
 	volumeName := CmdShouldPass(oc.path, "get", "dc", dcName, "--namespace", namespace,

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -1,10 +1,11 @@
 package devfile
 
 import (
-	"github.com/openshift/odo/pkg/component"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/openshift/odo/pkg/component"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -89,7 +90,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", "describe", "-o", "json", "--context", context))
 			Expect(err).Should(BeNil())
-			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.dev/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + namespace + `","creationTimestamp": null},"spec":{"app": "testing", "env": [{"name": "PROJECTS_ROOT", "value": "/project"}, {"name": "DEBUG_PORT","value": "5858"}],"type":"nodejs","urls": {"kind": "List", "apiVersion": "odo.dev/v1alpha1", "metadata": {}, "items": [{"kind": "url", "apiVersion": "odo.dev/v1alpha1", "metadata": {"name": "url-1", "creationTimestamp": null}, "spec": {"host": "url-1.example.com", "path": "/",
+			expected, err := helper.Unindented(`{"kind": "Component","apiVersion": "odo.dev/v1alpha1","metadata": {"name": "cmp-git","namespace": "` + namespace + `","creationTimestamp": null},"spec":{"app": "testing", "env": [{"name": "PROJECTS_ROOT", "value": "/project"},{"name": "PROJECT_SOURCE", "value": "/project"}, {"name": "DEBUG_PORT","value": "5858"}],"type":"nodejs","urls": {"kind": "List", "apiVersion": "odo.dev/v1alpha1", "metadata": {}, "items": [{"kind": "url", "apiVersion": "odo.dev/v1alpha1", "metadata": {"name": "url-1", "creationTimestamp": null}, "spec": {"host": "url-1.example.com", "path": "/",
             "kind": "ingress", "port": 3000, "secure": false}, "status": {"state": "` + string(component.StateTypePushed) + `"}}, {"kind": "url", "apiVersion": "odo.dev/v1alpha1", "metadata": {"name": "url-2", "creationTimestamp": null}, "spec": {"host": "url-2.example.com", "port": 4000, "path": "/", "secure": false, "kind": "ingress"}, "status": {"state": "` + string(component.StateTypePushed) + `"}}]},"storages": {"kind": "List", "apiVersion": "odo.dev/v1alpha1", "metadata": {}, "items": [{"kind": "storage", "apiVersion": "odo.dev/v1alpha1", "metadata": {"name": "storage-1", "creationTimestamp": null}, "spec": {"containerName": "runtime","size": "1Gi", "path": "/data1"}}]},"ports": ["5858"]},"status": {"state": "` + string(component.StateTypePushed) + `"}}`)
 			Expect(err).Should(BeNil())
 			Expect(cmpDescribeJSON).Should(MatchJSON(expected))

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -857,6 +857,7 @@ var _ = Describe("odo devfile push command tests", func() {
 
 		})
 	})
+
 	Context("Verify source code sync location", func() {
 
 		It("Should sync to the correct dir in container if project and clonePath is present", func() {
@@ -874,6 +875,9 @@ var _ = Describe("odo devfile push command tests", func() {
 			// so source code would be synced to /apps/webapp
 			output := cliRunner.ExecListDir(podName, namespace, "/apps/webapp")
 			helper.MatchAllInOutput(output, []string{"package.json"})
+
+			// Verify the sync env variables are correct
+			utils.VerifyContainerSyncEnv(podName, "runtime", namespace, "/apps/webapp", "/apps", cliRunner)
 		})
 
 		It("Should sync to the correct dir in container if project present", func() {
@@ -890,6 +894,9 @@ var _ = Describe("odo devfile push command tests", func() {
 			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
 			output := cliRunner.ExecListDir(podName, namespace, "/apps/nodeshift")
 			helper.MatchAllInOutput(output, []string{"package.json"})
+
+			// Verify the sync env variables are correct
+			utils.VerifyContainerSyncEnv(podName, "runtime", namespace, "/apps/nodeshift", "/apps", cliRunner)
 		})
 
 		It("Should sync to the correct dir in container if multiple project is present", func() {
@@ -900,9 +907,12 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "push", "--context", context)
 			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
 			// for devfile-with-multiple-projects.yaml source mapping is not set so $PROJECTS_ROOT is /projects
-			// multiple projects, so source code would sync to /projects
-			output := cliRunner.ExecListDir(podName, namespace, "/projects")
+			// multiple projects, so source code would sync to the first project /projects/webapp
+			output := cliRunner.ExecListDir(podName, namespace, "/projects/webapp")
 			helper.MatchAllInOutput(output, []string{"package.json"})
+
+			// Verify the sync env variables are correct
+			utils.VerifyContainerSyncEnv(podName, "runtime", namespace, "/projects/webapp", "/projects", cliRunner)
 		})
 
 		It("Should sync to the correct dir in container if no project is present", func() {
@@ -914,6 +924,9 @@ var _ = Describe("odo devfile push command tests", func() {
 			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
 			output := cliRunner.ExecListDir(podName, namespace, "/projects")
 			helper.MatchAllInOutput(output, []string{"package.json"})
+
+			// Verify the sync env variables are correct
+			utils.VerifyContainerSyncEnv(podName, "runtime", namespace, "/projects", "/projects", cliRunner)
 		})
 
 	})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -887,7 +887,6 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			// reset clonePath and change the workdir accordingly, it should sync to project name
 			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "clonePath: webapp/", "# clonePath: webapp/")
-			helper.ReplaceString(filepath.Join(context, "devfile.yaml"), "workingDir: ${PROJECTS_ROOT}/webapp", "workingDir: ${PROJECTS_ROOT}/nodeshift")
 
 			helper.CmdShouldPass("odo", "push", "--context", context)
 

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -703,3 +703,27 @@ func VerifyCatalogListComponent(output string, cmpName []string) error {
 	}
 	return nil
 }
+
+// VerifyContainerSyncEnv verifies the sync env in the container
+func VerifyContainerSyncEnv(podName, containerName, namespace, projectSourceValue, projectsRootValue string, cliRunner helper.CliRunner) {
+	envProjectsRoot, envProjectSource := "PROJECTS_ROOT", "PROJECT_SOURCE"
+	projectSourceMatched, projectsRootMatched := false, false
+
+	envNamesAndValues := cliRunner.GetContainerEnv(podName, "runtime", namespace)
+	envNamesAndValuesArr := strings.Fields(envNamesAndValues)
+
+	for _, envNamesAndValues := range envNamesAndValuesArr {
+		envNameAndValueArr := strings.Split(envNamesAndValues, ":")
+
+		if envNameAndValueArr[0] == envProjectSource && strings.Contains(envNameAndValueArr[1], projectSourceValue) {
+			projectSourceMatched = true
+		}
+
+		if envNameAndValueArr[0] == envProjectsRoot && strings.Contains(envNameAndValueArr[1], projectsRootValue) {
+			projectsRootMatched = true
+		}
+	}
+
+	Expect(projectSourceMatched).To(Equal(true))
+	Expect(projectsRootMatched).To(Equal(true))
+}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

/kind feature


**What does does this PR do / why we need it**:
- Introduces an env, `PROJECT_SOURCE` to all component containers that mount sources
- devfile can now use `PROJECT_SOURCE` which holds the project path in a container
- `PROJECT_SOURCE` value depends upon container's `sourceMapping` & project's `clonePath`
- Updated `GetSyncFolder()` logic for devfile containing more than one project ie; the first project is now selected
- New and updated tests
- Updated public docs about env
- `PROJECTS_ROOT` & `PROJECT_SOURCE` are reserved, check https://github.com/devfile/api/issues/132

**Which issue(s) this PR fixes**:

Fixes #3781 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
- push odo component by varying number of projects, project's `clonePath` and container's `sourceMapping`
- `PROJECT_SOURCE` cannot be explicitly mentioned in the devfile

```
schemaVersion: 2.0.0
metadata:
  name: java-springboot
  version: 1.1.0
# projects:
#   - name: myproj1
#     # clonePath: myapp1/
#     git:
#       remotes:
#         origin: https://github.com/odo-devfiles/springboot-ex
#   - name: myproj2
#     clonePath: myapp2/
#     git:
#       remotes:
#         origin: https://github.com/odo-devfiles/springboot-ex
starterProjects:
- name: springbootproject
  git:
    remotes:
      origin: https://github.com/odo-devfiles/springboot-ex.git
components:
- name: tools
  container:
    endpoints:
    - name: 8080-tcp
      targetPort: 8080
    - exposure: public
      path: /
      name: myjava
      targetPort: 8080
      protocol: http
    image: quay.io/eclipse/che-java11-maven:nightly
    memoryLimit: 768Mi
    mountSources: true
    volumeMounts:
    - name: m2
      path: /home/user/.m2
    # env:
    # - name: PROJECTS_ROOT
    #   value: /mycustom/path/
- name: dummy
  container:
    image: quay.io/eclipse/che-java11-maven:nightly
    memoryLimit: 768Mi
    mountSources: true
    sourceMapping: /test
    command: ['tail']
    args: [ '-f', '/dev/null']
    # env:
    # - name: PROJECT_SOURCE
    #   value: /mycustom/path/
- name: m2
  volume:
    size: 3Gi
commands:
- exec:
    commandLine: mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true
    workingDir: ${PROJECT_SOURCE}
    component: tools
    group:
      isDefault: true
      kind: build
  id: build
- exec:
    commandLine: mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run
    workingDir: ${PROJECT_SOURCE}
    component: tools
    group:
      isDefault: true
      kind: run
  id: run
- exec:
    commandLine: java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar
    component: tools
    group:
      isDefault: true
      kind: debug
  id: debug
```