### PR TITLE
Adding the latest java image ubi8/openjdk-11 in odo supported list

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -32,6 +32,7 @@ var supportedImages = map[string]bool{
 	"redhat-openjdk-18/openjdk18-openshift:latest": true,
 	"openjdk/openjdk-11-rhel8:latest":              true,
 	"openjdk/openjdk-11-rhel7:latest":              true,
+	"ubi8/openjdk-11:latest":                       true,
 	"centos/nodejs-10-centos7:latest":              true,
 	"centos/nodejs-12-centos7:latest":              true,
 	"rhscl/nodejs-10-rhel7:latest":                 true,

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -37,7 +37,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.6"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.7"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -21,7 +21,7 @@ export KUBECONFIG=$ORIGINAL_KUBECONFIG
 USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odologinnoproject odologinsingleproject1"
 
 # list of namespace to create
-IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12"
+IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12 openjdk-11"
 
 # Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -143,6 +143,11 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("ubi8", "nodejs-12:latest"), "nodejs:latest", "nodejs-12")
 			verifySupportedImage(filepath.Join("ubi8", "nodejs-12:latest"), "nodejs", "nodejs:latest", "nodejs-12", appName, commonVar.Context)
 		})
+
+		It("Should be able to verify the openjdk-11 image", func() {
+			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("ubi8", "openjdk-11:latest"), "java:8", "openjdk-11")
+			verifySupportedImage(filepath.Join("ubi8", "openjdk-11:latest"), "openjdk", "java:8", "openjdk-11", appName, commonVar.Context)
+		})
 	})
 
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind feature

**What does does this PR do / why we need it**:

There is latest java image difference on 4.6 and 4.5 cluster. So, adding `ubi8/openjdk-11` image as supported will unblock enabling odo periodic job on 4.6 cluster https://github.com/openshift/odo/issues/4138

**Which issue(s) this PR fixes**:

Fixes - part of issue https://github.com/openshift/odo/issues/4138

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Latest java image on 4.6 should execute successfully for odo