### PR TITLE
Document Operator installation on minikube

### DIFF
--- a/docs/public/operator-hub.adoc
+++ b/docs/public/operator-hub.adoc
@@ -12,7 +12,7 @@ odo utilizes Operators in order to provide a seamless method for custom controll
 
 ==== Prerequisites
 
-* You must have cluster permissions to install an Operator on either link:https://docs.openshift.com/container-platform/latest/operators/olm-adding-operators-to-cluster.html[OpenShift] or link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md[Kubernetes].
+* You must have cluster permissions to install an Operator on either link:https://docs.openshift.com/container-platform/latest/operators/olm-adding-operators-to-cluster.html[OpenShift] or link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md[Kubernetes]. If you're running a link:https://minikube.sigs.k8s.io/docs/[minikube] cluster, you can refer link:operators-on-minikube.adoc[this guide] to install Operators required to run example mentioned in this document.
 
 == Creating a project
 

--- a/docs/public/operators-on-minikube.adoc
+++ b/docs/public/operators-on-minikube.adoc
@@ -98,128 +98,15 @@ Once the pod for this `CatalogSource` is up, wait a few seconds before trying to
 
 === Installing the Service Binding Operator
 
-We use the link:https://github.com/redhat-developer/service-binding-operator/[Service Binding Operator] to provide `odo link` feature which links an odo component with an Operator backed service. Thus, to be able to use this feature, it's essential that we install the Operator first.
+odo uses the link:https://github.com/redhat-developer/service-binding-operator/[Service Binding Operator] to provide `odo link` feature which links an odo component with an Operator backed service. Thus, to be able to use this feature, it's essential that we install the Operator first.
 
 Service Binding Operator is not yet available via the OLM. The team is link:https://github.com/redhat-developer/service-binding-operator/issues/727[working on making it available] through OLM.
 
-At the moment, to make Service Binding Operator work on Kubernetes, we need to keep a couple of things in mind:
-
-. It needs to be installed by cloning its GitHub repository
-. It must be installed in a namespace other than `operators` namespace.
-. In this guide, we're installing the Service Binding Operator in `default` namespace. You can install it in the namespace you prefer to use it in
-
-Let's setup the Service Binding Operator now.
-
-. First, let's clone its repository on the host system where we're running minikube and checkout the specific tag that is currently supported by `odo link` command:
-+
+To install the Operator, execute the following `kubectl` command:
 [source,sh]
 ----
-$ git clone https://github.com/redhat-developer/service-binding-operator/
-$ cd service-binding-operator
-$ git fetch --tags
-$ git checkout tags/v0.1.1-364 -b v0.1.1-364
-$ cd deploy
+$ kubectl apply -f https://github.com/redhat-developer/service-binding-operator/releases/download/v0.1.1-364/install-v0.1.1-364.yaml
 ----
-
-. Next, install its CRD (link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-extending-api-with-crds.html[Custom Resource Definition]) and create link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[ServiceAccount], https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[Role] and link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding[RoleBinding] it requires:
-+
-[source,sh]
-----
-$ kubectl create -f https://raw.githubusercontent.com/redhat-developer/service-binding-operator/v0.1.1-364/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
-$ kubectl create -f service_account.yaml -f role.yaml -f role_binding.yaml
-----
-
-. Now, create a link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[ClusterRole] and a link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding[ClusterRoleBinding] that are required to allow the Service Binding Operator access resources of API groups `apps.openshift.io` and `apiextensions.k8s.io` at cluster level:
-+
-[source,sh]
-----
-$ kubectl create -f - << EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sbo-cluster-role
-rules:
-- apiGroups: 
-  - apps.openshift.io
-  resources: 
-  - "*"
-  verbs:
-  - "*"
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  - customresourcedefinitions/status
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-EOF
-
-$ kubectl create -f - << EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: sbo-cluster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: service-binding-operator
-  namespace: default
-roleRef:
-  kind: ClusterRole
-  name: sbo-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-EOF
-----
-
-. Next, we modify the `operator.yaml` file to install the Operator in a specific namespace and use the container image that matches the version of Service Binding Operator that odo supports. Below is the resulting `operator.yaml` file (set the value of namespace to suit your environment):
-+
-[source,yaml]
-----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: service-binding-operator
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: service-binding-operator
-  template:
-    metadata:
-      labels:
-        name: service-binding-operator
-    spec:
-      serviceAccountName: service-binding-operator
-      containers:
-        - name: service-binding-operator
-          # Replace this with the built image name
-          image: quay.io/redhat-developer/app-binding-operator:v0.1.1-364
-          command:
-          - service-binding-operator
-          imagePullPolicy: Always
-          env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "service-binding-operator"
-----
-
-. Finally, install the Operator using below command:
-+
-[source,sh]
-----
-$ kubectl create -f operator.yaml
-----
-
 
 You should now see a `Deployment` for Service Binding Operator in the namespace where you installed it:
 [source,sh]
