### PR TITLE
Adds debug-command flag to odo watch

### DIFF
--- a/docs/public/deploying-a-devfile-using-odo.adoc
+++ b/docs/public/deploying-a-devfile-using-odo.adoc
@@ -482,6 +482,13 @@ Pushing devfile component myopenliberty
 
 You can now continue developing your application. Just refreshing the browser will render the source code changes.
 
+You can also trigger `odo watch` with custom devfile build, run and debug commands.
+
+[source,sh]
+-----
+$ odo watch --build-command="mybuild" --run-command="myrun" --debug-command="mydebug"
+----
+
 Run `odo delete` to delete the application from cluster.
 
 . To delete your deployed application:

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -38,8 +38,8 @@ var watchLongDesc = ktemplates.LongDesc(`Watch for changes, update component on 
 var watchExampleWithDevfile = ktemplates.Examples(`  # Watch for changes in directory for current component
 %[1]s
 
-# Watch source code changes with custom devfile commands using --build-command and --run-command for experimental mode
-%[1]s --build-command="mybuild" --run-command="myrun"
+# Watch source code changes with custom devfile commands using --build-command, --run-command and --debug-command for devfile based components
+%[1]s --build-command="mybuild" --run-command="myrun" --debug-command="mydebug"
   `)
 
 // WatchOptions contains attributes of the watch command

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -52,6 +52,8 @@ type WatchParameters struct {
 	DevfileBuildCmd string
 	// DevfileRunCmd takes the run command through the command line and overwrites devfile run command
 	DevfileRunCmd string
+	// DevfileDebugCmd takes the debug command through the command line and overwrites the devfile debug command
+	DevfileDebugCmd string
 }
 
 // addRecursiveWatch handles adding watches recursively for the path provided
@@ -347,6 +349,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							ForceBuild:               false,
 							DevfileBuildCmd:          parameters.DevfileBuildCmd,
 							DevfileRunCmd:            parameters.DevfileRunCmd,
+							DevfileDebugCmd:          parameters.DevfileDebugCmd,
 							DevfileScanIndexForWatch: !hasFirstSuccessfulPushOccurred,
 							EnvSpecificInfo:          *parameters.EnvSpecificInfo,
 							Debug:                    parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,
@@ -373,6 +376,7 @@ func WatchAndPush(client *occlient.Client, out io.Writer, parameters WatchParame
 							ForceBuild:               false,
 							DevfileBuildCmd:          parameters.DevfileBuildCmd,
 							DevfileRunCmd:            parameters.DevfileRunCmd,
+							DevfileDebugCmd:          parameters.DevfileDebugCmd,
 							DevfileScanIndexForWatch: !hasFirstSuccessfulPushOccurred,
 							EnvSpecificInfo:          *parameters.EnvSpecificInfo,
 							Debug:                    parameters.EnvSpecificInfo.GetRunMode() == envinfo.Debug,

--- a/pkg/watch/watch_test.go
+++ b/pkg/watch/watch_test.go
@@ -103,6 +103,10 @@ type mockPushParameters struct {
 	show            bool
 	isDebug         bool
 	debugPort       int
+
+	devfileBuildCmd string
+	devfileRunCmd   string
+	devfileDebugCmd string
 }
 
 var mockPush mockPushParameters
@@ -116,6 +120,15 @@ func mockDevFilePush(parameters common.PushParameters, _ WatchParameters) error 
 			"show:" + strconv.FormatBool(parameters.Show),
 			"debug:" + strconv.FormatBool(parameters.Debug),
 			"debugPort:" + strconv.Itoa(parameters.DebugPort),
+		})
+		os.Exit(1)
+	}
+
+	if parameters.DevfileBuildCmd != mockPush.devfileBuildCmd || parameters.DevfileRunCmd != mockPush.devfileRunCmd || parameters.DevfileDebugCmd != mockPush.devfileDebugCmd {
+		fmt.Printf("some of the push parameters are different, wanted: %v, got: %v", mockPush, []string{
+			"devfileBuildCmd:" + parameters.DevfileBuildCmd,
+			"devfileRunCmd:" + parameters.DevfileRunCmd,
+			"devfileDebugCmd:" + parameters.DevfileDebugCmd,
 		})
 		os.Exit(1)
 	}
@@ -203,6 +216,9 @@ func TestWatchAndPush(t *testing.T) {
 		setupEnv          func(componentName string, requiredFilePaths []testingutil.FileProperties) (string, map[string]testingutil.FileProperties, error)
 		isExperimental    bool
 		isDebug           bool
+		devfileBuildCmd   string
+		devfileRunCmd     string
+		devfileDebugCmd   string
 		debugPort         int
 	}{
 		{
@@ -410,9 +426,10 @@ func TestWatchAndPush(t *testing.T) {
 					ModificationType: testingutil.DELETE,
 				},
 			},
-			want:        []string{"__init__.py"},
-			wantDeleted: []string{"src/read_licenses.py"},
-			setupEnv:    setUpF8AnalyticsComponentSrc,
+			want:            []string{"__init__.py"},
+			wantDeleted:     []string{"src/read_licenses.py"},
+			setupEnv:        setUpF8AnalyticsComponentSrc,
+			devfileBuildCmd: "build-new",
 		},
 		{
 			name:            "Case 3: Valid watch with list of files to be ignored with a create and a delete event",
@@ -506,9 +523,10 @@ func TestWatchAndPush(t *testing.T) {
 					ModificationType: testingutil.DELETE,
 				},
 			},
-			want:        []string{"__init__.py"},
-			wantDeleted: []string{"src/read_licenses.py"},
-			setupEnv:    setUpF8AnalyticsComponentSrc,
+			want:          []string{"__init__.py"},
+			wantDeleted:   []string{"src/read_licenses.py"},
+			setupEnv:      setUpF8AnalyticsComponentSrc,
+			devfileRunCmd: "run-new",
 		},
 		{
 			name:            "Case 4: Valid watch with list of files to be ignored with a folder create event",
@@ -608,9 +626,10 @@ func TestWatchAndPush(t *testing.T) {
 					ModificationType: testingutil.CREATE,
 				},
 			},
-			want:        []string{"__init__.py"},
-			wantDeleted: []string{"src/read_licenses.py"},
-			setupEnv:    setUpF8AnalyticsComponentSrc,
+			want:            []string{"__init__.py"},
+			wantDeleted:     []string{"src/read_licenses.py"},
+			setupEnv:        setUpF8AnalyticsComponentSrc,
+			devfileDebugCmd: "debug-new",
 		},
 		{
 			name:            "Case 5: Valid watch with list of files to be ignored with a folder delete event",
@@ -740,8 +759,11 @@ func TestWatchAndPush(t *testing.T) {
 					isForcePush:     tt.forcePush,
 					globExps:        tt.ignores,
 					show:            tt.show,
-					debugPort:       tt.debugPort,
 					isDebug:         tt.isDebug,
+					debugPort:       tt.debugPort,
+					devfileBuildCmd: tt.devfileBuildCmd,
+					devfileRunCmd:   tt.devfileRunCmd,
+					devfileDebugCmd: tt.devfileDebugCmd,
 				}
 
 				ExpectedChangedFiles = tt.want
@@ -812,11 +834,14 @@ func TestWatchAndPush(t *testing.T) {
 					ComponentName: tt.componentName,
 					Path:          basePath,
 					// convert the glob expressions to absolute form for WatchAndPush to work properly
-					FileIgnores:   util.GetAbsGlobExps(basePath, tt.ignores),
-					PushDiffDelay: tt.delayInterval,
-					StartChan:     StartChan,
-					ExtChan:       ExtChan,
-					Show:          tt.show,
+					FileIgnores:     util.GetAbsGlobExps(basePath, tt.ignores),
+					StartChan:       StartChan,
+					ExtChan:         ExtChan,
+					PushDiffDelay:   tt.delayInterval,
+					Show:            tt.show,
+					DevfileBuildCmd: tt.devfileBuildCmd,
+					DevfileRunCmd:   tt.devfileRunCmd,
+					DevfileDebugCmd: tt.devfileDebugCmd,
 				}
 
 				if tt.isExperimental {

--- a/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-debugrun.yaml
@@ -40,3 +40,10 @@ commands:
       group:
         kind: debug
         isDefault: true
+  - id: debug
+    exec:
+      component: runtime
+      commandLine: npm run debug
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: debug

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -184,7 +184,15 @@ var _ = Describe("odo devfile watch command tests", func() {
 			// odo watch and validate if we can port forward successfully
 			utils.OdoWatchWithDebug(odoV2Watch, commonVar.Context, watchFlag)
 
+			// check the --debug-command flag
+			watchFlag = "--debug-command debug"
+			odoV2Watch.StringsToBeMatched = []string{"Executing debug command"}
+
+			// odo watch and validate if we can port forward successfully
+			utils.OdoWatchWithDebug(odoV2Watch, commonVar.Context, watchFlag)
+
 			// revert to normal odo push
+			watchFlag = ""
 			output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
@@ -194,6 +202,10 @@ var _ = Describe("odo devfile watch command tests", func() {
 				StringsToBeMatched: []string{"Executing devbuild command", "Executing devrun command"},
 			}
 			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, commonVar.Project, commonVar.Context, watchFlag, commonVar.CliRunner, "kube")
+
+			// check that the --debug-command fails when the component is not pushed using debug mode
+			output = helper.CmdShouldFailWithRetry(1, 1, "odo", "watch", "--context", commonVar.Context, "--debug-command", "debug")
+			Expect(output).To(ContainSubstring("please start the component in debug mode"))
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does does this PR do / why we need it**:

It takes the custom debug command from the CLI while trigerring odo watch.

**Which issue(s) this PR fixes**:

Fixes #4357 

**PR acceptance criteria**:

- [X] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- `odo watch --debug-command <custom debug command>` should work.