### PR TITLE
Update docs to install SBO from OperatorHub.io

### DIFF
--- a/docs/public/install-service-binding-operator.adoc
+++ b/docs/public/install-service-binding-operator.adoc
@@ -1,6 +1,6 @@
 == Installing Service Binding Operator
 
-This document walks you through the steps to install link:https://github.com/redhat-developer/service-binding-operator/tree/v0.3.0[Service Binding Operator v0.3.0] on OpenShift and Kubernetes clusters.
+This document walks you through the steps to install link:https://github.com/redhat-developer/service-binding-operator/tree/v0.3.0[Service Binding Operator v0.3.0] on OpenShift cluster and link:https://operatorhub.io/operator/service-binding-operator[Service Binding Operator v0.4.0] on Kubernetes cluster.
 
 === Why do I need the Service Binding Operator?
 
@@ -12,31 +12,40 @@ To install Service Binding Operator on OpenShift, refer link:https://www.youtube
 
 === Installing Service Binding Operator on Kubernetes
 
-Steps mentioned in this section were tested on link:https://minikube.sigs.k8s.io/[minikube]. We tested this on minikube v1.15.1 but it should work on v1.11.0 and above.
-
-For Kubernetes, Service Binding Operator is not yet available via the OLM. The team is link:https://github.com/redhat-developer/service-binding-operator/issues/727[working on making it available].
-
-To install the Operator, execute the following `kubectl` command:
+To install the Operator, execute the following `kubectl` command provided on its link:https://operatorhub.io/operator/service-binding-operator[OperatorHub.io page]:
 [source,sh]
 ----
-$ kubectl apply -f https://gist.githubusercontent.com/dharmit/0e05be20e98c9271b2117acea7908cc2/raw/1e45fc89fc576e184e41fcc23e88d35f0e08a7e9/install.yaml
+$ kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
 ----
 
-You should now see a `Deployment` for Service Binding Operator in the `default` namespace:
+==== Making sure that Service Binding Operator installed successfully on Kubernetes
+
+1. One way to make sure that the Operator installed properly is to verify that its link:https://kubernetes.io/docs/concepts/workloads/pods/[pod] started and is in "Running" state (note that you will have to specify the namespace where you installed Service Binding Operator in earlier step, and the pod name will be different in your setup than what's shown in below output):
++
 [source,sh]
 ----
-$ kubectl get deploy -n default
-----
-
-If you would like to install the Service Binding Operator in a different namespace, edit link:https://gist.github.com/dharmit/0e05be20e98c9271b2117acea7908cc2#file-install-yaml-L464[this line] by downloading the YAML mentioned in previous set to the namespace of your choice.
-
-==== Making sure that Service Binding Operator got correctly installed
-
-One way to make sure that the Operator installed properly is to verify that its link:https://kubernetes.io/docs/concepts/workloads/pods/[pod] started and is in "Running" state (note that you will have to specify the namespace where you installed Service Binding Operator in earlier step, and the pod name will be different in your setup than what's shown in below output):
-
-[source,sh]
-----
-$ kubectl get pods --namespace default
+$ kubectl get pods --namespace operators
 NAME                                        READY   STATUS     RESTARTS   AGE
 service-binding-operator-6b7c654c89-rg9gq   1/1     Running    0          15m
+----
+
+1. Another aspect to check is output of below command as suggested in the Operator's installation instruction:
++
+[source,sh]
+----
+$ kubectl get csv -n operators
+----
+If you see the value under `PHASE` column to be anything other than `Installing` or `Succeeded`, please take a look at the pods in `olm` namespace and ensure that the pod starting with the name `operatorhubio-catalog` is in `Running` state:
++
+[source,sh]
+----
+$ kubectl get pods -n olm
+NAME                                READY   STATUS             RESTARTS   AGE
+operatorhubio-catalog-x24dq         0/1     CrashLoopBackOff   6          9m40s
+----
+If you see output like above where the pod is in `CrashLoopBackOff` state or any other state other than `Running`, delete the pod (note that exact name of the pod will be different on your cluster):
++
+[source,sh]
+----
+$ kubectl delete pods -n olm operatorhubio-catalog-x24dq
 ----


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
[skip ci]

**What does this PR do / why we need it**:
This PR updates the documentation section about installing SBO on minikube/k8s to use the steps mentioned on https://operatorhub.io/operator/service-binding-operator.

**Which issue(s) this PR fixes**:

Fixes #4299 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
