### PR TITLE
Ignore lifecycle/rotten labels when generating changelog

### DIFF
--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -36,6 +36,7 @@ github_changelog_generator \
 --future-release $2 \
 --base /tmp/base \
 --output /tmp/changelog \
+--exclude-tags "lifecycle/rotten" \
 --header-label "# Release of $2" \
 --enhancement-label "**Code Refactoring:**" \
 --enhancement-labels "kind/cleanup,kind/api-change,kind/code-refactoring" \


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind cleanup

**What does does this PR do / why we need it**:

Ignores "lifecycle/rotten" issues when generating the changelog

**Which issue(s) this PR fixes**:

Closes https://github.com/openshift/odo/issues/3192#issuecomment-707521200

**PR acceptance criteria**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>