### PR TITLE
Update vendor-update makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ upload-packages:
 # Update vendoring
 .PHONY: vendor-update
 vendor-update:
-	glide update --strip-vendor
+	go mod vendor
 
 .PHONY: openshiftci-presubmit-unittests
 openshiftci-presubmit-unittests:


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
Ran in to this while trying to add a dependency to odo and realized that `make vendor-update` needs to be updated since odo uses go modules now.

This PR updates the `vendor-update` make target to use `go mod vendor` rather than using `glide up`.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
