### PR TITLE
Ignore Configmap mounted in DeploymentConfig

### DIFF
--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3069,7 +3069,7 @@ func (c *Client) IsVolumeAnEmptyDir(volumeMountName string, dc *appsv1.Deploymen
 	return false
 }
 
-// IsVolumeAnEmptyDir returns true if the volume is an EmptyDir, false if not
+// IsVolumeAnConfigMap returns true if the volume is an ConfigMap, false if not
 func (c *Client) IsVolumeAnConfigMap(volumeMountName string, dc *appsv1.DeploymentConfig) bool {
 	for _, volume := range dc.Spec.Template.Spec.Volumes {
 		if volume.Name == volumeMountName {

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3069,6 +3069,18 @@ func (c *Client) IsVolumeAnEmptyDir(volumeMountName string, dc *appsv1.Deploymen
 	return false
 }
 
+// IsVolumeAnEmptyDir returns true if the volume is an EmptyDir, false if not
+func (c *Client) IsVolumeAnConfigMap(volumeMountName string, dc *appsv1.DeploymentConfig) bool {
+	for _, volume := range dc.Spec.Template.Spec.Volumes {
+		if volume.Name == volumeMountName {
+			if volume.ConfigMap != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // GetPVCNameFromVolumeMountName returns the PVC associated with the given volume
 // An empty string is returned if the volume is not found
 func (c *Client) GetPVCNameFromVolumeMountName(volumeMountName string, dc *appsv1.DeploymentConfig) string {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -147,7 +147,7 @@ func List(client *occlient.Client, componentName string, applicationName string)
 			continue
 		}
 
-		// We should ignore ConfigMap
+		// We should ignore ConfigMap (while PR2142 and PR2601 are not fixed)
 		if client.IsVolumeAnConfigMap(volumeMount.Name, dc) {
 			continue
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -147,6 +147,11 @@ func List(client *occlient.Client, componentName string, applicationName string)
 			continue
 		}
 
+		// We should ignore ConfigMap
+		if client.IsVolumeAnConfigMap(volumeMount.Name, dc) {
+			continue
+		}
+
 		pvcName := client.GetPVCNameFromVolumeMountName(volumeMount.Name, dc)
 		if pvcName == "" {
 			return StorageList{}, fmt.Errorf("no PVC associated with Volume Mount %v", volumeMount.Name)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
When creating applications on OpenShift Kubernetes, a (12-factor) best practice is to externalize the configuration in a ConfigMap. When mounting this ConfigMap in the DC, odo is not working anymore because it expects a volume with a PVC. As odo cannot manage ConfigMap yet, we should ignore them (as we ignore empty volume) to  apply best practices while using odo.

**Which issue(s) this PR fixes**:

This is an alternance for waiting for the [PR2142](https://github.com/openshift/odo/issues/2142) and [PR2601](https://github.com/openshift/odo/issues/2601)

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
