### PR TITLE
Execute make target consecutively even on failure

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -49,8 +49,20 @@ elif  [ "${ARCH}" == "ppc64le" ]; then
     # E2e tests
     make test-e2e-all
 else
-    # Integration and E2e tests
-    make test-integration || make test-integration-devfile || make test-cmd-login-logout || make test-cmd-project || make test-operator-hub || make test-e2e-all
+    # Integration tests
+    make test-integration || error=true
+    make test-integration-devfile || error=true
+    make test-cmd-login-logout || error=true
+    make test-cmd-project || error=true
+    make test-operator-hub || error=true
+
+    # E2e tests
+    make test-e2e-all || error=true
+
+    # Fail the build if there is any error while test execution
+    if [ $error ]; then 
+        exit -1
+    fi
 fi
 
 cp -r reports $ARTIFACTS_DIR 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -49,14 +49,8 @@ elif  [ "${ARCH}" == "ppc64le" ]; then
     # E2e tests
     make test-e2e-all
 else
-    # Integration tests
-    make test-integration
-    make test-integration-devfile
-    make test-cmd-login-logout
-    make test-cmd-project
-    make test-operator-hub
-    # E2e tests
-    make test-e2e-all
+    # Integration and E2e tests
+    make test-integration || make test-integration-devfile || make test-cmd-login-logout || make test-cmd-project || make test-operator-hub || make test-e2e-all
 fi
 
 cp -r reports $ARTIFACTS_DIR 

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -44,9 +44,6 @@ var _ = Describe("odo app command tests", func() {
 			expected := []string{"List", "{}", "[]"}
 			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 
-			// intentionally failing the tests to verify the behavior of the pr
-			Expect(helper.GjsonMatcher(values, expected)).To(Equal(false))
-
 			appDelete := helper.CmdShouldFail("odo", "app", "delete", "test", "--project", commonVar.Project, "-f")
 			Expect(appDelete).To(ContainSubstring("test app does not exists"))
 			appDescribe := helper.CmdShouldFail("odo", "app", "describe", "test", "--project", commonVar.Project)

--- a/tests/integration/cmd_app_test.go
+++ b/tests/integration/cmd_app_test.go
@@ -44,6 +44,9 @@ var _ = Describe("odo app command tests", func() {
 			expected := []string{"List", "{}", "[]"}
 			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 
+			// intentionally failing the tests to verify the behavior of the pr
+			Expect(helper.GjsonMatcher(values, expected)).To(Equal(false))
+
 			appDelete := helper.CmdShouldFail("odo", "app", "delete", "test", "--project", commonVar.Project, "-f")
 			Expect(appDelete).To(ContainSubstring("test app does not exists"))
 			appDescribe := helper.CmdShouldFail("odo", "app", "describe", "test", "--project", commonVar.Project)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

This PR enables the next make target execution even if the the existing one fails. For ex - If `make test-integration` fails It won't fail the overall execution, instead start the next make target execution.

**Which issue(s) this PR fixes**:

Fixes NA (Interop team has particularly urged for this feature as part of https://github.com/openshift/odo/issues/4223 )

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

Prow should not fail overall execution. It should try executing the next target if existing one fails.
