### PR TITLE
Adds subDir checkout for git components

### DIFF
--- a/docs/file-reference/index.md
+++ b/docs/file-reference/index.md
@@ -82,10 +82,10 @@ metadata:
 starterProjects:
   - name: quarkus-quickstart
     description: minimal CRUD app with quarkus
+    subDir: /getting-started/ # optional checkout dir
     git:
       location: https://github.com/quarkusio/quarkus-quickstarts
       branch: master
-      sparseCheckoutDir: /getting-started/ # optional checkout dir
       startPoint: 1.7.0.Final # tag or commit to start at
 ```
 
@@ -245,10 +245,10 @@ metadata:
 starterProjects:
   - name: quarkus-quickstart
     description: minimal CRUD app with quarkus
+    subDir: /getting-started/ # optional checkout dir
     git:
       location: https://github.com/quarkusio/quarkus-quickstarts
       branch: master
-      sparseCheckoutDir: /getting-started/ # optional checkout dir
       startPoint: 1.7.0.Final # tag or commit to start at
 ```   
 
@@ -259,10 +259,10 @@ starterProjects:
 starterProjects:
   - name: nodejs-web-app
     description: nodejs app
+    subDir: /app/ # optional checkout dir
     github:
       location: https://github.com/odo-devfiles/nodejs-ex.git
       branch: master
-      sparseCheckoutDir: /app/ # optional checkout dir
       startPoint: 1.0.0 # tag or commit to start at
 ```
 
@@ -272,9 +272,9 @@ starterProjects:
 starterProjects:
   - name: nodejs-web-app
     description: nodejs web app
+    subDir: /app/ # optional checkout dir
     zip:
       location: https://github.com/odo-devfiles/nodejs-ex/archive/0.0.1.zip
-      sparseCheckoutDir: /app/ # optional checkout dir
 ```
 
 Each starter project may contain three different objects, `git`, `github` or `zip`.
@@ -298,10 +298,10 @@ Each starter project may contain three different objects, `git`, `github` or `zi
 ```yaml
 starterProjects:
   - name: nodejs-web-app
+    subDir: /app/ # optional checkout dir
     git:
       location: https://github.com/odo-devfiles/nodejs-ex.git
       branch: master
-      sparseCheckoutDir: /app/ # optional checkout dir
       startPoint: 1.0.0 # tag or commit to start at
 ```
 
@@ -319,10 +319,10 @@ starterProjects:
 ```yaml
 starterProjects:
   - name: nodejs-web-app
+    subDir: /app/ # optional checkout dir
     github:
       location: https://github.com/odo-devfiles/nodejs-ex.git
       branch: master
-      sparseCheckoutDir: /app/ # optional checkout dir
       startPoint: 1.0.0 # tag or commit to start at
 ```
 
@@ -340,9 +340,9 @@ starterProjects:
 ```yaml
 starterProjects:
   - name: nodejs-web-app
+    subDir: /app/ # optional checkout dir
     zip:
       location: https://github.com/odo-devfiles/nodejs-ex/archive/0.0.1.zip
-      sparseCheckoutDir: /app/ # optional checkout dir
 ```
 
 | Key              | Type   | Description                        |

--- a/pkg/devfile/parser/configurables_test.go
+++ b/pkg/devfile/parser/configurables_test.go
@@ -74,8 +74,8 @@ func TestSetConfiguration(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/projects",
-							Name:      "starter-project-2",
+							SubDir: "/projects",
+							Name:   "starter-project-2",
 						},
 					},
 				},
@@ -149,8 +149,8 @@ func TestSetConfiguration(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/projects",
-							Name:      "starter-project-2",
+							SubDir: "/projects",
+							Name:   "starter-project-2",
 						},
 					},
 				},
@@ -280,8 +280,8 @@ func TestAddAndRemoveEnvVars(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/projects",
-							Name:      "starter-project-2",
+							SubDir: "/projects",
+							Name:   "starter-project-2",
 						},
 					},
 				},
@@ -356,8 +356,8 @@ func testDevfileObj(fs filesystem.Filesystem) DevfileObj {
 			},
 			StarterProjects: []common.DevfileStarterProject{
 				{
-					ClonePath: "/projects",
-					Name:      "starter-project-2",
+					SubDir: "/projects",
+					Name:   "starter-project-2",
 				},
 			},
 		},

--- a/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
+++ b/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
@@ -2,359 +2,21 @@ package version200
 
 // https://raw.githubusercontent.com/devfile/api/master/schemas/devfile.json
 const JsonSchema200 = `{
-  "description": "Devfile schema.",
+  "description": "Devfile describes the structure of a cloud-native workspace and development environment.",
+  "type": "object",
+  "title": "Devfile schema - Version 2.0.0-alpha2",
+  "required": [
+    "schemaVersion"
+  ],
   "properties": {
     "commands": {
       "description": "Predefined, ready-to-use, workspace-related commands",
+      "type": "array",
       "items": {
-        "properties": {
-          "apply": {
-            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-            "properties": {
-              "attributes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Optional map of free-form additional command attributes",
-                "type": "object",
-                "markdownDescription": "Optional map of free-form additional command attributes"
-              },
-              "component": {
-                "description": "Describes component that will be applied",
-                "type": "string",
-                "markdownDescription": "Describes component that will be applied"
-              },
-              "group": {
-                "description": "Defines the group this command is part of",
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean",
-                    "markdownDescription": "Identifies the default command for a given group kind"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ],
-                    "type": "string",
-                    "markdownDescription": "Kind of group the command is part of"
-                  }
-                },
-                "required": [
-                  "kind"
-                ],
-                "type": "object",
-                "markdownDescription": "Defines the group this command is part of",
-                "additionalProperties": false
-              },
-              "label": {
-                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string",
-                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-            "additionalProperties": false
-          },
-          "composite": {
-            "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-            "properties": {
-              "attributes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Optional map of free-form additional command attributes",
-                "type": "object",
-                "markdownDescription": "Optional map of free-form additional command attributes"
-              },
-              "commands": {
-                "description": "The commands that comprise this composite command",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array",
-                "markdownDescription": "The commands that comprise this composite command"
-              },
-              "group": {
-                "description": "Defines the group this command is part of",
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean",
-                    "markdownDescription": "Identifies the default command for a given group kind"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ],
-                    "type": "string",
-                    "markdownDescription": "Kind of group the command is part of"
-                  }
-                },
-                "required": [
-                  "kind"
-                ],
-                "type": "object",
-                "markdownDescription": "Defines the group this command is part of",
-                "additionalProperties": false
-              },
-              "label": {
-                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string",
-                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-              },
-              "parallel": {
-                "description": "Indicates if the sub-commands should be executed concurrently",
-                "type": "boolean",
-                "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-            "additionalProperties": false
-          },
-          "exec": {
-            "description": "CLI Command executed in an existing component container",
-            "properties": {
-              "attributes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Optional map of free-form additional command attributes",
-                "type": "object",
-                "markdownDescription": "Optional map of free-form additional command attributes"
-              },
-              "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-              },
-              "component": {
-                "description": "Describes component to which given action relates",
-                "type": "string",
-                "markdownDescription": "Describes component to which given action relates"
-              },
-              "env": {
-                "description": "Optional list of environment variables that have to be set before running the command",
-                "items": {
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "value"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array",
-                "markdownDescription": "Optional list of environment variables that have to be set before running the command"
-              },
-              "group": {
-                "description": "Defines the group this command is part of",
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean",
-                    "markdownDescription": "Identifies the default command for a given group kind"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ],
-                    "type": "string",
-                    "markdownDescription": "Kind of group the command is part of"
-                  }
-                },
-                "required": [
-                  "kind"
-                ],
-                "type": "object",
-                "markdownDescription": "Defines the group this command is part of",
-                "additionalProperties": false
-              },
-              "hotReloadCapable": {
-                "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
-                "type": "boolean",
-                "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'"
-              },
-              "label": {
-                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                "type": "string",
-                "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-              },
-              "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "CLI Command executed in an existing component container",
-            "additionalProperties": false,
-            "required": [
-              "commandLine"
-            ]
-          },
-          "id": {
-            "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-            "type": "string",
-            "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
-          },
-          "vscodeLaunch": {
-            "description": "Command providing the definition of a VsCode launch action",
-            "properties": {
-              "attributes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Optional map of free-form additional command attributes",
-                "type": "object",
-                "markdownDescription": "Optional map of free-form additional command attributes"
-              },
-              "group": {
-                "description": "Defines the group this command is part of",
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean",
-                    "markdownDescription": "Identifies the default command for a given group kind"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ],
-                    "type": "string",
-                    "markdownDescription": "Kind of group the command is part of"
-                  }
-                },
-                "required": [
-                  "kind"
-                ],
-                "type": "object",
-                "markdownDescription": "Defines the group this command is part of",
-                "additionalProperties": false
-              },
-              "inlined": {
-                "description": "Inlined content of the VsCode configuration",
-                "type": "string",
-                "markdownDescription": "Inlined content of the VsCode configuration"
-              },
-              "uri": {
-                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string",
-                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Command providing the definition of a VsCode launch action",
-            "additionalProperties": false,
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ]
-          },
-          "vscodeTask": {
-            "description": "Command providing the definition of a VsCode Task",
-            "properties": {
-              "attributes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Optional map of free-form additional command attributes",
-                "type": "object",
-                "markdownDescription": "Optional map of free-form additional command attributes"
-              },
-              "group": {
-                "description": "Defines the group this command is part of",
-                "properties": {
-                  "isDefault": {
-                    "description": "Identifies the default command for a given group kind",
-                    "type": "boolean",
-                    "markdownDescription": "Identifies the default command for a given group kind"
-                  },
-                  "kind": {
-                    "description": "Kind of group the command is part of",
-                    "enum": [
-                      "build",
-                      "run",
-                      "test",
-                      "debug"
-                    ],
-                    "type": "string",
-                    "markdownDescription": "Kind of group the command is part of"
-                  }
-                },
-                "required": [
-                  "kind"
-                ],
-                "type": "object",
-                "markdownDescription": "Defines the group this command is part of",
-                "additionalProperties": false
-              },
-              "inlined": {
-                "description": "Inlined content of the VsCode configuration",
-                "type": "string",
-                "markdownDescription": "Inlined content of the VsCode configuration"
-              },
-              "uri": {
-                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                "type": "string",
-                "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Command providing the definition of a VsCode Task",
-            "additionalProperties": false,
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ]
-          }
-        },
+        "type": "object",
         "required": [
           "id"
         ],
