### PR TITLE
 Disable preStart event using validations

### DIFF
--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -44,5 +44,5 @@ type UnsupportedFieldError struct {
 }
 
 func (e *UnsupportedFieldError) Error() string {
-	return fmt.Sprintf("%s is not supported in odo", e.fieldName)
+	return fmt.Sprintf("%q is not supported in odo", e.fieldName)
 }

--- a/pkg/devfile/validate/errors.go
+++ b/pkg/devfile/validate/errors.go
@@ -38,3 +38,11 @@ type CompositeRunKindError struct {
 func (e *CompositeRunKindError) Error() string {
 	return "composite commands of run kind are not supported currently"
 }
+
+type UnsupportedFieldError struct {
+	fieldName string
+}
+
+func (e *UnsupportedFieldError) Error() string {
+	return fmt.Sprintf("%s is not supported in odo", e.fieldName)
+}

--- a/pkg/devfile/validate/events.go
+++ b/pkg/devfile/validate/events.go
@@ -1,0 +1,23 @@
+package validate
+
+import "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+
+func validatePreStart(preStart []string) (err error) {
+	// This is odo specific validation. There is still discussion about how PreStart should be implemented.
+	// https://github.com/devfile/api/issues/204
+	// https://github.com/openshift/odo/issues/4187
+	// This is here to prevent anyone from using PreStart event until we have a proper implementation
+	if len(preStart) != 0 {
+		return &UnsupportedFieldError{fieldName: "preStart"}
+	}
+	return nil
+}
+
+func validateEvents(events v1alpha2.Events) (err error) {
+
+	if err := validatePreStart(events.PreStart); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/devfile/validate/events_test.go
+++ b/pkg/devfile/validate/events_test.go
@@ -1,0 +1,42 @@
+package validate
+
+import (
+	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"testing"
+)
+
+func Test_validateEvents(t *testing.T) {
+
+	var tests = []struct {
+		name    string
+		events  v1alpha2.Events
+		wantErr bool
+	}{
+		{
+			name: "just postStart event present",
+			events: v1alpha2.Events{
+				WorkspaceEvents: v1alpha2.WorkspaceEvents{
+					PostStart: []string{"asdf"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "preStart event present",
+			events: v1alpha2.Events{
+				WorkspaceEvents: v1alpha2.WorkspaceEvents{
+					PostStart: []string{"asdf"},
+					PreStart:  []string{"asdf"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateEvents(tt.events); (err != nil) != tt.wantErr {
+				t.Errorf("validateEvents() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/devfile/validate/validate.go
+++ b/pkg/devfile/validate/validate.go
@@ -15,6 +15,7 @@ import (
 func ValidateDevfileData(data interface{}) error {
 	var components []devfilev1.Component
 	var commandsMap map[string]devfilev1.Command
+	var events devfilev1.Events
 
 	// Validate the generic devfile data before validating odo specific logic
 	if err := generic.ValidateDevfileData(data); err != nil {
@@ -25,6 +26,7 @@ func ValidateDevfileData(data interface{}) error {
 	case *v2.DevfileV2:
 		components = d.GetComponents()
 		commandsMap = d.GetCommands()
+		events = d.GetEvents()
 
 		// Validate all the devfile components before validating commands
 		if err := validateComponents(components); err != nil {
@@ -33,6 +35,10 @@ func ValidateDevfileData(data interface{}) error {
 
 		// Validate all the devfile commands before validating events
 		if err := validateCommands(commandsMap); err != nil {
+			return err
+		}
+
+		if err := validateEvents(events); err != nil {
 			return err
 		}
 	default:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-preStart.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-preStart.yaml
@@ -112,6 +112,9 @@ commands:
       group:
         kind: run
 events:
+  preStart:
+    - "myPreStart" 
+    - "preStartComp"
   postStart:
     - "myPostStart" 
     - "secondpoststart"

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -368,7 +368,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-preStart.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			output := helper.CmdShouldFail("odo", "push", "--project", commonVar.Project)
 			// This is expected to fail for now.

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -363,61 +363,67 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 
 		It("should execute PreStart commands if present during pod startup", func() {
-			expectedInitContainers := []string{"tools-myprestart-1", "tools-myprestart-2", "runtime-secondprestart-3"}
+			// expectedInitContainers := []string{"tools-myprestart-1", "tools-myprestart-2", "runtime-secondprestart-3"}
 
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
-			helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
+			output := helper.CmdShouldFail("odo", "push", "--project", commonVar.Project)
+			// This is expected to fail for now.
+			// see https://github.com/openshift/odo/issues/4187 for more info
+			helper.MatchAllInOutput(output, []string{"\"preStart\" is not supported in odo"})
 
-			firstPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+			/*
+				helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
 
-			firstPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
-			// 3 preStart events + 1 supervisord init containers
-			Expect(len(firstPushInitContainers)).To(Equal(4))
-			helper.MatchAllInOutput(strings.Join(firstPushInitContainers, ","), expectedInitContainers)
+				firstPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 
-			// Need to force so build and run get triggered again with the component already created.
-			output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-f")
-			helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
+				firstPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
+				// 3 preStart events + 1 supervisord init containers
+				Expect(len(firstPushInitContainers)).To(Equal(4))
+				helper.MatchAllInOutput(strings.Join(firstPushInitContainers, ","), expectedInitContainers)
 
-			secondPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				// Need to force so build and run get triggered again with the component already created.
+				output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-f")
+				helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
 
-			secondPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
-			// 3 preStart events + 1 supervisord init containers
-			Expect(len(secondPushInitContainers)).To(Equal(4))
-			helper.MatchAllInOutput(strings.Join(secondPushInitContainers, ","), expectedInitContainers)
+				secondPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 
-			Expect(firstPushPodName).To(Equal(secondPushPodName))
-			Expect(firstPushInitContainers).To(Equal(secondPushInitContainers))
+				secondPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
+				// 3 preStart events + 1 supervisord init containers
+				Expect(len(secondPushInitContainers)).To(Equal(4))
+				helper.MatchAllInOutput(strings.Join(secondPushInitContainers, ","), expectedInitContainers)
 
-			var statErr error
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				firstPushPodName,
-				"runtime",
-				commonVar.Project,
-				[]string{"cat", "/projects/test.txt"},
-				func(cmdOp string, err error) bool {
-					if err != nil {
-						statErr = err
-					} else if cmdOp == "" {
-						statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got empty string")
-					} else {
-						fileContents := strings.Split(cmdOp, "\n")
-						if len(fileContents)-1 != 3 {
-							statErr = fmt.Errorf("prestart event action count error, expected: 3 strings, got %d strings: %s", len(fileContents), strings.Join(fileContents, ","))
-						} else if cmdOp != "hello test2\nhello test2\nhello test\n" {
-							statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got: %s", cmdOp)
+				Expect(firstPushPodName).To(Equal(secondPushPodName))
+				Expect(firstPushInitContainers).To(Equal(secondPushInitContainers))
+
+				var statErr error
+				commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+					firstPushPodName,
+					"runtime",
+					commonVar.Project,
+					[]string{"cat", "/projects/test.txt"},
+					func(cmdOp string, err error) bool {
+						if err != nil {
+							statErr = err
+						} else if cmdOp == "" {
+							statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got empty string")
+						} else {
+							fileContents := strings.Split(cmdOp, "\n")
+							if len(fileContents)-1 != 3 {
+								statErr = fmt.Errorf("prestart event action count error, expected: 3 strings, got %d strings: %s", len(fileContents), strings.Join(fileContents, ","))
+							} else if cmdOp != "hello test2\nhello test2\nhello test\n" {
+								statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got: %s", cmdOp)
+							}
 						}
-					}
 
-					return true
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
+						return true
+					},
+				)
+				Expect(statErr).ToNot(HaveOccurred())
+			*/
 		})
 
 		It("should execute PostStart commands if present and not execute when component already exists", func() {


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug


**What does does this PR do / why we need it**:

preStart even is still not clearly defined in Devfile and it is clear how it should be defined. This will make sure that no one is using PreStart event until we have a proper implementation.


**Which issue(s) this PR fixes**:

Fixes #4187

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Create a devfile with the preStart event command

```
events:
  preStart:
     - some-command
``` 
