### PR TITLE
Change default value for ephemral preference

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -87,6 +87,9 @@ const (
 
 	// EphemeralSetting specifies if ephemeral volumes needs to be used as source volume.
 	EphemeralSetting = "Ephemeral"
+
+	// DefaultEphemeralSettings is a default value for Ephemeral preference
+	DefaultEphemeralSettings = true
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting
@@ -102,7 +105,7 @@ var BuildTimeoutSettingDescription = fmt.Sprintf("BuildTimeout (in seconds) for 
 var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo will cache information from Devfile registry (Default: %d)", DefaultRegistryCacheTime)
 
 // EphemeralDescription adds a description for EphemeralSourceVolume
-var EphemeralDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code(Default: %t)", false)
+var EphemeralDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code (Default: %t)", DefaultEphemeralSettings)
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
@@ -501,7 +504,7 @@ func (c *PreferenceInfo) GetUpdateNotification() bool {
 // GetEphemeralSourceVolume returns the value of ephemeral from preferences
 // and if absent then returns default
 func (c *PreferenceInfo) GetEphemeralSourceVolume() bool {
-	return util.GetBoolOrDefault(c.OdoSettings.Ephemeral, false)
+	return util.GetBoolOrDefault(c.OdoSettings.Ephemeral, DefaultEphemeralSettings)
 }
 
 // GetNamePrefix returns the value of Prefix from preferences

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -251,4 +251,44 @@ var _ = Describe("odo devfile storage command tests", func() {
 			Expect(len(PVCs)).To(Equal(0))
 		})
 	})
+
+	Context("When ephemeral is set to false in preference.yaml", func() {
+		It("should create a pvc to store source code", func() {
+
+			helper.CmdShouldPass("odo", "preference", "set", "ephemeral", "false")
+
+			args := []string{"create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project}
+			helper.CmdShouldPass("odo", args...)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+
+			// Verify the pvc size
+			PVCs := commonVar.CliRunner.GetAllPVCNames(commonVar.Project)
+
+			Expect(len(PVCs)).To(Not(Equal(0)))
+		})
+	})
+
+	Context("When ephemeral is not set in preference.yaml", func() {
+		It("should not create a pvc to store source code  (default is ephemeral=false)", func() {
+
+			args := []string{"create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project}
+			helper.CmdShouldPass("odo", args...)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+
+			helper.CmdShouldPass("odo", "preference", "view")
+
+			// Verify the pvc size
+			PVCs := commonVar.CliRunner.GetAllPVCNames(commonVar.Project)
+
+			Expect(len(PVCs)).To(Equal(0))
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -99,8 +99,7 @@ var _ = Describe("odo devfile storage command tests", func() {
 
 			// Verify the pvc size
 			PVCs := commonVar.CliRunner.GetAllPVCNames(commonVar.Project)
-			// additional source pvc the odo creates
-			Expect(len(PVCs)).To(Equal(2))
+			Expect(len(PVCs)).To(Equal(1))
 		})
 
 		It("should create and output in json format", func() {


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

For now, it assumes default value for ephemeral 'false'.

In future releases, we might change it 'true'. But for now, we should
play it safe and keep the old behavior. We are not sure about all the
consequences that this can have.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
