### PR TITLE
Refactor help examples to use go templates

### DIFF
--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -22,16 +22,7 @@ var (
 
 %[1]s`)
 	setExample = ktemplates.Examples(`
-   # Set a preference value in the global preference
-   %[1]s %[2]s false
-   %[1]s %[3]s "app"
-   %[1]s %[4]s 20
-   %[1]s %[5]s 40
-   %[1]s %[6]s 30
-   %[1]s %[7]s true
-   %[1]s %[8]s docker
-   %[1]s %[9]s true
-	`)
+   # Set a preference value in the global preference`)
 )
 
 // SetOptions encapsulates the options for the command
@@ -93,10 +84,18 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: "Set a value in odo config file",
 		Long:  fmt.Sprintf(setLongDesc, preference.FormatSupportedParameters()),
-		Example: fmt.Sprintf(fmt.Sprint("\n", setExample), fullName,
-			preference.UpdateNotificationSetting, preference.NamePrefixSetting,
-			preference.TimeoutSetting, preference.BuildTimeoutSetting, preference.PushTimeoutSetting,
-			preference.ExperimentalSetting, preference.ConsentTelemetrySetting),
+		Example: func(exampleString, fullName string) string {
+			cfg, _ := preference.New()
+			properties := preference.NewPreferenceList(*cfg)
+			for _, property := range properties.Items {
+				value := property.Default
+				if value == "" {
+					value = "smh"
+				}
+				exampleString += fmt.Sprintf("\n  %s %s %v", fullName, property.Name, value)
+			}
+			return "\n" + exampleString
+		}(setExample, fullName),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return fmt.Errorf("please provide a parameter name and value")

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -90,7 +90,7 @@ func NewCmdSet(name, fullName string) *cobra.Command {
 			for _, property := range properties.Items {
 				value := property.Default
 				if value == "" {
-					value = "smh"
+					value = "foobar"
 				}
 				exampleString += fmt.Sprintf("\n  %s %s %v", fullName, property.Name, value)
 			}

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -20,19 +20,9 @@ var (
 	unsetLongDesc = ktemplates.LongDesc(`Unset an individual value in the odo preference file.
 
 %[1]s
-%[2]s
 `)
 	unsetExample = ktemplates.Examples(`
-   # Unset a preference value in the global preference
-   %[1]s %[2]s
-   %[1]s %[3]s
-   %[1]s %[4]s
-   %[1]s %[5]s
-   %[1]s %[6]s
-   %[1]s %[7]s
-   %[1]s %[8]s
-   %[1]s %[9]s
-	`)
+   # Unset a preference value in the global preference`)
 )
 
 // UnsetOptions encapsulates the options for the command
@@ -95,10 +85,12 @@ func NewCmdUnset(name, fullName string) *cobra.Command {
 		Use:   name,
 		Short: "Unset a value in odo preference file",
 		Long:  fmt.Sprintf(unsetLongDesc, preference.FormatSupportedParameters()),
-		Example: fmt.Sprintf(fmt.Sprint("\n", unsetExample), fullName,
-			preference.UpdateNotificationSetting, preference.NamePrefixSetting,
-			preference.TimeoutSetting, preference.BuildTimeoutSetting, preference.PushTimeoutSetting,
-			preference.ExperimentalSetting, preference.ConsentTelemetrySetting),
+		Example: func(exampleString, fullName string) string {
+			for _, property := range preference.GetSupportedParameters() {
+				exampleString += fmt.Sprintf("\n  %s %s", fullName, property)
+			}
+			return "\n" + exampleString
+		}(unsetExample, fullName),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("please provide a parameter name")


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does does this PR do / why we need it**:
This PR refactors the preference examples to use Go templates instead of normal string formatting

**Which issue(s) this PR fixes**:

Fixes #4654 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
```
odo preference --help
odo preference unset --help
```
