### PR TITLE
Follow same initialization pattern as other clients

### DIFF
--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -93,11 +93,10 @@ func NewForConfig(config clientcmd.ClientConfig) (client *Client, err error) {
 		return nil, err
 	}
 
-	appsClient, err := appsclientset.NewForConfig(client.KubeClientConfig)
+	client.appsClient, err = appsclientset.NewForConfig(client.KubeClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	client.appsClient = appsClient
 
 	client.serviceCatalogClient, err = servicecatalogclienset.NewForConfig(client.KubeClientConfig)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind code-refactoring

**What does this PR do / why we need it**:
All the other clients are initiated in similar manner except
`client.appsClient`. This commit just makes things uniform.

**Which issue(s) this PR fixes**:

Fixes NA.
Part of #4298 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Tests should pass