### PR TITLE
List only installed Operators; some refactor

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -295,12 +295,7 @@ func ListServices(client *occlient.Client) (ServiceTypeList, error) {
 
 // ListOperatorServices fetches a list of Operators from the cluster and
 // returns only those Operators which are successfully installed on the cluster
-func ListOperatorServices() (*olm.ClusterServiceVersionList, error) {
-	client, err := kclient.New()
-	if err != nil {
-		return nil, err
-	}
-
+func ListOperatorServices(client *kclient.Client) (*olm.ClusterServiceVersionList, error) {
 	allCsvs, err := client.GetClusterServiceVersionList()
 	if err != nil {
 		return nil, err

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -45,7 +45,6 @@ func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []s
 		var noCsvs, noServices bool
 		o.Context = genericclioptions.NewContext(cmd)
 		o.csvs, err = catalog.ListOperatorServices()
-		// o.csvs, err = o.KClient.GetClusterServiceVersionList()
 		if err != nil {
 			// Error only occurs when OperatorHub is not installed/enabled on the
 			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/catalog/util"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	cmdutil "github.com/openshift/odo/pkg/odo/util"
+	svc "github.com/openshift/odo/pkg/service"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/spf13/cobra"
 )
@@ -39,12 +39,13 @@ func NewListServicesOptions() *ListServicesOptions {
 
 // Complete completes ListServicesOptions after they've been created
 func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+	if o.csvSupport, err = svc.IsCSVSupported(); err != nil {
 		return err
 	} else if o.csvSupport {
 		var noCsvs, noServices bool
 		o.Context = genericclioptions.NewContext(cmd)
-		o.csvs, err = o.KClient.GetClusterServiceVersionList()
+		o.csvs, err = catalog.ListOperatorServices()
+		// o.csvs, err = o.KClient.GetClusterServiceVersionList()
 		if err != nil {
 			// Error only occurs when OperatorHub is not installed/enabled on the
 			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -44,7 +44,7 @@ func (o *ListServicesOptions) Complete(name string, cmd *cobra.Command, args []s
 	} else if o.csvSupport {
 		var noCsvs, noServices bool
 		o.Context = genericclioptions.NewContext(cmd)
-		o.csvs, err = catalog.ListOperatorServices()
+		o.csvs, err = catalog.ListOperatorServices(o.KClient)
 		if err != nil {
 			// Error only occurs when OperatorHub is not installed/enabled on the
 			// Kubernetes or OpenShift 4.x cluster. It doesn't occur when there are

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -7,13 +7,13 @@ import (
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	odoutil "github.com/openshift/odo/pkg/odo/util"
+	svc "github.com/openshift/odo/pkg/service"
 	sbo "github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 
-	"github.com/openshift/odo/pkg/odo/util"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
@@ -88,7 +88,7 @@ type LinkOptions struct {
 func NewLinkOptions() *LinkOptions {
 	options := LinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
-	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
+	options.commonLinkOptions.csvSupport, _ = svc.IsCSVSupported()
 	options.commonLinkOptions.sbr = &sbo.ServiceBindingRequest{}
 	return &options
 }

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -8,6 +8,7 @@ import (
 	appCmd "github.com/openshift/odo/pkg/odo/cli/application"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	svc "github.com/openshift/odo/pkg/service"
 
 	"github.com/openshift/odo/pkg/odo/util"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -48,7 +49,7 @@ type UnlinkOptions struct {
 func NewUnlinkOptions() *UnlinkOptions {
 	options := UnlinkOptions{}
 	options.commonLinkOptions = newCommonLinkOptions()
-	options.commonLinkOptions.csvSupport, _ = util.IsCSVSupported()
+	options.commonLinkOptions.csvSupport, _ = svc.IsCSVSupported()
 	return &options
 }
 

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/cli/service/ui"
 	commonui "github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	cmdutil "github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/odo/util/validation"
 	svc "github.com/openshift/odo/pkg/service"
@@ -134,7 +133,7 @@ func (o *ServiceCreateOptions) Complete(name string, cmd *cobra.Command, args []
 		o.interactive = true
 	}
 
-	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+	if o.csvSupport, err = svc.IsCSVSupported(); err != nil {
 		return err
 	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)
@@ -520,7 +519,7 @@ func NewCmdServiceCreate(name, fullName string) *cobra.Command {
 	}
 
 	// we ignore the error because it doesn't matter at this place to deal with it and the function returns a *cobra.Command
-	csvSupport, _ := cmdutil.IsCSVSupported()
+	csvSupport, _ := svc.IsCSVSupported()
 
 	if csvSupport {
 		serviceCreateCmd.Use += fmt.Sprintf(" [flags]\n  %s <operator_type>/<crd_name> [service_name] [flags]", o.CmdFullName)

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/odo/cli/ui"
-	cmdutil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -45,7 +44,7 @@ func NewServiceDeleteOptions() *ServiceDeleteOptions {
 
 // Complete completes ServiceDeleteOptions after they've been created
 func (o *ServiceDeleteOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if o.csvSupport, err = cmdutil.IsCSVSupported(); err != nil {
+	if o.csvSupport, err = svc.IsCSVSupported(); err != nil {
 		return err
 	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -44,7 +44,7 @@ func NewServiceListOptions() *ServiceListOptions {
 
 // Complete completes ServiceListOptions after they've been created
 func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	if o.csvSupport, err = odoutil.IsCSVSupported(); err != nil {
+	if o.csvSupport, err = svc.IsCSVSupported(); err != nil {
 		return err
 	} else if o.csvSupport {
 		o.Context = genericclioptions.NewDevfileContext(cmd)

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -299,14 +299,3 @@ func ThrowContextError() error {
 	return errors.Errorf(`Please specify the application name and project name
 Or use the command from inside a directory containing an odo component.`)
 }
-
-// IsCSVSupported checks if the cluster supports resources of type ClusterServiceVersion
-func IsCSVSupported() (bool, error) {
-
-	oclient, err := occlient.New()
-	if err != nil {
-		return false, err
-	}
-
-	return oclient.IsCSVSupported()
-}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -680,3 +680,13 @@ func isRequired(required []string, name string) bool {
 	}
 	return false
 }
+
+// IsCSVSupported checks if the cluster supports resources of type ClusterServiceVersion
+func IsCSVSupported() (bool, error) {
+	oclient, err := occlient.New()
+	if err != nil {
+		return false, err
+	}
+
+	return oclient.IsCSVSupported()
+}

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -30,10 +30,10 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.CmdShouldPass("odo", "project", "set", project)
 
 		// wait till oc can see the all operators installed by setup script in the namespace
-		ocArgs := []string{"get", "csv"}
-		operators := []string{"etcd", "Service Binding Operator"}
+		ocArgs := []string{"catalog", "list", "services"}
+		operators := []string{"etcdoperator", "service-binding-operator"}
 		for _, operator := range operators {
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+			helper.WaitForCmdOut("odo", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, operator)
 			})
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind code-refactoring

**What does does this PR do / why we need it**:
This PR makes sure that odo lists only those Operators that are successfully installed. This success is determined on the basis of the `Phase` of Operator. If the phase evaluates to `Succeeded`, the Operator is considered available to use.

**Which issue(s) this PR fixes**:

Fixes #4155 & https://bugzilla.redhat.com/show_bug.cgi?id=1889961

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
This can be better tested on a minikube setup.
```sh
$ minikube start
$ minikube addons enable olm

# make sure you're working on default namespace
$ kubectl apply -f https://gist.github.com/dharmit/89079ad3daa7df83b92cc39c499f670f/raw/ea8808fcc6ec876b1c7c1f0838295f21324f3baf/operators.yaml

# Check the PHASE column in output. Give it a few seconds or about a minute for etcd Operator to show up
$ kubectl get csv   
NAME                                  DISPLAY                    VERSION             REPLACES                              PHASE
etcdoperator.v0.9.4-clusterwide       etcd                       0.9.4-clusterwide                                         Succeeded
service-binding-operator.v0.1.1-364   Service Binding Operator   0.1.1-364           service-binding-operator.v0.1.1-354   Failed

# odo doesn't show service binding operator since it failed to install
$ odo catalog list services
Operators available in the cluster
NAME                                CRDs
etcdoperator.v0.9.4-clusterwide     EtcdCluster, EtcdBackup, EtcdRestore
```
