### PR TITLE
Update the prow help command link

### DIFF
--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -108,7 +108,7 @@ dependencies with other features, forward and backward compatibility, API and fl
 
 * Avoid merging the PR manually (unless it is an emergency and  you have the required permissions). Prow’s tide component automatically merges the PR once all the conditions are met.
 It also ensures that post-submit tests (tests that run before merge) validate the PR.
-* Use the link:https://deck-ci.svc.ci.openshift.org/command-help[command-help] to see the list of possible bot commands.
+* Use the link:https://prow.ci.openshift.org/command-help[command-help] to see the list of possible bot commands.
 
 === Setting custom Init Container image for bootstrapping Supervisord
 For quick deployment of components, odo uses the link:https://github.com/ochinchina/supervisord[Supervisord] process manager.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Update the correct link for prow help command

**Which issue(s) this PR fixes**:

Fixes - comment https://github.com/openshift/odo/pull/4265#issuecomment-735755308

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

We should be able to see the help commands with the update link.