### PR TITLE
Prints help message based on backend cluster

### DIFF
--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -182,8 +182,8 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 
 	// Update the use / example / long to the Devfile description
 	linkCmd.Use = fmt.Sprintf("%s <service-type>/<service-name>", name)
-	linkCmd.Example = fmt.Sprintf(linkExampleExperimental, fullName)
-	linkCmd.Long = linkLongDescExperimental
+	linkCmd.Example = fmt.Sprintf(linkExample, fullName)
+	linkCmd.Long = linkLongDesc
 
 	// we ignore the error because it doesn't matter at this place to deal with it and the function returns a *cobra.Command
 	csvSupport, _ := cmdutil.IsCSVSupported()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:
It fixes bug wherein `odo link -h` prints same help message for both 3.x & 4.x clusters

**Which issue(s) this PR fixes**:

Fixes #3992 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Check `odo link -h` by logging into OCP 3.x & 4.x clusters.