### PR TITLE
resolve need for image stream tags to be in order in catalog list

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -502,14 +502,21 @@ func createImageTagMap(tagRefs []imagev1.TagReference) map[string]string {
 			// here we remove the tag and digest
 			ns, img, tag, _, _ := occlient.ParseImageName(urlImageName)
 			imageName = ns + "/" + img + ":" + tag
-		} else if tagRef.From.Kind == "ImageStreamTag" {
+			tagMap[tagRef.Name] = imageName
+		}
+	}
+
+	for _, tagRef := range tagRefs {
+		if tagRef.From.Kind == "ImageStreamTag" {
+			imageName := tagRef.From.Name
 			tagList := strings.Split(imageName, ":")
 			tag := tagList[len(tagList)-1]
 			// if the kind is a image stream tag that means its pointing to an existing dockerImage or image stream image
 			// we just look it up from the tapMap we already have
 			imageName = tagMap[tag]
+			tagMap[tagRef.Name] = imageName
 		}
-		tagMap[tagRef.Name] = imageName
+
 	}
 	return tagMap
 }

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -317,7 +317,7 @@ func MockImageStream() *imagev1.ImageStream {
 		"12": "docker.io/rhscl/nodejs-12-rhel7:latest",
 		"10": "docker.io/rhscl/nodejs-10-rhel7:latest",
 
-		// an unsupported one
+		// unsupported ones
 		"8": "docker.io/rhoar-nodejs/nodejs-8:latest",
 		"6": "docker.io/rhoar-nodejs/nodejs-6:latest",
 	}
@@ -328,6 +328,18 @@ func MockImageStream() *imagev1.ImageStream {
 			Namespace: "openshift",
 		},
 	}
+
+	// this append is intentionally added before adding other tags
+	// to confirm that tag references work even when they are out of order
+	imageStream.Spec.Tags = append(imageStream.Spec.Tags,
+		imagev1.TagReference{
+			Name:        "latest",
+			Annotations: map[string]string{"tags": "builder"},
+			From: &corev1.ObjectReference{
+				Kind: "ImageStreamTag",
+				Name: "12",
+			},
+		})
 
 	for tagName, imageName := range tags {
 		imageTag := imagev1.TagReference{
@@ -340,16 +352,6 @@ func MockImageStream() *imagev1.ImageStream {
 		}
 		imageStream.Spec.Tags = append(imageStream.Spec.Tags, imageTag)
 	}
-
-	imageStream.Spec.Tags = append(imageStream.Spec.Tags,
-		imagev1.TagReference{
-			Name:        "latest",
-			Annotations: map[string]string{"tags": "builder"},
-			From: &corev1.ObjectReference{
-				Kind: "ImageStreamTag",
-				Name: "12",
-			},
-		})
 
 	return imageStream
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes showing `java:latest` as unsupported on openshift 4.6 cluster

**PR acceptance criteria**:

- [X] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

Java should show up as supported now on openshift 4.6
<img width="760" alt="Screenshot 2020-11-27 at 1 11 39 PM" src="https://user-images.githubusercontent.com/6551988/100423521-1fc13600-30b2-11eb-9d94-091b5fa7448f.png">