@@ -227,3 +114,14 @@ You should now see a `Deployment` for Service Binding Operator in the namespace 
 $ kubectl get deploy -n <replace-namespace-value>
 ----
 
+==== Troubleshooting
+
+If linking doesn't work after installing the Service Binding Operator as described above, please open an issue on the odo repository describing the issue. On the issue, please provide the logs of the `Pod` created by the `Deployment` of Service Binding Operator. Execute below command in the namespace where you installed Service Binding Operator (note that `Pod` name will be different in your environment than what's shown below):
+[source,sh]
+----
+$ kubectl get pods
+NAME                                        READY   STATUS    RESTARTS   AGE
+service-binding-operator-65745c4bdc-gc6km   1/1     Running   0          34m
+
+$ kubectl logs service-binding-operator-65745c4bdc-gc6km --follow
+----

--- a/docs/public/operators-on-minikube.adoc
+++ b/docs/public/operators-on-minikube.adoc
@@ -105,7 +105,7 @@ Service Binding Operator is not yet available via the OLM. The team is link:http
 At the moment, to make Service Binding Operator work on Kubernetes, we need to keep a couple of things in mind:
 
 . It needs to be installed by cloning its GitHub repository
-. It must be installed in an individual namespace unlike the cluster wide installation we saw for etcd Operator in previous section
+. It must be installed in a namespace other than `operators` namespace.
 . In this guide, we're installing the Service Binding Operator in `default` namespace. You can install it in the namespace you prefer to use it in
 
 Let's setup the Service Binding Operator now.
@@ -125,7 +125,7 @@ $ cd deploy
 +
 [source,sh]
 ----
-$ kubectl create -f crds/apps.openshift.io_servicebindingrequests_crd.yaml
+$ kubectl create -f https://raw.githubusercontent.com/redhat-developer/service-binding-operator/v0.1.1-364/deploy/crds/apps.openshift.io_servicebindingrequests_crd.yaml
 $ kubectl create -f service_account.yaml -f role.yaml -f role_binding.yaml
 ----
 
@@ -173,19 +173,44 @@ roleRef:
 EOF
 ----
 
-. Next, we modify the `operator.yaml` file to install the Operator in a specific namespace and use the container image that matches the version of the git commit (`git log -n1 --oneline`) of the repository. Make change as per below `git diff` but make sure to set the value of `namespace` to the namespace where you want to install the Operator:
+. Next, we modify the `operator.yaml` file to install the Operator in a specific namespace and use the container image that matches the version of Service Binding Operator that odo supports. Below is the resulting `operator.yaml` file (set the value of namespace to suit your environment):
 +
-[source,diff]
+[source,yaml]
 ----
