### PR TITLE
3968-add more optional metadata

### DIFF
--- a/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
+++ b/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
@@ -3854,6 +3854,14 @@ const JsonSchema200 = `{
         "name": {
           "type": "string",
           "description": "Optional devfile name"
+        },
+        "alpha.build-dockerfile": {
+          "type": "string",
+          "description": "Optional build dockerfile link"
+        },
+        "alpha.deployment-manifest": {
+          "type": "string",
+          "description": "Optional deployment manifest link"
         }
       }
     },

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -54,6 +54,10 @@ type DevfileMetadata struct {
 
 	// Version Optional semver-compatible version
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	AlphaBuildDockerfile string `json:"alpha.build-dockerfile,omitempty" yaml:"alpha.build-dockerfile,omitempty"`
+
+	AlphaDeploymentManifest string `json:"alpha.deployment-manifest,omitempty" yaml:"alpha.deployment-manifest,omitempty"`
 }
 
 // DevfileCommand command specified in devfile


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

**What type of PR is this?**

/kind bug
/area devfile

**What does does this PR do / why we need it**:
Our devfile schema and type defined are missing the two optional metadata shown in the devfiles. Which result in the devObj parsed from the devfile missing those optional metadata. 
And modification action to the devfile through odo would lose those metadata in the new devfile. 

**Which issue(s) this PR fixes**:

Fixes #3968 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

create a devfile component, ` odo create nodejs --starter`

create a new url to update the existing devfile, `odo url create --port 4000`

check the updated devfile, should still see those two optional metadata in devfile
