### PR TITLE
Adds a check to error out if the run command didn't start properly.

### DIFF
--- a/pkg/devfile/adapters/common/interface.go
+++ b/pkg/devfile/adapters/common/interface.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"io"
+
+	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 // ComponentAdapter defines the functions that platform-specific adapters must implement
@@ -11,8 +13,9 @@ type ComponentAdapter interface {
 	DoesComponentExist(cmpName string) (bool, error)
 	Delete(labels map[string]string, show bool) error
 	Test(testCmd string, show bool) error
+	CheckSupervisordCtlStatus(command devfilev1.Command) error
 	StartContainerStatusWatch()
 	StartSupervisordCtlStatusWatch()
-	Log(follow, debug bool) (io.ReadCloser, error)
+	Log(follow bool, command devfilev1.Command) (io.ReadCloser, error)
 	Exec(command []string) error
 }

--- a/pkg/devfile/adapters/docker/adapter.go
+++ b/pkg/devfile/adapters/docker/adapter.go
@@ -38,6 +38,10 @@ func (d Adapter) Push(parameters common.PushParameters) error {
 	return nil
 }
 
+func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
+	return nil
+}
+
 // DoesComponentExist returns true if a component with the specified name exists
 func (d Adapter) DoesComponentExist(cmpName string) (bool, error) {
 	return d.componentAdapter.DoesComponentExist(cmpName)
@@ -54,8 +58,8 @@ func (d Adapter) Test(testCmd string, show bool) error {
 }
 
 // Log shows logs from component
-func (d Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
-	return d.componentAdapter.Log(follow, debug)
+func (d Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, error) {
+	return d.componentAdapter.Log(follow, command)
 }
 
 // Exec executes a command in the component

--- a/pkg/devfile/adapters/docker/component/adapter.go
+++ b/pkg/devfile/adapters/docker/component/adapter.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -182,6 +181,10 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	return nil
 }
 
+func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
+	return nil
+}
+
 // Test runs the devfile test command
 func (a Adapter) Test(testCmd string, show bool) (err error) {
 	componentExists, err := utils.ComponentExists(a.Client, a.Devfile.Data, a.ComponentName)
@@ -346,7 +349,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 }
 
 // Log returns log from component
