### PR TITLE
Fixes panic while collecting events from the pod.

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -295,7 +295,7 @@ func CreateFromPath(client *occlient.Client, params occlient.CreateArgs) error {
 		}
 
 		podSelector := fmt.Sprintf("deploymentconfig=%s", selectorLabels)
-		_, err = client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start", false)
+		_, err = client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return err
 		}
@@ -684,7 +684,7 @@ func PushLocal(client *occlient.Client, componentName string, applicationName st
 	podSelector := fmt.Sprintf("deploymentconfig=%s", dc.Name)
 
 	// Wait for Pod to be in running state otherwise we can't sync data to it.
-	pod, err := client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start", false)
+	pod, err := client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 	if err != nil {
 		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
 	}

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -49,7 +49,7 @@ func (a Adapter) getPod(refresh bool) (*corev1.Pod, error) {
 		podSelector := fmt.Sprintf("component=%s", a.ComponentName)
 
 		// Wait for Pod to be in running state otherwise we can't sync data to it.
-		pod, err := a.Client.WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start", true)
+		pod, err := a.Client.WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return nil, errors.Wrapf(err, "error while waiting for pod %s", podSelector)
 		}

--- a/pkg/kclient/pods_test.go
+++ b/pkg/kclient/pods_test.go
@@ -78,7 +78,7 @@ func TestWaitAndGetPodWithEvents(t *testing.T) {
 
 			podSelector := fmt.Sprintf("deploymentconfig=%s", tt.podName)
 
-			pod, err := fakeClient.WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start", false)
+			pod, err := fakeClient.WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("client.WaitAndGetPod(string) unexpected error %v, wantErr %v", err, tt.wantErr)

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -418,13 +418,13 @@ func (o *commonLinkOptions) waitForLinkToComplete() (err error) {
 	// first wait for the pod to be pending (meaning that the deployment is being put into effect)
 	// we need this intermediate wait because there is a change that the this point could be reached
 	// without Openshift having had the time to launch the new deployment
-	_, err = o.Client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodPending, "Waiting for component to redeploy", false)
+	_, err = o.Client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodPending, "Waiting for component to redeploy")
 	if err != nil {
 		return err
 	}
 
 	// now wait for the pod to be running
-	_, err = o.Client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start", false)
+	_, err = o.Client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 	return err
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

It removes the hideSpinner parameter from WaitAndGetPodWithEvents().

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Tests should pass and panic shouldn't occur while collecting events from the pod.