### PR TITLE
Remove specifying a component when deleting

### DIFF
--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -29,9 +29,9 @@ import (
 // DeleteRecommendedCommandName is the recommended delete command name
 const DeleteRecommendedCommandName = "delete"
 
-var deleteExample = ktemplates.Examples(`  # Delete component named 'frontend'. 
-%[1]s frontend
-%[1]s frontend --all
+var deleteExample = ktemplates.Examples(`  # Delete the component in your current directory
+%[1]s
+%[1]s --all
   `)
 
 // DeleteOptions is a container to attach complete, validate and run pattern
@@ -295,11 +295,11 @@ func NewCmdDelete(name, fullName string) *cobra.Command {
 	do := NewDeleteOptions()
 
 	var componentDeleteCmd = &cobra.Command{
-		Use:         fmt.Sprintf("%s <component_name>", name),
+		Use:         fmt.Sprintf("%s", name),
 		Short:       "Delete component",
 		Long:        "Delete component.",
 		Example:     fmt.Sprintf(deleteExample, fullName),
-		Args:        cobra.MaximumNArgs(1),
+		Args:        cobra.MaximumNArgs(0),
 		Annotations: map[string]string{"command": "component"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(do, cmd, args)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:

This is a temporary fix by removing the current feature of being able to
pass in a component name to `odo delete`.

For example. `odo delete foobar` does not work. We remove that
functionality so you may only specify `odo delete` in the current
directory.

**Which issue(s) this PR fixes**:

Does not fix any issues, but please see: https://github.com/openshift/odo/issues/3892

**PR acceptance criteria**:

- [X] Unit test

- [X] Integration test

- [X] Documentation

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

```sh
odo create nodejs --starter
odo push
odo delete
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>