-        "type": "object",
-        "additionalProperties": false,
         "oneOf": [
           {
             "required": [
@@ -381,102 +43,142 @@ const JsonSchema200 = `{
               "composite"
             ]
           }
-        ]
-      },
-      "type": "array",
-      "markdownDescription": "Predefined, ready-to-use, workspace-related commands"
-    },
-    "components": {
-      "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
-      "items": {
+        ],
         "properties": {
-          "container": {
-            "description": "Allows adding and configuring workspace-related containers",
+          "apply": {
+            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+            "type": "object",
+            "required": [
+              "component"
+            ],
             "properties": {
-              "args": {
-                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                "items": {
+              "attributes": {
+                "description": "Optional map of free-form additional command attributes",
+                "type": "object",
+                "additionalProperties": {
                   "type": "string"
-                },
-                "type": "array",
-                "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
+                }
               },
-              "command": {
-                "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array",
-                "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
+              "component": {
+                "description": "Describes component that will be applied",
+                "type": "string"
               },
-              "dedicatedPod": {
-                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
-                "type": "boolean",
-                "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'"
-              },
-              "endpoints": {
-                "items": {
-                  "properties": {
-                    "attributes": {
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object",
-                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                    },
-                    "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                      "enum": [
-                        "public",
-                        "internal",
-                        "none"
-                      ],
-                      "type": "string",
-                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "path": {
-                      "description": "Path of the endpoint URL",
-                      "type": "string",
-                      "markdownDescription": "Path of the endpoint URL"
-                    },
-                    "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                      "type": "string",
-                      "enum": [
-                        "http",
-                        "https",
-                        "ws",
-                        "wss",
-                        "tcp",
-                        "udp"
-                      ],
-                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                    },
-                    "secure": {
-                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean",
-                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                    },
-                    "targetPort": {
-                      "type": "integer"
-                    }
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
                   },
-                  "required": [
-                    "name",
-                    "targetPort"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
                 },
-                "type": "array"
+                "additionalProperties": false
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "composite": {
+            "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+            "type": "object",
+            "properties": {
+              "attributes": {
+                "description": "Optional map of free-form additional command attributes",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "commands": {
+                "description": "The commands that comprise this composite command",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                "type": "string"
+              },
+              "parallel": {
+                "description": "Indicates if the sub-commands should be executed concurrently",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "exec": {
+            "description": "CLI Command executed in an existing component container",
+            "type": "object",
+            "required": [
+              "commandLine",
+              "component"
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Optional map of free-form additional command attributes",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "commandLine": {
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "type": "string"
+              },
+              "component": {
+                "description": "Describes component to which given action relates",
+                "type": "string"
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Optional list of environment variables that have to be set before running the command",
+                "type": "array",
                 "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "value"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -485,1046 +187,55 @@ const JsonSchema200 = `{
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "value"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
-                },
-                "type": "array",
-                "markdownDescription": "Environment variables used in this container"
+                }
               },
-              "image": {
-                "type": "string"
-              },
-              "memoryLimit": {
-                "type": "string"
-              },
-              "mountSources": {
-                "type": "boolean"
-              },
-              "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used.",
-                "type": "string",
-                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used."
-              },
-              "volumeMounts": {
-                "description": "List of volumes mounts that should be mounted is this container.",
-                "items": {
-                  "description": "Volume that should be mounted to a component container",
-                  "properties": {
-                    "name": {
-                      "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string",
-                      "markdownDescription": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
-                    },
-                    "path": {
-                      "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'.",
-                      "type": "string",
-                      "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'."
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
-                  "markdownDescription": "Volume that should be mounted to a component container",
-                  "additionalProperties": false
-                },
-                "type": "array",
-                "markdownDescription": "List of volumes mounts that should be mounted is this container."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Allows adding and configuring workspace-related containers",
-            "additionalProperties": false,
-            "required": [
-              "image"
-            ]
-          },
-          "kubernetes": {
-            "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-            "properties": {
-              "endpoints": {
-                "items": {
-                  "properties": {
-                    "attributes": {
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object",
-                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                    },
-                    "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                      "enum": [
-                        "public",
-                        "internal",
-                        "none"
-                      ],
-                      "type": "string",
-                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "path": {
-                      "description": "Path of the endpoint URL",
-                      "type": "string",
-                      "markdownDescription": "Path of the endpoint URL"
-                    },
-                    "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                      "type": "string",
-                      "enum": [
-                        "http",
-                        "https",
-                        "ws",
-                        "wss",
-                        "tcp",
-                        "udp"
-                      ],
-                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                    },
-                    "secure": {
-                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean",
-                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                    },
-                    "targetPort": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "targetPort"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "inlined": {
-                "description": "Inlined manifest",
-                "type": "string",
-                "markdownDescription": "Inlined manifest"
-              },
-              "uri": {
-                "description": "Location in a file fetched from a uri.",
-                "type": "string",
-                "markdownDescription": "Location in a file fetched from a uri."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-            "additionalProperties": false,
-            "oneOf": [
-              {
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
                 "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ]
-          },
-          "name": {
-            "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-            "type": "string",
-            "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
-          },
-          "openshift": {
-            "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-            "properties": {
-              "endpoints": {
-                "items": {
-                  "properties": {
-                    "attributes": {
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                      "type": "object",
-                      "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                    },
-                    "exposure": {
-                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                      "enum": [
-                        "public",
-                        "internal",
-                        "none"
-                      ],
-                      "type": "string",
-                      "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "path": {
-                      "description": "Path of the endpoint URL",
-                      "type": "string",
-                      "markdownDescription": "Path of the endpoint URL"
-                    },
-                    "protocol": {
-                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                      "type": "string",
-                      "enum": [
-                        "http",
-                        "https",
-                        "ws",
-                        "wss",
-                        "tcp",
-                        "udp"
-                      ],
-                      "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                    },
-                    "secure": {
-                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                      "type": "boolean",
-                      "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                    },
-                    "targetPort": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "targetPort"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "inlined": {
-                "description": "Inlined manifest",
-                "type": "string",
-                "markdownDescription": "Inlined manifest"
-              },
-              "uri": {
-                "description": "Location in a file fetched from a uri.",
-                "type": "string",
-                "markdownDescription": "Location in a file fetched from a uri."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-            "additionalProperties": false,
-            "oneOf": [
-              {
-                "required": [
-                  "uri"
-                ]
-              },
-              {
-                "required": [
-                  "inlined"
-                ]
-              }
-            ]
-          },
-          "plugin": {
-            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
-            "properties": {
-              "commands": {
-                "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch",
-                "items": {
-                  "properties": {
-                    "apply": {
-                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Optional map of free-form additional command attributes",
-                          "type": "object",
-                          "markdownDescription": "Optional map of free-form additional command attributes"
-                        },
-                        "component": {
-                          "description": "Describes component that will be applied",
-                          "type": "string",
-                          "markdownDescription": "Describes component that will be applied"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean",
-                              "markdownDescription": "Identifies the default command for a given group kind"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ],
-                              "type": "string",
-                              "markdownDescription": "Kind of group the command is part of"
-                            }
-                          },
-                          "required": [
-                            "kind"
-                          ],
-                          "type": "object",
-                          "markdownDescription": "Defines the group this command is part of",
-                          "additionalProperties": false
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string",
-                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                      "additionalProperties": false
-                    },
-                    "composite": {
-                      "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Optional map of free-form additional command attributes",
-                          "type": "object",
-                          "markdownDescription": "Optional map of free-form additional command attributes"
-                        },
-                        "commands": {
-                          "description": "The commands that comprise this composite command",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "markdownDescription": "The commands that comprise this composite command"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean",
-                              "markdownDescription": "Identifies the default command for a given group kind"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ],
-                              "type": "string",
-                              "markdownDescription": "Kind of group the command is part of"
-                            }
-                          },
-                          "required": [
-                            "kind"
-                          ],
-                          "type": "object",
-                          "markdownDescription": "Defines the group this command is part of",
-                          "additionalProperties": false
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string",
-                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                        },
-                        "parallel": {
-                          "description": "Indicates if the sub-commands should be executed concurrently",
-                          "type": "boolean",
-                          "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                      "additionalProperties": false
-                    },
-                    "exec": {
-                      "description": "CLI Command executed in an existing component container",
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Optional map of free-form additional command attributes",
-                          "type": "object",
-                          "markdownDescription": "Optional map of free-form additional command attributes"
-                        },
-                        "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                          "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-                        },
-                        "component": {
-                          "description": "Describes component to which given action relates",
-                          "type": "string",
-                          "markdownDescription": "Describes component to which given action relates"
-                        },
-                        "env": {
-                          "description": "Optional list of environment variables that have to be set before running the command",
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "value"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array",
-                          "markdownDescription": "Optional list of environment variables that have to be set before running the command"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean",
-                              "markdownDescription": "Identifies the default command for a given group kind"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ],
-                              "type": "string",
-                              "markdownDescription": "Kind of group the command is part of"
-                            }
-                          },
-                          "required": [
-                            "kind"
-                          ],
-                          "type": "object",
-                          "markdownDescription": "Defines the group this command is part of",
-                          "additionalProperties": false
-                        },
-                        "hotReloadCapable": {
-                          "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
-                          "type": "boolean",
-                          "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'"
-                        },
-                        "label": {
-                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                          "type": "string",
-                          "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                        },
-                        "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                          "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "CLI Command executed in an existing component container",
-                      "additionalProperties": false
-                    },
-                    "id": {
-                      "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                      "type": "string",
-                      "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
-                    },
-                    "vscodeLaunch": {
-                      "description": "Command providing the definition of a VsCode launch action",
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Optional map of free-form additional command attributes",
-                          "type": "object",
-                          "markdownDescription": "Optional map of free-form additional command attributes"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean",
-                              "markdownDescription": "Identifies the default command for a given group kind"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ],
-                              "type": "string",
-                              "markdownDescription": "Kind of group the command is part of"
-                            }
-                          },
-                          "required": [
-                            "kind"
-                          ],
-                          "type": "object",
-                          "markdownDescription": "Defines the group this command is part of",
-                          "additionalProperties": false
-                        },
-                        "inlined": {
-                          "description": "Inlined content of the VsCode configuration",
-                          "type": "string",
-                          "markdownDescription": "Inlined content of the VsCode configuration"
-                        },
-                        "uri": {
-                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string",
-                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Command providing the definition of a VsCode launch action",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ]
-                    },
-                    "vscodeTask": {
-                      "description": "Command providing the definition of a VsCode Task",
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Optional map of free-form additional command attributes",
-                          "type": "object",
-                          "markdownDescription": "Optional map of free-form additional command attributes"
-                        },
-                        "group": {
-                          "description": "Defines the group this command is part of",
-                          "properties": {
-                            "isDefault": {
-                              "description": "Identifies the default command for a given group kind",
-                              "type": "boolean",
-                              "markdownDescription": "Identifies the default command for a given group kind"
-                            },
-                            "kind": {
-                              "description": "Kind of group the command is part of",
-                              "enum": [
-                                "build",
-                                "run",
-                                "test",
-                                "debug"
-                              ],
-                              "type": "string",
-                              "markdownDescription": "Kind of group the command is part of"
-                            }
-                          },
-                          "required": [
-                            "kind"
-                          ],
-                          "type": "object",
-                          "markdownDescription": "Defines the group this command is part of",
-                          "additionalProperties": false
-                        },
-                        "inlined": {
-                          "description": "Inlined content of the VsCode configuration",
-                          "type": "string",
-                          "markdownDescription": "Inlined content of the VsCode configuration"
-                        },
-                        "uri": {
-                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                          "type": "string",
-                          "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Command providing the definition of a VsCode Task",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "id"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false,
-                  "oneOf": [
-                    {
-                      "required": [
-                        "exec"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "apply"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "vscodeTask"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "vscodeLaunch"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "composite"
-                      ]
-                    }
-                  ]
-                },
-                "type": "array",
-                "markdownDescription": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch"
-              },
-              "components": {
-                "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge patch. A plugin cannot override embedded plugin components.",
-                "items": {
-                  "properties": {
-                    "container": {
-                      "description": "Configuration overriding for a Container component in a plugin",
-                      "properties": {
-                        "args": {
-                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
-                        },
-                        "command": {
-                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
-                        },
-                        "dedicatedPod": {
-                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
-                          "type": "boolean",
-                          "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'"
-                        },
-                        "endpoints": {
-                          "items": {
-                            "properties": {
-                              "attributes": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ],
-                                "type": "string",
-                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string",
-                                "markdownDescription": "Path of the endpoint URL"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ],
-                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean",
-                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "env": {
-                          "description": "Environment variables used in this container",
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "value"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array",
-                          "markdownDescription": "Environment variables used in this container"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "memoryLimit": {
-                          "type": "string"
-                        },
-                        "mountSources": {
-                          "type": "boolean"
-                        },
-                        "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used.",
-                          "type": "string",
-                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used."
-                        },
-                        "volumeMounts": {
-                          "description": "List of volumes mounts that should be mounted is this container.",
-                          "items": {
-                            "description": "Volume that should be mounted to a component container",
-                            "properties": {
-                              "name": {
-                                "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string",
-                                "markdownDescription": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
-                              },
-                              "path": {
-                                "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'.",
-                                "type": "string",
-                                "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'."
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "markdownDescription": "Volume that should be mounted to a component container",
-                            "additionalProperties": false
-                          },
-                          "type": "array",
-                          "markdownDescription": "List of volumes mounts that should be mounted is this container."
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Configuration overriding for a Container component in a plugin",
-                      "additionalProperties": false
-                    },
-                    "kubernetes": {
-                      "description": "Configuration overriding for a Kubernetes component in a plugin",
-                      "properties": {
-                        "endpoints": {
-                          "items": {
-                            "properties": {
-                              "attributes": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ],
-                                "type": "string",
-                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string",
-                                "markdownDescription": "Path of the endpoint URL"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ],
-                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean",
-                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "inlined": {
-                          "description": "Inlined manifest",
-                          "type": "string",
-                          "markdownDescription": "Inlined manifest"
-                        },
-                        "uri": {
-                          "description": "Location in a file fetched from a uri.",
-                          "type": "string",
-                          "markdownDescription": "Location in a file fetched from a uri."
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Configuration overriding for a Kubernetes component in a plugin",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ]
-                    },
-                    "name": {
-                      "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                      "type": "string",
-                      "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
-                    },
-                    "openshift": {
-                      "description": "Configuration overriding for an OpenShift component in a plugin",
-                      "properties": {
-                        "endpoints": {
-                          "items": {
-                            "properties": {
-                              "attributes": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                "type": "object",
-                                "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                              },
-                              "exposure": {
-                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                "enum": [
-                                  "public",
-                                  "internal",
-                                  "none"
-                                ],
-                                "type": "string",
-                                "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "path": {
-                                "description": "Path of the endpoint URL",
-                                "type": "string",
-                                "markdownDescription": "Path of the endpoint URL"
-                              },
-                              "protocol": {
-                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "https",
-                                  "ws",
-                                  "wss",
-                                  "tcp",
-                                  "udp"
-                                ],
-                                "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                              },
-                              "secure": {
-                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                "type": "boolean",
-                                "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                              },
-                              "targetPort": {
-                                "type": "integer"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "inlined": {
-                          "description": "Inlined manifest",
-                          "type": "string",
-                          "markdownDescription": "Inlined manifest"
-                        },
-                        "uri": {
-                          "description": "Location in a file fetched from a uri.",
-                          "type": "string",
-                          "markdownDescription": "Location in a file fetched from a uri."
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Configuration overriding for an OpenShift component in a plugin",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "uri"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "inlined"
-                          ]
-                        }
-                      ]
-                    },
-                    "volume": {
-                      "description": "Configuration overriding for a Volume component in a plugin",
-                      "properties": {
-                        "size": {
-                          "description": "Size of the volume",
-                          "type": "string",
-                          "markdownDescription": "Size of the volume"
-                        }
-                      },
-                      "type": "object",
-                      "markdownDescription": "Configuration overriding for a Volume component in a plugin",
-                      "additionalProperties": false
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false,
-                  "oneOf": [
-                    {
-                      "required": [
-                        "container"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "kubernetes"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "openshift"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "volume"
-                      ]
-                    }
-                  ]
-                },
-                "type": "array",
-                "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge patch. A plugin cannot override embedded plugin components."
-              },
-              "id": {
-                "description": "Id in a registry that contains a Devfile yaml file",
-                "type": "string",
-                "markdownDescription": "Id in a registry that contains a Devfile yaml file"
-              },
-              "kubernetes": {
-                "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                  "kind"
+                ],
                 "properties": {
-                  "name": {
-                    "type": "string"
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
                   },
-                  "namespace": {
-                    "type": "string"
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
                   }
                 },
-                "required": [
-                  "name"
-                ],
-                "type": "object",
-                "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                 "additionalProperties": false
               },
-              "registryUrl": {
+              "hotReloadCapable": {
+                "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
+                "type": "boolean"
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                 "type": "string"
               },
-              "uri": {
-                "description": "Uri of a Devfile yaml file",
-                "type": "string",
-                "markdownDescription": "Uri of a Devfile yaml file"
+              "workingDir": {
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "type": "string"
               }
             },
+            "additionalProperties": false
+          },
+          "id": {
+            "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+            "type": "string"
+          },
+          "vscodeLaunch": {
+            "description": "Command providing the definition of a VsCode launch action",
             "type": "object",
-            "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
-            "additionalProperties": false,
             "oneOf": [
               {
                 "required": [
@@ -1533,35 +244,123 @@ const JsonSchema200 = `{
               },
               {
                 "required": [
-                  "id"
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Optional map of free-form additional command attributes",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "inlined": {
+                "description": "Inlined content of the VsCode configuration",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "vscodeTask": {
+            "description": "Command providing the definition of a VsCode Task",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
                 ]
               },
               {
                 "required": [
-                  "kubernetes"
+                  "inlined"
                 ]
               }
-            ]
-          },
-          "volume": {
-            "description": "Allows specifying the definition of a volume shared by several other components",
+            ],
             "properties": {
-              "size": {
-                "description": "Size of the volume",
-                "type": "string",
-                "markdownDescription": "Size of the volume"
+              "attributes": {
+                "description": "Optional map of free-form additional command attributes",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "inlined": {
+                "description": "Inlined content of the VsCode configuration",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                "type": "string"
               }
             },
-            "type": "object",
-            "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
             "additionalProperties": false
           }
         },
+        "additionalProperties": false
+      }
+    },
+    "components": {
+      "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
+      "type": "array",
+      "items": {
+        "type": "object",
         "required": [
           "name"
         ],
-        "type": "object",
-        "additionalProperties": false,
         "oneOf": [
           {
             "required": [
@@ -1588,402 +387,1087 @@ const JsonSchema200 = `{
               "plugin"
             ]
           }
-        ]
-      },
-      "type": "array",
-      "markdownDescription": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components"
-    },
-    "events": {
-      "description": "Bindings of commands to events. Each command is referred-to by its name.",
-      "properties": {
-        "postStart": {
-          "description": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "markdownDescription": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser."
-        },
-        "postStop": {
-          "description": "Names of commands that should be executed after stopping the workspace.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "markdownDescription": "Names of commands that should be executed after stopping the workspace."
-        },
-        "preStart": {
-          "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "markdownDescription": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD."
-        },
-        "preStop": {
-          "description": "Names of commands that should be executed before stopping the workspace.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "markdownDescription": "Names of commands that should be executed before stopping the workspace."
-        }
-      },
-      "type": "object",
-      "markdownDescription": "Bindings of commands to events. Each command is referred-to by its name.",
-      "additionalProperties": false
-    },
-    "parent": {
-      "description": "Parent workspace template",
-      "properties": {
-        "commands": {
-          "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch",
-          "items": {
+        ],
+        "properties": {
+          "container": {
+            "description": "Allows adding and configuring workspace-related containers",
+            "type": "object",
+            "required": [
+              "image"
+            ],
             "properties": {
-              "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                "properties": {
-                  "attributes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Optional map of free-form additional command attributes",
-                    "type": "object",
-                    "markdownDescription": "Optional map of free-form additional command attributes"
-                  },
-                  "component": {
-                    "description": "Describes component that will be applied",
-                    "type": "string",
-                    "markdownDescription": "Describes component that will be applied"
-                  },
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean",
-                        "markdownDescription": "Identifies the default command for a given group kind"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ],
-                        "type": "string",
-                        "markdownDescription": "Kind of group the command is part of"
+              "args": {
+                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "dedicatedPod": {
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
+                "type": "boolean"
+              },
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     },
-                    "required": [
-                      "kind"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Defines the group this command is part of",
-                    "additionalProperties": false
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                      "type": "string",
+                      "default": "http"
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
                   },
-                  "label": {
-                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string",
-                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                "additionalProperties": false
+                  "additionalProperties": false
+                }
               },
-              "composite": {
-                "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                "properties": {
-                  "attributes": {
-                    "additionalProperties": {
+              "env": {
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - '$PROJECTS_ROOT'\n\n - '$PROJECT_SOURCE'",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "properties": {
+                    "name": {
                       "type": "string"
                     },
-                    "description": "Optional map of free-form additional command attributes",
-                    "type": "object",
-                    "markdownDescription": "Optional map of free-form additional command attributes"
+                    "value": {
+                      "type": "string"
+                    }
                   },
-                  "commands": {
-                    "description": "The commands that comprise this composite command",
-                    "items": {
+                  "additionalProperties": false
+                }
+              },
+              "image": {
+                "type": "string"
+              },
+              "memoryLimit": {
+                "type": "string"
+              },
+              "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set 'dedicatedPod' to true.",
+                "type": "boolean"
+              },
+              "sourceMapping": {
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the default value of /projects is used.",
+                "type": "string",
+                "default": "/projects"
+              },
+              "volumeMounts": {
+                "description": "List of volumes mounts that should be mounted is this container.",
+                "type": "array",
+                "items": {
+                  "description": "Volume that should be mounted to a component container",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string"
                     },
-                    "type": "array",
-                    "markdownDescription": "The commands that comprise this composite command"
+                    "path": {
+                      "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/\u003cname\u003e'.",
+                      "type": "string"
+                    }
                   },
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean",
-                        "markdownDescription": "Identifies the default command for a given group kind"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ],
-                        "type": "string",
-                        "markdownDescription": "Kind of group the command is part of"
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "kubernetes": {
+            "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     },
-                    "required": [
-                      "kind"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Defines the group this command is part of",
-                    "additionalProperties": false
-                  },
-                  "label": {
-                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string",
-                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  },
-                  "parallel": {
-                    "description": "Indicates if the sub-commands should be executed concurrently",
-                    "type": "boolean",
-                    "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                "additionalProperties": false
-              },
-              "exec": {
-                "description": "CLI Command executed in an existing component container",
-                "properties": {
-                  "attributes": {
-                    "additionalProperties": {
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
                       "type": "string"
                     },
-                    "description": "Optional map of free-form additional command attributes",
-                    "type": "object",
-                    "markdownDescription": "Optional map of free-form additional command attributes"
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                      "type": "string",
+                      "default": "http"
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
                   },
-                  "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                    "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                  "additionalProperties": false
+                }
+              },
+              "inlined": {
+                "description": "Inlined manifest",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location in a file fetched from a uri.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "name": {
+            "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+            "type": "string"
+          },
+          "openshift": {
+            "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                      "type": "string",
+                      "default": "http"
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
                   },
-                  "component": {
-                    "description": "Describes component to which given action relates",
-                    "type": "string",
-                    "markdownDescription": "Describes component to which given action relates"
-                  },
-                  "env": {
-                    "description": "Optional list of environment variables that have to be set before running the command",
-                    "items": {
+                  "additionalProperties": false
+                }
+              },
+              "inlined": {
+                "description": "Inlined manifest",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location in a file fetched from a uri.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "plugin": {
+            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              },
+              {
+                "required": [
+                  "kubernetes"
+                ]
+              }
+            ],
+            "properties": {
+              "commands": {
+                "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "oneOf": [
+                    {
+                      "required": [
+                        "exec"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apply"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "vscodeTask"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "vscodeLaunch"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "composite"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "apply": {
+                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                      "type": "object",
                       "properties": {
-                        "name": {
+                        "attributes": {
+                          "description": "Optional map of free-form additional command attributes",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "component": {
+                          "description": "Describes component that will be applied",
                           "type": "string"
                         },
-                        "value": {
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array",
-                    "markdownDescription": "Optional list of environment variables that have to be set before running the command"
-                  },
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean",
-                        "markdownDescription": "Identifies the default command for a given group kind"
+                    "composite": {
+                      "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "description": "Optional map of free-form additional command attributes",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "commands": {
+                          "description": "The commands that comprise this composite command",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                          "type": "string"
+                        },
+                        "parallel": {
+                          "description": "Indicates if the sub-commands should be executed concurrently",
+                          "type": "boolean"
+                        }
                       },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ],
-                        "type": "string",
-                        "markdownDescription": "Kind of group the command is part of"
-                      }
+                      "additionalProperties": false
                     },
-                    "required": [
-                      "kind"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Defines the group this command is part of",
-                    "additionalProperties": false
+                    "exec": {
+                      "description": "CLI Command executed in an existing component container",
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "description": "Optional map of free-form additional command attributes",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "commandLine": {
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "type": "string"
+                        },
+                        "component": {
+                          "description": "Describes component to which given action relates",
+                          "type": "string"
+                        },
+                        "env": {
+                          "description": "Optional list of environment variables that have to be set before running the command",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "hotReloadCapable": {
+                          "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                          "type": "string"
+                        },
+                        "workingDir": {
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                      "type": "string"
+                    },
+                    "vscodeLaunch": {
+                      "description": "Command providing the definition of a VsCode launch action",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Optional map of free-form additional command attributes",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "inlined": {
+                          "description": "Inlined content of the VsCode configuration",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "vscodeTask": {
+                      "description": "Command providing the definition of a VsCode Task",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Optional map of free-form additional command attributes",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "inlined": {
+                          "description": "Inlined content of the VsCode configuration",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
                   },
-                  "hotReloadCapable": {
-                    "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
-                    "type": "boolean",
-                    "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'"
+                  "additionalProperties": false
+                }
+              },
+              "components": {
+                "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "oneOf": [
+                    {
+                      "required": [
+                        "container"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "kubernetes"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "openshift"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "volume"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "container": {
+                      "description": "Allows adding and configuring workspace-related containers",
+                      "type": "object",
+                      "properties": {
+                        "args": {
+                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "command": {
+                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "dedicatedPod": {
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
+                          "type": "boolean"
+                        },
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                "type": "string"
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "env": {
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - '$PROJECTS_ROOT'\n\n - '$PROJECT_SOURCE'",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "memoryLimit": {
+                          "type": "string"
+                        },
+                        "mountSources": {
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set 'dedicatedPod' to true.",
+                          "type": "boolean"
+                        },
+                        "sourceMapping": {
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the default value of /projects is used.",
+                          "type": "string"
+                        },
+                        "volumeMounts": {
+                          "description": "List of volumes mounts that should be mounted is this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "Volume that should be mounted to a component container",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/\u003cname\u003e'.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "kubernetes": {
+                      "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                "type": "string"
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "inlined": {
+                          "description": "Inlined manifest",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location in a file fetched from a uri.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                      "type": "string"
+                    },
+                    "openshift": {
+                      "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                "type": "string"
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "inlined": {
+                          "description": "Inlined manifest",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location in a file fetched from a uri.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "volume": {
+                      "description": "Allows specifying the definition of a volume shared by several other components",
+                      "type": "object",
+                      "properties": {
+                        "size": {
+                          "description": "Size of the volume",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
                   },
-                  "label": {
-                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                    "type": "string",
-                    "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  },
-                  "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                    "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "CLI Command executed in an existing component container",
-                "additionalProperties": false
+                  "additionalProperties": false
+                }
               },
               "id": {
-                "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string",
-                "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
+                "description": "Id in a registry that contains a Devfile yaml file",
+                "type": "string"
               },
-              "vscodeLaunch": {
-                "description": "Command providing the definition of a VsCode launch action",
+              "kubernetes": {
+                "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
                 "properties": {
-                  "attributes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Optional map of free-form additional command attributes",
-                    "type": "object",
-                    "markdownDescription": "Optional map of free-form additional command attributes"
+                  "name": {
+                    "type": "string"
                   },
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean",
-                        "markdownDescription": "Identifies the default command for a given group kind"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ],
-                        "type": "string",
-                        "markdownDescription": "Kind of group the command is part of"
-                      }
-                    },
-                    "required": [
-                      "kind"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Defines the group this command is part of",
-                    "additionalProperties": false
-                  },
-                  "inlined": {
-                    "description": "Inlined content of the VsCode configuration",
-                    "type": "string",
-                    "markdownDescription": "Inlined content of the VsCode configuration"
-                  },
-                  "uri": {
-                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string",
-                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
+                  "namespace": {
+                    "type": "string"
                   }
                 },
-                "type": "object",
-                "markdownDescription": "Command providing the definition of a VsCode launch action",
-                "additionalProperties": false,
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ]
+                "additionalProperties": false
               },
-              "vscodeTask": {
-                "description": "Command providing the definition of a VsCode Task",
-                "properties": {
-                  "attributes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Optional map of free-form additional command attributes",
-                    "type": "object",
-                    "markdownDescription": "Optional map of free-form additional command attributes"
-                  },
-                  "group": {
-                    "description": "Defines the group this command is part of",
-                    "properties": {
-                      "isDefault": {
-                        "description": "Identifies the default command for a given group kind",
-                        "type": "boolean",
-                        "markdownDescription": "Identifies the default command for a given group kind"
-                      },
-                      "kind": {
-                        "description": "Kind of group the command is part of",
-                        "enum": [
-                          "build",
-                          "run",
-                          "test",
-                          "debug"
-                        ],
-                        "type": "string",
-                        "markdownDescription": "Kind of group the command is part of"
-                      }
-                    },
-                    "required": [
-                      "kind"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Defines the group this command is part of",
-                    "additionalProperties": false
-                  },
-                  "inlined": {
-                    "description": "Inlined content of the VsCode configuration",
-                    "type": "string",
-                    "markdownDescription": "Inlined content of the VsCode configuration"
-                  },
-                  "uri": {
-                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                    "type": "string",
-                    "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Command providing the definition of a VsCode Task",
-                "additionalProperties": false,
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ]
+              "registryUrl": {
+                "type": "string"
+              },
+              "uri": {
+                "description": "Uri of a Devfile yaml file",
+                "type": "string"
               }
             },
+            "additionalProperties": false
+          },
+          "volume": {
+            "description": "Allows specifying the definition of a volume shared by several other components",
+            "type": "object",
+            "properties": {
+              "size": {
+                "description": "Size of the volume",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "events": {
+      "description": "Bindings of commands to events. Each command is referred-to by its name.",
+      "type": "object",
+      "properties": {
+        "postStart": {
+          "description": "Names of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "postStop": {
+          "description": "Names of commands that should be executed after stopping the workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preStart": {
+          "description": "Names of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preStop": {
+          "description": "Names of commands that should be executed before stopping the workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "description": "Optional metadata",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Optional devfile name",
+          "type": "string"
+        },
+        "version": {
+          "description": "Optional semver-compatible version",
+          "type": "string",
+          "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        }
+      },
+      "additionalProperties": true
+    },
+    "parent": {
+      "description": "Parent workspace template",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "uri"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        },
+        {
+          "required": [
+            "kubernetes"
+          ]
+        }
+      ],
+      "properties": {
+        "commands": {
+          "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
             "required": [
               "id"
             ],
-            "type": "object",
-            "additionalProperties": false,
             "oneOf": [
               {
                 "required": [
@@ -2010,101 +1494,128 @@ const JsonSchema200 = `{
                   "composite"
                 ]
               }
-            ]
-          },
-          "type": "array",
-          "markdownDescription": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch"
-        },
-        "components": {
-          "description": "Overrides of components encapsulated in a parent devfile. Overriding is done using a strategic merge patch",
-          "items": {
+            ],
             "properties": {
-              "container": {
-                "description": "Allows adding and configuring workspace-related containers",
+              "apply": {
+                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "type": "object",
                 "properties": {
-                  "args": {
-                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                    "items": {
+                  "attributes": {
+                    "description": "Optional map of free-form additional command attributes",
+                    "type": "object",
+                    "additionalProperties": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
+                    }
                   },
-                  "command": {
-                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array",
-                    "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
+                  "component": {
+                    "description": "Describes component that will be applied",
+                    "type": "string"
                   },
-                  "dedicatedPod": {
-                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
-                    "type": "boolean",
-                    "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'"
-                  },
-                  "endpoints": {
-                    "items": {
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object",
-                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                        },
-                        "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                          "enum": [
-                            "public",
-                            "internal",
-                            "none"
-                          ],
-                          "type": "string",
-                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "path": {
-                          "description": "Path of the endpoint URL",
-                          "type": "string",
-                          "markdownDescription": "Path of the endpoint URL"
-                        },
-                        "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                          "type": "string",
-                          "enum": [
-                            "http",
-                            "https",
-                            "ws",
-                            "wss",
-                            "tcp",
-                            "udp"
-                          ],
-                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                        },
-                        "secure": {
-                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean",
-                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                        },
-                        "targetPort": {
-                          "type": "integer"
-                        }
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
                       },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "composite": {
+                "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                "type": "object",
+                "properties": {
+                  "attributes": {
+                    "description": "Optional map of free-form additional command attributes",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "commands": {
+                    "description": "The commands that comprise this composite command",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                    "type": "string"
+                  },
+                  "parallel": {
+                    "description": "Indicates if the sub-commands should be executed concurrently",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "exec": {
+                "description": "CLI Command executed in an existing component container",
+                "type": "object",
+                "properties": {
+                  "attributes": {
+                    "description": "Optional map of free-form additional command attributes",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "commandLine": {
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "type": "string"
+                  },
+                  "component": {
+                    "description": "Describes component to which given action relates",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "Optional list of environment variables that have to be set before running the command",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "env": {
-                    "description": "Environment variables used in this container",
-                    "items": {
                       "properties": {
                         "name": {
                           "type": "string"
@@ -2113,1041 +1624,52 @@ const JsonSchema200 = `{
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
-                    },
-                    "type": "array",
-                    "markdownDescription": "Environment variables used in this container"
+                    }
                   },
-                  "image": {
-                    "type": "string"
-                  },
-                  "memoryLimit": {
-                    "type": "string"
-                  },
-                  "mountSources": {
-                    "type": "boolean"
-                  },
-                  "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used.",
-                    "type": "string",
-                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used."
-                  },
-                  "volumeMounts": {
-                    "description": "List of volumes mounts that should be mounted is this container.",
-                    "items": {
-                      "description": "Volume that should be mounted to a component container",
-                      "properties": {
-                        "name": {
-                          "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string",
-                          "markdownDescription": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
-                        },
-                        "path": {
-                          "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'.",
-                          "type": "string",
-                          "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'."
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "markdownDescription": "Volume that should be mounted to a component container",
-                      "additionalProperties": false
-                    },
-                    "type": "array",
-                    "markdownDescription": "List of volumes mounts that should be mounted is this container."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Allows adding and configuring workspace-related containers",
-                "additionalProperties": false
-              },
-              "kubernetes": {
-                "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-                "properties": {
-                  "endpoints": {
-                    "items": {
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object",
-                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                        },
-                        "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                          "enum": [
-                            "public",
-                            "internal",
-                            "none"
-                          ],
-                          "type": "string",
-                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "path": {
-                          "description": "Path of the endpoint URL",
-                          "type": "string",
-                          "markdownDescription": "Path of the endpoint URL"
-                        },
-                        "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                          "type": "string",
-                          "enum": [
-                            "http",
-                            "https",
-                            "ws",
-                            "wss",
-                            "tcp",
-                            "udp"
-                          ],
-                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                        },
-                        "secure": {
-                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean",
-                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                        },
-                        "targetPort": {
-                          "type": "integer"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "inlined": {
-                    "description": "Inlined manifest",
-                    "type": "string",
-                    "markdownDescription": "Inlined manifest"
-                  },
-                  "uri": {
-                    "description": "Location in a file fetched from a uri.",
-                    "type": "string",
-                    "markdownDescription": "Location in a file fetched from a uri."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
-                "additionalProperties": false,
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ]
-              },
-              "name": {
-                "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                "type": "string",
-                "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
-              },
-              "openshift": {
-                "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-                "properties": {
-                  "endpoints": {
-                    "items": {
-                      "properties": {
-                        "attributes": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                          "type": "object",
-                          "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                        },
-                        "exposure": {
-                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                          "enum": [
-                            "public",
-                            "internal",
-                            "none"
-                          ],
-                          "type": "string",
-                          "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "path": {
-                          "description": "Path of the endpoint URL",
-                          "type": "string",
-                          "markdownDescription": "Path of the endpoint URL"
-                        },
-                        "protocol": {
-                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                          "type": "string",
-                          "enum": [
-                            "http",
-                            "https",
-                            "ws",
-                            "wss",
-                            "tcp",
-                            "udp"
-                          ],
-                          "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                        },
-                        "secure": {
-                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                          "type": "boolean",
-                          "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                        },
-                        "targetPort": {
-                          "type": "integer"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "inlined": {
-                    "description": "Inlined manifest",
-                    "type": "string",
-                    "markdownDescription": "Inlined manifest"
-                  },
-                  "uri": {
-                    "description": "Location in a file fetched from a uri.",
-                    "type": "string",
-                    "markdownDescription": "Location in a file fetched from a uri."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
-                "additionalProperties": false,
-                "oneOf": [
-                  {
-                    "required": [
-                      "uri"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "inlined"
-                    ]
-                  }
-                ]
-              },
-              "plugin": {
-                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
-                "properties": {
-                  "commands": {
-                    "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch",
-                    "items": {
-                      "properties": {
-                        "apply": {
-                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                          "properties": {
-                            "attributes": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Optional map of free-form additional command attributes",
-                              "type": "object",
-                              "markdownDescription": "Optional map of free-form additional command attributes"
-                            },
-                            "component": {
-                              "description": "Describes component that will be applied",
-                              "type": "string",
-                              "markdownDescription": "Describes component that will be applied"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Identifies the default command for a given group kind"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ],
-                                  "type": "string",
-                                  "markdownDescription": "Kind of group the command is part of"
-                                }
-                              },
-                              "required": [
-                                "kind"
-                              ],
-                              "type": "object",
-                              "markdownDescription": "Defines the group this command is part of",
-                              "additionalProperties": false
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string",
-                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
-                          "additionalProperties": false
-                        },
-                        "composite": {
-                          "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                          "properties": {
-                            "attributes": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Optional map of free-form additional command attributes",
-                              "type": "object",
-                              "markdownDescription": "Optional map of free-form additional command attributes"
-                            },
-                            "commands": {
-                              "description": "The commands that comprise this composite command",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array",
-                              "markdownDescription": "The commands that comprise this composite command"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Identifies the default command for a given group kind"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ],
-                                  "type": "string",
-                                  "markdownDescription": "Kind of group the command is part of"
-                                }
-                              },
-                              "required": [
-                                "kind"
-                              ],
-                              "type": "object",
-                              "markdownDescription": "Defines the group this command is part of",
-                              "additionalProperties": false
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string",
-                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            },
-                            "parallel": {
-                              "description": "Indicates if the sub-commands should be executed concurrently",
-                              "type": "boolean",
-                              "markdownDescription": "Indicates if the sub-commands should be executed concurrently"
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Composite command that allows executing several sub-commands either sequentially or concurrently",
-                          "additionalProperties": false
-                        },
-                        "exec": {
-                          "description": "CLI Command executed in an existing component container",
-                          "properties": {
-                            "attributes": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Optional map of free-form additional command attributes",
-                              "type": "object",
-                              "markdownDescription": "Optional map of free-form additional command attributes"
-                            },
-                            "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                              "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-                            },
-                            "component": {
-                              "description": "Describes component to which given action relates",
-                              "type": "string",
-                              "markdownDescription": "Describes component to which given action relates"
-                            },
-                            "env": {
-                              "description": "Optional list of environment variables that have to be set before running the command",
-                              "items": {
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "name",
-                                  "value"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array",
-                              "markdownDescription": "Optional list of environment variables that have to be set before running the command"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Identifies the default command for a given group kind"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ],
-                                  "type": "string",
-                                  "markdownDescription": "Kind of group the command is part of"
-                                }
-                              },
-                              "required": [
-                                "kind"
-                              ],
-                              "type": "object",
-                              "markdownDescription": "Defines the group this command is part of",
-                              "additionalProperties": false
-                            },
-                            "hotReloadCapable": {
-                              "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
-                              "type": "boolean",
-                              "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'"
-                            },
-                            "label": {
-                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
-                              "type": "string",
-                              "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            },
-                            "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
-                              "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '${PROJECTS_ROOT}': A path where projects sources are mounted\n\n - '${PROJECT_SOURCE}': A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "CLI Command executed in an existing component container",
-                          "additionalProperties": false
-                        },
-                        "id": {
-                          "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string",
-                          "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
-                        },
-                        "vscodeLaunch": {
-                          "description": "Command providing the definition of a VsCode launch action",
-                          "properties": {
-                            "attributes": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Optional map of free-form additional command attributes",
-                              "type": "object",
-                              "markdownDescription": "Optional map of free-form additional command attributes"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Identifies the default command for a given group kind"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ],
-                                  "type": "string",
-                                  "markdownDescription": "Kind of group the command is part of"
-                                }
-                              },
-                              "required": [
-                                "kind"
-                              ],
-                              "type": "object",
-                              "markdownDescription": "Defines the group this command is part of",
-                              "additionalProperties": false
-                            },
-                            "inlined": {
-                              "description": "Inlined content of the VsCode configuration",
-                              "type": "string",
-                              "markdownDescription": "Inlined content of the VsCode configuration"
-                            },
-                            "uri": {
-                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string",
-                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Command providing the definition of a VsCode launch action",
-                          "additionalProperties": false,
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ]
-                        },
-                        "vscodeTask": {
-                          "description": "Command providing the definition of a VsCode Task",
-                          "properties": {
-                            "attributes": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Optional map of free-form additional command attributes",
-                              "type": "object",
-                              "markdownDescription": "Optional map of free-form additional command attributes"
-                            },
-                            "group": {
-                              "description": "Defines the group this command is part of",
-                              "properties": {
-                                "isDefault": {
-                                  "description": "Identifies the default command for a given group kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Identifies the default command for a given group kind"
-                                },
-                                "kind": {
-                                  "description": "Kind of group the command is part of",
-                                  "enum": [
-                                    "build",
-                                    "run",
-                                    "test",
-                                    "debug"
-                                  ],
-                                  "type": "string",
-                                  "markdownDescription": "Kind of group the command is part of"
-                                }
-                              },
-                              "required": [
-                                "kind"
-                              ],
-                              "type": "object",
-                              "markdownDescription": "Defines the group this command is part of",
-                              "additionalProperties": false
-                            },
-                            "inlined": {
-                              "description": "Inlined content of the VsCode configuration",
-                              "type": "string",
-                              "markdownDescription": "Inlined content of the VsCode configuration"
-                            },
-                            "uri": {
-                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
-                              "type": "string",
-                              "markdownDescription": "Location as an absolute of relative URI the VsCode configuration will be fetched from"
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Command providing the definition of a VsCode Task",
-                          "additionalProperties": false,
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "id"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "exec"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "apply"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "vscodeTask"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "vscodeLaunch"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "composite"
-                          ]
-                        }
-                      ]
-                    },
-                    "type": "array",
-                    "markdownDescription": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done using a strategic merge patch"
-                  },
-                  "components": {
-                    "description": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge patch. A plugin cannot override embedded plugin components.",
-                    "items": {
-                      "properties": {
-                        "container": {
-                          "description": "Configuration overriding for a Container component in a plugin",
-                          "properties": {
-                            "args": {
-                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array",
-                              "markdownDescription": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
-                            },
-                            "command": {
-                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array",
-                              "markdownDescription": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image."
-                            },
-                            "dedicatedPod": {
-                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
-                              "type": "boolean",
-                              "markdownDescription": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'"
-                            },
-                            "endpoints": {
-                              "items": {
-                                "properties": {
-                                  "attributes": {
-                                    "additionalProperties": {
-                                      "type": "string"
-                                    },
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ],
-                                    "type": "string",
-                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string",
-                                    "markdownDescription": "Path of the endpoint URL"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ],
-                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean",
-                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "env": {
-                              "description": "Environment variables used in this container",
-                              "items": {
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "name",
-                                  "value"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array",
-                              "markdownDescription": "Environment variables used in this container"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "memoryLimit": {
-                              "type": "string"
-                            },
-                            "mountSources": {
-                              "type": "boolean"
-                            },
-                            "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used.",
-                              "type": "string",
-                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the value of the 'PROJECTS_ROOT' environment variable is used."
-                            },
-                            "volumeMounts": {
-                              "description": "List of volumes mounts that should be mounted is this container.",
-                              "items": {
-                                "description": "Volume that should be mounted to a component container",
-                                "properties": {
-                                  "name": {
-                                    "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string",
-                                    "markdownDescription": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
-                                  },
-                                  "path": {
-                                    "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'.",
-                                    "type": "string",
-                                    "markdownDescription": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/<name>'."
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": "object",
-                                "markdownDescription": "Volume that should be mounted to a component container",
-                                "additionalProperties": false
-                              },
-                              "type": "array",
-                              "markdownDescription": "List of volumes mounts that should be mounted is this container."
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Configuration overriding for a Container component in a plugin",
-                          "additionalProperties": false
-                        },
-                        "kubernetes": {
-                          "description": "Configuration overriding for a Kubernetes component in a plugin",
-                          "properties": {
-                            "endpoints": {
-                              "items": {
-                                "properties": {
-                                  "attributes": {
-                                    "additionalProperties": {
-                                      "type": "string"
-                                    },
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ],
-                                    "type": "string",
-                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string",
-                                    "markdownDescription": "Path of the endpoint URL"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ],
-                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean",
-                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "inlined": {
-                              "description": "Inlined manifest",
-                              "type": "string",
-                              "markdownDescription": "Inlined manifest"
-                            },
-                            "uri": {
-                              "description": "Location in a file fetched from a uri.",
-                              "type": "string",
-                              "markdownDescription": "Location in a file fetched from a uri."
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Configuration overriding for a Kubernetes component in a plugin",
-                          "additionalProperties": false,
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ]
-                        },
-                        "name": {
-                          "description": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent",
-                          "type": "string",
-                          "markdownDescription": "Mandatory name that allows referencing the Volume component in Container volume mounts or inside a parent"
-                        },
-                        "openshift": {
-                          "description": "Configuration overriding for an OpenShift component in a plugin",
-                          "properties": {
-                            "endpoints": {
-                              "items": {
-                                "properties": {
-                                  "attributes": {
-                                    "additionalProperties": {
-                                      "type": "string"
-                                    },
-                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
-                                    "type": "object",
-                                    "markdownDescription": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\","
-                                  },
-                                  "exposure": {
-                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
-                                    "enum": [
-                                      "public",
-                                      "internal",
-                                      "none"
-                                    ],
-                                    "type": "string",
-                                    "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "Path of the endpoint URL",
-                                    "type": "string",
-                                    "markdownDescription": "Path of the endpoint URL"
-                                  },
-                                  "protocol": {
-                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
-                                    "type": "string",
-                                    "enum": [
-                                      "http",
-                                      "https",
-                                      "ws",
-                                      "wss",
-                                      "tcp",
-                                      "udp"
-                                    ],
-                                    "markdownDescription": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'"
-                                  },
-                                  "secure": {
-                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
-                                    "type": "boolean",
-                                    "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process"
-                                  },
-                                  "targetPort": {
-                                    "type": "integer"
-                                  }
-                                },
-                                "required": [
-                                  "name"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "inlined": {
-                              "description": "Inlined manifest",
-                              "type": "string",
-                              "markdownDescription": "Inlined manifest"
-                            },
-                            "uri": {
-                              "description": "Location in a file fetched from a uri.",
-                              "type": "string",
-                              "markdownDescription": "Location in a file fetched from a uri."
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Configuration overriding for an OpenShift component in a plugin",
-                          "additionalProperties": false,
-                          "oneOf": [
-                            {
-                              "required": [
-                                "uri"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "inlined"
-                              ]
-                            }
-                          ]
-                        },
-                        "volume": {
-                          "description": "Configuration overriding for a Volume component in a plugin",
-                          "properties": {
-                            "size": {
-                              "description": "Size of the volume",
-                              "type": "string",
-                              "markdownDescription": "Size of the volume"
-                            }
-                          },
-                          "type": "object",
-                          "markdownDescription": "Configuration overriding for a Volume component in a plugin",
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false,
-                      "oneOf": [
-                        {
-                          "required": [
-                            "container"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "kubernetes"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "openshift"
-                          ]
-                        },
-                        {
-                          "required": [
-                            "volume"
-                          ]
-                        }
-                      ]
-                    },
-                    "type": "array",
-                    "markdownDescription": "Overrides of components encapsulated in a plugin. Overriding is done using a strategic merge patch. A plugin cannot override embedded plugin components."
-                  },
-                  "id": {
-                    "description": "Id in a registry that contains a Devfile yaml file",
-                    "type": "string",
-                    "markdownDescription": "Id in a registry that contains a Devfile yaml file"
-                  },
-                  "kubernetes": {
-                    "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
                     "properties": {
-                      "name": {
-                        "type": "string"
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
                       },
-                      "namespace": {
-                        "type": "string"
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object",
-                    "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
                     "additionalProperties": false
                   },
-                  "registryUrl": {
+                  "hotReloadCapable": {
+                    "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string"
                   },
-                  "uri": {
-                    "description": "Uri of a Devfile yaml file",
-                    "type": "string",
-                    "markdownDescription": "Uri of a Devfile yaml file"
+                  "workingDir": {
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "type": "string"
                   }
                 },
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                "type": "string"
+              },
+              "vscodeLaunch": {
+                "description": "Command providing the definition of a VsCode launch action",
                 "type": "object",
-                "markdownDescription": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
-                "additionalProperties": false,
                 "oneOf": [
                   {
                     "required": [
@@ -3156,35 +1678,117 @@ const JsonSchema200 = `{
                   },
                   {
                     "required": [
-                      "id"
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "attributes": {
+                    "description": "Optional map of free-form additional command attributes",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "inlined": {
+                    "description": "Inlined content of the VsCode configuration",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "vscodeTask": {
+                "description": "Command providing the definition of a VsCode Task",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
                     ]
                   },
                   {
                     "required": [
-                      "kubernetes"
+                      "inlined"
                     ]
                   }
-                ]
-              },
-              "volume": {
-                "description": "Allows specifying the definition of a volume shared by several other components",
+                ],
                 "properties": {
-                  "size": {
-                    "description": "Size of the volume",
-                    "type": "string",
-                    "markdownDescription": "Size of the volume"
+                  "attributes": {
+                    "description": "Optional map of free-form additional command attributes",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "inlined": {
+                    "description": "Inlined content of the VsCode configuration",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                    "type": "string"
                   }
                 },
-                "type": "object",
-                "markdownDescription": "Allows specifying the definition of a volume shared by several other components",
                 "additionalProperties": false
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "components": {
+          "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false,
             "oneOf": [
               {
                 "required": [
@@ -3211,18 +1815,1000 @@ const JsonSchema200 = `{
                   "plugin"
                 ]
               }
-            ]
-          },
-          "type": "array",
-          "markdownDescription": "Overrides of components encapsulated in a parent devfile. Overriding is done using a strategic merge patch"
+            ],
+            "properties": {
+              "container": {
+                "description": "Allows adding and configuring workspace-related containers",
+                "type": "object",
+                "properties": {
+                  "args": {
+                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "command": {
+                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "dedicatedPod": {
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
+                    "type": "boolean"
+                  },
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "env": {
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - '$PROJECTS_ROOT'\n\n - '$PROJECT_SOURCE'",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "image": {
+                    "type": "string"
+                  },
+                  "memoryLimit": {
+                    "type": "string"
+                  },
+                  "mountSources": {
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set 'dedicatedPod' to true.",
+                    "type": "boolean"
+                  },
+                  "sourceMapping": {
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the default value of /projects is used.",
+                    "type": "string"
+                  },
+                  "volumeMounts": {
+                    "description": "List of volumes mounts that should be mounted is this container.",
+                    "type": "array",
+                    "items": {
+                      "description": "Volume that should be mounted to a component container",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/\u003cname\u003e'.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "inlined": {
+                    "description": "Inlined manifest",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location in a file fetched from a uri.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                "type": "string"
+              },
+              "openshift": {
+                "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                          "type": "string"
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "inlined": {
+                    "description": "Inlined manifest",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location in a file fetched from a uri.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "plugin": {
+                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as 'DevWorkspaceTemplate' Kubernetes Custom Resources",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kubernetes"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "commands": {
+                    "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "id"
+                      ],
+                      "oneOf": [
+                        {
+                          "required": [
+                            "exec"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apply"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "vscodeTask"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "vscodeLaunch"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "composite"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "apply": {
+                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                          "type": "object",
+                          "properties": {
+                            "attributes": {
+                              "description": "Optional map of free-form additional command attributes",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "component": {
+                              "description": "Describes component that will be applied",
+                              "type": "string"
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "composite": {
+                          "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                          "type": "object",
+                          "properties": {
+                            "attributes": {
+                              "description": "Optional map of free-form additional command attributes",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "commands": {
+                              "description": "The commands that comprise this composite command",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            },
+                            "parallel": {
+                              "description": "Indicates if the sub-commands should be executed concurrently",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "exec": {
+                          "description": "CLI Command executed in an existing component container",
+                          "type": "object",
+                          "properties": {
+                            "attributes": {
+                              "description": "Optional map of free-form additional command attributes",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "commandLine": {
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "type": "string"
+                            },
+                            "component": {
+                              "description": "Describes component to which given action relates",
+                              "type": "string"
+                            },
+                            "env": {
+                              "description": "Optional list of environment variables that have to be set before running the command",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "hotReloadCapable": {
+                              "description": "Whether the command is capable to reload itself when source code changes. If set to 'true' the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is 'false'",
+                              "type": "boolean"
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            },
+                            "workingDir": {
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - '$PROJECTS_ROOT': A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - '$PROJECT_SOURCE': A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "id": {
+                          "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                          "type": "string"
+                        },
+                        "vscodeLaunch": {
+                          "description": "Command providing the definition of a VsCode launch action",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "attributes": {
+                              "description": "Optional map of free-form additional command attributes",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "inlined": {
+                              "description": "Inlined content of the VsCode configuration",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "vscodeTask": {
+                          "description": "Command providing the definition of a VsCode Task",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "attributes": {
+                              "description": "Optional map of free-form additional command attributes",
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "inlined": {
+                              "description": "Inlined content of the VsCode configuration",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "components": {
+                    "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "oneOf": [
+                        {
+                          "required": [
+                            "container"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "kubernetes"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "openshift"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "volume"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "container": {
+                          "description": "Allows adding and configuring workspace-related containers",
+                          "type": "object",
+                          "properties": {
+                            "args": {
+                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "dedicatedPod": {
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
+                              "type": "boolean"
+                            },
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                    "type": "string"
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "env": {
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - '$PROJECTS_ROOT'\n\n - '$PROJECT_SOURCE'",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "memoryLimit": {
+                              "type": "string"
+                            },
+                            "mountSources": {
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set 'dedicatedPod' to true.",
+                              "type": "boolean"
+                            },
+                            "sourceMapping": {
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when 'mountSources' is 'true'. When omitted, the default value of /projects is used.",
+                              "type": "string"
+                            },
+                            "volumeMounts": {
+                              "description": "List of volumes mounts that should be mounted is this container.",
+                              "type": "array",
+                              "items": {
+                                "description": "Volume that should be mounted to a component container",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "The volume mount name is the name of an existing 'Volume' component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is '/\u003cname\u003e'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "kubernetes": {
+                          "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                    "type": "string"
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "inlined": {
+                              "description": "Inlined manifest",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location in a file fetched from a uri.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "name": {
+                          "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                          "type": "string"
+                        },
+                        "openshift": {
+                          "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- 'public' means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- 'internal' means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- 'none' means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is 'public'",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- 'http': Endpoint will have 'http' traffic, typically on a TCP connection. It will be automaticaly promoted to 'https' when the 'secure' field is set to 'true'.\n- 'https': Endpoint will have 'https' traffic, typically on a TCP connection.\n- 'ws': Endpoint will have 'ws' traffic, typically on a TCP connection. It will be automaticaly promoted to 'wss' when the 'secure' field is set to 'true'.\n- 'wss': Endpoint will have 'wss' traffic, typically on a TCP connection.\n- 'tcp': Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- 'udp': Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is 'http'",
+                                    "type": "string"
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "inlined": {
+                              "description": "Inlined manifest",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location in a file fetched from a uri.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "volume": {
+                          "description": "Allows specifying the definition of a volume shared by several other components",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "description": "Size of the volume",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "id": {
+                    "description": "Id in a registry that contains a Devfile yaml file",
+                    "type": "string"
+                  },
+                  "kubernetes": {
+                    "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "registryUrl": {
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Uri of a Devfile yaml file",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "volume": {
+                "description": "Allows specifying the definition of a volume shared by several other components",
+                "type": "object",
+                "properties": {
+                  "size": {
+                    "description": "Size of the volume",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "id": {
           "description": "Id in a registry that contains a Devfile yaml file",
-          "type": "string",
-          "markdownDescription": "Id in a registry that contains a Devfile yaml file"
+          "type": "string"
         },
         "kubernetes": {
           "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+          "type": "object",
+          "required": [
+            "name"
+          ],
           "properties": {
             "name": {
               "type": "string"
@@ -3231,129 +2817,16 @@ const JsonSchema200 = `{
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
-          "type": "object",
-          "markdownDescription": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
           "additionalProperties": false
         },
         "projects": {
-          "description": "Overrides of projects encapsulated in a parent devfile. Overriding is done using a strategic merge patch.",
+          "description": "Overrides of projects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
           "items": {
-            "properties": {
-              "clonePath": {
-                "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                "type": "string",
-                "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
-              },
-              "git": {
-                "description": "Project's Git source",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string",
-                        "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string",
-                        "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                      }
-                    },
-                    "type": "object",
-                    "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's Git source",
-                "additionalProperties": false
-              },
-              "github": {
-                "description": "Project's GitHub source",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string",
-                        "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string",
-                        "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                      }
-                    },
-                    "type": "object",
-                    "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's GitHub source",
-                "additionalProperties": false
-              },
-              "name": {
-                "description": "Project name",
-                "type": "string",
-                "markdownDescription": "Project name"
-              },
-              "zip": {
-                "description": "Project's Zip source",
-                "properties": {
-                  "location": {
-                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
-                    "type": "string",
-                    "markdownDescription": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's Zip source",
-                "additionalProperties": false
-              }
-            },
+            "type": "object",
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false,
             "oneOf": [
               {
                 "required": [
@@ -3370,140 +2843,107 @@ const JsonSchema200 = `{
                   "zip"
                 ]
               }
-            ]
-          },
-          "type": "array",
-          "markdownDescription": "Overrides of projects encapsulated in a parent devfile. Overriding is done using a strategic merge patch."
+            ],
+            "properties": {
+              "clonePath": {
+                "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
+                "type": "string"
+              },
+              "git": {
+                "description": "Project's Git source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "github": {
+                "description": "Project's GitHub source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Project name",
+                "type": "string"
+              },
+              "sparseCheckoutDirs": {
+                "description": "Populate the project sparsely with selected directories.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "zip": {
+                "description": "Project's Zip source",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "registryUrl": {
           "type": "string"
         },
         "starterProjects": {
-          "description": "Overrides of startedProjects encapsulated in a parent devfile. Overriding is done using a strategic merge patch.",
+          "description": "Overrides of starterProjects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
           "items": {
-            "properties": {
-              "clonePath": {
-                "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-                "type": "string",
-                "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
-              },
-              "description": {
-                "description": "Description of a starter project",
-                "type": "string",
-                "markdownDescription": "Description of a starter project"
-              },
-              "git": {
-                "description": "Project's Git source",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string",
-                        "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string",
-                        "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                      }
-                    },
-                    "type": "object",
-                    "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's Git source",
-                "additionalProperties": false
-              },
-              "github": {
-                "description": "Project's GitHub source",
-                "properties": {
-                  "checkoutFrom": {
-                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "properties": {
-                      "remote": {
-                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                        "type": "string",
-                        "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                      },
-                      "revision": {
-                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                        "type": "string",
-                        "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                      }
-                    },
-                    "type": "object",
-                    "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                    "additionalProperties": false
-                  },
-                  "remotes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                    "type": "object",
-                    "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's GitHub source",
-                "additionalProperties": false
-              },
-              "name": {
-                "description": "Project name",
-                "type": "string",
-                "markdownDescription": "Project name"
-              },
-              "zip": {
-                "description": "Project's Zip source",
-                "properties": {
-                  "location": {
-                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
-                    "type": "string",
-                    "markdownDescription": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH"
-                  },
-                  "sparseCheckoutDir": {
-                    "description": "Part of project to populate in the working directory.",
-                    "type": "string",
-                    "markdownDescription": "Part of project to populate in the working directory."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Project's Zip source",
-                "additionalProperties": false
-              },
-              "markdownDescription": {
-                "description": "Description of a starter project",
-                "type": "string",
-                "markdownDescription": "Description of a starter project"
-              }
-            },
+            "type": "object",
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false,
             "oneOf": [
               {
                 "required": [
@@ -3520,160 +2960,108 @@ const JsonSchema200 = `{
                   "zip"
                 ]
               }
-            ]
-          },
-          "type": "array",
-          "markdownDescription": "Overrides of startedProjects encapsulated in a parent devfile. Overriding is done using a strategic merge patch."
+            ],
+            "properties": {
+              "description": {
+                "description": "Description of a starter project",
+                "type": "string"
+              },
+              "git": {
+                "description": "Project's Git source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "github": {
+                "description": "Project's GitHub source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Project name",
+                "type": "string"
+              },
+              "subDir": {
+                "description": "Sub-directory from a starter project to be used as root for starter project.",
+                "type": "string"
+              },
+              "zip": {
+                "description": "Project's Zip source",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "uri": {
           "description": "Uri of a Devfile yaml file",
-          "type": "string",
-          "markdownDescription": "Uri of a Devfile yaml file"
+          "type": "string"
         }
       },
-      "type": "object",
-      "markdownDescription": "Parent workspace template",
-      "additionalProperties": false,
-      "oneOf": [
-        {
-          "required": [
-            "uri"
-          ]
-        },
-        {
-          "required": [
-            "id"
-          ]
-        },
-        {
-          "required": [
-            "kubernetes"
-          ]
-        }
-      ]
+      "additionalProperties": false
     },
     "projects": {
       "description": "Projects worked on in the workspace, containing names and sources locations",
+      "type": "array",
       "items": {
-        "properties": {
-          "clonePath": {
-            "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-            "type": "string",
-            "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
-          },
-          "git": {
-            "description": "Project's Git source",
-            "properties": {
-              "checkoutFrom": {
-                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "properties": {
-                  "remote": {
-                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string",
-                    "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                  },
-                  "revision": {
-                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string",
-                    "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "additionalProperties": false
-              },
-              "remotes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                "type": "object",
-                "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Project's Git source",
-            "additionalProperties": false,
-            "required": [
-              "remotes"
-            ]
-          },
-          "github": {
-            "description": "Project's GitHub source",
-            "properties": {
-              "checkoutFrom": {
-                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "properties": {
-                  "remote": {
-                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string",
-                    "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
-                  },
-                  "revision": {
-                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string",
-                    "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
-                  }
-                },
-                "type": "object",
-                "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
-                "additionalProperties": false
-              },
-              "remotes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
-                "type": "object",
-                "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Project's GitHub source",
-            "additionalProperties": false,
-            "required": [
-              "remotes"
-            ]
-          },
-          "name": {
-            "description": "Project name",
-            "type": "string",
-            "markdownDescription": "Project name"
-          },
-          "zip": {
-            "description": "Project's Zip source",
-            "properties": {
-              "location": {
-                "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
-                "type": "string",
-                "markdownDescription": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
-              }
-            },
-            "type": "object",
-            "markdownDescription": "Project's Zip source",
-            "additionalProperties": false
-          }
-        },
+        "type": "object",
         "required": [
           "name"
         ],
-        "type": "object",
-        "additionalProperties": false,
         "oneOf": [
           {
             "required": [
@@ -3690,192 +3078,224 @@ const JsonSchema200 = `{
               "zip"
             ]
           }
-        ]
-      },
-      "type": "array",
-      "markdownDescription": "Projects worked on in the workspace, containing names and sources locations"
-    },
-    "starterProjects": {
-      "description": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects",
-      "items": {
+        ],
         "properties": {
           "clonePath": {
             "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
-            "type": "string",
-            "markdownDescription": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
-          },
-          "description": {
-            "description": "Description of a starter project",
-            "type": "string",
-            "markdownDescription": "Description of a starter project"
+            "type": "string"
           },
           "git": {
             "description": "Project's Git source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
             "properties": {
               "checkoutFrom": {
                 "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
                 "properties": {
                   "remote": {
                     "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string",
-                    "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
+                    "type": "string"
                   },
                   "revision": {
                     "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string",
-                    "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
+                    "type": "string"
                   }
                 },
-                "type": "object",
-                "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
                 "additionalProperties": false
               },
               "remotes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
                 "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
                 "type": "object",
-                "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             },
-            "type": "object",
-            "markdownDescription": "Project's Git source",
             "additionalProperties": false
           },
           "github": {
             "description": "Project's GitHub source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
             "properties": {
               "checkoutFrom": {
                 "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
                 "properties": {
                   "remote": {
                     "description": "The remote name should be used as init. Required if there are more than one remote configured",
-                    "type": "string",
-                    "markdownDescription": "The remote name should be used as init. Required if there are more than one remote configured"
+                    "type": "string"
                   },
                   "revision": {
                     "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
-                    "type": "string",
-                    "markdownDescription": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found."
+                    "type": "string"
                   }
                 },
-                "type": "object",
-                "markdownDescription": "Defines from what the project should be checked out. Required if there are more than one remote configured",
                 "additionalProperties": false
               },
               "remotes": {
-                "additionalProperties": {
-                  "type": "string"
-                },
                 "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
                 "type": "object",
-                "markdownDescription": "The remotes map which should be initialized in the git project. Must have at least one remote configured"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             },
-            "type": "object",
-            "markdownDescription": "Project's GitHub source",
             "additionalProperties": false
           },
           "name": {
             "description": "Project name",
-            "type": "string",
-            "markdownDescription": "Project name"
+            "type": "string"
+          },
+          "sparseCheckoutDirs": {
+            "description": "Populate the project sparsely with selected directories.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "zip": {
             "description": "Project's Zip source",
+            "type": "object",
             "properties": {
               "location": {
                 "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
-                "type": "string",
-                "markdownDescription": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH"
-              },
-              "sparseCheckoutDir": {
-                "description": "Part of project to populate in the working directory.",
-                "type": "string",
-                "markdownDescription": "Part of project to populate in the working directory."
+                "type": "string"
               }
             },
-            "type": "object",
-            "markdownDescription": "Project's Zip source",
             "additionalProperties": false
-          },
-          "markdownDescription": {
-            "description": "Description of a starter project",
-            "type": "string",
-            "markdownDescription": "Description of a starter project"
           }
         },
-        "required": [
-          "name"
-        ],
-        "type": "object",
-        "additionalProperties": false,
-        "oneOf": [
-          {
-            "required": [
-              "git"
-            ]
-          },
-          {
-            "required": [
-              "github"
-            ]
-          },
-          {
-            "required": [
-              "zip"
-            ]
-          }
-        ]
-      },
-      "type": "array",
-      "markdownDescription": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects"
-    },
-    "metadata": {
-      "type": "object",
-      "description": "Optional metadata",
-      "properties": {
-        "version": {
-          "type": "string",
-          "description": "Optional semver-compatible version",
-          "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
-        },
-        "name": {
-          "type": "string",
-          "description": "Optional devfile name"
-        },
-        "alpha.build-dockerfile": {
-          "type": "string",
-          "description": "Optional build dockerfile link"
-        },
-        "alpha.deployment-manifest": {
-          "type": "string",
-          "description": "Optional deployment manifest link"
-        }
+        "additionalProperties": false
       }
     },
     "schemaVersion": {
-      "type": "string",
       "description": "Devfile schema version",
-      "pattern": "^([2-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+      "type": "string",
+      "pattern": "^([2-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "starterProjects": {
+      "description": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "git"
+            ]
+          },
+          {
+            "required": [
+              "github"
+            ]
+          },
+          {
+            "required": [
+              "zip"
+            ]
+          }
+        ],
+        "properties": {
+          "description": {
+            "description": "Description of a starter project",
+            "type": "string"
+          },
+          "git": {
+            "description": "Project's Git source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "github": {
+            "description": "Project's GitHub source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "name": {
+            "description": "Project name",
+            "type": "string"
+          },
+          "subDir": {
+            "description": "Sub-directory from a starter project to be used as root for starter project.",
+            "type": "string"
+          },
+          "zip": {
+            "description": "Project's Zip source",
+            "type": "object",
+            "properties": {
+              "location": {
+                "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
-  "type": "object",
-  "markdownDescription": "Structure of the workspace. This is also the specification of a workspace template.",
-  "additionalProperties": false,
-  "required": [
-    "schemaVersion"
-  ]
-}
-`
+  "additionalProperties": false
+}`

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -213,9 +213,6 @@ type GitLikeProjectSource struct {
 	// Defines from what the project should be checked out. Required if there are more than one remote configured
 	// +optional
 	CheckoutFrom *CheckoutFrom `json:"checkoutFrom,omitempty" yaml:"checkoutFrom,omitempty"`
-
-	// Part of project to populate in the working directory.
-	SparseCheckoutDir string `json:"sparseCheckoutDir,omitempty" yaml:"sparseCheckoutDir,omitempty"`
 }
 
 // Git Project's Git source
@@ -343,9 +340,6 @@ type DevfileStarterProject struct {
 	// Description of a starter project
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
-	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
-	ClonePath string `json:"clonePath,omitempty" yaml:"clonePath,omitempty"`
-
 	// Project's Git source
 	Git *Git `json:"git,omitempty" yaml:"git,omitempty"`
 
@@ -354,6 +348,9 @@ type DevfileStarterProject struct {
 
 	// Project's Zip source
 	Zip *Zip `json:"zip,omitempty" yaml:"zip,omitempty"`
+
+	// Sub-directory from a starter project to be used as root for starter project.
+	SubDir string `json:"subDir,omitempty" yaml:"subDir,omitempty"`
 }
 
 // Volume Allows specifying the definition of a volume shared by several other components
@@ -378,9 +375,6 @@ type Zip struct {
 
 	// Project's source location address. Should be URL for git and github located projects, or; file:// for zip
 	Location string `json:"location,omitempty" yaml:"location,omitempty"`
-
-	// Part of project to populate in the working directory.
-	SparseCheckoutDir string `json:"sparseCheckoutDir,omitempty" yaml:"sparseCheckoutDir,omitempty"`
 }
 
 // CheckoutFrom Defines from what the project should be checked out. Required if there are more than one remote configured

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -57,8 +57,8 @@ func Test_parseParent(t *testing.T) {
 							},
 							StarterProjects: []common.DevfileStarterProject{
 								{
-									ClonePath: "/projects",
-									Name:      "starter-project-1",
+									SubDir: "/projects",
+									Name:   "starter-project-1",
 								},
 							},
 						},
@@ -67,6 +67,7 @@ func Test_parseParent(t *testing.T) {
 							{
 								Id: "devbuild",
 								Exec: &common.Exec{
+									Component:  "runtime",
 									WorkingDir: "/projects/nodejs-starter",
 								},
 							},
@@ -90,8 +91,8 @@ func Test_parseParent(t *testing.T) {
 						},
 						StarterProjects: []common.DevfileStarterProject{
 							{
-								ClonePath: "/projects",
-								Name:      "starter-project-2",
+								SubDir: "/projects",
+								Name:   "starter-project-2",
 							},
 						},
 					},
@@ -104,6 +105,7 @@ func Test_parseParent(t *testing.T) {
 						{
 							Id: "devrun",
 							Exec: &common.Exec{
+								Component:   "nodejs",
 								WorkingDir:  "/projects",
 								CommandLine: "npm run",
 							},
@@ -134,7 +136,7 @@ func Test_parseParent(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -152,12 +154,14 @@ func Test_parseParent(t *testing.T) {
 						{
 							Id: "devbuild",
 							Exec: &common.Exec{
+								Component:  "runtime",
 								WorkingDir: "/projects/nodejs-starter",
 							},
 						},
 						{
 							Id: "devrun",
 							Exec: &common.Exec{
+								Component:   "nodejs",
 								CommandLine: "npm run",
 								WorkingDir:  "/projects/nodejs-starter",
 							},
@@ -199,11 +203,11 @@ func Test_parseParent(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/projects",
-							Name:      "starter-project-2",
+							SubDir: "/projects",
+							Name:   "starter-project-2",
 						},
 						{
-							ClonePath: "/projects",
+							SubDir: "/projects",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -217,7 +221,7 @@ func Test_parseParent(t *testing.T) {
 			},
 		},
 		{
-			name: "case 2: handle a parent'data without any local override and add the local devfile's data",
+			name: "case 2: handle a parent's data without any local override and add the local devfile's data",
 			args: args{
 				devFileObj: DevfileObj{
 					Ctx: parser.NewDevfileCtx(devfileTempPath),
@@ -226,6 +230,7 @@ func Test_parseParent(t *testing.T) {
 							{
 								Id: "devbuild",
 								Exec: &common.Exec{
+									Component:  "runtime",
 									WorkingDir: "/projects/nodejs-starter",
 								},
 							},
@@ -250,8 +255,8 @@ func Test_parseParent(t *testing.T) {
 
 						StarterProjects: []common.DevfileStarterProject{
 							{
-								ClonePath: "/projects",
-								Name:      "starter-project-1",
+								SubDir: "/projects",
+								Name:   "starter-project-1",
 							},
 						},
 					},
@@ -264,6 +269,7 @@ func Test_parseParent(t *testing.T) {
 						{
 							Id: "devrun",
 							Exec: &common.Exec{
+								Component:   "nodejs",
 								WorkingDir:  "/projects",
 								CommandLine: "npm run",
 							},
@@ -294,7 +300,7 @@ func Test_parseParent(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -312,12 +318,14 @@ func Test_parseParent(t *testing.T) {
 						{
 							Id: "devbuild",
 							Exec: &common.Exec{
+								Component:  "runtime",
 								WorkingDir: "/projects/nodejs-starter",
 							},
 						},
 						{
 							Id: "devrun",
 							Exec: &common.Exec{
+								Component:   "nodejs",
 								CommandLine: "npm run",
 								WorkingDir:  "/projects",
 							},
@@ -359,11 +367,11 @@ func Test_parseParent(t *testing.T) {
 					},
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/projects",
-							Name:      "starter-project-1",
+							SubDir: "/projects",
+							Name:   "starter-project-1",
 						},
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},

--- a/pkg/devfile/parser/types_test.go
+++ b/pkg/devfile/parser/types_test.go
@@ -869,7 +869,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 				Data: &v200.Devfile200{
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -884,7 +884,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 			args: args{
 				overridePatch: []common.DevfileStarterProject{
 					{
-						ClonePath: "/source",
+						SubDir: "/source",
 						Github: &common.Github{
 							GitLikeProjectSource: common.GitLikeProjectSource{
 								Remotes:      map[string]string{"origin": "url"},
@@ -901,7 +901,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 				Data: &v200.Devfile200{
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/source",
+							SubDir: "/source",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -921,7 +921,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 				Data: &v200.Devfile200{
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -945,7 +945,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 			args: args{
 				overridePatch: []common.DevfileStarterProject{
 					{
-						ClonePath: "/source",
+						SubDir: "/source",
 						Github: &common.Github{
 							GitLikeProjectSource: common.GitLikeProjectSource{
 								Remotes:      map[string]string{"origin": "url"},
@@ -961,7 +961,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 				Data: &v200.Devfile200{
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/source",
+							SubDir: "/source",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -991,7 +991,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 				Data: &v200.Devfile200{
 					StarterProjects: []common.DevfileStarterProject{
 						{
-							ClonePath: "/data",
+							SubDir: "/data",
 							Github: &common.Github{
 								GitLikeProjectSource: common.GitLikeProjectSource{
 									Remotes:      map[string]string{"origin": "url"},
@@ -1007,7 +1007,7 @@ func TestDevfileObj_OverrideStarterProjects(t *testing.T) {
 			args: args{
 				overridePatch: []common.DevfileStarterProject{
 					{
-						ClonePath: "/source",
+						SubDir: "/source",
 						Github: &common.Github{
 							GitLikeProjectSource: common.GitLikeProjectSource{
 								Remotes:      map[string]string{"origin": "url"},

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 	"github.com/openshift/odo/pkg/preference"
-	"github.com/openshift/odo/pkg/testingutil/filesystem"
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -986,7 +985,7 @@ func (co *CreateOptions) downloadStarterProject(devObj parser.DevfileObj, projec
 
 		if starterProject.SubDir != "" {
 			err = util.GitSubDir(path, originalPath,
-				starterProject.SubDir, filesystem.DefaultFs{})
+				starterProject.SubDir)
 			if err != nil {
 				return err
 			}

--- a/pkg/testingutil/filesystem/default_fs.go
+++ b/pkg/testingutil/filesystem/default_fs.go
@@ -126,6 +126,11 @@ func (DefaultFs) Walk(root string, walkFn filepath.WalkFunc) error {
 	return filepath.Walk(root, walkFn)
 }
 
+// Chmod via os.Chmod
+func (f DefaultFs) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
 // defaultFile implements File using same-named functions from "os"
 type defaultFile struct {
 	file *os.File
@@ -158,4 +163,12 @@ func (file *defaultFile) Close() error {
 
 func (file *defaultFile) Readdir(n int) ([]os.FileInfo, error) {
 	return file.file.Readdir(n)
+}
+
+func (file *defaultFile) Read(b []byte) (n int, err error) {
+	return file.file.Read(b)
+}
+
+func (file *defaultFile) Chmod(name string, mode os.FileMode) error {
+	return file.file.Chmod(mode)
 }

--- a/pkg/testingutil/filesystem/fake_fs.go
+++ b/pkg/testingutil/filesystem/fake_fs.go
@@ -130,6 +130,11 @@ func (fs *fakeFs) Remove(name string) error {
 	return fs.a.Remove(name)
 }
 
+// Chmod via afero.Chmod
+func (fs *fakeFs) Chmod(name string, mode os.FileMode) error {
+	return fs.a.Chmod(name, mode)
+}
+
 // fakeFile implements File; for use with fakeFs
 type fakeFile struct {
 	file afero.File
@@ -162,4 +167,8 @@ func (file *fakeFile) Close() error {
 
 func (file *fakeFile) Readdir(n int) ([]os.FileInfo, error) {
 	return file.file.Readdir(n)
+}
+
+func (file *fakeFile) Read(b []byte) (n int, err error) {
+	return file.file.Read(b)
 }

--- a/pkg/testingutil/filesystem/filesystem.go
+++ b/pkg/testingutil/filesystem/filesystem.go
@@ -39,6 +39,7 @@ type Filesystem interface {
 	Chtimes(name string, atime time.Time, mtime time.Time) error
 	RemoveAll(path string) error
 	Remove(name string) error
+	Chmod(name string, mode os.FileMode) error
 
 	// from "io/ioutil"
 	ReadFile(filename string) ([]byte, error)
@@ -58,5 +59,6 @@ type File interface {
 	WriteString(s string) (n int, err error)
 	Sync() error
 	Close() error
+	Read(b []byte) (n int, err error)
 	Readdir(n int) ([]os.FileInfo, error)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -888,7 +888,7 @@ func GetAndExtractZip(zipURL string, destination string, pathToUnzip string, sta
 	}
 
 	if len(filenames) == 0 {
-		return errors.New("no files were unzipped, ensure that the project repo is not empty or that sparseCheckoutDir has a valid path")
+		return errors.New("no files were unzipped, ensure that the project repo is not empty or that subDir has a valid path")
 	}
 
 	return nil
@@ -921,7 +921,7 @@ func Unzip(src, dest, pathToUnzip string) ([]string, error) {
 			continue
 		}
 
-		// if sparseCheckoutDir has a pattern
+		// if subDir has a pattern
 		match, err := filepath.Match(pathToUnzip, filename)
 		if err != nil {
 			return filenames, err
@@ -1247,4 +1247,167 @@ func DisplayLog(followLog bool, rd io.ReadCloser, compName string) (err error) {
 	}
 	return
 
+}
+
+// CopyFileWithFs copies a single file from src to dst
+func CopyFileWithFs(src, dst string, fs filesystem.Filesystem) error {
+	var err error
+	var srcinfo os.FileInfo
+
+	srcfd, err := fs.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := srcfd.Close()
+		if err != nil {
+			klog.V(4).Infof("err occurred while closing file: %v", err)
+		}
+	}()
+
+	dstfd, err := fs.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := dstfd.Close()
+		if err != nil {
+			klog.V(4).Infof("err occurred while closing file: %v", err)
+		}
+	}()
+
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	if srcinfo, err = fs.Stat(src); err != nil {
+		return err
+	}
+	return fs.Chmod(dst, srcinfo.Mode())
+}
+
+// CopyDirWithFS copies a whole directory recursively
+func CopyDirWithFS(src string, dst string, fs filesystem.Filesystem) error {
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = fs.Stat(src); err != nil {
+		return err
+	}
+
+	if err = fs.MkdirAll(dst, srcinfo.Mode()); err != nil {
+		return err
+	}
+
+	if fds, err = fs.ReadDir(src); err != nil {
+		return err
+	}
+	for _, fd := range fds {
+		srcfp := path.Join(src, fd.Name())
+		dstfp := path.Join(dst, fd.Name())
+
+		if fd.IsDir() {
+			if err = CopyDirWithFS(srcfp, dstfp, fs); err != nil {
+				return err
+			}
+		} else {
+			if err = CopyFileWithFs(srcfp, dstfp, fs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// StartSignalWatcher watches for kill,interrupt etc signals and cleans up temp files and folders
+func StartSignalWatcher(handle func()) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	defer signal.Stop(signals)
+
+	<-signals
+	handle()
+	// exit here to stop spinners from rotating
+	os.Exit(1)
+}
+
+// CleanDir cleans the original folder during events like interrupted copy etc
+// it leaves the given files behind for later use
+func CleanDir(originalPath string, leaveBehindFiles map[string]bool, fs filesystem.Filesystem) error {
+	// Open the directory.
+	outputDirRead, err := fs.Open(originalPath)
+	if err != nil {
+		return err
+	}
+
+	// Call Readdir to get all files.
+	outputDirFiles, err := outputDirRead.Readdir(0)
+	if err != nil {
+		return err
+	}
+
+	// Loop over files.
+	for _, file := range outputDirFiles {
+		if value, ok := leaveBehindFiles[file.Name()]; ok && value {
+			continue
+		}
+		err = fs.RemoveAll(filepath.Join(originalPath, file.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// GitSubDir handles subDir for git components
+func GitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem) error {
+	go StartSignalWatcher(func() {
+		err := CleanDir(destinationPath, map[string]bool{
+			"devfile.yaml": true,
+		}, fs)
+		if err != nil {
+			klog.V(4).Infof("error %v occurred while calling handleInterruptedSubDir", err)
+		}
+		err = fs.RemoveAll(srcPath)
+		if err != nil {
+			klog.V(4).Infof("error %v occurred during temp folder clean up", err)
+		}
+	})
+
+	// Open the directory.
+	outputDirRead, err := fs.Open(filepath.Join(srcPath, subDir))
+	if err != nil {
+		return err
+	}
+
+	// Call Readdir to get all files.
+	outputDirFiles, err := outputDirRead.Readdir(0)
+	if err != nil {
+		return err
+	}
+
+	// Loop over files.
+	for outputIndex := range outputDirFiles {
+		outputFileHere := outputDirFiles[outputIndex]
+
+		// Get name of file.
+		fileName := outputFileHere.Name()
+
+		oldPath := filepath.Join(srcPath, subDir, fileName)
+
+		if outputFileHere.IsDir() {
+			err = CopyDirWithFS(oldPath, filepath.Join(destinationPath, fileName), fs)
+		} else {
+			err = CopyFileWithFs(oldPath, filepath.Join(destinationPath, fileName), fs)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return fs.RemoveAll(srcPath)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2172,7 +2172,7 @@ func TestCopyFileWithFS(t *testing.T) {
 				t.Errorf("error while setting up test: %v", err)
 			}
 
-			err = CopyFileWithFs(tt.args.src, tt.args.dst, tt.args.fs)
+			err = copyFileWithFs(tt.args.src, tt.args.dst, tt.args.fs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MoveFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -2281,7 +2281,7 @@ func TestCopyDirWithFS(t *testing.T) {
 				t.Errorf("error while setting up test: %v", err)
 			}
 
-			err = CopyDirWithFS(tt.args.src, tt.args.dst, tt.args.fs)
+			err = copyDirWithFS(tt.args.src, tt.args.dst, tt.args.fs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MoveDir() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -2431,7 +2431,7 @@ func TestCleanDir(t *testing.T) {
 				t.Errorf("error while setting up test: %v", err)
 			}
 
-			err = CleanDir(tt.args.originalPath, tt.args.leaveBehindFiles, tt.args.fs)
+			err = cleanDir(tt.args.originalPath, tt.args.leaveBehindFiles, tt.args.fs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CleanDir() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -2565,7 +2565,7 @@ func TestGitSubDir(t *testing.T) {
 				t.Errorf("error while setting up test: %v", err)
 			}
 
-			err = GitSubDir(tt.args.srcPath, tt.args.destinationPath, tt.args.subDir, tt.args.fs)
+			err = gitSubDir(tt.args.srcPath, tt.args.destinationPath, tt.args.subDir, tt.args.fs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GitSubDir() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/testingutil/filesystem"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -2014,6 +2015,613 @@ func TestSliceContainsString(t *testing.T) {
 			if !reflect.DeepEqual(gotVal, tt.wantVal) {
 				t.Errorf("Got %v, want %v", gotVal, tt.wantVal)
 			}
+		})
+	}
+}
+
+// FileType custom type to indicate type of file
+type FileType int
+
+const (
+	// RegularFile enum to represent regular file
+	RegularFile FileType = 0
+	// Directory enum to represent directory
+	Directory FileType = 1
+)
+
+// FileProperties to contain meta-data of a file like, file/folder name, file/folder parent dir, file type and desired file modification type
+type FileProperties struct {
+	FilePath string
+	FileType FileType
+}
+
+func folderCheck(originalFolderMode os.FileMode, newFolderInfo os.FileInfo, path string) error {
+	if originalFolderMode.String() != newFolderInfo.Mode().String() {
+		return fmt.Errorf("folder %s created with wrong permission", path)
+	}
+	return nil
+}
+
+func fileCheck(fs filesystem.Filesystem, originalFile filesystem.File, newFilePath string, newFileInfo os.FileInfo) error {
+	originalFileData, err := fs.ReadFile(originalFile.Name())
+	if err != nil {
+		return err
+	}
+
+	createdFileData, err := fs.ReadFile(newFilePath)
+	if err != nil {
+		return err
+	}
+
+	// check the written data
+	if string(createdFileData) == string(originalFileData) {
+		originalInfo, err := fs.Stat(originalFile.Name())
+		if err != nil {
+			return err
+		}
+
+		// check the file permission
+		if newFileInfo.Mode() != originalInfo.Mode() {
+			return fmt.Errorf("file %s created with wrong permission", newFilePath)
+		}
+	} else {
+		return fmt.Errorf("file %s created with wrong data", newFilePath)
+	}
+	return nil
+}
+
+func setupFileTest(fs filesystem.Filesystem, sourceName string, filePaths []FileProperties) (map[string]filesystem.File, map[string]os.FileMode, error) {
+
+	fileMap := make(map[string]filesystem.File)
+	folderMap := make(map[string]os.FileMode)
+
+	for i, path := range filePaths {
+
+		if path.FileType == RegularFile {
+			file, err := fs.Create(path.FilePath)
+			if err != nil {
+				return nil, nil, err
+			}
+			_, err = file.Write([]byte("some text" + string(rune(i))))
+			if err != nil {
+				return nil, nil, err
+			}
+
+			name, err := filepath.Rel(sourceName, file.Name())
+			if err != nil {
+				return nil, nil, err
+			}
+			fileMap[name] = file
+		} else if path.FileType == Directory {
+			permission := os.ModeDir + 0755
+			err := fs.MkdirAll(path.FilePath, permission)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			name, err := filepath.Rel(sourceName, path.FilePath)
+			if err != nil {
+				return nil, nil, err
+			}
+			folderMap[name] = permission
+		}
+	}
+
+	return fileMap, folderMap, nil
+}
+
+func TestCopyFileWithFS(t *testing.T) {
+	fileName := "blah.js"
+
+	fs := filesystem.NewFakeFs()
+
+	sourceName := filepath.Join(os.TempDir(), "source")
+	destinationDirName := filepath.Join(os.TempDir(), "destination")
+
+	filePaths := []FileProperties{
+		{
+			FilePath: sourceName,
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, fileName),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: destinationDirName,
+			FileType: Directory,
+		},
+	}
+
+	printError := func(err error) {
+		t.Errorf("some error occured while procession file/folder: %v", err)
+	}
+
+	type args struct {
+		src string
+		dst string
+		fs  filesystem.Filesystem
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "case 1: normal file exists",
+			args: args{
+				src: filepath.Join(sourceName, fileName),
+				dst: filepath.Join(destinationDirName, fileName),
+				fs:  fs,
+			},
+		},
+		{
+			name: "case 2: file doesn't exist",
+			args: args{
+				src: filepath.Join(sourceName, fileName) + "blah",
+				dst: filepath.Join(destinationDirName, fileName),
+				fs:  fs,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileMap, _, err := setupFileTest(fs, sourceName, filePaths)
+			if err != nil {
+				t.Errorf("error while setting up test: %v", err)
+			}
+
+			err = CopyFileWithFs(tt.args.src, tt.args.dst, tt.args.fs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MoveFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			files, err := fs.ReadDir(destinationDirName)
+			if err != nil {
+				t.Errorf("error occured while reading directory %s: %v", destinationDirName, err)
+			}
+
+			found := false
+			for _, file := range files {
+
+				relPath, err := filepath.Rel(destinationDirName, filepath.Join(destinationDirName, fileName))
+				if err != nil {
+					printError(err)
+					break
+				}
+
+				if originalFile, ok := fileMap[relPath]; ok {
+					err := fileCheck(fs, originalFile, filepath.Join(destinationDirName, file.Name()), file)
+					if err != nil {
+						break
+					}
+					found = true
+				} else {
+					t.Errorf("extra file %s created", file.Name())
+				}
+			}
+
+			if !found && !tt.wantErr {
+				t.Errorf("%s not created in directory %s", fileName, destinationDirName)
+			}
+
+			_ = fs.RemoveAll(tt.args.src)
+			_ = fs.RemoveAll(tt.args.dst)
+		})
+	}
+}
+
+func TestCopyDirWithFS(t *testing.T) {
+
+	fs := filesystem.NewFakeFs()
+
+	sourceName := filepath.Join(os.TempDir(), "source")
+	destinationName := filepath.Join(os.TempDir(), "destination")
+
+	filePaths := []FileProperties{
+		{
+			FilePath: sourceName,
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "blah.js"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "some-other-blah.js"),
+			FileType: RegularFile,
+		},
+	}
+
+	printError := func(err error) {
+		t.Errorf("some error occured while procession file/folder: %v", err)
+	}
+
+	type args struct {
+		src string
+		dst string
+		fs  filesystem.Filesystem
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "case 1: folder with a nested file and folder",
+			args: args{
+				src: sourceName,
+				dst: destinationName,
+				fs:  fs,
+			},
+		},
+		{
+			name: "case 2: source folder doesn't exist",
+			args: args{
+				src: sourceName + "/extra",
+				dst: destinationName,
+				fs:  fs,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileMap, folderMap, err := setupFileTest(fs, sourceName, filePaths)
+			if err != nil {
+				t.Errorf("error while setting up test: %v", err)
+			}
+
+			err = CopyDirWithFS(tt.args.src, tt.args.dst, tt.args.fs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MoveDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr && err != nil {
+				return
+			}
+
+			folderCount := 0
+			fileCount := 0
+
+			err = fs.Walk(destinationName, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				relPath, err := filepath.Rel(destinationName, path)
+				if err != nil {
+					printError(err)
+					return err
+				}
+
+				if info.IsDir() {
+
+					// check the permission on the folder
+					if originalFolderMode, ok := folderMap[relPath]; ok {
+						err := folderCheck(originalFolderMode, info, path)
+						if err != nil {
+							printError(err)
+							return err
+						}
+						folderCount++
+					} else {
+						t.Errorf("extra folder %s created", path)
+					}
+				} else {
+					if file, ok := fileMap[relPath]; ok {
+						err := fileCheck(fs, file, path, info)
+						if err != nil {
+							printError(err)
+							return err
+						}
+						fileCount++
+					} else {
+						t.Errorf("extra file %s created", path)
+					}
+				}
+				return nil
+			})
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if folderCount != 2 {
+				t.Errorf("some folder were not created")
+			}
+
+			if fileCount != 2 {
+				t.Errorf("some files were not created")
+			}
+
+			_ = fs.RemoveAll(tt.args.src)
+			_ = fs.RemoveAll(tt.args.dst)
+		})
+	}
+}
+
+func TestCleanDir(t *testing.T) {
+	fs := filesystem.NewFakeFs()
+
+	sourceName := filepath.Join(os.TempDir(), "source")
+
+	filePaths := []FileProperties{
+		{
+			FilePath: sourceName,
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "devfile.yaml"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "preference.yaml"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "blah.js"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "some-other-blah.js"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "another-blah.js"),
+			FileType: RegularFile,
+		},
+	}
+
+	type args struct {
+		originalPath     string
+		leaveBehindFiles map[string]bool
+		fs               filesystem.Filesystem
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "case 1: leave behind two files",
+			args: args{
+				originalPath: sourceName,
+				fs:           fs,
+				leaveBehindFiles: map[string]bool{
+					"devfile.yaml":    true,
+					"preference.yaml": true,
+				},
+			},
+		},
+		{
+			name: "case 2: source doesn't exist",
+			args: args{
+				originalPath: sourceName + "blah",
+				fs:           fs,
+				leaveBehindFiles: map[string]bool{
+					"devfile.yaml":    true,
+					"preference.yaml": true,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := setupFileTest(fs, sourceName, filePaths)
+			if err != nil {
+				t.Errorf("error while setting up test: %v", err)
+			}
+
+			err = CleanDir(tt.args.originalPath, tt.args.leaveBehindFiles, tt.args.fs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CleanDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil && tt.wantErr {
+				return
+			}
+
+			files, err := fs.ReadDir(sourceName)
+			if err != nil {
+				t.Errorf("error occured while reading directory %s: %v", sourceName, err)
+			}
+
+			found := 0
+			for _, file := range files {
+				if _, ok := tt.args.leaveBehindFiles[file.Name()]; !ok {
+					t.Errorf("file %s isn't cleaned up", file.Name())
+				} else {
+					found++
+				}
+			}
+
+			if found != 2 {
+				t.Errorf("some extra file were deleted")
+			}
+
+			_ = fs.RemoveAll(tt.args.originalPath)
+		})
+	}
+}
+
+func TestGitSubDir(t *testing.T) {
+
+	fs := filesystem.NewFakeFs()
+
+	sourceName := filepath.Join(os.TempDir(), "source")
+	destinationName := filepath.Join(os.TempDir(), "destination")
+
+	filePaths := []FileProperties{
+		{
+			FilePath: sourceName,
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "blah.js"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "some-other-blah.js"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "test"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "test", "test.java"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "java"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "java", "main.java"),
+			FileType: RegularFile,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "resources"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "resources", "layout"),
+			FileType: Directory,
+		},
+		{
+			FilePath: filepath.Join(sourceName, "main", "src", "resources", "index.html"),
+			FileType: RegularFile,
+		},
+	}
+
+	type args struct {
+		destinationPath string
+		srcPath         string
+		subDir          string
+		fs              filesystem.Filesystem
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "case 1: normal sub dir exist",
+			args: args{
+				srcPath:         sourceName,
+				destinationPath: destinationName,
+				subDir:          filepath.Join("main", "src"),
+				fs:              fs,
+			},
+		},
+		{
+			name: "case 2: sub dir doesn't exist",
+			args: args{
+				srcPath:         sourceName,
+				destinationPath: destinationName,
+				subDir:          filepath.Join("main", "blah"),
+				fs:              fs,
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 3: src doesn't exist",
+			args: args{
+				srcPath:         sourceName + "blah",
+				destinationPath: destinationName,
+				subDir:          filepath.Join("main", "src"),
+				fs:              fs,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := setupFileTest(fs, sourceName, filePaths)
+			if err != nil {
+				t.Errorf("error while setting up test: %v", err)
+			}
+
+			err = GitSubDir(tt.args.srcPath, tt.args.destinationPath, tt.args.subDir, tt.args.fs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitSubDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr && err != nil {
+				return
+			}
+
+			pathsToValidate := map[string]bool{
+				filepath.Join(tt.args.destinationPath, "java"):                    true,
+				filepath.Join(tt.args.destinationPath, "java", "main.java"):       true,
+				filepath.Join(tt.args.destinationPath, "resources"):               true,
+				filepath.Join(tt.args.destinationPath, "resources", "layout"):     true,
+				filepath.Join(tt.args.destinationPath, "resources", "index.html"): true,
+			}
+
+			pathsNotToBePresent := map[string]bool{
+				filepath.Join(tt.args.destinationPath, "src"):  true,
+				filepath.Join(tt.args.destinationPath, "main"): true,
+			}
+
+			found := 0
+			notToBeFound := 0
+			err = fs.Walk(tt.args.destinationPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				if ok := pathsToValidate[path]; ok {
+					found++
+				}
+
+				if ok := pathsNotToBePresent[path]; ok {
+					notToBeFound++
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if found != 5 {
+				t.Errorf("all files were not copied")
+			}
+
+			if notToBeFound != 0 {
+				t.Errorf("extra files were created")
+			}
+
+			_, err = os.Stat(tt.args.srcPath)
+			if !os.IsNotExist(err) {
+				t.Errorf("src path was not deleted")
+			}
+
+			_ = fs.RemoveAll(tt.args.srcPath)
+			_ = fs.RemoveAll(tt.args.destinationPath)
 		})
 	}
 }

--- a/tests/examples/source/devfiles/nodejs/devfile-with-subDir.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-subDir.yaml
@@ -2,12 +2,11 @@ apiVersion: 1.0.0
 metadata:
   name: nodejs
 starterProjects:
-  -
-    name: nodejs-starter
+  - name: nodejs-starter
+    subDir: /app/
     git:
       remotes:
         origin: "https://github.com/che-samples/web-nodejs-sample.git"
-      sparseCheckoutDir: /app/
 components:
   - type: dockerimage
     image: registry.access.redhat.com/ubi8/nodejs-12:1-36

--- a/tests/examples/source/devfiles/springboot/devfile-with-subDir.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-subDir.yaml
@@ -1,0 +1,51 @@
+---
+schemaVersion: 2.0.0
+metadata:
+  name: java-springboot
+starterProjects:
+  - name: springbootproject
+    subDir: "/src/main"
+    git:
+      remotes:
+        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+components:
+  - name: tools
+    container:
+      image: quay.io/eclipse/che-java11-maven:nightly
+      memoryLimit: 768Mi
+      command: ['tail']
+      args: [ '-f', '/dev/null']
+      mountSources: true
+      volumeMounts:
+        - name: springbootpvc
+          path: /data/cache/.m2
+  - name: runtime
+    container:
+      image: quay.io/eclipse/che-java11-maven:nightly
+      memoryLimit: 768Mi
+      endpoints:
+        - name: "8080/tcp"
+          targetPort: 8080
+      volumeMounts:
+        - name: springbootpvc
+          path: /data/cache/.m2
+      mountSources: true
+  - name: springbootpvc
+    volume:
+      size: 3Gi
+commands:
+  - id: defaultBuild
+    exec:
+      component: tools
+      commandLine: "mvn clean -Dmaven.repo.local=/data/cache/.m2/repository package -Dmaven.test.skip=true"
+      workingDir: /projects
+      group:
+        kind: build
+  - id: defaultRun
+    exec:
+      component: runtime
+      commandLine: "mvn -Dmaven.repo.local=/data/cache/.m2/repository spring-boot:run"
+      workingDir: /projects
+      group:
+        kind: run
+        isDefault: true


### PR DESCRIPTION
Signed-off-by: mik-dass <mrinald7@gmail.com>

**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

Updates schema to change sparseCheckoutDir to subDir and adds support of it for git starter projects.

**Which issue(s) this PR fixes**:

Fixes #3933 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create a devfile with subDir set and place it in a empty folder.
- Run `odo create --starter`
- The starter project's `subDir` content should be downloaded only and the temp folder should be removed.