### PR TITLE
Fixes no default build command error.

### DIFF
--- a/pkg/devfile/adapters/common/command.go
+++ b/pkg/devfile/adapters/common/command.go
@@ -8,6 +8,7 @@ import (
 	devfilev1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
+	"github.com/openshift/odo/pkg/log"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
@@ -69,6 +70,18 @@ func getCommandFromDevfile(data data.DevfileData, groupType devfilev1.CommandGro
 	// since we know the command kind from the push flags
 	err = validateCommandsForGroup(data, groupType)
 	if err != nil {
+		if groupType == devfilev1.BuildCommandGroupKind || groupType == devfilev1.DebugCommandGroupKind {
+			if _, ok := err.(NoDefaultForGroup); ok {
+				log.Warning(err.Error())
+				return devfilev1.Command{}, nil
+			}
+
+			if _, ok := err.(NoCommandForGroup); ok {
+				klog.V(2).Info(err.Error())
+				return devfilev1.Command{}, nil
+			}
+		}
+
 		return devfilev1.Command{}, err
 	}
 
@@ -90,12 +103,12 @@ func getCommandFromDevfile(data data.DevfileData, groupType devfilev1.CommandGro
 		return onlyCommand, nil
 	}
 
-	msg := fmt.Sprintf("the command group of kind \"%v\" is not found in the devfile", groupType)
+	notFoundError := NoCommandForGroup{Group: groupType}
 	// if run command or test command is not found in devfile then it is an error
 	if groupType == devfilev1.RunCommandGroupKind || groupType == devfilev1.TestCommandGroupKind {
-		err = fmt.Errorf(msg)
+		err = notFoundError
 	} else {
-		klog.V(2).Info(msg)
+		klog.V(2).Info(notFoundError)
 	}
 
 	return
@@ -139,6 +152,10 @@ func validateCommandsForGroup(data data.DevfileData, groupType devfilev1.Command
 
 	commands := getCommandsByGroup(data, groupType)
 
+	if len(commands) == 0 {
+		return NoCommandForGroup{Group: groupType}
+	}
+
 	defaultCommandCount := 0
 
 	if len(commands) > 1 {
@@ -163,44 +180,22 @@ func validateCommandsForGroup(data data.DevfileData, groupType devfilev1.Command
 
 // GetBuildCommand iterates through the components in the devfile and returns the build command
 func GetBuildCommand(data data.DevfileData, devfileBuildCmd string) (buildCommand devfilev1.Command, err error) {
-	supportedCommand, err := getCommand(data, devfileBuildCmd, devfilev1.BuildCommandGroupKind)
-	// since build command is not necessary
-	// check if we can ignore it
-	if _, ok := err.(NoDefaultForGroup); ok {
-		return devfilev1.Command{}, nil
-	}
-
-	return supportedCommand, err
+	return getCommand(data, devfileBuildCmd, devfilev1.BuildCommandGroupKind)
 }
 
 // GetDebugCommand iterates through the components in the devfile and returns the debug command
 func GetDebugCommand(data data.DevfileData, devfileDebugCmd string) (debugCommand devfilev1.Command, err error) {
-	supportedCommand, err := getCommand(data, devfileDebugCmd, devfilev1.DebugCommandGroupKind)
-	// since debug command is not necessary
-	// check if we can ignore it
-	if _, ok := err.(NoDefaultForGroup); ok {
-		return devfilev1.Command{}, nil
-	}
-
-	return supportedCommand, err
+	return getCommand(data, devfileDebugCmd, devfilev1.DebugCommandGroupKind)
 }
 
 // GetRunCommand iterates through the components in the devfile and returns the run command
 func GetRunCommand(data data.DevfileData, devfileRunCmd string) (runCommand devfilev1.Command, err error) {
-
 	return getCommand(data, devfileRunCmd, devfilev1.RunCommandGroupKind)
 }
 
 // GetTestCommand iterates through the components in the devfile and returns the test command
 func GetTestCommand(data data.DevfileData, devfileTestCmd string) (runCommand devfilev1.Command, err error) {
-	supportedCommand, err := getCommand(data, devfileTestCmd, devfilev1.TestCommandGroupKind)
-	// since test command is not necessary
-	// check if we can ignore it
-	if _, ok := err.(NoDefaultForGroup); ok {
-		return devfilev1.Command{}, nil
-	}
-
-	return supportedCommand, err
+	return getCommand(data, devfileTestCmd, devfilev1.TestCommandGroupKind)
 }
 
 // ValidateAndGetPushDevfileCommands validates the build and the run command,

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -7,6 +7,7 @@ import (
 
 	devfilev1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
+	"github.com/kylelemons/godebug/pretty"
 	"github.com/openshift/odo/pkg/testingutil"
 	"github.com/openshift/odo/pkg/util"
 )
@@ -977,6 +978,12 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			groupType: buildGroup,
 			wantErr:   false,
 		},
+		{
+			name:         "Case 6: No build command found",
+			execCommands: []devfilev1.Command{},
+			groupType:    buildGroup,
+			wantErr:      true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1011,6 +1018,7 @@ func TestGetBuildCommand(t *testing.T) {
 		name         string
 		commandName  string
 		execCommands []devfilev1.Command
+		wantCommand  devfilev1.Command
 		wantErr      bool
 	}{
 		{
@@ -1029,6 +1037,20 @@ func TestGetBuildCommand(t *testing.T) {
 							Component:   component,
 							WorkingDir:  workDir,
 						},
+					},
+				},
+			},
+			wantCommand: devfilev1.Command{
+				CommandUnion: devfilev1.CommandUnion{
+					Exec: &devfilev1.ExecCommand{
+						LabeledCommand: devfilev1.LabeledCommand{
+							BaseCommand: devfilev1.BaseCommand{
+								Group: &devfilev1.CommandGroup{Kind: buildGroup, IsDefault: true},
+							},
+						},
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
 					},
 				},
 			},
@@ -1069,10 +1091,25 @@ func TestGetBuildCommand(t *testing.T) {
 					},
 				},
 			},
+			wantCommand: devfilev1.Command{
+				Id: "flagcommand",
+				CommandUnion: devfilev1.CommandUnion{
+					Exec: &devfilev1.ExecCommand{
+						LabeledCommand: devfilev1.LabeledCommand{
+							BaseCommand: devfilev1.BaseCommand{
+								Group: &devfilev1.CommandGroup{Kind: buildGroup},
+							},
+						},
+						CommandLine: command,
+						Component:   component,
+						WorkingDir:  workDir,
+					},
+				},
+			},
 			wantErr: false,
 		},
 		{
-			name:        "Case 3: Missing Build Command",
+			name:        "Case 3: Build Command not found",
 			commandName: "customcommand123",
 			execCommands: []devfilev1.Command{
 				{
@@ -1093,6 +1130,28 @@ func TestGetBuildCommand(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Case 4: No build command",
+			execCommands: []devfilev1.Command{
+				{
+					Id: "run command",
+					CommandUnion: devfilev1.CommandUnion{
+						Exec: &devfilev1.ExecCommand{
+							LabeledCommand: devfilev1.LabeledCommand{
+								BaseCommand: devfilev1.BaseCommand{
+									Group: &devfilev1.CommandGroup{Kind: runGroup},
+								},
+							},
+							CommandLine: command,
+							Component:   component,
+							WorkingDir:  workDir,
+						},
+					},
+				},
+			},
+			wantCommand: emptyCommand,
+			wantErr:     false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1108,8 +1167,8 @@ func TestGetBuildCommand(t *testing.T) {
 
 			if !tt.wantErr == (err != nil) {
 				t.Errorf("TestGetBuildCommand: unexpected error for command \"%v\" expected: %v actual: %v", tt.commandName, tt.wantErr, err)
-			} else if !tt.wantErr && reflect.DeepEqual(emptyCommand, command) {
-				t.Errorf("TestGetBuildCommand: unexpected empty command returned for command: %v", tt.commandName)
+			} else if !tt.wantErr && !reflect.DeepEqual(tt.wantCommand, command) {
+				t.Errorf("TestGetBuildCommand: unexpected command returned: %v", pretty.Compare(tt.wantCommand, command))
 			}
 
 		})

--- a/pkg/devfile/adapters/common/command_test.go
+++ b/pkg/devfile/adapters/common/command_test.go
@@ -423,6 +423,26 @@ func TestGetCommandFromDevfile(t *testing.T) {
 			requestedType:  []devfilev1.CommandGroupKind{buildGroup},
 			wantErr:        false,
 		},
+		{
+			name: "Case 7: no build and debug commands",
+			execCommands: []devfilev1.Command{
+				getExecCommand("", runGroup),
+			},
+			requestedType: []devfilev1.CommandGroupKind{buildGroup, debugGroup},
+			wantErr:       false,
+		},
+		{
+			name: "Case 8: no default build and debug commands",
+			execCommands: []devfilev1.Command{
+				getExecCommand("build-0", buildGroup),
+				getExecCommand("build-1", buildGroup),
+				getExecCommand("debug-0", debugGroup),
+				getExecCommand("debug-1", debugGroup),
+				getExecCommand("", runGroup),
+			},
+			requestedType: []devfilev1.CommandGroupKind{buildGroup, debugGroup},
+			wantErr:       false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -979,7 +999,7 @@ func TestValidateCommandsForGroup(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:         "Case 6: No build command found",
+			name:         "Case 6: No command found",
 			execCommands: []devfilev1.Command{},
 			groupType:    buildGroup,
 			wantErr:      true,
@@ -1011,8 +1031,6 @@ func TestGetBuildCommand(t *testing.T) {
 	component := "alias1"
 	workDir := "/"
 	emptyString := ""
-
-	var emptyCommand devfilev1.Command
 
 	tests := []struct {
 		name         string
@@ -1129,28 +1147,6 @@ func TestGetBuildCommand(t *testing.T) {
 				},
 			},
 			wantErr: true,
-		},
-		{
-			name: "Case 4: No build command",
-			execCommands: []devfilev1.Command{
-				{
-					Id: "run command",
-					CommandUnion: devfilev1.CommandUnion{
-						Exec: &devfilev1.ExecCommand{
-							LabeledCommand: devfilev1.LabeledCommand{
-								BaseCommand: devfilev1.BaseCommand{
-									Group: &devfilev1.CommandGroup{Kind: runGroup},
-								},
-							},
-							CommandLine: command,
-							Component:   component,
-							WorkingDir:  workDir,
-						},
-					},
-				},
-			},
-			wantCommand: emptyCommand,
-			wantErr:     false,
 		},
 	}
 

--- a/pkg/devfile/adapters/common/errors.go
+++ b/pkg/devfile/adapters/common/errors.go
@@ -23,3 +23,12 @@ type MoreDefaultForGroup struct {
 func (m MoreDefaultForGroup) Error() string {
 	return fmt.Sprintf("there should be exactly one default command for command group %v, currently there is more than one default command", m.Group)
 }
+
+// NoCommandForGroup indicates a error when no command was found for the given Group
+type NoCommandForGroup struct {
+	Group v1alpha2.CommandGroupKind
+}
+
+func (n NoCommandForGroup) Error() string {
+	return fmt.Sprintf("the command group of kind \"%v\" is not found in the devfile", n.Group)
+}

--- a/pkg/devfile/adapters/common/errors.go
+++ b/pkg/devfile/adapters/common/errors.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+)
+
+// NoDefaultForGroup indicates a error when no default command was found for the given Group
+type NoDefaultForGroup struct {
+	Group v1alpha2.CommandGroupKind
+}
+
+func (n NoDefaultForGroup) Error() string {
+	return fmt.Sprintf("there should be exactly one default command for command group %v, currently there is no default command", n.Group)
+}
+
+// MoreDefaultForGroup indicates a error when more than one default command was found for the given Group
+type MoreDefaultForGroup struct {
+	Group v1alpha2.CommandGroupKind
+}
+
+func (m MoreDefaultForGroup) Error() string {
+	return fmt.Sprintf("there should be exactly one default command for command group %v, currently there is more than one default command", m.Group)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

It introduces two error types called NoDefaultForGroup and MoreDefaultForGroup.

**Which issue(s) this PR fixes**:

Fixes #4363 

**PR acceptance criteria**:

- [X] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create a component and remove the `build` kind command from the devfile.
- `odo push` should pass.