### PR TITLE
nit: remove the 'Devfile path' log even when using --s2i in odo create --context

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -363,7 +363,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	// Configure the context
 	if co.componentContext != "" {
 		DevfilePath = filepath.Join(co.componentContext, devFile)
-		log.Infof("Devfile path: %s", co.DevfilePath)
 		EnvFilePath = filepath.Join(co.componentContext, envFile)
 		ConfigFilePath = filepath.Join(co.componentContext, configFile)
 		co.PushOptions.componentContext = co.componentContext


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`
 /kind cleanup

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
- Before :
```
~ odo create --s2i nodejs --context ./import2
Devfile path: 
Validation
 ✓  Validating component [429ms]

Please use `odo push` command to create the component with source deployed
```
- After :
```
~ odo create --s2i nodejs --context ./import
Validation
 ✓  Validating component [429ms]

Please use `odo push` command to create the component with source deployed
```