### PR TITLE
Revert centos nodejs tags to older version

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -93,14 +93,15 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage("rhoar-nodejs/nodejs-10:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
+		// Changing docker.io/centos/nodejs-10-centos7 and docker.io/centos/nodejs-12-centos7 to older version till issue:https://github.com/openshift/odo/issues/4347/ gets fixed
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-10-centos7:20200930-19a850a", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos/nodejs-10-centos7:20200930-19a850a", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-12-centos7:20200930-19a850a", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos/nodejs-12-centos7:20200930-19a850a", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:
This is just a work around untill we get https://github.com/openshift/odo/issues/4347 done

**Which issue(s) this PR fixes**:

Fixes - Work around

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

`make test-e2e-images` should pass .