### PR TITLE
Modifies odo create for devfile components to not require a cluster access.

### DIFF
--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -140,6 +140,19 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 				return errors.Wrap(err, "failed to create env.yaml for devfile component")
 			}
 
+		} else if envFileInfo.GetNamespace() == "" {
+			// Since the project name doesn't exist in the environment file, we will retrieve a correct namespace from
+			// either cmd commands or the current default kubernetes namespace
+			// and write it to the env.yaml
+			namespace, err := retrieveCmdNamespace(cmd)
+			if err != nil {
+				return errors.Wrap(err, "unable to determine target namespace for devfile")
+			}
+
+			err = envFileInfo.SetConfiguration("project", namespace)
+			if err != nil {
+				return errors.Wrap(err, "failed to write the project to the env.yaml for devfile component")
+			}
 		}
 
 		po.EnvSpecificInfo = envFileInfo

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/occlient"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
@@ -119,6 +120,10 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 				return errors.Wrap(err, "unable to determine target namespace for devfile")
 			}
 
+			if err := checkDefaultProject(genericclioptions.Client(cmd), namespace); err != nil {
+				return err
+			}
+
 			// Retrieve a default name
 			// 1. Use args[0] if the user has supplied a name to be used
 			// 2. If the user did not provide a name, use gatherName to retrieve a name from the devfile.Metadata
@@ -149,9 +154,17 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 				return errors.Wrap(err, "unable to determine target namespace for devfile")
 			}
 
+			if err := checkDefaultProject(genericclioptions.Client(cmd), namespace); err != nil {
+				return err
+			}
+
 			err = envFileInfo.SetConfiguration("project", namespace)
 			if err != nil {
 				return errors.Wrap(err, "failed to write the project to the env.yaml for devfile component")
+			}
+		} else if envFileInfo.GetNamespace() == "default" {
+			if err := checkDefaultProject(genericclioptions.Client(cmd), envFileInfo.GetNamespace()); err != nil {
+				return err
 			}
 		}
 
@@ -282,4 +295,19 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)
 
 	return pushCmd
+}
+
+// checkDefaultProject errors out if the project resource is supported and the value is "default"
+func checkDefaultProject(client *occlient.Client, name string) error {
+	// Check whether resource "Project" is supported
+	projectSupported, err := client.IsProjectSupported()
+
+	if err != nil {
+		return errors.Wrap(err, "resource project validation check failed.")
+	}
+
+	if projectSupported && name == "default" {
+		return errors.New("odo may not work as expected in the default project, please run the odo component in a non-default project")
+	}
+	return nil
 }

--- a/pkg/odo/genericclioptions/util.go
+++ b/pkg/odo/genericclioptions/util.go
@@ -46,7 +46,7 @@ func checkProjectCreateOrDeleteOnlyOnInvalidNamespace(command *cobra.Command, er
 // compare to checkProjectCreateOrDeleteOnlyOnInvalidNamespace, no %s is needed
 func checkProjectCreateOrDeleteOnlyOnInvalidNamespaceNoFmt(command *cobra.Command, errFormatForCommand string) {
 	// do not error out when its odo delete -a, so that we let users delete the local config on missing namespace
-	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || (command.Name() == "delete" && !command.Flags().Changed("all"))) {
+	if command.HasParent() && command.Parent().Name() != "project" && (command.Name() == "create" || command.Name() == "push" || (command.Name() == "delete" && !command.Flags().Changed("all"))) {
 		err := fmt.Errorf(errFormatForCommand)
 		util.LogErrorAndExit(err, "")
 	}

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -52,12 +52,9 @@ var _ = Describe("odo devfile create command tests", func() {
 		It("should successfully create the devfile component", func() {
 			componentNamespace := helper.RandString(6)
 			helper.CmdShouldPass("odo", "create", "java-openliberty", "--project", componentNamespace)
-		})
-
-		It("should fail to create the devfile component if --project value is 'default'", func() {
-			output := helper.CmdShouldFail("odo", "create", "java", "--project", "default")
-			expectedString := "odo may not work as expected in the default project, please run the odo component in a non-default project"
-			helper.MatchAllInOutput(output, []string{expectedString})
+			fileContents, err := helper.ReadFile(filepath.Join(commonVar.Context, ".odo/env/env.yaml"))
+			Expect(err).To(BeNil())
+			Expect(fileContents).To(ContainSubstring(componentNamespace))
 		})
 
 	})

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -28,7 +28,7 @@ var _ = Describe("odo devfile env command tests", func() {
 
 	Context("When executing env view", func() {
 		It("Should view all default parameters", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
 			output := helper.CmdShouldPass("odo", "env", "view")
 			wantOutput := []string{
 				"PARAMETER NAME",

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1083,4 +1083,43 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
+	Context("Testing Push for OpenShift specific scenarios", func() {
+		JustBeforeEach(func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+		})
+
+		It("throw an error when the project value is default", func() {
+			componentName := helper.RandString(6)
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", "default", componentName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			stdout := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			helper.MatchAllInOutput(stdout, []string{"odo may not work as expected in the default project, please run the odo component in a non-default project"})
+		})
+	})
+
+	Context("Testing Push for Kubernetes specific scenarios", func() {
+		JustBeforeEach(func() {
+			if os.Getenv("KUBERNETES") != "true" {
+				Skip("This is a Kubernetes specific scenario, skipping")
+			}
+		})
+
+		It("should push successfully project value is default", func() {
+			componentName := helper.RandString(6)
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", "default", componentName)
+
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			stdout := helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			helper.DontMatchAllInOutput(stdout, []string{"odo may not work as expected in the default project"})
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

It also modifies odo push to fill the project name in env.yaml if no project is not found in it.

**Which issue(s) this PR fixes**:

Fixes #3811 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- `odo create` should work without a cluster.
- `odo create --project <name>` should fill the project name in env.yaml during creation.
- `odo push` should fill the project name in the env.yaml if none was provided during creation.