### PR TITLE
Output service name when creating Operator backed service

### DIFF
--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -377,6 +377,13 @@ func (o *ServiceCreateOptions) Validate() (err error) {
 			// CRD is valid. We can use it further to create a service from it.
 			o.CustomResourceDefinition = d.OriginalCRD
 
+			if o.ServiceName == "" {
+				o.ServiceName, err = d.getServiceNameFromCRD()
+				if err != nil {
+					return err
+				}
+			}
+
 			return nil
 		} else {
 			// This block is executed only when user has neither provided a

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -77,7 +77,8 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
 			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", project)
+			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", project)
+			Expect(stdOut).To(ContainSubstring("Service 'example' was created"))
 
 			// now verify if the pods for the operator have started
 			pods := helper.CmdShouldPass("oc", "get", "pods", "-n", project)
@@ -90,7 +91,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			})
 
 			// now test listing of the service using odo
-			stdOut := helper.CmdShouldPass("odo", "service", "list")
+			stdOut = helper.CmdShouldPass("odo", "service", "list")
 			Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
 
 			// now test the deletion of the service using odo


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
It fixes a bug which leads to bad UX.

**Which issue(s) this PR fixes**:

Fixes #4013

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Create an Operator backed service without providing a name. You should now see the service name being used from the alm example:
```sh
$ odo service create etcdoperator.v0.9.4-clusterwide/EtcdCluster
Deploying service of type: EtcdCluster
 ✓  Deploying service [3ms]
 ✓  Service 'example' was created

Progress of the provisioning will not be reported and might take a long time
You can see the current status by executing 'odo service list'
Optionally, link etcdoperator.v0.9.4-clusterwide to your component by running: 'odo link <component-name>'
```

Earlier, we were seeing `Service ' ' was created`.