### PR TITLE
nit: dont show url as :// in odo url list

### DIFF
--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -693,11 +693,11 @@ func ConvertEnvinfoURL(envinfoURL envinfo.EnvInfoURL, serviceName string) URL {
 
 // GetURLString returns a string representation of given url
 func GetURLString(protocol, URL string, ingressDomain string, isS2I bool) string {
-	if !isS2I && URL == "" {
-		return protocol + "://" + ingressDomain
-	}
 	if protocol == "" && URL == "" && ingressDomain == "" {
 		return ""
+	}
+	if !isS2I && URL == "" {
+		return protocol + "://" + ingressDomain
 	}
 	return protocol + "://" + URL
 }

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -692,7 +692,7 @@ func ConvertEnvinfoURL(envinfoURL envinfo.EnvInfoURL, serviceName string) URL {
 }
 
 // GetURLString returns a string representation of given url
-func GetURLString(protocol, URL string, ingressDomain string, isS2I bool) string {
+func GetURLString(protocol, URL, ingressDomain string, isS2I bool) string {
 	if protocol == "" && URL == "" && ingressDomain == "" {
 		return ""
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -696,6 +696,9 @@ func GetURLString(protocol, URL string, ingressDomain string, isS2I bool) string
 	if !isS2I && URL == "" {
 		return protocol + "://" + ingressDomain
 	}
+	if protocol == "" && URL == "" && ingressDomain == "" {
+		return ""
+	}
 	return protocol + "://" + URL
 }
 

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -3062,3 +3062,57 @@ func TestRemoveEndpointInDevfile(t *testing.T) {
 		})
 	}
 }
+
+func TestGetURLString(t *testing.T) {
+	cases := []struct {
+		name          string
+		protocol      string
+		URL           string
+		ingressDomain string
+		isS2I         bool
+		expected      string
+	}{
+		{
+			name:          "simple s2i case",
+			protocol:      "http",
+			URL:           "example.com",
+			ingressDomain: "",
+			isS2I:         true,
+			expected:      "http://example.com",
+		},
+		{
+			name:          "all blank with s2i",
+			protocol:      "",
+			URL:           "",
+			ingressDomain: "",
+			isS2I:         true,
+			expected:      "",
+		},
+		{
+			name:          "all blank without s2i",
+			protocol:      "",
+			URL:           "",
+			ingressDomain: "",
+			isS2I:         false,
+			expected:      "",
+		},
+		{
+			name:          "devfile case",
+			protocol:      "http",
+			URL:           "",
+			ingressDomain: "spring-8080.192.168.39.247.nip.io",
+			isS2I:         false,
+			expected:      "http://spring-8080.192.168.39.247.nip.io",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			output := GetURLString(testCase.protocol, testCase.URL, testCase.ingressDomain, testCase.isS2I)
+			if output != testCase.expected {
+				t.Errorf("Expected: %v, got %v", testCase.expected, output)
+
+			}
+		})
+	}
+}

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -38,6 +38,7 @@ var _ = Describe("odo url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", commonVar.Context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
 			helper.MatchAllInOutput(stdout, []string{url1, "Not Pushed", url1, "odo push"})
+			helper.DontMatchAllInOutput(stdout, []string{"://"})
 
 			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
 			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -112,11 +112,8 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			// we check the default url
-			stdout := helper.CmdShouldPass("odo", "url", "list")
-			helper.DontMatchAllInOutput(stdout, []string{"://"})
 			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
-			stdout = helper.CmdShouldPass("odo", "url", "list")
+			stdout := helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "3000", "Not Pushed"})
 		})
 

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -2,10 +2,11 @@ package devfile
 
 import (
 	"fmt"
-	"github.com/openshift/odo/tests/helper"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/openshift/odo/tests/helper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -115,6 +116,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
 			stdout := helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "3000", "Not Pushed"})
+			helper.DontMatchAllInOutput(stdout, []string{"://"})
 		})
 
 		It("should create a secure URL", func() {

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -112,11 +112,12 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
+			// we check the default url
 			stdout := helper.CmdShouldPass("odo", "url", "list")
-			helper.MatchAllInOutput(stdout, []string{url1, "3000", "Not Pushed"})
 			helper.DontMatchAllInOutput(stdout, []string{"://"})
+			helper.CmdShouldPass("odo", "url", "create", url1, "--host", host, "--ingress")
+			stdout = helper.CmdShouldPass("odo", "url", "list")
+			helper.MatchAllInOutput(stdout, []string{url1, "3000", "Not Pushed"})
 		})
 
 		It("should create a secure URL", func() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

**What does does this PR do / why we need it**:
before doing odo push if there is a url present then we show it as `://` and that's confusing. Resolved it by making it a blank until user pushes.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4109

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
way to reproduce 
```
odo create nodejs
odo url create --port 3000
odo url list
```

Output:
```
Found the following URLs for component nodejs
NAME STATE URL PORT SECURE KIND
nodejs-3000 Not Pushed :// 3000 false route
```

After fix the url would be blank