### PR TITLE
Change API & Operator version for Serice Binding Operator

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -573,6 +573,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -868,6 +869,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -21,7 +21,7 @@ const (
 
 // IsServiceBindingSupported checks if resource of type service binding request present on the cluster
 func (c *Client) IsServiceBindingSupported() (bool, error) {
-	return c.IsResourceSupported("operators.coreos.com", "v1alpha1", "servicebindings")
+	return c.IsResourceSupported("binding.operators.coreos.com", "v1alpha1", "servicebindings")
 }
 
 // IsCSVSupported checks if resource of type service binding request present on the cluster

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -25,7 +25,7 @@ import (
 var (
 	// Hardcoded variables since we can't install SBO on k8s using OLM
 	// (https://github.com/redhat-developer/service-binding-operator/issues/536)
-	serviceBindingGroup    = "operators.coreos.com"
+	serviceBindingGroup    = "binding.operators.coreos.com"
 	serviceBindingVersion  = "v1alpha1"
 	serviceBindingKind     = "ServiceBinding"
 	serviceBindingResource = "servicebindings"

--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -34,7 +34,7 @@ install_service_binding_operator(){
     name: rh-service-binding-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: service-binding-operator.v0.3.0
+    startingCSV: service-binding-operator.v0.5.0
 EOF
 }
 

--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -15,7 +15,6 @@ install_etcd_operator(){
     name: etcd
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: etcdoperator.v0.9.4-clusterwide
 EOF
 }
 
@@ -34,7 +33,6 @@ install_service_binding_operator(){
     name: rh-service-binding-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: service-binding-operator.v0.5.0
 EOF
 }
 


### PR DESCRIPTION
This is to be compatible with SBO 0.5.0

**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
Makes odo compatible with SBO 0.5.0

**Which issue(s) this PR fixes**:

Fixes #4480

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
4.7 tests should pass