### PR TITLE
resolve the panic on odo list when the project contains non-odo DCs

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -890,8 +891,10 @@ func List(client *occlient.Client, applicationName string, localConfigInfo *conf
 		if err != nil {
 			return ComponentList{}, errors.Wrap(err, "Unable to get component")
 		}
-		components = append(components, component)
-		componentNamesMap[component.Name] = true
+		if !reflect.ValueOf(component).IsZero() {
+			components = append(components, component)
+			componentNamesMap[component.Name] = true
+		}
 	}
 
 	if deploymentConfigSupported && client != nil {
@@ -907,8 +910,10 @@ func List(client *occlient.Client, applicationName string, localConfigInfo *conf
 			if err != nil {
 				return ComponentList{}, errors.Wrap(err, "Unable to get component")
 			}
-			components = append(components, component)
-			componentNamesMap[component.Name] = true
+			if !reflect.ValueOf(component).IsZero() {
+				components = append(components, component)
+				componentNamesMap[component.Name] = true
+			}
 		}
 	}
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1428,7 +1428,7 @@ func GetComponent(client *occlient.Client, componentName string, applicationName
 // getRemoteComponentMetadata provides component metadata from the cluster
 func getRemoteComponentMetadata(client *occlient.Client, componentName string, applicationName string, projectName string, getUrls, getStorage bool) (component Component, err error) {
 	fromCluster, err := GetPushedComponent(client, componentName, applicationName)
-	if err != nil {
+	if err != nil || fromCluster == nil {
 		return Component{}, errors.Wrapf(err, "unable to get remote metadata for %s component", componentName)
 	}
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:
I took an educated guess that if getting DC by name fails with not found error then the line below doesn't report it as an error
https://github.com/openshift/odo/blob/a28e37838c5cbaa396f6675fe90a9986168165f5/pkg/component/pushed_component.go#L258

Hence this line paniced
https://github.com/openshift/odo/blob/cabd4a13eea9e8091c2a79962e00c9a8d6f6c070/pkg/component/component.go#L1414

Note - I wasn't able to reproduce this hence took this guess

**Which issue(s) this PR fixes**:

fixes https://github.com/openshift/odo/issues/4183

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
