### PR TITLE
Add telemetry consent to preference

### DIFF
--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -69,6 +69,7 @@ func (o *SetOptions) Run() (err error) {
 
 	if !o.configForceFlag {
 		if isSet := cfg.IsSet(o.paramName); isSet {
+			// TODO: could add a logic to check if the new value set by the user is not same as the current value
 			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the config", o.paramName)) {
 				log.Info("Aborted by the user")
 				return nil

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -30,6 +30,7 @@ var (
    %[1]s %[6]s 30
    %[1]s %[7]s true
    %[1]s %[8]s docker
+   %[1]s %[9]s true
 	`)
 )
 
@@ -94,7 +95,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName,
 			preference.UpdateNotificationSetting, preference.NamePrefixSetting,
 			preference.TimeoutSetting, preference.BuildTimeoutSetting, preference.PushTimeoutSetting,
-			preference.ExperimentalSetting, preference.PushTargetSetting),
+			preference.ExperimentalSetting, preference.PushTargetSetting, preference.ConsentTelemetrySetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return fmt.Errorf("please provide a parameter name and value")

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -31,6 +31,7 @@ var (
    %[1]s %[6]s
    %[1]s %[7]s
    %[1]s %[8]s
+   %[1]s %[9]s
 	`)
 )
 
@@ -97,7 +98,7 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName,
 			preference.UpdateNotificationSetting, preference.NamePrefixSetting,
 			preference.TimeoutSetting, preference.BuildTimeoutSetting, preference.PushTimeoutSetting,
-			preference.ExperimentalSetting, preference.PushTargetSetting),
+			preference.ExperimentalSetting, preference.PushTargetSetting, preference.ConsentTelemetrySetting),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("please provide a parameter name")

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -68,6 +68,7 @@ func (o *ViewOptions) Run() (err error) {
 	fmt.Fprintln(w, "Experimental", "\t", showBlankIfNil(cfg.OdoSettings.Experimental))
 	fmt.Fprintln(w, "PushTarget", "\t", showBlankIfNil(cfg.OdoSettings.PushTarget))
 	fmt.Fprintln(w, "Ephemeral", "\t", showBlankIfNil(cfg.OdoSettings.Ephemeral))
+	fmt.Fprintln(w, "ConsentTelemetry", "\t", showBlankIfNil(cfg.OdoSettings.ConsentTelemetry))
 
 	w.Flush()
 	return

--- a/pkg/preference/machine_output.go
+++ b/pkg/preference/machine_output.go
@@ -86,6 +86,13 @@ func toPreferenceItems(prefInfo PreferenceInfo) []PreferenceItem {
 			Type:        getType(prefInfo.GetPushTarget()),
 			Description: PushTargetDescription,
 		},
+		{
+			Name:        ConsentTelemetrySetting,
+			Value:       odoSettings.ConsentTelemetry,
+			Default:     DefaultConsentTelemetrySetting,
+			Type:        getType(prefInfo.GetConsentTelemetry()),
+			Description: ConsentTelemetryDescription,
+		},
 	}
 }
 

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -114,7 +114,7 @@ var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo wi
 var EphemeralDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code (Default: %t)", DefaultEphemeralSettings)
 
 //TelemetryConsentDescription adds a description for TelemetryConsentSetting
-var ConsentTelemetryDescription = fmt.Sprintf("If true odo will collect telemetry for the user's odo usage (Default: %t)", DefaultConsentTelemetrySetting)
+var ConsentTelemetryDescription = fmt.Sprintf("If true odo will collect telemetry for the user's odo usage (Default: %t)\n\t\t    For more information: https://developers.redhat.com/article/tool-data-collection", DefaultConsentTelemetrySetting)
 
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
@@ -424,6 +424,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 			}
 			c.OdoSettings.UpdateNotification = &val
 
+		//	TODO: should we add a validator here? What is the use of nameprefix?
 		case "nameprefix":
 			c.OdoSettings.NamePrefix = &value
 

--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -90,6 +90,12 @@ const (
 
 	// DefaultEphemeralSettings is a default value for Ephemeral preference
 	DefaultEphemeralSettings = true
+
+	// ConsentTelemetrySettings specifies if the user consents to telemetry
+	ConsentTelemetrySetting = "ConsentTelemetry"
+
+	// DefaultConsentTelemetry is a default value for ConsentTelemetry preference
+	DefaultConsentTelemetrySetting = false
 )
 
 // TimeoutSettingDescription is human-readable description for the timeout setting
