### PR TITLE
Add warning for default namespace during odo create

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -536,7 +536,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		}
 
 		if componentNamespace == "default" {
-			log.Warning("odo may not work as expected in default project, please run odo component in non default project. You can use `odo project create` to create a new project")
+			log.Warning("odo may not work as expected in a default project, please run the odo component in a non-default project. To create a new project, use `odo project create`.")
 		}
 
 		// Set devfileMetadata struct

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -462,7 +462,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 						return err
 					}
 				} else if !pushtarget.IsPushTargetDocker() {
-					componentNamespace = ui.EnterDevfileComponentNamespace(defaultComponentNamespace)
+					componentNamespace = ui.EnterDevfileComponentProject(defaultComponentNamespace)
 				}
 			}
 
@@ -533,6 +533,10 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			} else {
 				componentNamespace = defaultComponentNamespace
 			}
+		}
+
+		if componentNamespace == "default" {
+			log.Warning("odo may not work as expected in default project, please run odo component in non default project. You can use `odo project create` to create a new project")
 		}
 
 		// Set devfileMetadata struct

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -140,6 +140,10 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
 		if !pushtarget.IsPushTargetDocker() {
 			po.namespace = po.KClient.Namespace
+			// log warning in case of default namespace
+			if po.namespace == "default" {
+				log.Warning("odo may not work as expected in default namespace, please run odo component in non default namespace")
+			}
 		}
 
 		return nil

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -140,10 +140,6 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		// The namespace was retrieved from the --project flag (or from the kube client if not set) and stored in kclient when initalizing the context
 		if !pushtarget.IsPushTargetDocker() {
 			po.namespace = po.KClient.Namespace
-			// log warning in case of default namespace
-			if po.namespace == "default" {
-				log.Warning("odo may not work as expected in default project, please run odo component in non default project. You can use `odo project create` to create a new project")
-			}
 		}
 
 		return nil

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -142,7 +142,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 			po.namespace = po.KClient.Namespace
 			// log warning in case of default namespace
 			if po.namespace == "default" {
-				log.Warning("odo may not work as expected in default namespace, please run odo component in non default namespace")
+				log.Warning("odo may not work as expected in default project, please run odo component in non default project. You can use `odo project create` to create a new project")
 			}
 		}
 

--- a/pkg/odo/cli/component/ui/ui.go
+++ b/pkg/odo/cli/component/ui/ui.go
@@ -77,11 +77,11 @@ func EnterDevfileComponentName(defaultComponentName string) string {
 	return componentName
 }
 
-// EnterDevfileComponentNamespace lets the user to specify the component namespace in the prompt
-func EnterDevfileComponentNamespace(defaultComponentNamespace string) string {
+// EnterDevfileComponentProject lets the user to specify the component project in the prompt
+func EnterDevfileComponentProject(defaultComponentNamespace string) string {
 	var name string
 	prompt := &survey.Input{
-		Message: "What namespace do you want the devfile component to be created in",
+		Message: "What project do you want the devfile component to be created in",
 		Default: defaultComponentNamespace,
 	}
 	err := survey.AskOne(prompt, &name, validation.NameValidator)


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug


**What does does this PR do / why we need it**:
Add explicit warning while using default namespace with odo, component fails due to volume permission issue
I have added warning for `odo push` only as in we want `odo create` to run without cluster access so avoided adding namespace warning in `odo create`

**Which issue(s) this PR fixes**:

Fixes #4053 #4027 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