-diff --git a/deploy/operator.yaml b/deploy/operator.yaml
-index 2cd90ec7..21c4768c 100644
---- a/deploy/operator.yaml
-+++ b/deploy/operator.yaml
-@@ -4,0 +5 @@ metadata:
-+  namespace: default
-@@ -19 +20 @@ spec:
--          image: REPLACE_IMAGE
-+          image: quay.io/redhat-developer/app-binding-operator:0799ba7
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-binding-operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: service-binding-operator
+  template:
+    metadata:
+      labels:
+        name: service-binding-operator
+    spec:
+      serviceAccountName: service-binding-operator
+      containers:
+        - name: service-binding-operator
+          # Replace this with the built image name
+          image: quay.io/redhat-developer/app-binding-operator:v0.1.1-364
+          command:
+          - service-binding-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "service-binding-operator"
 ----
 
 . Finally, install the Operator using below command:

--- a/docs/public/operators-on-minikube.adoc
+++ b/docs/public/operators-on-minikube.adoc
@@ -1,4 +1,4 @@
-== Installing Operators on minkube
+== Installing Operators on minikube
 
 This guide assumes that you are using link:https://minikube.sigs.k8s.io/docs/[minikube] v1.11.0 or newer.
 
@@ -106,7 +106,7 @@ At the moment, to make Service Binding Operator work on Kubernetes, we need to k
 
 . It needs to be installed by cloning its GitHub repository
 . It must be installed in an individual namespace unlike the cluster wide installation we saw for etcd Operator in previous section
-
+. In this guide, we're installing the Service Binding Operator in `default` namespace. You can install it in the namespace you prefer to use it in
 
 Let's setup the Service Binding Operator now.
 

