### PR TITLE
check if devfile exist in the context folder instead of working directory

### DIFF
--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -3,12 +3,13 @@ package component
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/devfile/parser/data/common"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
-	"strings"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"

--- a/pkg/odo/cli/component/component.go
+++ b/pkg/odo/cli/component/component.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift/odo/pkg/util"
 
@@ -30,7 +31,9 @@ type ComponentOptions struct {
 
 // Complete completes component options
 func (co *ComponentOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if util.CheckPathExists(DevfilePath) {
+	context := genericclioptions.GetContextFlagValue(cmd)
+	devfilePath := filepath.Join(context, devFile)
+	if util.CheckPathExists(devfilePath) {
 		co.Context = genericclioptions.NewDevfileContext(cmd)
 	} else {
 		co.Context = genericclioptions.NewContext(cmd)

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -238,6 +239,19 @@ func componentTests(args ...string) {
 			helper.CmdShouldPass("odo", append(args, "delete", "-f", "--all", "--context", commonVar.Context)...)
 		})
 
+		It("checks that odo describe works for s2i component from a devfile directory", func() {
+			newContext := path.Join(commonVar.Context, "newContext")
+			helper.MakeDir(newContext)
+			helper.Chdir(newContext)
+			cmpName2 := helper.RandString(6)
+			helper.CmdShouldPass("odo", "create", "--starter", "nodejs")
+			context2 := helper.CreateNewContext()
+			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context2, cmpName2)
+			output := helper.CmdShouldPass("odo", "describe", "--context", context2)
+			Expect(output).To(ContainSubstring(fmt.Sprint("Component Name: ", cmpName2)))
+			helper.Chdir(commonVar.OriginalWorkingDirectory)
+			helper.DeleteDir(context2)
+		})
 		It("should describe not pushed component when it is created with json output", func() {
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 			cmpDescribeJSON, err := helper.Unindented(helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing", "-o", "json")...))

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -267,10 +267,10 @@ var _ = Describe("odo devfile create command tests", func() {
 		It("checks that odo describe works for s2i component from a devfile directory", func() {
 			helper.Chdir(newContext)
 			cmpName2 := helper.RandString(6)
-			output := helper.CmdShouldPass("odo", "create", "--starter", "nodejs")
+			helper.CmdShouldPass("odo", "create", "--starter", "nodejs")
 			context2 := helper.CreateNewContext()
 			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context2, cmpName2)
-			output = helper.CmdShouldPass("odo", "describe", "--context", context2)
+			output := helper.CmdShouldPass("odo", "describe", "--context", context2)
 			Expect(output).To(ContainSubstring(fmt.Sprint("Component Name: ", cmpName2)))
 			helper.Chdir(commonVar.OriginalWorkingDirectory)
 			helper.DeleteDir(context2)

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -2,7 +2,6 @@ package devfile
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -264,17 +263,6 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.MatchAllInOutput(output, []string{"you can't set --s2i flag as true if you want to use the registry via --registry flag"})
 		})
 
-		It("checks that odo describe works for s2i component from a devfile directory", func() {
-			helper.Chdir(newContext)
-			cmpName2 := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "--starter", "nodejs")
-			context2 := helper.CreateNewContext()
-			helper.CmdShouldPass("odo", "create", "--s2i", "nodejs", "--context", context2, cmpName2)
-			output := helper.CmdShouldPass("odo", "describe", "--context", context2)
-			Expect(output).To(ContainSubstring(fmt.Sprint("Component Name: ", cmpName2)))
-			helper.Chdir(commonVar.OriginalWorkingDirectory)
-			helper.DeleteDir(context2)
-		})
 	})
 
 	// Currently these tests need interactive mode in order to set the name of the component.

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -213,7 +213,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.MakeDir(newContext)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
 		})
-		AfterEach(func() {
+		JustAfterEach(func() {
 			helper.DeleteDir(newContext)
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Currently we were deciding the type of context ( devfile or s2i ) based on presence of devfile in the working directory which is a problem when user provides `--context`.  For e.g.
- `odo describe --context <s2i-component-dir>` <- this from a directory that has devfile directory would fail as it would initialise a `DevfileContext` that looks for `env.yaml`. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/3902

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- create a nodejs s2i component - `nodejs2i`
- create a nodejs devfile component - `nodejsdevfile` along side the s2i component so that both sit in the same dir
- now go to the `nodejsdevfile` component dir and run `odo describe --context ../nodejs2i`

Before this PR it should fail with
```
 ✗  The current directory does not represent an odo component. Use 'odo create' to create component here or switch to directory with a component
```

Now it should show the description.