### PR TITLE
renamed Openshift to S2I in odo to remove confusion

### DIFF
--- a/docs/dev/experimental-mode.adoc
+++ b/docs/dev/experimental-mode.adoc
@@ -24,11 +24,11 @@ odo preference set experimental true
 #### Working with experimental mode:
 
 ##### Listing devfile components:
-When the experimental mode is enabled, `odo catalog list components` will list the devfile components alongside the OpenShift components.
+When the experimental mode is enabled, `odo catalog list components` will list the devfile components alongside the S2I components.
 
 ```
 $ odo catalog list components
-Odo OpenShift Components:
+Odo S2I Components:
 NAME                       PROJECT       TAGS                                        SUPPORTED
 nodejs                     openshift     10,8,8-RHOAR,latest                         YES
 codewind-odo-openjdk18     che           latest                                      YES

--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -75,7 +75,7 @@ Ingress IP is usually the external IP of ingress controller service, for Minikub
   java-springboot      Spring Boot® using Java                DefaultDevfileRegistry
   nodejs               Stack with NodeJS 12                   DefaultDevfileRegistry
 
-  Odo OpenShift Components:
+  Odo S2I Components:
   NAME        PROJECT       TAGS                                                                           SUPPORTED
   java        openshift     11,8,latest                                                                    YES
   dotnet      openshift     2.1,3.1,latest                                                                 NO

--- a/docs/public/s2i-to-devfile.adoc
+++ b/docs/public/s2i-to-devfile.adoc
@@ -17,7 +17,7 @@ Existing users using S2I based components can migrate to a devfile component by 
 ----
  $ odo list
 
-Openshift Components: 
+S2I Components: 
 APP     NAME      PROJECT        TYPE       SOURCETYPE     STATE
 app     myapp     myproject      nodejs     local          Pushed
 
@@ -71,7 +71,7 @@ app     myapp     myproject      nodejs     local          Pushed
  APP     NAME      PROJECT        TYPE      STATE
  app     myapp     myproject      myapp     Pushed
 
- Openshift Components: 
+ S2I Components: 
  APP     NAME      PROJECT        TYPE       SOURCETYPE     STATE
  app     myapp     myproject      nodejs     local          Pushed
 ----

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -139,7 +139,7 @@ func (o *ListComponentsOptions) Run() (err error) {
 			if len(o.catalogDevfileList.Items) != 0 {
 				fmt.Fprintln(w)
 			}
-			fmt.Fprintln(w, "Odo OpenShift Components:")
+			fmt.Fprintln(w, "Odo S2I Components:")
 			fmt.Fprintln(w, "NAME", "\t", "PROJECT", "\t", "TAGS", "\t", "SUPPORTED")
 
 			if len(supCatalogList) != 0 {

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -297,12 +297,9 @@ func (lo *ListOptions) Run() (err error) {
 		}
 
 		if len(components) != 0 {
-			if lo.hasDevfileComponents {
-				fmt.Println()
-			}
 			lo.hasS2IComponents = true
 			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "Openshift Components: ")
+			fmt.Fprintln(w, "S2I Components: ")
 			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
 			for _, comp := range components {
 				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)

--- a/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
+++ b/tests/integration/devfile/docker/cmd_docker_devfile_catalog_test.go
@@ -37,7 +37,7 @@ var _ = Describe("odo docker devfile catalog command tests", func() {
 		It("should list all supported devfile components", func() {
 			output := helper.CmdShouldPass("odo", "catalog", "list", "components")
 			helper.MatchAllInOutput(output, []string{"Odo Devfile Components", "java-springboot", "java-openliberty", "DefaultDevfileRegistry"})
-			helper.DontMatchAllInOutput(output, []string{"SUPPORTED", "Odo OpenShift Components"})
+			helper.DontMatchAllInOutput(output, []string{"SUPPORTED", "Odo S2I Components"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
Renamed `Openshift` to `S2I` in 
- `odo list`
- `odo catalog list components`

This has been done to remove the confusion around "Openshift" components. This looking at the name "Openshift" makes people think that these are the components people need to use to deploy on openshift and they might ignore "Devfile" components.

## I would also suggest renaming "S2I" to Legacy maybe so that people dont get confused on which ones to use.

**Which issue(s) this PR fixes**:

Partly https://github.com/openshift/odo/issues/4023

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
