### PR TITLE
Removing mongo db operator

### DIFF
--- a/scripts/setup-operators.sh
+++ b/scripts/setup-operators.sh
@@ -1,26 +1,6 @@
 #!/bin/bash
 set -x
 
-CI_OPERATOR_HUB_PROJECT=ci-operator-hub-project
-
-install_mongo_operator() {
-  # First, enable a cluster-wide mongo operator
-  oc create -f - <<EOF
-  apiVersion: operators.coreos.com/v1alpha1
-  kind: Subscription
-  metadata:
-    name: percona-server-mongodb-operator-certified
-    namespace: openshift-operators
-  spec:
-    channel: stable
-    installPlanApproval: Automatic
-    name: percona-server-mongodb-operator-certified
-    source: certified-operators
-    sourceNamespace: openshift-marketplace
-    startingCSV: percona-server-mongodb-operator.v1.4.0
-EOF
-}
-
 install_etcd_operator(){
   # Create subscription
   oc create -f - <<EOF
@@ -56,41 +36,10 @@ install_service_binding_operator(){
 EOF
 }
 
-# install mongo operator
-count=0
-while [ "$count" -lt "5" ];
-do
-    if oc get csv -n openshift-operators | grep mongo; then
-        break
-    else
-        install_mongo_operator
-        count=`expr $count + 1`
-        sleep 15
-    fi
-done
-
 # install etcd operator
-count=0
-while [ "$count" -lt "5" ];
-do
-    if oc get csv -n openshift-operators | grep etcd; then
-        break
-    else
-        install_etcd_operator
-        count=`expr $count + 1`
-        sleep 15
-    fi
-done
+
+install_etcd_operator
 
 # install service-binding-operator
-count=0
-while [ "$count" -lt "5" ];
-do
-    if oc get csv -n openshift-operators | grep service-binding-operator; then
-        break
-    else
-        install_service_binding_operator
-        count=`expr $count + 1`
-        sleep 15
-    fi
-done
+
+install_service_binding_operator

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -31,7 +31,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		// wait till oc can see the all operators installed by setup script in the namespace
 		ocArgs := []string{"get", "csv"}
-		operators := []string{"etcd"}
+		operators := []string{"etcd", "Service Binding Operator"}
 		for _, operator := range operators {
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, operator)
@@ -51,11 +51,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		JustAfterEach(func() {
 			cleanPreSetup()
-		})
-
-		It("should list operators installed in the namespace", func() {
-			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
 		})
 
 		It("should list operators installed in the namespace", func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What does does this PR do / why we need it**:

Removing mongodb operator setup due to instability of the operator on 4.* cluster. Fixing the CI failure we are hitting currently.

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-operator-hub` should pass.