### PR TITLE
Add additional test for port and env flag

### DIFF
--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -135,6 +135,15 @@ var _ = Describe("odo devfile create command tests", func() {
 			output := helper.CmdShouldFail("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(context, "sb.jar"), "--context", context)
 			Expect(output).Should(ContainSubstring("flag --binary, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
 		})
+
+		It("should fail the create command as --env flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			output := helper.CmdShouldFail("odo", "create", "nodejs", "cmp-env", "--env", "HTTPS_PROXY=https://1.2.3.4:3128", "--context", context, "--app", "testing")
+			Expect(output).Should(ContainSubstring("flag --env, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
+		})
+		It("should fail the create command as --port flag, which is specific to s2i component creation, is used without --s2i flag", func() {
+			output := helper.CmdShouldFail("odo", "create", "nodejs", "cmp-port", "--port", "8080", "--context", context, "--app", "testing")
+			Expect(output).Should(ContainSubstring("flag --port, requires --s2i flag to be set, when deploying S2I (Source-to-Image) components."))
+		})
 	})
 
 	Context("When executing odo create with devfile component type argument and --project flag", func() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

Add additional test for `env` and `port` flag
**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
