### PR TITLE
Do not check for CSV when initializing odo link command

### DIFF
--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -52,7 +52,7 @@ For example:
 We have created a frontend application called 'frontend' using:
 odo create nodejs frontend
 
-If you wish to connect an EtcdCluster service craeted using etcd Operator to this component:
+If you wish to connect an EtcdCluster service created using etcd Operator to this component:
 odo link EtcdCluster/myetcdcluster
 
 Here myetcdcluster is the name of the EtcdCluster service which can be found using "odo service list"

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -44,7 +44,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link command", func() {
 		It("should display the help", func() {
 			appHelp := helper.CmdShouldPass("odo", "link", "-h")
-			Expect(appHelp).To(ContainSubstring("Link component to an operator backed service"))
+			helper.MatchAllInOutput(appHelp, []string{"Link component to a service ", "backed by an Operator or Service Catalog", "or component", "works only with s2i components"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind code-refactoring

**What does this PR do / why we need it**:
It removes check for CSV support by a cluster at the time of initialization of `odo link` command.

**Which issue(s) this PR fixes**:

Fixes #4008 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo link -h` should display same message irrespective of the backing cluster being 3.x, 4.x or k8s.