### PR TITLE
Keeping the current active project/namespace when re-logging in

### DIFF
--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -58,6 +58,15 @@ func Login(server, username, password, token, caAuth string, skipTLS bool) error
 		}
 	}
 
+	// if defaultNamespace is not defined, we will look for current namespace from kubeconfig file if defined
+	if len(a.DefaultNamespace) == 0 {
+		if defaultContext, defaultContextExists := a.StartingKubeConfig.Contexts[a.StartingKubeConfig.CurrentContext]; defaultContextExists {
+			if len(defaultContext.Namespace) > 0 {
+				a.DefaultNamespace = defaultContext.Namespace
+			}
+		}
+	}
+
 	// 1. Say we're connecting
 	odolog.Info("Connecting to the OpenShift cluster\n")
 


### PR DESCRIPTION
/kind bug

**What does does this PR do / why we need it**:

The command `odo login` overwrites the current active project/namespace even if a current context is already defined.

**Which issue(s) this PR fixes**:

https://github.com/openshift/odo/issues/4387

**PR acceptance criteria**:

- [X] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

To reproduce the bug:

`odo login`
`odo project create my-project`
`odo project get` --> result: 'my-project'
`odo login`
`odo project get` --> result should be 'my-project'