--- a/docs/public/operators-on-minikube.adoc
+++ b/docs/public/operators-on-minikube.adoc
@@ -1,0 +1,204 @@
+== Installing Operators on minkube
+
+This guide assumes that you are using link:https://minikube.sigs.k8s.io/docs/[minikube] v1.11.0 or newer.
+
+In this guide, we will discuss installing two Operators on a minikube environment:
+
+. etcd Operator
+. Service Binding Operator
+
+=== Prerequisites
+
+You must enable the `olm` addon for your minikube cluster by doing:
+[source,sh]
+----
+$ minikube addons enable olm
+----
+
+=== Installing etcd Operator
+
+Operators can be installed in a specific namepsace or across the cluster (that is, for all the namespaces). We will install etcd Operator across the cluster such that if you create a new namespace, the etcd Operator will be automatically available for use.
+
+To install an Operator, we need to make sure that the namespace in which we're installing it has an `OperatorGroup`. Since we want to install etcd Operator across all the namespaces, we will install it in `operators` namespace and `olm` takes care of making it available across all the namespace.
+
+[NOTE]
+====
+You can't install any Operator in the `operators` namespace and expect it to be available across all namespaces. The Operator you're trying to installing needs to be designed to be available in this way as well. Certain Operators only support installation in a single namespace.
+
+Discussing this topic is out of scope of this guide so we have stated it as a note.
+====
+
+Enabling the `olm` addon will, among other things, create an `OperatorGroup` in the `operators` namepsace. Make sure that it's there:
+[source,sh]
+----
+$ kubectl get og -n operators
+NAME               AGE
+global-operators   3m37s
+----
+
+If you don't see one, create it using below command:
+[source,sh]
+----
+$ kubectl create -f - << EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: global-operators 
+  namespace: operators 
+spec:
+  targetNamespaces:
+  - operators
+EOF
+----
+
+Now, install the etcd Operator using below command:
+[source,sh]
+----
+$ kubectl create -f - << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: etcd
+  namespace: operators
+spec:
+  channel: clusterwide-alpha
+  name: etcd
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  startingCSV: etcdoperator.v0.9.4-clusterwide
+  installPlanApproval: Automatic
+EOF
+----
+
+Give it a few seconds before checking the availability of the etcd Operator:
+[source,sh]
+----
+$ odo catalog list services
+Operators available in the cluster
+NAME                                CRDs
+etcdoperator.v0.9.4-clusterwide     EtcdCluster, EtcdBackup, EtcdRestore
+----
+
+==== Troubleshooting
+
+If you don't see etcd Operator using above command or by doing `kubectl get csv`, make sure that pod belonging to the CatalogSource named operatorhubio-catalog is running:
+[source,sh]
+----
+$ kubectl get po -n olm | grep operatorhubio-catalog
+----
+
+If the state of this pod is `CrashLoopBackOff`, delete it so that Kubernetes will automatically spin up a new pod for the `CatalogSource`:
+
+[source,sh]
+----
+$ kubectl delete po -n olm <name-of-operatorhubio-catalog-pod>
+----
+
+Once the pod for this `CatalogSource` is up, wait a few seconds and see if you can find the etcd Operator when you do `odo catalog list services`.
+
+=== Installing the Service Binding Operator
+
+We use the link:https://github.com/redhat-developer/service-binding-operator/[Service Binding Operator] to provide `odo link` feature which links an odo component with an Operator backed service. Thus, to be able to use this feature, it's essential that we install the Operator first.
+
+Service Binding Operator is not yet available via the OLM. The team is link:https://github.com/redhat-developer/service-binding-operator/issues/727[working on making it available] through OLM.
+
+At the moment, to make Service Binding Operator work on Kubernetes, we need to keep a couple of things in mind:
+
+. It needs to be installed from its GitHub repository
+. It must be installed in individual namespace unlike the cluster wide installation we saw for etcd Operator in previous section
+
+
+Let's setup the Service Binding Operator now.
+
+. First, let's clone its repository on the host system where we're running minikube and checkout the specific tag that is currently supported by `odo link` command`:
++
+[source,sh]
+----
+$ git clone https://github.com/redhat-developer/service-binding-operator/
+$ cd service-binding-operator
+$ git fetch --tags
+$ git checkout tags/v0.1.1-364 -b v0.1.1-364
+$ cd deploy
+----
+
+. Next, install its CRD (link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-extending-api-with-crds.html[Custom Resource Definition]):
++
+[source,sh]
+----
+$ kubectl create -f crds/apps.openshift.io_servicebindingrequests_crd.yaml
+$ kubectl create -f service_account.yaml -f role.yaml -f role_binding.yaml
+----
+
+. Now, create a link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[ClusterRole] and a link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding[ClusterRoleBinding] that are required to allow the Service Binding Operator access resources of API groups `apps.openshift.io` and `apiextensions.k8s.io` at cluster level:
++
+[source,sh]
+----
+$ kubectl create -f - << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sbo-cluster-role
+rules:
+- apiGroups: 
+  - apps.openshift.io
+  resources: 
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - list
+    - patch
+    - watch
+EOF
+
+$ kubectl create -f - << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sbo-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  name: service-binding-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: sbo-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+EOF
+----
+
+. Next, we modify the `operator.yaml` file to install the Operator in a specific namespace and use the container image that matches the version of the git commit (`git log -n1 --oneline`) of the repository. Make change as per below `git diff` but make sure to set the value of `namespace` to the namespace where you want to install the Operator:
++
+[source,diff]
+----
+diff --git a/deploy/operator.yaml b/deploy/operator.yaml
+index 2cd90ec7..21c4768c 100644
+--- a/deploy/operator.yaml
++++ b/deploy/operator.yaml
+@@ -4,0 +5 @@ metadata:
++  namespace: default
+@@ -19 +20 @@ spec:
+-          image: REPLACE_IMAGE
++          image: quay.io/redhat-developer/app-binding-operator:0799ba7
+----
+
+. Finally, install the Operator using below command:
++
+[source,sh]
+----
+$ kubectl create -f operator.yaml
+----
+
+
+You should now see a `Deployment` for Service Binding Operator in the namespace where you installed it:
+[source,sh]
+----
+$ kubectl get deploy -n <replace-namespace-value>
+----
+

--- a/docs/public/operators-on-minikube.adoc
+++ b/docs/public/operators-on-minikube.adoc
@@ -23,7 +23,7 @@ To install an Operator, we need to make sure that the namespace in which we're i
 
 [NOTE]
 ====
-You can't install any Operator in the `operators` namespace and expect it to be available across all namespaces. The Operator you're trying to installing needs to be designed to be available in this way as well. Certain Operators only support installation in a single namespace.
+You can't always install an Operator in the `operators` namespace and expect it to be available across all namespaces. The Operator you're trying to installing needs to be designed to be available in this way as well. Certain Operators only support installation in a single namespace.
 
 Discussing this topic is out of scope of this guide so we have stated it as a note.
 ====
@@ -81,7 +81,7 @@ etcdoperator.v0.9.4-clusterwide     EtcdCluster, EtcdBackup, EtcdRestore
 
 ==== Troubleshooting
 
-If you don't see etcd Operator using above command or by doing `kubectl get csv`, make sure that pod belonging to the CatalogSource named operatorhubio-catalog is running:
+If you don't see etcd Operator using above command or by doing `kubectl get csv -n operators`, make sure that pod belonging to the `CatalogSource` named `operatorhubio-catalog` is running:
 [source,sh]
 ----
 $ kubectl get po -n olm | grep operatorhubio-catalog
@@ -94,7 +94,7 @@ If the state of this pod is `CrashLoopBackOff`, delete it so that Kubernetes wil
 $ kubectl delete po -n olm <name-of-operatorhubio-catalog-pod>
 ----
 
-Once the pod for this `CatalogSource` is up, wait a few seconds and see if you can find the etcd Operator when you do `odo catalog list services`.
+Once the pod for this `CatalogSource` is up, wait a few seconds before trying to find the etcd Operator when you do `odo catalog list services`.
 
 === Installing the Service Binding Operator
 
@@ -104,13 +104,13 @@ Service Binding Operator is not yet available via the OLM. The team is link:http
 
 At the moment, to make Service Binding Operator work on Kubernetes, we need to keep a couple of things in mind:
 
-. It needs to be installed from its GitHub repository
-. It must be installed in individual namespace unlike the cluster wide installation we saw for etcd Operator in previous section
+. It needs to be installed by cloning its GitHub repository
+. It must be installed in an individual namespace unlike the cluster wide installation we saw for etcd Operator in previous section
 
 
 Let's setup the Service Binding Operator now.
 
-. First, let's clone its repository on the host system where we're running minikube and checkout the specific tag that is currently supported by `odo link` command`:
+. First, let's clone its repository on the host system where we're running minikube and checkout the specific tag that is currently supported by `odo link` command:
 +
 [source,sh]
 ----
@@ -121,7 +121,7 @@ $ git checkout tags/v0.1.1-364 -b v0.1.1-364
 $ cd deploy
 ----
 
-. Next, install its CRD (link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-extending-api-with-crds.html[Custom Resource Definition]):
+. Next, install its CRD (link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-extending-api-with-crds.html[Custom Resource Definition]) and create link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[ServiceAccount], https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[Role] and link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding[RoleBinding] it requires:
 +
 [source,sh]
 ----
@@ -146,15 +146,15 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-    - apiextensions.k8s.io
+  - apiextensions.k8s.io
   resources:
-    - customresourcedefinitions
-    - customresourcedefinitions/status
+  - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
-    - get
-    - list
-    - patch
-    - watch
+  - get
+  - list
+  - patch
+  - watch
 EOF
 
 $ kubectl create -f - << EOF


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
[skip ci]

**What does this PR do / why we need it**:
This PR documents steps to install Operators on minikube cluster. We need this to help Kubernetes users get up to speed with installing and working with Operators.

**Which issue(s) this PR fixes**:

Fixes #4103

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
