### PR TITLE
Add Docker container to run scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:buster
+LABEL maintainer="Charlie Drage <charlie@charliedrage.com>"
+
+RUN apt-get update && apt-get install -y \
+      asciidoctor \
+      pandoc
+
+RUN useradd -ms /bin/bash user
+USER user
+WORKDIR /home/user


### PR DESCRIPTION
Adds a docker container to run the scripts in rather than relying on
locla pandoc / asciidoctor. This removes the need of making sure that
the user has a particular version installed when running the
synchronization script.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>