### PR TITLE
Added missing s2i flag for e2e test

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -42,7 +42,7 @@ var _ = Describe("odo supported images e2e tests", func() {
 
 		// create the component
 		helper.CopyExample(filepath.Join("source", srcType), context)
-		helper.CmdShouldPass("odo", "create", cmpType, srcType+"-app", "--project", project, "--context", context, "--app", appName)
+		helper.CmdShouldPass("odo", "create", "--s2i", cmpType, srcType+"-app", "--project", project, "--context", context, "--app", appName)
 
 		helper.CmdShouldPass("odo", "config", "set", "minmemory", "400Mi", "--context", context)
 		helper.CmdShouldPass("odo", "config", "set", "maxmemory", "700Mi", "--context", context)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

Add missing `--s2i` flag in e2e image test for s2i components

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-e2e-all` should pass successfully.