### PR TITLE
Make starter project download work with custom context directory

### DIFF
--- a/pkg/component/starter_project.go
+++ b/pkg/component/starter_project.go
@@ -72,12 +72,17 @@ func GetStarterProject(projects []devfilev1.StarterProject, projectPassed string
 }
 
 // DownloadStarterProject Downloads first starter project from list of starter projects in devfile
-func DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string) error {
-
+func DownloadStarterProject(starterProject *devfilev1.StarterProject, decryptedToken string, contextDir string) error {
+	var path string
+	var err error
 	// Retrieve the working directory in order to clone correctly
-	path, err := os.Getwd()
-	if err != nil {
-		return errors.Wrapf(err, "Could not get the current working directory.")
+	if contextDir == "" {
+		path, err = os.Getwd()
+		if err != nil {
+			return errors.Wrapf(err, "Could not get the current working directory.")
+		}
+	} else {
+		path = contextDir
 	}
 
 	// We will check to see if the project has a valid directory

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -852,7 +852,7 @@ func (co *CreateOptions) devfileRun() (err error) {
 		co.devfileMetadata.starterToken = token
 	}
 
-	err = decideAndDownloadStarterProject(devObj, co.devfileMetadata.starter, co.devfileMetadata.starterToken, co.interactive)
+	err = decideAndDownloadStarterProject(devObj, co.devfileMetadata.starter, co.devfileMetadata.starterToken, co.interactive, co.componentContext)
 	if err != nil {
 		return errors.Wrap(err, "failed to download project for devfile component")
 	}

--- a/pkg/odo/cli/component/create_helpers.go
+++ b/pkg/odo/cli/component/create_helpers.go
@@ -40,7 +40,7 @@ func (co *CreateOptions) SetComponentSettings(args []string) error {
 
 // decideAndDownloadStarterProject decides the starter project from the value passed by the user and
 // downloads it
-func decideAndDownloadStarterProject(devObj parser.DevfileObj, projectPassed string, token string, interactive bool) error {
+func decideAndDownloadStarterProject(devObj parser.DevfileObj, projectPassed string, token string, interactive bool, contextDir string) error {
 	if projectPassed == "" && !interactive {
 		return nil
 	}
@@ -63,5 +63,5 @@ func decideAndDownloadStarterProject(devObj parser.DevfileObj, projectPassed str
 		return nil
 	}
 
-	return component.DownloadStarterProject(starterProject, token)
+	return component.DownloadStarterProject(starterProject, token, contextDir)
 }

--- a/tests/helper/helper_filesystem.go
+++ b/tests/helper/helper_filesystem.go
@@ -111,7 +111,7 @@ func Getwd() string {
 	return dir
 }
 
-// CopyExample copies an example from tests/e2e/examples/<exampleName> into targetDir
+// CopyExample copies an example from tests/examples/<binaryOrSource>/<componentName>/<exampleName> into targetDir
 func CopyExample(exampleName string, targetDir string) {
 	// filename of this file
 	_, filename, _, _ := runtime.Caller(0)
@@ -126,7 +126,8 @@ func CopyExample(exampleName string, targetDir string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-// CopyExampleDevFile copies an example devfile from tests/e2e/examples/<exampleName>/devfile.yaml into targetDst
+// CopyExampleDevFile copies an example devfile from tests/examples/source/devfiles/<componentName>/devfile.yaml
+// into targetDst
 func CopyExampleDevFile(devfilePath, targetDst string) {
 	// filename of this file
 	_, filename, _, _ := runtime.Caller(0)

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -76,18 +76,31 @@ var _ = Describe("odo devfile create command tests", func() {
 	})
 
 	Context("When executing odo create with devfile component type argument and --context flag", func() {
-		It("should successfully create the devfile component in the context", func() {
-			newContext := path.Join(commonVar.Context, "newContext")
+		var newContext, envFilePath string
+		JustBeforeEach(func() {
+			newContext = path.Join(commonVar.Context, "newContext")
 			devfilePath = filepath.Join(newContext, devfile)
-			envFilePath := filepath.Join(newContext, envFile)
 			helper.MakeDir(newContext)
+		})
 
+		JustAfterEach(func() {
+			helper.DeleteDir(newContext)
+		})
+
+		It("should successfully create the devfile component in the context", func() {
+			envFilePath = filepath.Join(newContext, envFile)
 			helper.CmdShouldPass("odo", "create", "java-openliberty", "--context", newContext)
 			output := util.CheckPathExists(devfilePath)
 			Expect(output).Should(BeTrue())
 			output = util.CheckPathExists(envFilePath)
 			Expect(output).Should(BeTrue())
-			helper.DeleteDir(newContext)
+		})
+
+		It("should successfully create the devfile component and download the source when used with --starter flag", func() {
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(devfilePath))
+			helper.CmdShouldPass("odo", "create", "nodejs", "--starter", "--context", newContext)
+			expectedFiles := []string{"package.json", "package-lock.json", "README.md", devfile}
+			Expect(helper.VerifyFilesExist(newContext, expectedFiles)).To(Equal(true))
 		})
 	})
 

--- a/tests/template/template_cleantest_test.go
+++ b/tests/template/template_cleantest_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/odo/tests/helper"
 )
 
-// following command will tests in Describe section below in parallel (in 2 nodes)
+// following command will run tests in Describe section below in parallel (in 2 nodes)
 // ginkgo -nodes=2 -focus="Example of a clean test" slowSpecThreshold=120 -randomizeAllSpecs  tests/e2e/
 var _ = Describe("Example of a clean test", func() {
 	// new clean project and context for each test


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does does this PR do / why we need it**:
`odo create <component_name>  --starter --context <empty_context_dir>`
This PR fixes the failure caused when running the above command. There was no case covering a scenario where a starter project needs to be downloaded for a custom context directory, now there is.

Output - 
```
odo create nodejs --starter --context sub_dir
 ⚠  odo may not work as expected in a default project, please run the odo component in a non-default project. To create a new project, use `odo project create`.
Devfile Object Validation
 ✓  Checking devfile existence [24643ns]
 ✓  Creating a devfile component from registry: DefaultDevfileRegistry [19872ns]
Validation
 ✓  Validating if devfile name is correct [82590ns]

Starter Project
 ✓  Downloading starter project nodejs-starter from https://github.com/odo-devfiles/nodejs-ex.git [1s]

Please use `odo push` command to create the component with source deployed

```

**Which issue(s) this PR fixes**:
Fixes #4370

**PR acceptance criteria**:

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
