### PR TITLE
Don't fail the command if listing a CR's instances fails

### DIFF
--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -98,12 +98,12 @@ func (o *ServiceListOptions) Run() (err error) {
 				fmt.Fprintln(w, strings.Join([]string{item.GetKind(), item.GetName()}, "/"), "\t", duration)
 			}
 
-			if len(failedListingCR) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("\nFailed to list services for Operator(s): %q", strings.Join(failedListingCR, " ")))
-			}
-
 			w.Flush()
 
+		}
+
+		if len(failedListingCR) > 0 {
+			fmt.Printf("\nFailed to list services for operator(s): %q\n", strings.Join(failedListingCR, ", "))
 		}
 
 		return err

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -99,7 +99,7 @@ func (o *ServiceListOptions) Run() (err error) {
 			}
 
 			if len(failedListingCR) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("\nFailed to list services for Operator(s): %q", strings.Join(failedListingCR, " ")))
+				fmt.Fprintf(w, fmt.Sprintf("\nFailed to list services for Operator(s): %q", strings.Join(failedListingCR, " ")))
 			}
 
 			w.Flush()

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -99,7 +99,7 @@ func (o *ServiceListOptions) Run() (err error) {
 			}
 
 			if len(failedListingCR) > 0 {
-				fmt.Fprintf(w, fmt.Sprintf("\nFailed to list services for Operator(s): %q", strings.Join(failedListingCR, " ")))
+				fmt.Fprintln(w, fmt.Sprintf("\nFailed to list services for Operator(s): %q", strings.Join(failedListingCR, " ")))
 			}
 
 			w.Flush()

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -80,7 +80,7 @@ func (o *ServiceListOptions) Run() (err error) {
 
 		if len(list) == 0 {
 			if len(failedListingCR) > 0 {
-				fmt.Printf("Failed to list services for operator(s): %q\n\n", strings.Join(failedListingCR, ", "))
+				fmt.Printf("Failed to fetch services for operator(s): %q\n\n", strings.Join(failedListingCR, ", "))
 			}
 			return fmt.Errorf("no operator backed services found in namespace: %s", o.KClient.Namespace)
 		}
@@ -103,7 +103,7 @@ func (o *ServiceListOptions) Run() (err error) {
 		}
 
 		if len(failedListingCR) > 0 {
-			fmt.Printf("\nFailed to list services for operator(s): %q\n", strings.Join(failedListingCR, ", "))
+			fmt.Printf("\nFailed to fetch services for operator(s): %q\n", strings.Join(failedListingCR, ", "))
 		}
 
 		return err

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -323,8 +323,9 @@ func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, 
 
 			list, err := GetCRInstances(client, &customResource)
 			if err != nil {
-				klog.V(4).Infof("Failed to list instances of %q with error: %s", cr.Name, err.Error())
-				failedListingCR = append(failedListingCR, cr.Name)
+				crName := strings.Join([]string{csv.Name, cr.Kind}, "/")
+				klog.V(4).Infof("Failed to list instances of %q with error: %s", crName, err.Error())
+				failedListingCR = append(failedListingCR, crName)
 				break
 			}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -296,17 +296,19 @@ func ListWithDetailedStatus(client *occlient.Client, applicationName string) (Se
 	}, nil
 }
 
-// ListOperatorServices lists all operator backed services
-func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, error) {
+// ListOperatorServices lists all operator backed services.
+// It returns list of services, slice of services that it failed (if any) to list and error (if any)
+func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, []string, error) {
 	klog.V(4).Info("Getting list of services")
 
 	// First let's get the list of all the operators in the namespace
 	csvs, err := client.ListClusterServiceVersions()
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to list operator backed services")
+		return nil, nil, errors.Wrap(err, "Unable to list operator backed services")
 	}
 
 	var allCRInstances []unstructured.Unstructured
