### PR TITLE
Update configure-installer-tests-cluster-s390x to support nodejs12 e2e test

### DIFF
--- a/scripts/configure-installer-tests-cluster-s390x.sh
+++ b/scripts/configure-installer-tests-cluster-s390x.sh
@@ -21,7 +21,7 @@ USERS="developer odonoprojectattemptscreate odosingleprojectattemptscreate odolo
 
 
 # list of namespace to create
-IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7"
+IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12"
 
 # Attempt resolution of kubeadmin, only if a CI is not set
 if [ -z $CI ]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature
**What does does this PR do / why we need it**:
Make conformance with PR #4070 
**Which issue(s) this PR fixes**:

Fixes #4016 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Latest nodejs image on 4.6 should work fine for odo