### PR TITLE
Validation spinners refactor

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -837,7 +837,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 // Validate validates the create parameters
 func (co *CreateOptions) Validate() (err error) {
 
-	log.Info("Devfile Component Name Validation")
+	log.Info("Validation")
 
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
 		// Validate if the devfile component name that user wants to create adheres to the k8s naming convention
@@ -862,7 +862,7 @@ func (co *CreateOptions) Validate() (err error) {
 		return nil
 	}
 
-	log.Info("Supportability Validation")
+	log.Info("Validation")
 
 	supported, err := catalog.IsComponentTypeSupported(co.Context.Client, *co.componentSettings.Type)
 	if err != nil {

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -544,7 +544,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		if util.CheckPathExists(co.DevfilePath) || co.devfileMetadata.devfilePath.value != "" {
 			// Categorize the sections
-			log.Info("Validation")
+			log.Info("Devfile Object Validation")
 
 			var devfileAbsolutePath string
 			if util.CheckPathExists(co.DevfilePath) || co.devfileMetadata.devfilePath.protocol == "file" {
@@ -583,7 +583,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		hasComponent := false
 		var devfileExistSpinner *log.Status
 		if !co.forceS2i {
-			log.Info("Validation")
+			log.Info("Devfile Object Validation")
 			devfileExistSpinner = log.Spinner("Checking devfile existence")
 			defer devfileExistSpinner.End(false)
 		}
@@ -837,9 +837,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 // Validate validates the create parameters
 func (co *CreateOptions) Validate() (err error) {
 
+	log.Info("Devfile Component Name Validation")
+
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
-		// Validate if the devfile component that user wants to create already exists
-		spinner := log.Spinner("Validating devfile component")
+		// Validate if the devfile component name that user wants to create adheres to the k8s naming convention
+		spinner := log.Spinner("Validating if devfile name is correct")
 		defer spinner.End(false)
 
 		err = util.ValidateK8sResourceName("component name", co.devfileMetadata.componentName)
@@ -860,7 +862,7 @@ func (co *CreateOptions) Validate() (err error) {
 		return nil
 	}
 
-	log.Info("Validation")
+	log.Info("Supportability Validation")
 
 	supported, err := catalog.IsComponentTypeSupported(co.Context.Client, *co.componentSettings.Type)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does does this PR do / why we need it**:
This PR redefine the "Validation" header into below different headers:

- Devfile Object Validation 
- Devfile Component Name Validation
- Supportability Validation

Also re-phrased ValidateK8sResourceName() spinner so it now reflects what kind of check it performs. 
`odo create` output now looks like:

<p align="center">
<img src="https://user-images.githubusercontent.com/10870596/102997593-cec42680-4525-11eb-8e12-1d425fe5cee9.png">
</p>

And,
<p align="center">
<img src="https://user-images.githubusercontent.com/10870596/102997799-2febfa00-4526-11eb-8c0a-57f33c80e3bf.png">
</p>

**Which issue(s) this PR fixes**:
Address issue #3924 

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
