### PR TITLE
Adding ubi8/nodejs-14 image as supported

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -41,6 +41,7 @@ var supportedImages = map[string]bool{
 	"rhscl/nodejs-12-rhel7:latest":                 true,
 	"rhoar-nodejs/nodejs-10:latest":                true,
 	"ubi8/nodejs-12:latest":                        true,
+	"ubi8/nodejs-14:latest":                        true,
 }
 
 // GetDevfileRegistries gets devfile registries from preference file,

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -37,7 +37,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.8"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.9"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -37,7 +37,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.9"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.10"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -37,7 +37,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.9"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.8"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -11,7 +11,7 @@ KUBEADMIN_SCRIPT="$LIBCOMMON/kubeconfigandadmin.sh"
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
 
 # list of namespace to create
-IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12 openjdk-11"
+IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12 openjdk-11 nodejs-14"
 
 . $KUBEADMIN_SCRIPT
 

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -148,6 +148,11 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.redhat.io", filepath.Join("ubi8", "openjdk-11:latest"), "java:8", "openjdk-11")
 			verifySupportedImage(filepath.Join("ubi8", "openjdk-11:latest"), "openjdk", "java:8", "openjdk-11", appName, commonVar.Context)
 		})
+
+		It("Should be able to verify the nodejs-14 image", func() {
+			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/nodejs-14:latest", "nodejs:latest", "nodejs-14")
+			verifySupportedImage("ubi8/nodejs-14:latest", "nodejs", "nodejs:latest", "nodejs-14", appName, commonVar.Context)
+		})
 	})
 
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind feature

**What does does this PR do / why we need it**:

There is latest nodejs image difference on ocp latest and upcoming version(4.7). So, adding ubi8/nodejs-14 image as supported will unblock https://github.com/openshift/odo/issues/4280
**Which issue(s) this PR fixes**:

Fixes #4303 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

Latest nodejs image on 4.7 should work fine for odo