### PR TITLE
removed some irrelevant steps from odo create and cleanup

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -578,8 +578,8 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			// if it is not supported we still need to run all the codes related with s2i after devfile compatibility check
 
 			hasComponent := false
-			existSpinner := log.Spinner("Checking devfile existence")
-			defer existSpinner.End(false)
+			devfileExistSpinner := log.Spinner("Checking devfile existence")
+			defer devfileExistSpinner.End(false)
 
 			for _, devfileComponent := range catalogDevfileList.Items {
 				if co.devfileMetadata.componentType == devfileComponent.Name {
@@ -605,9 +605,9 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			}
 
 			if hasComponent {
-				existSpinner.End(true)
+				devfileExistSpinner.End(true)
 			} else {
-				existSpinner.End(false)
+				devfileExistSpinner.End(false)
 			}
 
 			if co.devfileMetadata.devfileSupport {

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -578,6 +578,8 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			// if it is not supported we still need to run all the codes related with s2i after devfile compatibility check
 
 			hasComponent := false
+			existSpinner := log.Spinner("Checking devfile existence")
+			defer existSpinner.End(false)
 
 			for _, devfileComponent := range catalogDevfileList.Items {
 				if co.devfileMetadata.componentType == devfileComponent.Name {
@@ -602,14 +604,12 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 				}
 			}
 
-			existSpinner := log.Spinner("Checking devfile existence")
 			if hasComponent {
 				existSpinner.End(true)
 			} else {
 				existSpinner.End(false)
 			}
 
-			supportSpinner := log.Spinner("Checking devfile compatibility")
 			if co.devfileMetadata.devfileSupport {
 				registrySpinner := log.Spinnerf("Creating a devfile component from registry: %s", co.devfileMetadata.devfileRegistry.Name)
 
@@ -619,11 +619,9 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					return err
 				}
 
-				supportSpinner.End(true)
 				registrySpinner.End(true)
 				return nil
 			}
-			supportSpinner.End(false)
 
 			// Currently only devfile component supports --registry flag, so if user specifies --registry when creating devfile component,
 			// we should error out instead of running s2i componet code and throw warning message


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:
Removed the `Checking devfile compatibility` stage from odo create as it does nothing for the time being.

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
## Now 
```
$$ odo create java tttt
Validation
 ✗  Checking devfile existence [25365ns]
 ⚠  Devfile component type java is not supported, please run `odo catalog list components` for a list of supported devfile component types

```

## Before

```
$$ odo create java tttt
Validation
 ✗  Checking devfile existence [22940ns]
 ✗  Checking devfile compatibility [9417ns]
 ⚠  Devfile component type ls is not supported, please run `odo catalog list components` for a list of supported devfile component types
```
Its funny that we are trying to check compatibility of a devfile which doesn't exist