+	var failedListingCR []string
 
 	// let's get the Services a.k.a Custom Resources (CR) defined by each operator, one by one
 	for _, csv := range csvs.Items {
@@ -315,16 +317,27 @@ func ListOperatorServices(client *kclient.Client) ([]unstructured.Unstructured, 
 		customResources := client.GetCustomResourcesFromCSV(&clusterServiceVersion)
 
 		// list and write active instances of each service/CR
-		instances, err := GetInstancesOfCustomResources(client, customResources)
-		if err != nil {
-			return nil, err
+		var instances []unstructured.Unstructured
+		for _, cr := range *customResources {
+			customResource := cr
+
+			list, err := GetCRInstances(client, &customResource)
+			if err != nil {
+				klog.V(4).Infof("Failed to list instances of %q with error: %s", cr.Name, err.Error())
+				failedListingCR = append(failedListingCR, cr.Name)
+				break
+			}
+
+			if len(list.Items) > 0 {
+				instances = append(instances, list.Items...)
+			}
 		}
 
 		// assuming there are more than one instances of a CR
 		allCRInstances = append(allCRInstances, instances...)
 	}
 
-	return allCRInstances, nil
+	return allCRInstances, failedListingCR, nil
 }
 
 // GetGVKRFromCR returns values for group, version, kind and resource for a
@@ -430,26 +443,8 @@ func getAlmExample(almExamples []map[string]interface{}, crd, operator string) (
 	return nil, errors.Errorf("could not find example yaml definition for %q service in %q Operator's definition.", crd, operator)
 }
 
-// GetInstancesOfCustomResources returns active instances of given Custom Resource (service in
-// odo lingo) in the active namespace of the cluster
-func GetInstancesOfCustomResources(client *kclient.Client, customResources *[]olm.CRDDescription) ([]unstructured.Unstructured, error) {
-	var instances []unstructured.Unstructured
-
-	for _, cr := range *customResources {
-		customResource := cr
-
-		list, err := GetCRInstances(client, &customResource)
-		if err != nil {
-			return []unstructured.Unstructured{}, err
-		}
-
-		if len(list.Items) > 0 {
-			instances = append(instances, list.Items...)
-		}
-	}
-	return instances, nil
-}
-
+// GetCRInstances fetches and returns instances of the CR provided in the
+// "customResource" field. It also returns error (if any)
 func GetCRInstances(client *kclient.Client, customResource *olm.CRDDescription) (*unstructured.UnstructuredList, error) {
 	klog.V(4).Infof("Getting instances of: %s\n", customResource.Name)
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -350,8 +350,8 @@ spec:
 			stdOut = helper.CmdShouldFail("odo", "service", "list")
 			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
 
-			msg := fmt.Sprintf("No operator backed services found in namespace: %s", project)
-			msgWithQuote := fmt.Sprintf("\"message\": \"No operator backed services found in namespace: %s\"", project)
+			msg := fmt.Sprintf("no operator backed services found in namespace: %s", project)
+			msgWithQuote := fmt.Sprintf("\"message\": \"no operator backed services found in namespace: %s\"", project)
 			Expect(stdOut).To(ContainSubstring(msg))
 			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
It prevents `odo service list` from entirely failing if listing instances of one or a few of the CRs fails.

**Which issue(s) this PR fixes**:

Fixes #4221 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. On a CRC system, install etcd Operator and Red Hat OpenShift Pipelines Operator
1. Look for output similar to below:
    ```sh
    $ odo catalog list services
    Operators available in the cluster
    NAME                                           CRDs
    etcdoperator.v0.9.4-clusterwide                EtcdCluster, EtcdBackup, EtcdRestore
    redhat-openshift-pipelines-operator.v1.2.1     Config
    ```
1. Do `odo service list`. We didn't start a service from any CR/Operator yet so you should see output like below:
    ```sh
    $ odo service list           
    Failed to list services for operator(s): "redhat-openshift-pipelines-operator.v1.2.1/Config"
    ✗  no operator backed services found in namespace: myproject
    ```
1. Now create an EtcdCluster using: `odo service create etcdoperator.v0.9.4-clusterwide/EtcdCluster`. Listing the services should show output like below:
    ```sh
    $ odo service list
    NAME                    AGE
    EtcdCluster/example     6m2s

    Failed to list services for Operator(s): "redhat-openshift-pipelines-operator.v1.2.1/Config"
    ```