### PR TITLE
Fix install URL link

### DIFF
--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -19,7 +19,7 @@ then
 fi
 
 MIRROR="https://mirror.openshift.com/pub/openshift-v4/clients/odo/$2/"
-INSTALLATION_GUIDE="https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/installing-odo.html"
+INSTALLATION_GUIDE="https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html"
 
 echo -e "# Installation of $2
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

/kind documentation
[skip ci]

**What does does this PR do / why we need it**:

Looks like the install link changed within the OpenShift doc.

Old: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/installing-odo.html
New: https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html


**PR acceptance criteria**:


- [X ] Documentation 

- [X ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