@@ -107,6 +113,9 @@ var RegistryCacheTimeDescription = fmt.Sprintf("For how long (in minutes) odo wi
 // EphemeralDescription adds a description for EphemeralSourceVolume
 var EphemeralDescription = fmt.Sprintf("If true odo will create a emptyDir volume to store source code (Default: %t)", DefaultEphemeralSettings)
 
+//TelemetryConsentDescription adds a description for TelemetryConsentSetting
+var ConsentTelemetryDescription = fmt.Sprintf("If true odo will collect telemetry for the user's odo usage (Default: %t)", DefaultConsentTelemetrySetting)
+
 // This value can be provided to set a seperate directory for users 'homedir' resolution
 // note for mocking purpose ONLY
 var customHomeDir = os.Getenv("CUSTOM_HOMEDIR")
@@ -123,6 +132,7 @@ var (
 		PushTargetSetting:         PushTargetDescription,
 		RegistryCacheTimeSetting:  RegistryCacheTimeDescription,
 		EphemeralSetting:          EphemeralDescription,
+		ConsentTelemetrySetting:   ConsentTelemetryDescription,
 	}
 
 	// set-like map to quickly check if a parameter is supported
@@ -167,6 +177,9 @@ type OdoSettings struct {
 
 	// Ephemeral if true creates odo emptyDir to store odo source code
 	Ephemeral *bool `yaml:"Ephemeral,omitempty"`
+
+	// ConsentTelemetry if true collects telemetry for odo
+	ConsentTelemetry *bool `yaml:"ConsentTelemetry,omitempty"`
 }
 
 // Registry includes the registry metadata
@@ -434,6 +447,13 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 				return errors.Errorf("cannot set pushtarget to values other than '%s' or '%s'", DockerPushTarget, KubePushTarget)
 			}
 			c.OdoSettings.PushTarget = &val
+
+		case "consenttelemetry":
+			val, err := strconv.ParseBool(strings.ToLower(value))
+			if err != nil {
+				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
+			}
+			c.OdoSettings.ConsentTelemetry = &val
 		}
 	} else {
 		return errors.Errorf("unknown parameter :'%s' is not a parameter in odo preference", parameter)
@@ -521,10 +541,17 @@ func (c *PreferenceInfo) GetExperimental() bool {
 }
 
 // GetPushTarget returns the value of PushTarget from preferences
-// and if absent then returns defualt
+// and if absent then returns default
 // default value: kube, docker push target needs to be manually enabled
 func (c *PreferenceInfo) GetPushTarget() string {
 	return util.GetStringOrDefault(c.OdoSettings.PushTarget, KubePushTarget)
+}
+
+// GetConsentTelemetry returns the value of ConsentTelemetry from preferences
+// and if absent then returns default
+// default value: false, consent telemetry is disabled by default
+func (c *PreferenceInfo) GetConsentTelemetry() bool {
+	return util.GetBoolOrDefault(c.OdoSettings.ConsentTelemetry, DefaultConsentTelemetrySetting)
 }
 
 // FormatSupportedParameters outputs supported parameters and their description

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -919,3 +919,57 @@ func TestHandleWithRegistryExist(t *testing.T) {
 		}
 	}
 }
+
+func TestGetConsentTelemetry(t *testing.T) {
+	tempConfigFile, err := ioutil.TempFile("", "odoconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempConfigFile.Close()
+	os.Setenv(GlobalConfigEnvName, tempConfigFile.Name())
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name           string
+		existingConfig Preference
+		want           bool
+	}{{
+		name:           fmt.Sprintf("Case 1: %s nil", ConsentTelemetrySetting),
+		existingConfig: Preference{},
+		want:           false,
+	},
+		{
+			name: fmt.Sprintf("Case 2: %s true", ConsentTelemetrySetting),
+			existingConfig: Preference{
+				OdoSettings: OdoSettings{
+					ConsentTelemetry: &trueValue,
+				},
+			},
+			want: true,
+		},
+		{
+			name: fmt.Sprintf("Case 3: %s false", ConsentTelemetrySetting),
+			existingConfig: Preference{
+				OdoSettings: OdoSettings{
+					ConsentTelemetry: &falseValue,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := PreferenceInfo{
+				Preference: tt.existingConfig,
+			}
+			output := cfg.GetConsentTelemetry()
+
+			if output != tt.want {
+				t.Errorf("GetConsentTelemetry returned unexpeced value expected \ngot: %t \nexpected: %t\n", output, tt.want)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What does does this PR do / why we need it**:
This PR adds telemetry consent to preference, so that user can set and unset their telemetry preference.

**Which issue(s) this PR fixes**:

Partly Fixes #1236 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. `odo preference --help` and check if ConsentTelemetry appears in the help.
2. `odo preference set ConsentTelemetry true` and check if the preference was set correctly.
3. `odo preference unset ConsentTelemetry` and check if the preference was unset.
4. `odo preference view` and check if ConsentTelemetry is present in the output.

Note that this does not yet collect data, this just adds `ConsentTelemetry` to preferences.