### PR TITLE
fix odo catalog list service erroring out when no service templates / CSVs are present

### DIFF
--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -83,15 +83,6 @@ func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []s
 
 // Validate validates the ListServicesOptions based on completed values
 func (o *ListServicesOptions) Validate() (err error) {
-	if o.csvSupport {
-		if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
-			return fmt.Errorf("no deployable services/operators found")
-		}
-	} else {
-		if len(o.services.Items) == 0 {
-			return fmt.Errorf("no deployable services found")
-		}
-	}
 	return
 }
 
@@ -107,6 +98,16 @@ func (o *ListServicesOptions) Run() (err error) {
 		}
 		if len(o.services.Items) > 0 {
 			util.DisplayServices(o.services)
+		}
+
+		if o.csvSupport {
+			if len(o.services.Items) == 0 && len(o.csvs.Items) == 0 {
+				log.Info("no deployable services/operators found")
+			}
+		} else {
+			if len(o.services.Items) == 0 {
+				log.Info("no deployable services found")
+			}
 		}
 	}
 	return

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -273,7 +273,6 @@ func (lo *ListOptions) Run() (err error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to fetch component list")
 			}
-			fmt.Print("%+v", components)
 		}
 	}
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -238,8 +238,6 @@ func (lo *ListOptions) Run() (err error) {
 		}
 	}
 
-	// non-experimental workflow
-
 	var components []component.Component
 	// we now check if DC is supported
 	if lo.hasDCSupport {
@@ -275,6 +273,7 @@ func (lo *ListOptions) Run() (err error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to fetch component list")
 			}
+			fmt.Print("%+v", components)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
`odo catalog list services` fails if there are no services templates / CSVs are present, that shouldn't be happening as its an outcome which a user might expect when they just install operatorhub. However this PR doesn't remove the checks for "service catalog" or "operator hub" being installed correctly.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4024

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
