### PR TITLE
Fix configure script run locally

### DIFF
--- a/scripts/configure-cluster/common/kubeconfigandadmin.sh
+++ b/scripts/configure-cluster/common/kubeconfigandadmin.sh
@@ -4,8 +4,9 @@
 # Setup Kubeconfig and login as kubeadmin #
 ###########################################
 
+export DEFAULT_INSTALLER_ASSETS_DIR=${DEFAULT_INSTALLER_ASSETS_DIR:-$(pwd)}
+
 setup_kubeadmin() {
-    export DEFAULT_INSTALLER_ASSETS_DIR=${DEFAULT_INSTALLER_ASSETS_DIR:-$(pwd)}
     export KUBEADMIN_USER=${KUBEADMIN_USER:-"kubeadmin"}
     export KUBEADMIN_PASSWORD_FILE=${KUBEADMIN_PASSWORD_FILE:-"${DEFAULT_INSTALLER_ASSETS_DIR}/auth/kubeadmin-password"}
     if [[ -z $CI && ! -f $KUBEADMIN_PASSWORD_FILE ]]; then


### PR DESCRIPTION


**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

Configure scripts are failing locally.

```
$ make configure-installer-tests-cluster
. ./scripts/configure-installer-tests-cluster.sh
++ LIBDIR=./scripts/configure-cluster
++ LIBCOMMON=./scripts/configure-cluster/common
++ SETUP_OPERATORS=./scripts/configure-cluster/common/setup-operators.sh
++ AUTH_SCRIPT=./scripts/configure-cluster/common/auth.sh
++ KUBEADMIN_SCRIPT=./scripts/configure-cluster/common/kubeconfigandadmin.sh
++ CI_OPERATOR_HUB_PROJECT=ci-operator-hub-project
++ IMAGE_TEST_NAMESPACES='[openjdk-11](https://issues.redhat.com/browse/openjdk-11)-rhel8 nodejs-12-rhel7 nodejs-12 [openjdk-11](https://issues.redhat.com/browse/openjdk-11)'
++ . ./scripts/configure-cluster/common/kubeconfigandadmin.sh
+++ setup_kubeconfig
+++ export ORIGINAL_KUBECONFIG=/auth/kubeconfig
+++ ORIGINAL_KUBECONFIG=/auth/kubeconfig
+++ export KUBECONFIG=/auth/kubeconfig
+++ KUBECONFIG=/auth/kubeconfig
+++ [[ -z '' ]]
+++ [[ ! -f /auth/kubeconfig ]]
+++ echo 'Could not find kubeconfig file'
Could not find kubeconfig file
+++ exit 1
make: *** [configure-installer-tests-cluster] Error 1

$ ls ./auth/
kubeadmin-password      kubeconfig
```

**Which issue(s) this PR fixes**:

Fixes - Configure script issue locally

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

`make configure-installer-tests-cluster` should pass locally and on CI both