### PR TITLE
Default vol mount path to vol name if absent

### DIFF
--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog"
@@ -175,9 +176,15 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 				}
 			}
 
+			mountPath := filepath.Join(string(os.PathSeparator), volumeMount.Name)
+
+			if len(volumeMount.Path) > 0 {
+				mountPath = volumeMount.Path
+			}
+
 			vol := DevfileVolume{
 				Name:          volumeMount.Name,
-				ContainerPath: volumeMount.Path,
+				ContainerPath: mountPath,
 				Size:          size,
 			}
 			containerNameToVolumes[containerComp.Name] = append(containerNameToVolumes[containerComp.Name], vol)

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 
 	"k8s.io/klog"
@@ -181,7 +180,7 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 
 			// if there is no volume mount path, default to volume mount name as per devfile schema
 			if len(volumeMount.Path) <= 0 {
-				volumeMount.Path = filepath.Join(FwdSlash, volumeMount.Name)
+				volumeMount.Path = FwdSlash + volumeMount.Name
 			}
 
 			vol := DevfileVolume{

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -176,8 +176,8 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 				}
 			}
 
+			// if there is no volume mount path, default to volume mount name as per devfile schema
 			mountPath := filepath.Join(string(os.PathSeparator), volumeMount.Name)
-
 			if len(volumeMount.Path) > 0 {
 				mountPath = volumeMount.Path
 			}

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -156,6 +156,16 @@ func getCommandsByGroup(data data.DevfileData, groupType common.DevfileCommandGr
 	return commands
 }
 
+// GetVolumeMountPath gets the volume mount's path
+func GetVolumeMountPath(volumeMount common.VolumeMount) string {
+	// if there is no volume mount path, default to volume mount name as per devfile schema
+	if volumeMount.Path == "" {
+		volumeMount.Path = "/" + volumeMount.Name
+	}
+
+	return volumeMount.Path
+}
+
 // GetVolumes iterates through the components in the devfile and returns a map of container name to the devfile volumes
 func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume {
 	containerComponents := GetDevfileContainerComponents(devfileObj.Data)
@@ -175,14 +185,9 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 				}
 			}
 
