### PR TITLE
feat: Allow composite commands to be overridden

### DIFF
--- a/pkg/devfile/parser/data/2.0.0/components.go
+++ b/pkg/devfile/parser/data/2.0.0/components.go
@@ -165,7 +165,7 @@ func (d *Devfile200) AddCommands(commands ...common.DevfileCommand) error {
 func (d *Devfile200) UpdateCommand(command common.DevfileCommand) {
 	id := strings.ToLower(command.GetID())
 	for i := range d.Commands {
-		if d.Commands[i].GetID() == id {
+		if d.Commands[i].SetIDToLower() == id {
 			d.Commands[i] = command
 		}
 	}

--- a/pkg/devfile/parser/types.go
+++ b/pkg/devfile/parser/types.go
@@ -91,7 +91,7 @@ func (d DevfileObj) OverrideCommands(overridePatch []common.DevfileCommand) (err
 						return err
 					}
 				} else {
-					// If the original command and patch command are different types, then we can't patch, so throow an error
+					// If the original command and patch command are different types, then we can't patch, so throw an error
 					return fmt.Errorf("cannot overide command %q with a different type of command", originalCommand.Id)
 				}
 
@@ -105,7 +105,7 @@ func (d DevfileObj) OverrideCommands(overridePatch []common.DevfileCommand) (err
 	return nil
 }
 
-// overrideCompositeCommand overrides the given parent compoosite commmand
+// overrideCompositeCommand overrides the given parent composite commmand
 // patchCommand contains the patches to be applied to the parent's command
 func overrideCompositeCommand(patchCommand common.DevfileCommand, originalCommand common.DevfileCommand) (common.DevfileCommand, error) {
 	var updatedComposite common.Composite

--- a/pkg/devfile/parser/types.go
+++ b/pkg/devfile/parser/types.go
@@ -105,6 +105,8 @@ func (d DevfileObj) OverrideCommands(overridePatch []common.DevfileCommand) (err
 	return nil
 }
 
+// overrideCompositeCommand overrides the given parent compoosite commmand
+// patchCommand contains the patches to be applied to the parent's command
 func overrideCompositeCommand(patchCommand common.DevfileCommand, originalCommand common.DevfileCommand) (common.DevfileCommand, error) {
 	var updatedComposite common.Composite
 

--- a/pkg/devfile/parser/types_test.go
+++ b/pkg/devfile/parser/types_test.go
@@ -315,7 +315,7 @@ func TestDevfileObj_OverrideCommands(t *testing.T) {
 			},
 		},
 		{
-			name: "case 6: throw error if trying to overide command with different type",
+			name: "case 7: throw error if trying to overide command with different type",
 			devFileObj: DevfileObj{
 				Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
 				Data: &v200.Devfile200{

--- a/pkg/devfile/parser/types_test.go
+++ b/pkg/devfile/parser/types_test.go
@@ -239,6 +239,114 @@ func TestDevfileObj_OverrideCommands(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "case 6: override a composite command",
+			devFileObj: DevfileObj{
+				Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+				Data: &v200.Devfile200{
+					Commands: []common.DevfileCommand{
+						{
+							Id: "exec1",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "exec2",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "exec3",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "mycomposite",
+							Composite: &common.Composite{
+								Commands: []string{"exec1", "exec2"},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				overridePatch: []common.DevfileCommand{
+					{
+						Id: "mycomposite",
+						Composite: &common.Composite{
+							Commands: []string{"exec1", "exec3"},
+						},
+					},
+				},
+			},
+			wantDevFileObj: DevfileObj{
+				Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+				Data: &v200.Devfile200{
+					Commands: []common.DevfileCommand{
+						{
+							Id: "exec1",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "exec2",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "exec3",
+							Exec: &common.Exec{
+								CommandLine: commandLineBuild,
+							},
+						},
+						{
+							Id: "mycomposite",
+							Composite: &common.Composite{
+								Commands: []string{"exec1", "exec3"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 6: throw error if trying to overide command with different type",
+			devFileObj: DevfileObj{
+				Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+				Data: &v200.Devfile200{
+					Commands: []common.DevfileCommand{
+						{
+							Id: "devbuild",
+							Exec: &common.Exec{
+								Env: []common.Env{
+									testingutil.GetFakeEnv("env-0", "value-0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				overridePatch: []common.DevfileCommand{
+					{
+						Id:        "devbuild",
+						Composite: &common.Composite{},
+					},
+				},
+			},
+			wantDevFileObj: DevfileObj{
+				Ctx: devfileCtx.NewDevfileCtx(devfileTempPath),
+				Data: &v200.Devfile200{
+					Commands: []common.DevfileCommand{},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/examples/source/devfiles/parentSupport/devfile-with-parent-composite.yaml
+++ b/tests/examples/source/devfiles/parentSupport/devfile-with-parent-composite.yaml
@@ -1,0 +1,26 @@
+schemaVersion: 2.0.0
+metadata:
+  name: nodejs
+  version: 1.0.0
+parent:
+  uri: https://raw.githubusercontent.com/openshift/odo/master/tests/examples/source/devfiles/nodejs/devfileCompositeCommands.yaml
+  commands:
+  - id: buildAndMkdir
+    composite:
+         label: Build and Mkdir
+         commands:
+           - createfile
+           - install
+         parallel: false
+         group: 
+            kind: build
+            isDefault: true
+commands:
+  - id: createfile
+    exec:
+      component: runtime
+      commandLine: touch /projects/testfile
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: false

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1039,6 +1039,13 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(listDir).To(ContainSubstring("blah.js"))
 		})
 
+		It("should handle a devfile with a parent and override a composite command", func() {
+			utils.ExecPushWithCompositeOverride(context, cmpName, namespace)
+			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+			listDir := cliRunner.ExecListDir(podName, namespace, "/projects")
+			Expect(listDir).To(ContainSubstring("testfile"))
+		})
+
 		It("should handle a parent and override/append it's envs", func() {
 			utils.ExecPushWithParentOverride(context, cmpName, namespace, freePort)
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1037,9 +1037,9 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 
 		It("should handle a devfile with a parent and override a composite command", func() {
-			utils.ExecPushWithCompositeOverride(context, cmpName, namespace)
-			podName := cliRunner.GetRunningPodNameByComponent(cmpName, namespace)
-			listDir := cliRunner.ExecListDir(podName, namespace, "/projects")
+			utils.ExecPushWithCompositeOverride(commonVar.Context, cmpName, commonVar.Project)
+			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+			listDir := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 			Expect(listDir).To(ContainSubstring("testfile"))
 		})
 

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -228,7 +228,7 @@ func ExecPushWithCompositeOverride(projectDirPath, cmpName, namespace string) {
 	helper.CmdShouldPass("odo", args...)
 
 	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
-	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-parent-composite.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
+	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "parentSupport", "devfile-with-parent-composite.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
 
 	args = []string{"push"}
 	args = useProjectIfAvailable(args, namespace)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -222,6 +222,22 @@ func ExecPushWithParentOverride(projectDirPath, cmpName, namespace string, freeP
 	helper.CmdShouldPass("odo", args...)
 }
 
+func ExecPushWithCompositeOverride(projectDirPath, cmpName, namespace string) {
+	args := []string{"create", "nodejs", cmpName}
+	args = useProjectIfAvailable(args, namespace)
+	helper.CmdShouldPass("odo", args...)
+
+	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
+	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-parent-composite.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
+
+	args = []string{"push"}
+	args = useProjectIfAvailable(args, namespace)
+	helper.CmdShouldPass("odo", args...)
+
+	output := helper.CmdShouldPass("odo", args...)
+	helper.MatchAllInOutput(output, []string{"Executing createfile command", "touch /projects/testfile"})
+}
+
 func ExecPushWithMultiLayerParent(projectDirPath, cmpName, namespace string, freePort int) {
 	args := []string{"create", "nodejs", cmpName}
 	args = useProjectIfAvailable(args, namespace)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -232,9 +232,8 @@ func ExecPushWithCompositeOverride(projectDirPath, cmpName, namespace string) {
 
 	args = []string{"push"}
 	args = useProjectIfAvailable(args, namespace)
-	helper.CmdShouldPass("odo", args...)
-
 	output := helper.CmdShouldPass("odo", args...)
+
 	helper.MatchAllInOutput(output, []string{"Executing createfile command", "touch /projects/testfile"})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/area devfile

**What does does this PR do / why we need it**:
Adds support for overriding composite commands in parent devfiles. Also fixes a bug where parent commands could not be overridden if the parent command contained upper case letters.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3759

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Sample devfile:
```
schemaVersion: 2.0.0
metadata:
  name: nodejs
  version: 1.0.0
parent:
  uri: https://raw.githubusercontent.com/openshift/odo/master/tests/examples/source/devfiles/nodejs/devfileCompositeCommands.yaml
  commands:
  - id: buildAndMkdir
    composite:
         label: Build and Mkdir
         commands:
           - createfile
           - install
         parallel: false
         group: 
            kind: build
            isDefault: true
commands:
  - id: createfile
    exec:
      component: runtime
      commandLine: touch /projects/testfile
      workingDir: ${PROJECTS_ROOT}
      group:
        kind: build
        isDefault: false
```

Output should have:
```
Executing devfile commands for component nodejs
 ✓  Executing createfile command "touch /projects/testfile" [300ms]
 ✓  Executing install command "npm install" [2s]
 ✓  Executing run command "npm start" [1s]
```