-func (a Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
+func (a Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, error) {
 
 	exists, err := utils.ComponentExists(a.Client, a.Devfile.Data, a.ComponentName)
 
@@ -363,23 +366,6 @@ func (a Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
 		return nil, errors.Wrapf(err, "error while retrieving container for odo component %s", a.ComponentName)
 	}
 
-	var command devfilev1.Command
-	if debug {
-		command, err = common.GetDebugCommand(a.Devfile.Data, "")
-		if err != nil {
-			return nil, err
-		}
-		if reflect.DeepEqual(devfilev1.Command{}, command) {
-			return nil, errors.Errorf("no debug command found in devfile, please run \"odo log\" for run command logs")
-		}
-
-	} else {
-		command, err = common.GetRunCommand(a.Devfile.Data, "")
-		if err != nil {
-			return nil, err
-		}
-
-	}
 	containerID := utils.GetContainerIDForAlias(containers, command.Exec.Component)
 
 	return a.Client.GetContainerLogs(containerID, follow)

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -42,6 +42,16 @@ func (k Adapter) Push(parameters common.PushParameters) error {
 	return nil
 }
 
+// CheckSupervisordCtlStatus calls the component adapter's CheckSupervisordCtlStatus
+func (k Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
+	err := k.componentAdapter.CheckSupervisordCtlStatus(command)
+	if err != nil {
+		return errors.Wrap(err, "Failed to check the status")
+	}
+
+	return nil
+}
+
 // DoesComponentExist returns true if a component with the specified name exists
 func (k Adapter) DoesComponentExist(cmpName string) (bool, error) {
 	return k.componentAdapter.DoesComponentExist(cmpName)
@@ -64,8 +74,8 @@ func (k Adapter) Test(testCmd string, show bool) error {
 }
 
 // Log shows log from component
-func (k Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
-	return k.componentAdapter.Log(follow, debug)
+func (k Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, error) {
+	return k.componentAdapter.Log(follow, command)
 }
 
 // Exec executes a command in the component

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -3,8 +3,10 @@ package component
 import (
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/devfile/library/pkg/devfile/generator"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
@@ -34,6 +36,8 @@ import (
 	"github.com/openshift/odo/pkg/sync"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+const supervisorDStatusWaitTimeInterval = 1
 
 // New instantiates a component adapter
 func New(adapterContext common.AdapterContext, client kclient.Client) Adapter {
@@ -248,12 +252,66 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		if err != nil {
 			return err
 		}
+
+		runCommand := pushDevfileCommands[devfilev1.RunCommandGroupKind]
+		if parameters.Debug {
+			runCommand = pushDevfileCommands[devfilev1.DebugCommandGroupKind]
+		}
+
+		// wait for a second
+		wait := time.After(supervisorDStatusWaitTimeInterval * time.Second)
+		<-wait
+
+		err := a.CheckSupervisordCtlStatus(runCommand)
+		if err != nil {
+			return err
+		}
 	} else {
 		// no file was modified/added/deleted/renamed, thus return without syncing files
 		log.Success("No file changes detected, skipping build. Use the '-f' flag to force the build.")
 	}
 
 	return nil
+}
+
+// CheckSupervisordCtlStatus checks the supervisord status according to the given command
+// if the command is not in a running state, we fetch the last 20 lines of the component's log and display it
+func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
+	statusInContainer := getSupervisordStatusInContainer(a.pod.Name, command.Exec.Component, a)
+
+	supervisordProgramName := "devrun"
+
+	// if the command is a debug one, we check against `debugrun`
+	if command.Exec.Group.Kind == devfilev1.DebugCommandGroupKind {
+		supervisordProgramName = "debugrun"
+	}
+
+	for _, status := range statusInContainer {
+		if strings.ToLower(status.program) == strings.ToLower(supervisordProgramName) {
+			if strings.ToLower(status.status) == strings.ToLower("running") {
+				return nil
+			} else {
+				numberOfLines := 20
+				log.Errorf("devfile command \"%s\" exited with error status within %d sec", command.Id, supervisorDStatusWaitTimeInterval)
+				log.Infof("Last %d lines of the component's log:", numberOfLines)
+
+				rd, err := a.Log(false, command)
+				if err != nil {
+					return err
+				}
+
+				err = util.DisplayLog(false, rd, os.Stderr, a.ComponentName, numberOfLines)
+				if err != nil {
+					return err
+				}
+
+				log.Info("To get the full log output, please run 'odo log'")
+
+				return fmt.Errorf("error during component startup")
+			}
+		}
+	}
+	return fmt.Errorf("the supervisord program %s not found", supervisordProgramName)
 }
 
 // Test runs the devfile test command
@@ -530,7 +588,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 }
 
 // Log returns log from component
-func (a Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
+func (a Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, error) {
 
 	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
 	if err != nil {
@@ -539,23 +597,6 @@ func (a Adapter) Log(follow, debug bool) (io.ReadCloser, error) {
 
 	if pod.Status.Phase != corev1.PodRunning {
 		return nil, errors.Errorf("unable to show logs, component is not in running state. current status=%v", pod.Status.Phase)
-	}
-
-	var command devfilev1.Command
-	if debug {
-		command, err = common.GetDebugCommand(a.Devfile.Data, "")
-		if err != nil {
-			return nil, err
-		}
-		if reflect.DeepEqual(devfilev1.Command{}, command) {
-			return nil, errors.Errorf("no debug command found in devfile, please run \"odo log\" for run command logs")
-		}
-
-	} else {
-		command, err = common.GetRunCommand(a.Devfile.Data, "")
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	containerName := command.Exec.Component

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -287,8 +287,8 @@ func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
 	}
 
 	for _, status := range statusInContainer {
-		if strings.ToLower(status.program) == strings.ToLower(supervisordProgramName) {
-			if strings.ToLower(status.status) == strings.ToLower("running") {
+		if strings.EqualFold(status.program, supervisordProgramName) {
+			if strings.EqualFold(status.status, "running") {
 				return nil
 			} else {
 				numberOfLines := 20

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -292,7 +292,7 @@ func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
 				return nil
 			} else {
 				numberOfLines := 20
-				log.Errorf("devfile command \"%s\" exited with error status within %d sec", command.Id, supervisorDStatusWaitTimeInterval)
+				log.Warningf("devfile command \"%s\" exited with error status within %d sec", command.Id, supervisorDStatusWaitTimeInterval)
 				log.Infof("Last %d lines of the component's log:", numberOfLines)
 
 				rd, err := a.Log(false, command)
@@ -307,7 +307,7 @@ func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
 
 				log.Info("To get the full log output, please run 'odo log'")
 
-				return fmt.Errorf("error during component startup")
+				return nil
 			}
 		}
 	}

--- a/pkg/occlient/deploymentConfigs.go
+++ b/pkg/occlient/deploymentConfigs.go
@@ -3,6 +3,7 @@ package occlient
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -230,7 +231,7 @@ func (c *Client) DisplayDeploymentConfigLog(deploymentConfigName string, followL
 		return errors.New("unable to retrieve DeploymentConfig from OpenShift, does your component exist?")
 	}
 
-	return util.DisplayLog(followLog, rd, deploymentConfigName)
+	return util.DisplayLog(followLog, rd, os.Stdout, deploymentConfigName, -1)
 }
 
 // StartDeployment instantiates a given deployment

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -183,13 +183,13 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm run debug", "npm run debugs")
 
-			output := helper.CmdShouldFail("odo", "push", "--debug", "--context", commonVar.Context)
+			_, output := helper.CmdShouldPassIncludeErrStream("odo", "push", "--debug", "--context", commonVar.Context)
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean this?",
 			})
 
-			output = helper.CmdShouldFail("odo", "push", "--debug", "--context", commonVar.Context, "--debug-command", "debug")
+			_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "--debug", "--context", commonVar.Context, "--debug-command", "debug", "-f")
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean this?",

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -175,4 +175,25 @@ var _ = Describe("odo devfile debug command tests", func() {
 
 		})
 	})
+
+	Context("when the debug command throws an error during push", func() {
+		It("should wait and error out with some log", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm run debug", "npm run debugs")
+
+			output := helper.CmdShouldFail("odo", "push", "--debug", "--context", commonVar.Context)
+			helper.MatchAllInOutput(output, []string{
+				"exited with error status within 1 sec",
+				"Did you mean this?",
+			})
+
+			output = helper.CmdShouldFail("odo", "push", "--debug", "--context", commonVar.Context, "--debug-command", "debug")
+			helper.MatchAllInOutput(output, []string{
+				"exited with error status within 1 sec",
+				"Did you mean this?",
+			})
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1090,13 +1090,13 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
 
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			_, output := helper.CmdShouldPassIncludeErrStream("odo", "push", "--context", commonVar.Context)
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean one of these?",
 			})
 
-			output = helper.CmdShouldFail("odo", "push", "--context", commonVar.Context, "-f", "--run-command", "run")
+			_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "--context", commonVar.Context, "-f", "--run-command", "run")
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean one of these?",

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1083,6 +1083,27 @@ var _ = Describe("odo devfile push command tests", func() {
 		})
 	})
 
+	Context("when the run command throws an error", func() {
+		It("should wait and error out with some log", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
+
+			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			helper.MatchAllInOutput(output, []string{
+				"exited with error status within 1 sec",
+				"Did you mean one of these?",
+			})
+
+			output = helper.CmdShouldFail("odo", "push", "--context", commonVar.Context, "-f", "--run-command", "run")
+			helper.MatchAllInOutput(output, []string{
+				"exited with error status within 1 sec",
+				"Did you mean one of these?",
+			})
+		})
+	})
+
 	Context("Testing Push for OpenShift specific scenarios", func() {
 		JustBeforeEach(func() {
 			if os.Getenv("KUBERNETES") == "true" {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

It waits for 1 sec to check the status and displays the last 20 lines in case of a failure.

**Which issue(s) this PR fixes**:

Fixes #4197

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Push a component with a invalid run command, it should error out with the last 20 lines of the component's log.
- Repeat the above steps with a invalid debug command and using the `debug` flag during push.