### PR TITLE
adding project resource check before warning about default project usage

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -547,11 +547,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		projectSupported, err := co.Client.IsProjectSupported()
 
 		if err != nil {
-			return errors.Wrap(err, "Resource project validation check failed.")
+			return errors.Wrap(err, "resource project validation check failed.")
 		}
 
 		if projectSupported && componentNamespace == "default" {
-			return errors.New("odo may not work as expected in a default project, please run the odo component in a non-default project")
+			return errors.New("odo may not work as expected in the default project, please run the odo component in a non-default project")
 		}
 
 		// Set devfileMetadata struct

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -543,8 +543,16 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			}
 		}
 
-		if componentNamespace == "default" {
-			log.Warning("odo may not work as expected in a default project, please run the odo component in a non-default project. To create a new project, use `odo project create`.")
+		// Check whether resource "Project" is supported
+		projectSupported, err := co.Client.IsProjectSupported()
+
+		if err != nil {
+			// we don't need to return (fail) if this happens
+			log.Warning("Project resource supportability check failed.")
+		}
+
+		if projectSupported && componentNamespace == "default" {
+			return errors.New("odo may not work as expected in a default project, please run the odo component in a non-default project")
 		}
 
 		// Set devfileMetadata struct

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -547,8 +547,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		projectSupported, err := co.Client.IsProjectSupported()
 
 		if err != nil {
-			// we don't need to return (fail) if this happens
-			log.Warning("Project resource supportability check failed.")
+			return errors.Wrap(err, "Resource project validation check failed.")
 		}
 
 		if projectSupported && componentNamespace == "default" {

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -54,7 +54,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.CmdShouldPass("odo", "create", "java-openliberty", "--project", componentNamespace)
 		})
 
-		It("should fail tocreate the devfile component if --project value is 'default'", func() {
+		It("should fail to create the devfile component if --project value is 'default'", func() {
 			output := helper.CmdShouldFail("odo", "create", "java", "--project", "default")
 			expectedString := "odo may not work as expected in the default project, please run the odo component in a non-default project"
 			helper.MatchAllInOutput(output, []string{expectedString})

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -53,6 +53,13 @@ var _ = Describe("odo devfile create command tests", func() {
 			componentNamespace := helper.RandString(6)
 			helper.CmdShouldPass("odo", "create", "java-openliberty", "--project", componentNamespace)
 		})
+
+		It("should fail tocreate the devfile component if --project value is 'default'", func() {
+			output := helper.CmdShouldFail("odo", "create", "java", "--project", "default")
+			expectedString := "odo may not work as expected in the default project, please run the odo component in a non-default project"
+			helper.MatchAllInOutput(output, []string{expectedString})
+		})
+
 	})
 
 	Context("When executing odo create with devfile component type argument and --registry flag", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
Adding condition to check if `project` is a supported resource during `odo create` command, if so, check non-default project is being used. 

**Which issue(s) this PR fixes**:

Fixes #4309

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`odo create` should only error (and exit) with _odo may not work as expected[...]_ when using the default project in an Openshift cluster.
