### PR TITLE
Add centos7 nodejs latest as supported

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -35,6 +35,8 @@ var supportedImages = map[string]bool{
 	"ubi8/openjdk-11:latest":                       true,
 	"centos/nodejs-10-centos7:latest":              true,
 	"centos/nodejs-12-centos7:latest":              true,
+	"centos7/nodejs-10-centos7:latest":             true,
+	"centos7/nodejs-12-centos7:latest":             true,
 	"rhscl/nodejs-10-rhel7:latest":                 true,
 	"rhscl/nodejs-12-rhel7:latest":                 true,
 	"rhoar-nodejs/nodejs-10:latest":                true,

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -36,7 +36,7 @@ const (
 
 	// Default Image that will be used containing the supervisord binary and assembly scripts
 	// use GetBootstrapperImage() function instead of this variable
-	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.7"
+	defaultBootstrapperImage = "registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.9"
 
 	// SupervisordControlCommand sub command which stands for control
 	SupervisordControlCommand = "ctl"

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -94,12 +94,12 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("registry.centos.org", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("registry.centos.org", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -94,12 +94,12 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("registry.centos.org", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("registry.centos.org", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -93,15 +93,14 @@ var _ = Describe("odo supported images e2e tests", func() {
 			verifySupportedImage("rhoar-nodejs/nodejs-10:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
-		// Changing docker.io/centos/nodejs-10-centos7 and docker.io/centos/nodejs-12-centos7 to older version till issue:https://github.com/openshift/odo/issues/4347/ gets fixed
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-10-centos7:20200930-19a850a", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos/nodejs-10-centos7:20200930-19a850a", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos/nodejs-12-centos7:20200930-19a850a", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos/nodejs-12-centos7:20200930-19a850a", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})
 

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -94,12 +94,12 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("docker.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
+			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind feature

**What does does this PR do / why we need it**:
We need to sync with s2i nodejs container centos image. 

**Which issue(s) this PR fixes**:

Fixes #4347 
Fixes #4278

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

centos7 nodejs image should work fine for odo.