### PR TITLE
Adding ubi8/nodejs-12 images as supported

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -35,6 +35,7 @@ var supportedImages = map[string]bool{
 	"rhscl/nodejs-10-rhel7:latest":                 true,
 	"rhscl/nodejs-12-rhel7:latest":                 true,
 	"rhoar-nodejs/nodejs-10:latest":                true,
+	"ubi8/nodejs-12:latest":                        true,
 }
 
 // GetDevfileRegistries gets devfile registries from preference file,

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -35,7 +35,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.5"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.6"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -178,7 +178,7 @@ func ParseComponentImageName(imageName string) (string, string, string, string) 
 	componentVersion := "latest"
 
 	// Check if componentType includes ":", if so, then we need to spit it into using versions
-	if strings.ContainsAny(componentImageName, ":") {
+	if strings.ContainsAny(componentType, ":") {
 		versionSplit := strings.Split(imageName, ":")
 		componentType = versionSplit[0]
 		componentName = ExtractComponentType(componentType)

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -21,7 +21,7 @@ export KUBECONFIG=$ORIGINAL_KUBECONFIG
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
 # list of namespace to create
-IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7"
+IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12"
 
 # Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -138,6 +138,11 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs:latest", "nodejs-12-rhel7")
 			verifySupportedImage(filepath.Join("rhscl", "nodejs-12-rhel7:latest"), "nodejs", "nodejs:latest", "nodejs-12-rhel7", appName, commonVar.Context)
 		})
+
+		It("Should be able to verify the nodejs-12 image", func() {
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("ubi8", "nodejs-12:latest"), "nodejs:latest", "nodejs-12")
+			verifySupportedImage(filepath.Join("ubi8", "nodejs-12:latest"), "nodejs", "nodejs:latest", "nodejs-12", appName, commonVar.Context)
+		})
 	})
 
 })

--- a/tests/image-streams/supported-nodejs.json
+++ b/tests/image-streams/supported-nodejs.json
@@ -16,6 +16,27 @@
 			{
 				"name": "latest",
 				"annotations": {
+					"description": "Build and run Node.js applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"supports": "nodejs",
+					"tags": "builder,nodejs"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "12"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
 					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
 					"iconClass": "icon-nodejs",
 					"openshift.io/display-name": "Node.js (Latest)",
@@ -26,7 +47,7 @@
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "12-ubi8"
+					"name": "12-ubi"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/tests/image-streams/supported-nodejs.json
+++ b/tests/image-streams/supported-nodejs.json
@@ -35,27 +35,6 @@
 				}
 			},
 			{
-				"name": "latest",
-				"annotations": {
-					"description": "Build and run Node.js applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js (Latest)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"supports": "nodejs",
-					"tags": "builder,nodejs"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "12"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "12",
 				"annotations": {
 					"description": "Build and run Node.js 12 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",

--- a/tests/image-streams/supported-nodejs.json
+++ b/tests/image-streams/supported-nodejs.json
@@ -16,6 +16,27 @@
 			{
 				"name": "latest",
 				"annotations": {
+					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"supports": "nodejs",
+					"tags": "builder,nodejs"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "12-ubi8"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
 					"description": "Build and run Node.js applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
 					"iconClass": "icon-nodejs",
 					"openshift.io/display-name": "Node.js (Latest)",

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -600,8 +600,8 @@ func validateContainerExecListDir(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, 
 			ocRunner := runner.(helper.OcRunner)
 			podName := ocRunner.GetRunningPodNameOfComp(odoV1Watch.SrcType+"-app", project)
 			envs := ocRunner.GetEnvs(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
-			dir := envs["ODO_S2I_WORKING_DIR"]
-			stdOut = ocRunner.ExecListDir(podName, project, dir)
+			dir := envs["ODO_S2I_SRC_BIN_PATH"]
+			stdOut = ocRunner.ExecListDir(podName, project, filepath.Join(dir, "src"))
 		}
 	case "docker":
 		dockerRunner := runner.(helper.DockerRunner)

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -600,8 +600,8 @@ func validateContainerExecListDir(odoV1Watch OdoV1Watch, odoV2Watch OdoV2Watch, 
 			ocRunner := runner.(helper.OcRunner)
 			podName := ocRunner.GetRunningPodNameOfComp(odoV1Watch.SrcType+"-app", project)
 			envs := ocRunner.GetEnvs(odoV1Watch.SrcType+"-app", odoV1Watch.AppName, project)
-			dir := envs["ODO_S2I_SRC_BIN_PATH"]
-			stdOut = ocRunner.ExecListDir(podName, project, filepath.Join(dir, "src"))
+			dir := envs["ODO_S2I_WORKING_DIR"]
+			stdOut = ocRunner.ExecListDir(podName, project, dir)
 		}
 	case "docker":
 		dockerRunner := runner.(helper.DockerRunner)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**What does does this PR do / why we need it**:

There is latest nodejs image difference on 4.6 and 4.5 cluster. So, adding `ubi8/nodejs-12` image as supported will unblock enabling odo periodic job on 4.6 cluster.

**Which issue(s) this PR fixes**:

Fixes #4016 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

Latest nodejs image on 4.6 should work fine for odo