### PR TITLE
Fixes message indicating no build when run mode is switched

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -217,6 +217,9 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		if err != nil {
 			return err
 		}
+	} else {
+		// no file was modified/added/deleted/renamed, thus return without syncing files
+		log.Success("No file changes detected, skipping build. Use the '-f' flag to force the build.")
 	}
 
 	return nil

--- a/pkg/sync/adapter.go
+++ b/pkg/sync/adapter.go
@@ -146,8 +146,6 @@ func (a Adapter) SyncFiles(syncParameters common.SyncParameters) (isPushRequired
 		klog.V(4).Infof("List of files changed: +%v", changedFiles)
 
 		if len(filesChangedFiltered) == 0 && len(filesDeletedFiltered) == 0 && !isForcePush {
-			// no file was modified/added/deleted/renamed, thus return without synching files
-			log.Success("No file changes detected, skipping build. Use the '-f' flag to force the build.")
 			return false, nil
 		}
 	}

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -524,7 +524,8 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 
-			helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
+			stdOut := helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
+			Expect(stdOut).To(Not(ContainSubstring("No file changes detected, skipping build")))
 
 			logs := helper.CmdShouldPass("odo", "log")
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

This PR fixes the `skipping build` message when run mode is switched as a build does get triggered.

**Which issue(s) this PR fixes**:

Fixes #3929 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- odo create nodejs
- odo push
- odo push --debug

The message `skipping build` shouldn't be displayed.