### PR TITLE
make odo list's output for no components consistent

### DIFF
--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -312,7 +312,7 @@ func (lo *ListOptions) Run() (err error) {
 		}
 
 		if !lo.hasDevfileComponents && !lo.hasS2IComponents {
-			log.Error("There are no components deployed.")
+			log.Info("There are no components deployed.")
 			return
 		}
 	} else {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`


/kind bug

**What does does this PR do / why we need it**:
`odo list` returns an error when there are no components but `odo list -o json` returns empty lists. Both approach are subjective but we need to make things consistent. Hence we dont return an error now if there are no components

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [X] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Everything should work as expected