### PR TITLE
Change ServiceBinding API group to binding.operators.coreos.com

### DIFF
--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -25,7 +25,7 @@ import (
 var (
 	// Hardcoded variables since we can't install SBO on k8s using OLM
 	// (https://github.com/redhat-developer/service-binding-operator/issues/536)
-	serviceBindingGroup    = "operators.coreos.com"
+	serviceBindingGroup    = "binding.operators.coreos.com"
 	serviceBindingVersion  = "v1alpha1"
 	serviceBindingKind     = "ServiceBinding"
 	serviceBindingResource = "servicebindings"


### PR DESCRIPTION
From now on odo link will work only with  ServiceBindingOperator v0.5.0 and up

**What type of PR is this?**


/kind bug

/kind failing-test


**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4480

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
