### PR TITLE
resolve .kube/config.lock: file exists flake

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -288,11 +288,10 @@ func CommonBeforeEach() CommonVar {
 	commonVar.Context = CreateNewContext()
 	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
 	commonVar.CliRunner = GetCliRunner()
+	LocalKubeconfigSet(commonVar.Context)
 	commonVar.Project = commonVar.CliRunner.CreateRandNamespaceProject()
 	commonVar.OriginalWorkingDirectory = Getwd()
-
 	os.Setenv("GLOBALODOCONFIG", filepath.Join(commonVar.Context, "preference.yaml"))
-	LocalKubeconfigSet(commonVar.Context)
 
 	return commonVar
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:
Some PRs are failing with this error
```
Creating a new project: vhgeggwlqs
Running kubectl with args [kubectl create namespace vhgeggwlqs]
[kubectl] namespace/vhgeggwlqs created
Running kubectl with args [kubectl config set-context --current --namespace vhgeggwlqs]
[kubectl] error: open /home/travis/.kube/config.lock: file exists
``` 
Hence resolving this error
https://travis-ci.com/github/openshift/odo/jobs/440575550


**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4190

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
