### PR TITLE
Refactor catalog list services

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -272,8 +272,8 @@ func ComponentExists(client *occlient.Client, componentType string, componentVer
 	return true, nil
 }
 
-// ListServices lists all the available service types
-func ListServices(client *occlient.Client) (ServiceTypeList, error) {
+// ListSvcCatServices lists all the available services provided by Service Catalog
+func ListSvcCatServices(client *occlient.Client) (ServiceTypeList, error) {
 
 	clusterServiceClasses, err := getClusterCatalogServices(client)
 	if err != nil {
@@ -298,13 +298,14 @@ func ListServices(client *occlient.Client) (ServiceTypeList, error) {
 // ListOperatorServices fetches a list of Operators from the cluster and
 // returns only those Operators which are successfully installed on the cluster
 func ListOperatorServices(client *kclient.Client) (*olm.ClusterServiceVersionList, error) {
+	var csvList olm.ClusterServiceVersionList
+
 	allCsvs, err := client.ListClusterServiceVersions()
 	if err != nil {
-		return nil, err
+		return &csvList, err
 	}
 
 	// now let's filter only those csvs which are successfully installed
-	var csvList olm.ClusterServiceVersionList
 	csvList.TypeMeta = allCsvs.TypeMeta
 	csvList.ListMeta = allCsvs.ListMeta
 	for _, csv := range allCsvs.Items {
@@ -319,7 +320,7 @@ func ListOperatorServices(client *kclient.Client) (*olm.ClusterServiceVersionLis
 // SearchService searches for the services
 func SearchService(client *occlient.Client, name string) (ServiceTypeList, error) {
 	var result []ServiceType
-	serviceList, err := ListServices(client)
+	serviceList, err := ListSvcCatServices(client)
 	if err != nil {
 		return ServiceTypeList{}, errors.Wrap(err, "unable to list services")
 	}

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -48,6 +48,10 @@ func (o *ServiceOptions) Complete(name string, cmd *cobra.Command, args []string
 	o.services, err = catalog.ListSvcCatServices(o.Client)
 	if err != nil {
 		if strings.Contains(err.Error(), "the server could not find the requested resource") {
+			// this error is thrown when Service Catalog is not enabled on Kubernetes
+			err = nil
+		} else if strings.Contains(err.Error(), "cannot list resource \"clusterserviceclasses\" in API group \"servicecatalog.k8s.io\" at the cluster scope") {
+			// this error is thrown when Service Catalog is not enabled on OpenShift
 			err = nil
 		}
 		return err

--- a/pkg/odo/cli/catalog/util/util.go
+++ b/pkg/odo/cli/catalog/util/util.go
@@ -66,11 +66,12 @@ func FilterHiddenComponents(input []catalog.ComponentType) []catalog.ComponentTy
 // DisplayClusterServiceVersions displays installed Operators in a human friendly manner
 func DisplayClusterServiceVersions(csvs *olm.ClusterServiceVersionList) {
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-	log.Info("Operators available in the cluster")
+	log.Info("Services available through Operators")
 	fmt.Fprintln(w, "NAME", "\t", "CRDs")
 	for _, csv := range csvs.Items {
 		fmt.Fprintln(w, csv.ObjectMeta.Name, "\t", CsvOperators(csv.Spec.CustomResourceDefinitions))
 	}
+	fmt.Fprintln(w) // this newline helps when cluster has both Operator and Service Catalog enabled
 	w.Flush()
 }
 

--- a/pkg/odo/cli/catalog/util/util.go
+++ b/pkg/odo/cli/catalog/util/util.go
@@ -14,6 +14,7 @@ import (
 // DisplayServices displays the specified services
 func DisplayServices(services catalog.ServiceTypeList) {
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(w) // this newline helps when cluster has both Operator and Service Catalog enabled
 	log.Info("Services available through Service Catalog")
 	fmt.Fprintln(w, "NAME", "\t", "PLANS")
 	for _, service := range services.Items {
@@ -71,7 +72,6 @@ func DisplayClusterServiceVersions(csvs *olm.ClusterServiceVersionList) {
 	for _, csv := range csvs.Items {
 		fmt.Fprintln(w, csv.ObjectMeta.Name, "\t", CsvOperators(csv.Spec.CustomResourceDefinitions))
 	}
-	fmt.Fprintln(w) // this newline helps when cluster has both Operator and Service Catalog enabled
 	w.Flush()
 }
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -55,7 +55,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		It("should list operators installed in the namespace", func() {
 			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Operators available in the cluster", "etcdoperator"})
+			helper.MatchAllInOutput(stdOut, []string{"Services available through Operators", "etcdoperator"})
 		})
 
 		It("should not allow interactive mode command to be executed", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -414,7 +414,7 @@ spec:
 			}
 
 			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", componentName)
+			helper.CmdShouldPass("odo", "create", componentName, "--devfile", "devfile.yaml", "--starter")
 			helper.CmdShouldPass("odo", "push")
 
 			// start the Operator backed service first


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does this PR do / why we need it**:
This PR refactors the underlying code for `odo catalog list services`. It makes the code more readable.

We need this because odo will be supporting both Operator Hub as well as Service Catalog backends to let users spin up services from. This PR removes `if..else` blocks and various variables that made the code quite confusing.

**Which issue(s) this PR fixes**:

Fixes NA
Part of #4298

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Check output of `odo catalog list services` in following scenarios:
* a fresh minikube cluster with no Operators or Service Catalog enabled
* enable OLM addon (`minikube addons enable olm`) and install some Operator (for example [install Service Binding Operator](https://odo.dev/docs/install-service-binding-operator/))
* enable service catalog using helm cli (download and install latest helm cli from [its release page](https://github.com/helm/helm/releases/tag/v3.4.2)) by following below steps:
    ```sh
    $ git clone https://github.com/kubernetes-sigs/service-catalog/
    $ cd service-catalog/charts/catalog
    # enable the CRDs related to Service Catalog
    $ helm install . --generate-name
    
    # install minibroker (a kind of ClusterServiceBroker)
    $ helm repo add minibroker https://minibroker.blob.core.windows.net/charts
    
    # make sure the pods related to minibroker are in running state before moving to next step
    $ kubectl get pods
    
    # this installs services (ClusterServiceClasses) provided by minibroker 
    $ helm install minibroker --namespace default minibroker/minibroker
    ```