-			// if there is no volume mount path, default to volume mount name as per devfile schema
-			if len(volumeMount.Path) <= 0 {
-				volumeMount.Path = "/" + volumeMount.Name
-			}
-
 			vol := DevfileVolume{
 				Name:          volumeMount.Name,
-				ContainerPath: volumeMount.Path,
+				ContainerPath: GetVolumeMountPath(volumeMount),
 				Size:          size,
 			}
 			containerNameToVolumes[containerComp.Name] = append(containerNameToVolumes[containerComp.Name], vol)

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -61,9 +61,6 @@ const (
 	// BinBash The path to sh executable
 	BinBash = "/bin/sh"
 
-	// FwdSlash is the path separator in linux containers
-	FwdSlash = "/"
-
 	// DefaultVolumeSize Default volume size for volumes defined in a devfile
 	DefaultVolumeSize = "1Gi"
 
@@ -180,7 +177,7 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 
 			// if there is no volume mount path, default to volume mount name as per devfile schema
 			if len(volumeMount.Path) <= 0 {
-				volumeMount.Path = FwdSlash + volumeMount.Name
+				volumeMount.Path = "/" + volumeMount.Name
 			}
 
 			vol := DevfileVolume{

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -62,6 +62,9 @@ const (
 	// BinBash The path to sh executable
 	BinBash = "/bin/sh"
 
+	// FwdSlash is the path separator in linux containers
+	FwdSlash = "/"
+
 	// DefaultVolumeSize Default volume size for volumes defined in a devfile
 	DefaultVolumeSize = "1Gi"
 
@@ -177,14 +180,13 @@ func GetVolumes(devfileObj devfileParser.DevfileObj) map[string][]DevfileVolume 
 			}
 
 			// if there is no volume mount path, default to volume mount name as per devfile schema
-			mountPath := filepath.Join(string(os.PathSeparator), volumeMount.Name)
-			if len(volumeMount.Path) > 0 {
-				mountPath = volumeMount.Path
+			if len(volumeMount.Path) <= 0 {
+				volumeMount.Path = filepath.Join(FwdSlash, volumeMount.Name)
 			}
 
 			vol := DevfileVolume{
 				Name:          volumeMount.Name,
-				ContainerPath: mountPath,
+				ContainerPath: volumeMount.Path,
 				Size:          size,
 			}
 			containerNameToVolumes[containerComp.Name] = append(containerNameToVolumes[containerComp.Name], vol)

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -363,6 +363,41 @@ func TestGetBootstrapperImage(t *testing.T) {
 
 }
 
+func TestGetVolumeMountPath(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		volumeMount common.VolumeMount
+		wantPath    string
+	}{
+		{
+			name: "Case 1: Mount Path is present",
+			volumeMount: common.VolumeMount{
+				Name: "name1",
+				Path: "/path1",
+			},
+			wantPath: "/path1",
+		},
+		{
+			name: "Case 2: Mount Path is absent",
+			volumeMount: common.VolumeMount{
+				Name: "name1",
+			},
+			wantPath: "/name1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := GetVolumeMountPath(tt.volumeMount)
+
+			if path != tt.wantPath {
+				t.Errorf("TestGetVolumeMountPath error: mount path mismatch, expected: %v got: %v", tt.wantPath, path)
+			}
+		})
+	}
+
+}
+
 func TestGetCommandsForGroup(t *testing.T) {
 
 	component := []versionsCommon.DevfileComponent{

--- a/pkg/devfile/adapters/common/utils_test.go
+++ b/pkg/devfile/adapters/common/utils_test.go
@@ -205,6 +205,32 @@ func TestGetVolumes(t *testing.T) {
 			},
 			wantContainerNameToVolumes: map[string][]DevfileVolume{},
 		},
+		{
+			name: "Case 5: Valid devfile with container referencing no volume mount path",
+			component: []versionsCommon.DevfileComponent{
+				testingutil.GetFakeVolumeComponent("myvolume1", size),
+				{
+					Name: "mycontainer",
+					Container: &versionsCommon.Container{
+						Image: "image",
+						VolumeMounts: []versionsCommon.VolumeMount{
+							{
+								Name: "myvolume1",
+							},
+						},
+					},
+				},
+			},
+			wantContainerNameToVolumes: map[string][]DevfileVolume{
+				"mycontainer": {
+					{
+						Name:          "myvolume1",
+						Size:          "4Gi",
+						ContainerPath: "/myvolume1",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,8 +2,9 @@ package storage
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"reflect"
+
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/devfile/parser/data"
@@ -623,7 +624,9 @@ func devfileListMounted(kClient *kclient.Client, componentName string) (StorageL
 // GetLocalDevfileStorage lists the storage from the devfile
 func GetLocalDevfileStorage(devfileData data.DevfileData) StorageList {
 	volumeSizeMap := make(map[string]string)
-	for _, component := range devfileData.GetComponents() {
+	components := devfileData.GetComponents()
+
+	for _, component := range components {
 		if component.Volume == nil {
 			continue
 		}
@@ -633,7 +636,6 @@ func GetLocalDevfileStorage(devfileData data.DevfileData) StorageList {
 		volumeSizeMap[component.Name] = component.Volume.Size
 	}
 
-	components := devfileData.GetComponents()
 	var storage []Storage
 	for _, component := range components {
 		if component.Container == nil {
@@ -642,7 +644,7 @@ func GetLocalDevfileStorage(devfileData data.DevfileData) StorageList {
 		for _, volumeMount := range component.Container.VolumeMounts {
 			size, ok := volumeSizeMap[volumeMount.Name]
 			if ok {
-				storage = append(storage, GetMachineFormatWithContainer(volumeMount.Name, size, volumeMount.Path, component.Name))
+				storage = append(storage, GetMachineFormatWithContainer(volumeMount.Name, size, common.GetVolumeMountPath(volumeMount), component.Name))
 			}
 		}
 	}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
@@ -21,6 +21,7 @@ components:
       volumeMounts:
         - name: firstvol
           path: /data
+        - name: secondvol
   - name: runtime2
     container:
       image: quay.io/eclipse/che-nodejs10-ubi:nightly

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
@@ -28,7 +28,6 @@ components:
       mountSources: false
       volumeMounts:
         - name: myvol
-          path: /data
         - name: myvol2
           path: /data2
   - name: myvol
@@ -49,7 +48,7 @@ commands:
     exec:
       component: runtime2
       commandLine: "cat myfile.log"
-      workingDir: /data
+      workingDir: /myvol
       group:
         kind: run
         isDefault: true

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -33,12 +33,15 @@ var _ = Describe("odo storage command tests", func() {
 
 	Context("when running storage command without required flag(s)", func() {
 		It("should fail", func() {
+			requiredFlags := []string{"size", "path", "required"}
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			helper.CmdShouldPass("odo", "component", "create", "--s2i", "nodejs", "nodejs", "--app", "nodeapp", "--project", commonVar.Project, "--context", commonVar.Context)
-			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1", "--context", commonVar.Context)
-			Expect(stdErr).To(ContainSubstring("required flag"))
+			stdErr := helper.CmdShouldFail("odo", "storage", "create", "pv1", "--size", "1Gi", "--context", commonVar.Context)
+			helper.MatchAllInOutput(stdErr, requiredFlags)
 			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--path", "/data", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdErr, []string{"size", "required"})
+			helper.MatchAllInOutput(stdErr, requiredFlags)
+			stdErr = helper.CmdShouldFail("odo", "storage", "create", "pv1", "--context", commonVar.Context)
+			helper.MatchAllInOutput(stdErr, requiredFlags)
 			//helper.CmdShouldFail("odo", "storage", "create", "pv1", "-o", "json")
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -578,7 +578,7 @@ var _ = Describe("odo devfile push command tests", func() {
 				podName,
 				"runtime2",
 				commonVar.Project,
-				[]string{"cat", "/data/myfile.log"},
+				[]string{"cat", "/myvol/myfile.log"},
 				func(cmdOp string, err error) bool {
 					cmdOutput = cmdOp
 					statErr = err

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -34,11 +34,11 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			storageNames := []string{helper.RandString(5), helper.RandString(5)}
-			pathNames := []string{"/data", "/data-1"}
+			pathNames := []string{"/data", "/" + storageNames[1]}
 			sizes := []string{"5Gi", "1Gi"}
 
 			helper.CmdShouldPass("odo", "storage", "create", storageNames[0], "--path", pathNames[0], "--size", sizes[0], "--context", commonVar.Context)
-			helper.CmdShouldPass("odo", "storage", "create", storageNames[1], "--path", pathNames[1], "--size", sizes[1], "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "storage", "create", storageNames[1], "--size", sizes[1], "--context", commonVar.Context) // check storage create without the path name
 
 			args = []string{"push", "--context", commonVar.Context}
 			helper.CmdShouldPass("odo", args...)
@@ -159,17 +159,17 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			stdOut := helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Not Pushed", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "/data", "/data2", "Not Pushed", "CONTAINER", "runtime", "runtime2"})
 
 			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
 
 			stdOut = helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Pushed", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "/data", "/data2", "Pushed", "CONTAINER", "runtime", "runtime2"})
 
 			helper.CmdShouldPass("odo", "storage", "delete", "firstvol", "-f", "--context", commonVar.Context)
 
 			stdOut = helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Pushed", "Locally Deleted", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "/data", "/data2", "Pushed", "Locally Deleted", "CONTAINER", "runtime", "runtime2"})
 		})
 
 		It("should list output in json format", func() {

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -1,11 +1,12 @@
 package devfile
 
 import (
+	"path/filepath"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
-	"path/filepath"
-	"strings"
 )
 
 var _ = Describe("odo devfile storage command tests", func() {
@@ -158,17 +159,17 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			stdOut := helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "Not Pushed", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Not Pushed", "CONTAINER", "runtime", "runtime2"})
 
 			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
 
 			stdOut = helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "Pushed", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Pushed", "CONTAINER", "runtime", "runtime2"})
 
 			helper.CmdShouldPass("odo", "storage", "delete", "firstvol", "-f", "--context", commonVar.Context)
 
 			stdOut = helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "Pushed", "Locally Deleted", "CONTAINER", "runtime", "runtime2"})
+			helper.MatchAllInOutput(stdOut, []string{"firstvol", "secondvol", "/secondvol", "Pushed", "Locally Deleted", "CONTAINER", "runtime", "runtime2"})
 		})
 
 		It("should list output in json format", func() {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
If vol mount path is absent, it defaults to vol mount name acc to the devfile schema https://devfile.github.io/devfile/api-reference.html

**Which issue(s) this PR fixes**:

Fixes #4005 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
- Comment out the vol mount path in a devfile and push
- Confirm the volume mount path by `oc/kubectl describe pod`