### PR TITLE
Increase timeout for Operator Hub tests

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -30,10 +30,10 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.CmdShouldPass("odo", "project", "set", project)
 
 		// wait till oc can see the all operators installed by setup script in the namespace
-		ocArgs := []string{"catalog", "list", "services"}
+		odoArgs := []string{"catalog", "list", "services"}
 		operators := []string{"etcdoperator", "service-binding-operator"}
 		for _, operator := range operators {
-			helper.WaitForCmdOut("odo", ocArgs, 1, true, func(output string) bool {
+			helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
 				return strings.Contains(output, operator)
 			})
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What does does this PR do / why we need it**:
This increased timeout makes sure that `odo catalog list services` being
executed in `JustBeforeEach` gets enough time to check for existence of
two Operators that we're installing in CI to perform our checks.

We need to increase this timeout because it's taking a long time for
`odo catalog list services` to find "successfully installed" Operators
in the newly created namespace even if these Operators are installed at
cluster level, i.e., in the `openshift-operators` namespace.

The increase in the time taken by odo to find this info is mainly
attributed to https://github.com/openshift/odo/pull/4202. I am observing
that even `kubectl get csv` is taking more than usual time to list the
Operators or report their phase as "Succeeded" but there's not enough
data to back that up. So, in the interim, this seems like best way to
make sure that CI doesn't keep failing on `JustBeforeEach`.

**Which issue(s) this PR fixes**:

Fixes #? NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
