### PR TITLE
resolve project not being set in offline context creation

### DIFF
--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -2,12 +2,13 @@ package genericclioptions
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/devfile/library/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/validate"
 	"github.com/openshift/odo/pkg/localConfigProvider"
 	odoutil "github.com/openshift/odo/pkg/util"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -304,7 +305,7 @@ func NewOfflineDevfileContext(command *cobra.Command) *Context {
 	if projectFlag != "" {
 		internalCxt.Project = projectFlag
 	} else {
-		envInfo.GetNamespace()
+		internalCxt.Project = envInfo.GetNamespace()
 	}
 
 	// Create a context from the internal representation


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What does does this PR do / why we need it**:
when we are creating offline context - we are not setting the project which could be a major bug when using any command in non-cluster mode.

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

Not sure how to test this

~~ - [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation ~~

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
