### PR TITLE
Fix minor docs issue in community page

### DIFF
--- a/docs/public/community.adoc
+++ b/docs/public/community.adoc
@@ -40,8 +40,8 @@ Every two weeks, we have a contributors call meeting.
 
 Every three weeks, we have two planning calls:
 
-* ``Sprint Planning Preparation and Issue Triage'' - on Monday
-* ``Sprint Planning'' - on Wednesday
+* "Sprint Planning Preparation and Issue Triage" - on Monday
+* "Sprint Planning" - on Wednesday
 
 You can find the exact dates of all scheduled odo calls together with
 sprint dates in the


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Fixes minor docs issue in the community doc

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [X] Unit test

- [X] Integration test

- [X] Documentation

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>