### PR TITLE
refactor PushOptions.GetComponentContext method to a utils func

### DIFF
--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -53,7 +53,7 @@ func NewCommonPushOptions() *CommonPushOptions {
 //InitConfigFromContext initializes localconfiginfo from the context
 func (cpo *CommonPushOptions) InitConfigFromContext() error {
 	var err error
-	cpo.LocalConfigInfo, err = config.NewLocalConfigInfo(cpo.componentContext)
+	cpo.LocalConfigInfo, err = config.NewLocalConfigInfo(cpo.ComponentContext)
 	if err != nil {
 		return err
 	}
@@ -62,16 +62,16 @@ func (cpo *CommonPushOptions) InitConfigFromContext() error {
 
 //InitEnvInfoFromContext initializes envinfo from the context
 func (cpo *CommonPushOptions) InitEnvInfoFromContext() (err error) {
-	cpo.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(cpo.componentContext)
+	cpo.EnvSpecificInfo, err = envinfo.NewEnvSpecificInfo(cpo.ComponentContext)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-//AddContextFlag adds the context flag to specified command storing value of flag in options.componentContext
+//AddContextFlag adds the context flag to specified command storing value of flag in options.ComponentContext
 func (cpo *CommonPushOptions) AddContextFlag(cmd *cobra.Command) {
-	genericclioptions.AddContextFlag(cmd, &cpo.componentContext)
+	genericclioptions.AddContextFlag(cmd, &cpo.ComponentContext)
 }
 
 // ResolveSrcAndConfigFlags sets all pushes if none is asked
@@ -93,7 +93,7 @@ func (cpo *CommonPushOptions) ValidateComponentCreate() error {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", cpo.LocalConfigInfo.GetName(), cpo.LocalConfigInfo.GetApplication())
 	}
 
-	if err = component.ValidateComponentCreateRequest(cpo.Context.Client, cpo.LocalConfigInfo.GetComponentSettings(), cpo.componentContext); err != nil {
+	if err = component.ValidateComponentCreateRequest(cpo.Context.Client, cpo.LocalConfigInfo.GetComponentSettings(), cpo.ComponentContext); err != nil {
 		s.End(false)
 		log.Italic("\nRun 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *cpo.LocalConfigInfo.GetComponentSettings().Type, errors.Cause(err))
@@ -118,7 +118,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 	if !cpo.doesComponentExist {
 
 		// Classic case of component creation
-		if err := component.CreateComponent(cpo.Context.Client, *cpo.LocalConfigInfo, cpo.componentContext, stdout); err != nil {
+		if err := component.CreateComponent(cpo.Context.Client, *cpo.LocalConfigInfo, cpo.ComponentContext, stdout); err != nil {
 			log.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %v",
 				cmpName,
@@ -191,8 +191,8 @@ func (cpo *CommonPushOptions) Push() (err error) {
 	// force write the content to resolvePath
 	forceWrite := false
 
-	if cpo.componentContext == "" {
-		cpo.componentContext = strings.TrimSuffix(filepath.Dir(cpo.LocalConfigInfo.Filename), ".odo")
+	if cpo.ComponentContext == "" {
+		cpo.ComponentContext = strings.TrimSuffix(filepath.Dir(cpo.LocalConfigInfo.Filename), ".odo")
 	}
 
 	err = cpo.createCmpIfNotExistsAndApplyCmpConfig(stdout)
@@ -221,7 +221,7 @@ func (cpo *CommonPushOptions) Push() (err error) {
 		}
 
 		// run the indexer and find the modified/added/deleted/renamed files
-		ret, err = util.RunIndexer(cpo.componentContext, absIgnoreRules)
+		ret, err = util.RunIndexer(cpo.ComponentContext, absIgnoreRules)
 		spinner.End(true)
 
 		if err != nil {

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -31,7 +31,7 @@ type CommonPushOptions struct {
 
 	sourceType       config.SrcType
 	sourcePath       string
-	componentContext string
+	ComponentContext string
 
 	EnvSpecificInfo *envinfo.EnvSpecificInfo
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -358,7 +358,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 		DevfilePath = filepath.Join(co.componentContext, devFile)
 		EnvFilePath = filepath.Join(co.componentContext, envFile)
 		ConfigFilePath = filepath.Join(co.componentContext, configFile)
-		co.PushOptions.componentContext = co.componentContext
+		co.PushOptions.ComponentContext = co.componentContext
 	}
 	co.DevfilePath = DevfilePath
 

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -94,7 +94,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	componentName := po.EnvSpecificInfo.GetName()
 
 	// Set the source path to either the context or current working directory (if context not set)
-	po.sourcePath, err = util.GetAbsPath(po.componentContext)
+	po.sourcePath, err = util.GetAbsPath(po.ComponentContext)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source path")
 	}
@@ -115,7 +115,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 		platformContext = kc
 	}
 
-	devfileHandler, err := adapters.NewComponentAdapter(componentName, po.componentContext, po.Application, devObj, platformContext)
+	devfileHandler, err := adapters.NewComponentAdapter(componentName, po.ComponentContext, po.Application, devObj, platformContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -80,11 +80,6 @@ func (po *PushOptions) CompleteDevfilePath() {
 	}
 }
 
-// GetComponentContext gets the component context
-func (po *PushOptions) GetComponentContext() string {
-	return po.componentContext
-}
-
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.CompleteDevfilePath()

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -74,9 +74,9 @@ func NewPushOptions() *PushOptions {
 // CompleteDevfilePath completes the devfile path from context
 func (po *PushOptions) CompleteDevfilePath() {
 	if len(po.DevfilePath) > 0 {
-		po.DevfilePath = filepath.Join(po.componentContext, po.DevfilePath)
+		po.DevfilePath = filepath.Join(po.ComponentContext, po.DevfilePath)
 	} else {
-		po.DevfilePath = filepath.Join(po.componentContext, "devfile.yaml")
+		po.DevfilePath = filepath.Join(po.ComponentContext, "devfile.yaml")
 	}
 }
 
@@ -97,7 +97,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		}
 
 		// We retrieve the configuration information. If this does not exist, then BLANK is returned (important!).
-		envFileInfo, err := envinfo.NewEnvSpecificInfo(po.componentContext)
+		envFileInfo, err := envinfo.NewEnvSpecificInfo(po.ComponentContext)
 		if err != nil {
 			return errors.Wrap(err, "unable to retrieve configuration information")
 		}
@@ -195,7 +195,7 @@ func (po *PushOptions) Validate() (err error) {
 		return errors.Wrapf(err, "failed to check if component of name %s exists in application %s", po.LocalConfigInfo.GetName(), po.LocalConfigInfo.GetApplication())
 	}
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), po.componentContext); err != nil {
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.LocalConfigInfo.GetComponentSettings(), po.ComponentContext); err != nil {
 		s.End(false)
 		log.Italic("\nRun 'odo catalog list components' for a list of supported component types")
 		return fmt.Errorf("Invalid component type %s, %v", *po.LocalConfigInfo.GetComponentSettings().Type, errors.Cause(err))
@@ -243,7 +243,7 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 		},
 	}
 
-	genericclioptions.AddContextFlag(pushCmd, &po.componentContext)
+	genericclioptions.AddContextFlag(pushCmd, &po.ComponentContext)
 	pushCmd.Flags().BoolVar(&po.show, "show-log", false, "If enabled, logs will be shown when built")
 	pushCmd.Flags().StringSliceVar(&po.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
 	pushCmd.Flags().BoolVar(&po.pushConfig, "config", false, "Use config flag to only apply config on to cluster")

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -75,7 +75,7 @@ func NewUpdateOptions() *UpdateOptions {
 
 // Complete completes update args
 func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	uo.devfilePath = filepath.Join(uo.componentContext, DevfilePath)
+	uo.devfilePath = filepath.Join(uo.ComponentContext, DevfilePath)
 
 	if util.CheckPathExists(uo.devfilePath) {
 		// Configure the devfile context
@@ -83,7 +83,7 @@ func (uo *UpdateOptions) Complete(name string, cmd *cobra.Command, args []string
 		return
 	}
 	uo.Context = genericclioptions.NewContext(cmd)
-	uo.LocalConfigInfo, err = config.NewLocalConfigInfo(uo.componentContext)
+	uo.LocalConfigInfo, err = config.NewLocalConfigInfo(uo.ComponentContext)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update component")
 	}
@@ -133,14 +133,14 @@ func (uo *UpdateOptions) Validate() (err error) {
 		}
 	}
 
-	if len(uo.componentContext) == 0 {
+	if len(uo.ComponentContext) == 0 {
 		dir, err := os.Getwd()
 		if err != nil {
 			return errors.Wrapf(err, "failed to update component %s", uo.LocalConfigInfo.GetName())
 		}
-		uo.componentContext = dir
+		uo.ComponentContext = dir
 	}
-	fileInfo, err := os.Stat(uo.componentContext)
+	fileInfo, err := os.Stat(uo.ComponentContext)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func NewCmdUpdate(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(uo, cmd, args)
 		},
 	}
-	genericclioptions.AddContextFlag(updateCmd, &uo.componentContext)
+	genericclioptions.AddContextFlag(updateCmd, &uo.ComponentContext)
 	updateCmd.Flags().BoolVar(&uo.show, "show-log", false, "If enabled, logs will be shown when built")
 	updateCmd.Flags().StringVarP(&uo.git, "git", "g", "", "git source")
 	updateCmd.Flags().StringVarP(&uo.local, "local", "l", "", "Use local directory as a source for component.")

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/odo/pkg/localConfigProvider"
 	"github.com/openshift/odo/pkg/log"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
+	"github.com/openshift/odo/pkg/odo/cli/utils"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/pkg/errors"
@@ -79,7 +80,7 @@ func (o *CreateOptions) Complete(_ string, cmd *cobra.Command, args []string) (e
 	o.Context, err = genericclioptions.New(genericclioptions.CreateParameters{
 		Cmd:              cmd,
 		DevfilePath:      o.DevfilePath,
-		ComponentContext: o.GetComponentContext(),
+		ComponentContext: utils.GetComponentContext(o.PushOptions),
 		IsNow:            o.now,
 	})
 

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -6,10 +6,12 @@ import (
 	"github.com/openshift/odo/pkg/log"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
+	"github.com/openshift/odo/pkg/odo/cli/utils"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -41,7 +43,7 @@ func (o *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string)
 	o.Context, err = genericclioptions.New(genericclioptions.CreateParameters{
 		Cmd:              cmd,
 		DevfilePath:      o.DevfilePath,
-		ComponentContext: o.GetComponentContext(),
+		ComponentContext: utils.GetComponentContext(o.PushOptions),
 	})
 
 	o.urlName = args[0]

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -5,6 +5,8 @@ import (
 
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 
+	"github.com/openshift/odo/pkg/odo/cli/component"
+
 	"github.com/spf13/cobra"
 )
 
@@ -28,4 +30,9 @@ func NewCmdUtils(name, fullName string) *cobra.Command {
 	utilsCmd.AddCommand(terminalCmd)
 	utilsCmd.AddCommand(convertCmd)
 	return utilsCmd
+}
+
+// GetComponentContext gets the component context
+func GetComponentContext(po *component.PushOptions) string {
+	return po.ComponentContext
 }

--- a/pkg/odo/cli/utils/utils.go
+++ b/pkg/odo/cli/utils/utils.go
@@ -6,7 +6,6 @@ import (
 	odoutil "github.com/openshift/odo/pkg/odo/util"
 
 	"github.com/openshift/odo/pkg/odo/cli/component"
-
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

 /kind code-refactoring

**What does does this PR do / why we need it**:
Moved `GetComponentContext()` from a `PushOptions` method:
 
https://github.com/openshift/odo/blob/88fb37203d0c4782bef09d37187f883327967e89/pkg/odo/cli/component/push.go#L83-L86

To the `cli.utils` package so it can be used in other CLI packages as well:

```go
// GetComponentContext gets the component context
func GetComponentContext(po *component.PushOptions) string {
	return po.ComponentContext
}
```

**Which issue(s) this PR fixes**:

Fixes #4340 

**PR acceptance criteria**:

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
