### PR TITLE
Added odo watch test with debug flag

### DIFF
--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -303,7 +303,7 @@ func CreateSimpleFile(context, filePrefix, fileExtension string) (string, string
 
 	FilePath := filepath.Join(context, filePrefix+RandString(10)+fileExtension)
 	content := []byte(RandString(10))
-	err := ioutil.WriteFile(FilePath, content, 0644)
+	err := ioutil.WriteFile(FilePath, content, 0600)
 	Expect(err).NotTo(HaveOccurred())
 
 	return FilePath, string(content)

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -296,3 +296,15 @@ func ReadFile(filePath string) (string, error) {
 	}
 	return string(data), nil
 }
+
+// CreateSimpleFile creates a simple file
+// return the file path with random string
+func CreateSimpleFile(context, filePrefix, fileExtension string) (string, string) {
+
+	FilePath := filepath.Join(context, filePrefix+RandString(10)+fileExtension)
+	content := []byte(RandString(10))
+	err := ioutil.WriteFile(FilePath, content, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	return FilePath, string(content)
+}

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -167,16 +167,12 @@ var _ = Describe("odo devfile watch command tests", func() {
 
 	Context("when executing odo watch after odo push with debug flag", func() {
 		It("should be able to start a debug session after push with debug flag using odo watch and revert back after normal push", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
-
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			helper.CmdShouldPass("odo", "create", cmpName, "--project", commonVar.Project)
 
 			// push with debug flag
-			output = helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
+			output := helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			watchFlag := ""


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does does this PR do / why we need it**:

Adds debug flag tests with odo watch which got removed in https://github.com/openshift/odo/pull/4047 by mistake.

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-cmd-devfile-watch` should pass.