### PR TITLE
Implement PVC for odo source volume

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,7 @@ github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca/g
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b h1:it0YPE/evO6/m8t8wxis9KFI2F/aleOKsI6d9uz0cEk=
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
 github.com/openshift/kubernetes v1.17.0-alpha.0.0.20191216151305-079984b0a154/go.mod h1:ypOpFo7ff7y/tpC3zDdQ5NonHlPDTJ6iKnOChMPfloQ=
+github.com/openshift/kubernetes-apimachinery v0.0.0-20190820100751-ac02f8882ef6 h1:KRSXk0YTtZ5b8Wwg0H+Pleie6dKjRj6Qnwx6OW398cQ=
 github.com/openshift/kubernetes-apimachinery v0.0.0-20191211181342-5a804e65bdc1 h1:pBVMoJWgY4x5R3ZL7U8yXjnIXjUqfv0x21WUU2de3+4=
 github.com/openshift/kubernetes-apimachinery v0.0.0-20191211181342-5a804e65bdc1/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20200114162348-c8810ef308ee h1:Lq+Jnpe8ciNYRm1SyF50Uvk29zybO5g2IgpAi7XGBCI=

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -309,9 +309,9 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		return err
 	}
 
-	if !pref.GetEphermeralSourceVolume() {
+	if !pref.GetEphemeralSourceVolume() {
 
-		// If ephermeral volume is false, then we need to add to source volume in the map to create pvc.
+		// If ephemeral volume is false, then we need to add to source volume in the map to create pvc.
 		containerNameToVolumes["odosource"] = []common.DevfileVolume{
 			{
 				Name: utils.OdoSourceVolume,

--- a/pkg/devfile/adapters/kubernetes/storage/utils.go
+++ b/pkg/devfile/adapters/kubernetes/storage/utils.go
@@ -50,13 +50,13 @@ func CreateComponentStorage(Client *kclient.Client, storages []common.Storage, c
 func Create(Client *kclient.Client, name, size, componentName, pvcName string) (*corev1.PersistentVolumeClaim, error) {
 
 	label := map[string]string{
-		"component": componentName,
+		"component":                componentName,
+		labels.DevfileStorageLabel: name,
 	}
 
 	if strings.Contains(pvcName, kutils.OdoSourceVolume) {
+		// Add label for source pvc
 		label[labels.SourcePVCLabel] = name
-	} else {
-		label[labels.DevfileStorageLabel] = name
 	}
 
 	objectMeta := generator.GetObjectMeta(pvcName, Client.Namespace, label, nil)

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -26,11 +26,24 @@ const (
 )
 
 // GetOdoContainerVolumes returns the mandatory Kube volumes for an Odo component
-func GetOdoContainerVolumes() []corev1.Volume {
-	return []corev1.Volume{
-		{
+func GetOdoContainerVolumes(ephemeral bool, sourcePVCName string) []corev1.Volume {
+	var sourceVolume corev1.Volume
+
+	if !ephemeral {
+		sourceVolume = corev1.Volume{
 			Name: OdoSourceVolume,
-		},
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: sourcePVCName},
+			},
+		}
+	} else {
+		sourceVolume = corev1.Volume{
+			Name: OdoSourceVolume,
+		}
+	}
+
+	return []corev1.Volume{
+		sourceVolume,
 		{
 			// Create a volume that will be shared betwen InitContainer and the applicationContainer
 			// in order to pass over the SupervisorD binary

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -23,13 +23,16 @@ const (
 
 	// OdoSourceVolume is the constant containing the name of the emptyDir volume containing the project source
 	OdoSourceVolume = "odo-projects"
+
+	// OdoSourceVolumeSize specifies size for odo source volume.
+	OdoSourceVolumeSize = "2Gi"
 )
 
 // GetOdoContainerVolumes returns the mandatory Kube volumes for an Odo component
-func GetOdoContainerVolumes(ephemeral bool, sourcePVCName string) []corev1.Volume {
+func GetOdoContainerVolumes(sourcePVCName string) []corev1.Volume {
 	var sourceVolume corev1.Volume
 
-	if !ephemeral {
+	if sourcePVCName != "" {
 		sourceVolume = corev1.Volume{
 			Name: OdoSourceVolume,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -67,6 +67,8 @@ func (o *ViewOptions) Run() (err error) {
 	fmt.Fprintln(w, "PushTimeout", "\t", showBlankIfNil(cfg.OdoSettings.PushTimeout))
 	fmt.Fprintln(w, "Experimental", "\t", showBlankIfNil(cfg.OdoSettings.Experimental))
 	fmt.Fprintln(w, "PushTarget", "\t", showBlankIfNil(cfg.OdoSettings.PushTarget))
+	fmt.Fprintln(w, "Ephemeral", "\t", showBlankIfNil(cfg.OdoSettings.Ephemeral))
+
 	w.Flush()
 	return
 }

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -85,8 +85,8 @@ const (
 	// DefaultRegistryCacheTime is time (in minutes) for how long odo will cache information from Devfile registry
 	DefaultRegistryCacheTime = 15
 
-	// EphemeralSourceVolume specifies if ephemeral volumes needs to be used as source volume.
-	EphemeralSourceVolume = "ephemeral"
+	// EphemeralSetting specifies if ephemeral volumes needs to be used as source volume.
+	EphemeralSetting = "Ephemeral"
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting
@@ -101,8 +101,8 @@ var BuildTimeoutSettingDescription = fmt.Sprintf("BuildTimeout (in seconds) for 
 // RegistryCacheTimeDescription adds a description for RegistryCacheTime
 var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo will cache information from Devfile registry (Default: %d)", DefaultRegistryCacheTime)
 
-// EphemeralSourceVolumeDescription adds a description for EphemeralSourceVolume
-var EphemeralSourceVolumeDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
+// EphemeralDescription adds a description for EphemeralSourceVolume
+var EphemeralDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
@@ -119,7 +119,7 @@ var (
 		ExperimentalSetting:       ExperimentalDescription,
 		PushTargetSetting:         PushTargetDescription,
 		RegistryCacheTimeSetting:  RegistryCacheTimeDescription,
-		EphemeralSourceVolume:     EphemeralSourceVolumeDescription,
+		EphemeralSetting:          EphemeralDescription,
 	}
 
 	// set-like map to quickly check if a parameter is supported
@@ -162,7 +162,8 @@ type OdoSettings struct {
 	// RegistryCacheTime how long odo should cache information from registry
 	RegistryCacheTime *int `yaml:"RegistryCacheTime,omitempty"`
 
-	EphemeralSourceVolume *bool `yaml:"Ephemeral,omitempty"`
+	// Ephemeral if true creates odo emptyDir to store odo source code
+	Ephemeral *bool `yaml:"Ephemeral,omitempty"`
 }
 
 // Registry includes the registry metadata
@@ -422,7 +423,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 			if err != nil {
 				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
 			}
-			c.OdoSettings.EphemeralSourceVolume = &val
+			c.OdoSettings.Ephemeral = &val
 
 		case "pushtarget":
 			val := strings.ToLower(value)
@@ -500,7 +501,7 @@ func (c *PreferenceInfo) GetUpdateNotification() bool {
 // GetEphemeralSourceVolume returns the value of ephemeral from preferences
 // and if absent then returns default
 func (c *PreferenceInfo) GetEphemeralSourceVolume() bool {
-	return util.GetBoolOrDefault(c.OdoSettings.EphemeralSourceVolume, false)
+	return util.GetBoolOrDefault(c.OdoSettings.Ephemeral, false)
 }
 
 // GetNamePrefix returns the value of Prefix from preferences

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -84,6 +84,9 @@ const (
 
 	// DefaultRegistryCacheTime is time (in minutes) for how long odo will cache information from Devfile registry
 	DefaultRegistryCacheTime = 15
+
+	// EphermeralSourceVolume specifies if ephermeral volumes needs to be used as source volume.
+	EphermeralSourceVolume = "ephermeral"
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting
@@ -154,6 +157,8 @@ type OdoSettings struct {
 
 	// RegistryCacheTime how long odo should cache information from registry
 	RegistryCacheTime *int `yaml:"RegistryCacheTime,omitempty"`
+
+	EphermeralSourceVolume *bool `yaml:"ephermeral,omitempty"`
 }
 
 // Registry includes the registry metadata
@@ -479,6 +484,12 @@ func (c *PreferenceInfo) GetRegistryCacheTime() int {
 // and if absent then returns default
 func (c *PreferenceInfo) GetUpdateNotification() bool {
 	return util.GetBoolOrDefault(c.OdoSettings.UpdateNotification, true)
+}
+
+// GetEphermeralSourceVolume returns the value of ephermeral from preferences
+// and if absent then returns default
+func (c *PreferenceInfo) GetEphermeralSourceVolume() bool {
+	return util.GetBoolOrDefault(c.OdoSettings.EphermeralSourceVolume, false)
 }
 
 // GetNamePrefix returns the value of Prefix from preferences

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -162,7 +162,7 @@ type OdoSettings struct {
 	// RegistryCacheTime how long odo should cache information from registry
 	RegistryCacheTime *int `yaml:"RegistryCacheTime,omitempty"`
 
-	EphemeralSourceVolume *bool `yaml:"ephemeral,omitempty"`
+	EphemeralSourceVolume *bool `yaml:"Ephemeral,omitempty"`
 }
 
 // Registry includes the registry metadata

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -85,8 +85,8 @@ const (
 	// DefaultRegistryCacheTime is time (in minutes) for how long odo will cache information from Devfile registry
 	DefaultRegistryCacheTime = 15
 
-	// EphermeralSourceVolume specifies if ephermeral volumes needs to be used as source volume.
-	EphermeralSourceVolume = "ephermeral"
+	// EphemeralSourceVolume specifies if ephemeral volumes needs to be used as source volume.
+	EphemeralSourceVolume = "ephemeral"
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting
@@ -101,8 +101,8 @@ var BuildTimeoutSettingDescription = fmt.Sprintf("BuildTimeout (in seconds) for 
 // RegistryCacheTimeDescription adds a description for RegistryCacheTime
 var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo will cache information from Devfile registry (Default: %d)", DefaultRegistryCacheTime)
 
-// EphermeralSourceVolumeDescription adds a description for EphermeralSourceVolume
-var EphermeralSourceVolumeDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
+// EphemeralSourceVolumeDescription adds a description for EphemeralSourceVolume
+var EphemeralSourceVolumeDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
@@ -119,7 +119,7 @@ var (
 		ExperimentalSetting:       ExperimentalDescription,
 		PushTargetSetting:         PushTargetDescription,
 		RegistryCacheTimeSetting:  RegistryCacheTimeDescription,
-		EphermeralSourceVolume:    EphermeralSourceVolumeDescription,
+		EphemeralSourceVolume:     EphemeralSourceVolumeDescription,
 	}
 
 	// set-like map to quickly check if a parameter is supported
@@ -162,7 +162,7 @@ type OdoSettings struct {
 	// RegistryCacheTime how long odo should cache information from registry
 	RegistryCacheTime *int `yaml:"RegistryCacheTime,omitempty"`
 
-	EphermeralSourceVolume *bool `yaml:"ephermeral,omitempty"`
+	EphemeralSourceVolume *bool `yaml:"ephemeral,omitempty"`
 }
 
 // Registry includes the registry metadata
@@ -417,12 +417,12 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 			}
 			c.OdoSettings.Experimental = &val
 
-		case "ephermeral":
+		case "ephemeral":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
 				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
 			}
-			c.OdoSettings.EphermeralSourceVolume = &val
+			c.OdoSettings.EphemeralSourceVolume = &val
 
 		case "pushtarget":
 			val := strings.ToLower(value)
@@ -497,10 +497,10 @@ func (c *PreferenceInfo) GetUpdateNotification() bool {
 	return util.GetBoolOrDefault(c.OdoSettings.UpdateNotification, true)
 }
 
-// GetEphermeralSourceVolume returns the value of ephermeral from preferences
+// GetEphemeralSourceVolume returns the value of ephemeral from preferences
 // and if absent then returns default
-func (c *PreferenceInfo) GetEphermeralSourceVolume() bool {
-	return util.GetBoolOrDefault(c.OdoSettings.EphermeralSourceVolume, false)
+func (c *PreferenceInfo) GetEphemeralSourceVolume() bool {
+	return util.GetBoolOrDefault(c.OdoSettings.EphemeralSourceVolume, false)
 }
 
 // GetNamePrefix returns the value of Prefix from preferences

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -101,6 +101,9 @@ var BuildTimeoutSettingDescription = fmt.Sprintf("BuildTimeout (in seconds) for 
 // RegistryCacheTimeDescription adds a description for RegistryCacheTime
 var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo will cache information from Devfile registry (Default: %d)", DefaultRegistryCacheTime)
 
+// EphermeralSourceVolumeDescription adds a description for EphermeralSourceVolume
+var EphermeralSourceVolumeDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
+
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
 var customHomeDir = os.Getenv("CUSTOM_HOMEDIR")
@@ -116,6 +119,7 @@ var (
 		ExperimentalSetting:       ExperimentalDescription,
 		PushTargetSetting:         PushTargetDescription,
 		RegistryCacheTimeSetting:  RegistryCacheTimeDescription,
+		EphermeralSourceVolume:    EphermeralSourceVolumeDescription,
 	}
 
 	// set-like map to quickly check if a parameter is supported
@@ -412,6 +416,13 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
 			}
 			c.OdoSettings.Experimental = &val
+
+		case "ephermeral":
+			val, err := strconv.ParseBool(strings.ToLower(value))
+			if err != nil {
+				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
+			}
+			c.OdoSettings.EphermeralSourceVolume = &val
 
 		case "pushtarget":
 			val := strings.ToLower(value)

--- a/pkg/storage/labels/labels.go
+++ b/pkg/storage/labels/labels.go
@@ -12,6 +12,9 @@ const StorageLabel = "app.kubernetes.io/storage-name"
 // that are created
 const DevfileStorageLabel = "storage-name"
 
+// SourceStorageLabel
+const SourcePVCLabel = "odo-source-pvc"
+
 // GetLabels gets the labels to be applied to the given storage besides the
 // component labels and application labels.
 func GetLabels(storageName string, componentName string, applicationName string, additional bool) map[string]string {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -589,6 +589,7 @@ func DevfileListMounted(kClient *kclient.Client, componentName string) (StorageL
 	var volumeMounts []Storage
 	for _, container := range pod.Spec.Containers {
 		for _, volumeMount := range container.VolumeMounts {
+
 			volumeMounts = append(volumeMounts, Storage{
 				ObjectMeta: metav1.ObjectMeta{Name: volumeMount.Name},
 				Spec: StorageSpec{
@@ -596,6 +597,7 @@ func DevfileListMounted(kClient *kclient.Client, componentName string) (StorageL
 					ContainerName: container.Name,
 				},
 			})
+
 		}
 	}
 
@@ -603,8 +605,11 @@ func DevfileListMounted(kClient *kclient.Client, componentName string) (StorageL
 		return StorageList{}, nil
 	}
 
-	label := fmt.Sprintf("component=%s", componentName)
-	pvcs, err := kClient.ListPVCs(label)
+	var labels = make(map[string]string)
+	labels[storagelabels.SourcePVCLabel] = "odo-projects"
+	labels["component"] = componentName
+	selector := util.ConvertLabelsToSelector(labels)
+	pvcs, err := kClient.ListPVCs(selector)
 	if err != nil {
 		return StorageList{}, errors.Wrapf(err, "unable to get PVC using selector %v", storagelabels.StorageLabel)
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -605,10 +605,8 @@ func DevfileListMounted(kClient *kclient.Client, componentName string) (StorageL
 		return StorageList{}, nil
 	}
 
-	var labels = make(map[string]string)
-	labels[storagelabels.SourcePVCLabel] = "odo-projects"
-	labels["component"] = componentName
-	selector := util.ConvertLabelsToSelector(labels)
+	selector := fmt.Sprintf("component=%s,%s!=odo-projects", componentName, storagelabels.SourcePVCLabel)
+
 	pvcs, err := kClient.ListPVCs(selector)
 	if err != nil {
 		return StorageList{}, errors.Wrapf(err, "unable to get PVC using selector %v", storagelabels.StorageLabel)

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -669,7 +669,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			outputArr := strings.Split(output, "\n")
 			for _, line := range outputArr {
 
-				if !strings.HasPrefix(line, sourcePath+"/") {
+				if !strings.HasPrefix(line, sourcePath+"/") || strings.Contains(line, "lost+found") {
 					continue
 				}
 

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -100,7 +100,8 @@ var _ = Describe("odo devfile storage command tests", func() {
 
 			// Verify the pvc size
 			PVCs := commonVar.CliRunner.GetAllPVCNames(commonVar.Project)
-			Expect(len(PVCs)).To(Equal(1))
+			// additional source pvc the odo creates
+			Expect(len(PVCs)).To(Equal(2))
 		})
 
 		It("should create and output in json format", func() {
@@ -226,6 +227,25 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			helper.CmdShouldFail("odo", "storage", "delete", helper.RandString(5), "--context", commonVar.Context, "-f")
+		})
+	})
+	Context("When ephermeral is set to true in preference.yaml", func() {
+		It("should not create a pvc to store source code", func() {
+
+			helper.CmdShouldPass("odo", "preference", "set", "ephermeral", "true")
+
+			args := []string{"create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project}
+			helper.CmdShouldPass("odo", args...)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+
+			// Verify the pvc size
+			PVCs := commonVar.CliRunner.GetAllPVCNames(commonVar.Project)
+
+			Expect(len(PVCs)).To(Equal(0))
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -229,10 +229,10 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.CmdShouldFail("odo", "storage", "delete", helper.RandString(5), "--context", commonVar.Context, "-f")
 		})
 	})
-	Context("When ephermeral is set to true in preference.yaml", func() {
+	Context("When ephemeral is set to true in preference.yaml", func() {
 		It("should not create a pvc to store source code", func() {
 
-			helper.CmdShouldPass("odo", "preference", "set", "ephermeral", "true")
+			helper.CmdShouldPass("odo", "preference", "set", "ephemeral", "true")
 
 			args := []string{"create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project}
 			helper.CmdShouldPass("odo", args...)


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What does does this PR do / why we need it**:
This PR proposes to create a PVC for odo source code volume, Uptil now we were using emptyDir to store source code.  
It makes PVC as a default option to store source code, If user wants to use `emptyDir` as source code, it can use
`odo preference set ephemeral true`

**Which issue(s) this PR fixes**:

Fixes #3775

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
- odo create nodejs --starter
- odo push
- check if it has created source pvc using `oc get pvc` or `kubectl get pvc`