### PR TITLE
Fixing wrong validation of services

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -390,13 +390,13 @@ spec:
 			helper.CmdShouldPass("odo", "create", componentName)
 
 			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			Expect(stdOut).To(ContainSubstring("invalid service name"))
 
 			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			Expect(stdOut).To(ContainSubstring("invalid service name"))
 
 			stdOut = helper.CmdShouldFail("odo", "link", "/example")
-			Expect(stdOut).To(ContainSubstring("Invalid service name"))
+			Expect(stdOut).To(ContainSubstring("invalid service name"))
 		})
 
 		It("should fail if the provided service doesn't exist in the namespace", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

Fixes the wrong validation of services in operatorhub

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-operator-hub` should run successfully.