### PR TITLE
updated the Kind in odo describe to be different for s2i and devfile …

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/kclient"
@@ -1462,7 +1463,7 @@ func GetLogs(client *occlient.Client, componentName string, applicationName stri
 func getMachineReadableFormat(componentName, componentType string) Component {
 	return Component{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Component",
+			Kind:       KindComponent,
 			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -3,12 +3,13 @@ package component
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
-	"strings"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
@@ -102,10 +103,6 @@ func (cfd *ComponentFullDescription) fillEmptyFields(componentDesc Component, co
 		cfd.Namespace = projectName
 	}
 
-	if len(cfd.Kind) <= 0 {
-		cfd.Kind = "Component"
-	}
-
 	if len(cfd.APIVersion) <= 0 {
 		cfd.APIVersion = apiVersion
 	}
@@ -125,8 +122,10 @@ func NewComponentFullDescriptionFromClientAndLocalConfig(client *occlient.Client
 	var err error
 	if envInfo != nil {
 		componentDesc, devfile, err = GetComponentFromDevfile(envInfo)
+		cfd.Kind = KindDevfileComponent
 	} else {
 		componentDesc, err = GetComponentFromConfig(localConfigInfo)
+		cfd.Kind = KindComponent
 	}
 	if err != nil {
 		return cfd, err

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -552,7 +552,7 @@ func Test_getMachineReadableFormat(t *testing.T) {
 			args: args{componentName: "frontend", componentType: "nodejs"},
 			want: Component{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "Component",
+					Kind:       KindComponent,
 					APIVersion: "odo.dev/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -590,7 +590,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 				components: []Component{
 					{
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "Component",
+							Kind:       KindComponent,
 							APIVersion: "odo.dev/v1alpha1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
@@ -603,7 +603,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 					},
 					{
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "Component",
+							Kind:       KindComponent,
 							APIVersion: "odo.dev/v1alpha1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
@@ -625,7 +625,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 				Items: []Component{
 					{
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "Component",
+							Kind:       KindComponent,
 							APIVersion: "odo.dev/v1alpha1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
@@ -638,7 +638,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 					},
 					{
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "Component",
+							Kind:       KindComponent,
 							APIVersion: "odo.dev/v1alpha1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
@@ -873,7 +873,7 @@ func getFakeDC(name, namespace, appName, componentType string) appsv1.Deployment
 func getFakeComponent(compName, namespace, appName, compType string, state State) Component {
 	return Component{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Component",
+			Kind:       KindComponent,
 			APIVersion: "odo.dev/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -5,6 +5,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	KindDevfileComponent = "DevfileComponent"
+	KindComponent        = "Component"
+)
+
 // Component
 type Component struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
…component

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind api-change

**What does does this PR do / why we need it**:
Uses `DevfileComponent` for `odo describe` when a devfile component is present and `Component` for s2i 

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
test should pass