### PR TITLE
Fixes odo create when cluster access is limited

### DIFF
--- a/pkg/component/component_full_description.go
+++ b/pkg/component/component_full_description.go
@@ -8,10 +8,8 @@ import (
 	"github.com/openshift/odo/pkg/localConfigProvider"
 
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
-	"github.com/openshift/odo/pkg/envinfo"
-	"github.com/openshift/odo/pkg/kclient"
-
 	"github.com/openshift/odo/pkg/config"
+	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/storage"
@@ -50,7 +48,7 @@ func (cfd *ComponentFullDescription) copyFromComponentDesc(component *Component)
 }
 
 // loadStoragesFromClientAndLocalConfig collects information about storages both locally and from the cluster.
-func (cfd *ComponentFullDescription) loadStoragesFromClientAndLocalConfig(client *occlient.Client, kClient *kclient.Client, configProvider localConfigProvider.LocalConfigProvider, componentName string, applicationName string, componentDesc *Component) error {
+func (cfd *ComponentFullDescription) loadStoragesFromClientAndLocalConfig(client *occlient.Client, configProvider localConfigProvider.LocalConfigProvider, componentName string, applicationName string, componentDesc *Component) error {
 	var storages storage.StorageList
 	var err error
 	var derefClient occlient.Client
@@ -110,7 +108,7 @@ func (cfd *ComponentFullDescription) fillEmptyFields(componentDesc Component, co
 }
 
 // NewComponentFullDescriptionFromClientAndLocalConfig gets the complete description of the component from both localconfig and cluster
-func NewComponentFullDescriptionFromClientAndLocalConfig(client *occlient.Client, kClient *kclient.Client, localConfigInfo *config.LocalConfigInfo, envInfo *envinfo.EnvSpecificInfo, componentName string, applicationName string, projectName string) (*ComponentFullDescription, error) {
+func NewComponentFullDescriptionFromClientAndLocalConfig(client *occlient.Client, localConfigInfo *config.LocalConfigInfo, envInfo *envinfo.EnvSpecificInfo, componentName string, applicationName string, projectName string) (*ComponentFullDescription, error) {
 	cfd := &ComponentFullDescription{}
 	var state State
 	if client == nil {
@@ -188,7 +186,7 @@ func NewComponentFullDescriptionFromClientAndLocalConfig(client *occlient.Client
 	}
 	cfd.Spec.URL = urls
 
-	err = cfd.loadStoragesFromClientAndLocalConfig(client, kClient, configProvider, componentName, applicationName, &componentDesc)
+	err = cfd.loadStoragesFromClientAndLocalConfig(client, configProvider, componentName, applicationName, &componentDesc)
 	if err != nil {
 		return cfd, err
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -342,11 +342,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			return err
 		}
 	} else {
-		co.Context, err = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-		if err != nil {
-			co.Context = genericclioptions.NewOfflineDevfileContext(cmd)
-			err = nil
-		}
+		co.Context = genericclioptions.NewOfflineDevfileContext(cmd)
 	}
 	err = co.checkConflictingFlags()
 	if err != nil {
@@ -892,12 +888,18 @@ func (co *CreateOptions) Run() (err error) {
 			return err
 		}
 		if log.IsJSON() {
+
+			client, err := genericclioptions.Client()
+			if err == nil {
+				co.Client = client
+			}
+
 			envInfo, err := envinfo.NewEnvSpecificInfo(co.componentContext)
 			if err != nil {
 				return err
 			}
 
-			cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(co.Client, co.KClient, co.LocalConfigInfo, envInfo, envInfo.GetName(), envInfo.GetApplication(), co.Project)
+			cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(co.Client, co.LocalConfigInfo, envInfo, envInfo.GetName(), envInfo.GetApplication(), co.Project)
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -60,7 +60,7 @@ func (do *DescribeOptions) Run() (err error) {
 		return fmt.Errorf("Component %v does not exist", do.componentName)
 	}
 
-	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.Context.KClient, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, do.Context.Project)
+	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, do.Context.Project)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -119,7 +119,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 			if err != nil {
 				return errors.Wrap(err, "unable to determine target namespace for devfile")
 			}
-			client, err := genericclioptions.Client(cmd)
+			client, err := genericclioptions.Client()
 			if err != nil {
 				return err
 			}
@@ -156,7 +156,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 			if err != nil {
 				return errors.Wrap(err, "unable to determine target namespace for devfile")
 			}
-			client, err := genericclioptions.Client(cmd)
+			client, err := genericclioptions.Client()
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) 
 				return errors.Wrap(err, "failed to write the project to the env.yaml for devfile component")
 			}
 		} else if envFileInfo.GetNamespace() == "default" {
-			client, err := genericclioptions.Client(cmd)
+			client, err := genericclioptions.Client()
 			if err != nil {
 				return err
 			}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -129,7 +129,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 	if err != nil {
 		return err
 	}
-	wo.client, err = genericclioptions.Client(cmd)
+	wo.client, err = genericclioptions.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -87,7 +87,7 @@ func (o *CreateOptions) Complete(_ string, cmd *cobra.Command, args []string) (e
 		return err
 	}
 
-	o.Client, err = genericclioptions.Client(cmd)
+	o.Client, err = genericclioptions.Client()
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/genericclioptions/client.go
+++ b/pkg/odo/genericclioptions/client.go
@@ -3,16 +3,24 @@ package genericclioptions
 import (
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/occlient"
-	"github.com/spf13/cobra"
 )
 
 // Client returns an oc client "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"d for this command's options
-func Client(command *cobra.Command) (*occlient.Client, error) {
-	return client(command)
+func Client() (*occlient.Client, error) {
+	ocClient, err := client()
+	if err != nil {
+		return nil, err
+	}
+	kClient, err := kClient()
+	if err != nil {
+		return nil, err
+	}
+	ocClient.SetKubeClient(kClient)
+	return ocClient, nil
 }
 
-// client creates an oc client based on the command flags
-func client(command *cobra.Command) (*occlient.Client, error) {
+// client creates an oc client
+func client() (*occlient.Client, error) {
 	client, err := occlient.New()
 	if err != nil {
 		return nil, err
@@ -21,8 +29,8 @@ func client(command *cobra.Command) (*occlient.Client, error) {
 	return client, nil
 }
 
-// kClient creates an kclient based on the command flags
-func kClient(command *cobra.Command) (*kclient.Client, error) {
+// kClient creates an kclient
+func kClient() (*kclient.Client, error) {
 	kClient, err := kclient.New()
 	if err != nil {
 		return nil, err

--- a/pkg/odo/genericclioptions/client.go
+++ b/pkg/odo/genericclioptions/client.go
@@ -5,9 +5,9 @@ import (
 	"github.com/openshift/odo/pkg/occlient"
 )
 
-// Client returns an oc client "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"d for this command's options
+// Client returns an oc client with the kClient set
 func Client() (*occlient.Client, error) {
-	ocClient, err := client()
+	ocClient, err := ocClient()
 	if err != nil {
 		return nil, err
 	}
@@ -19,8 +19,8 @@ func Client() (*occlient.Client, error) {
 	return ocClient, nil
 }
 
-// client creates an oc client
-func client() (*occlient.Client, error) {
+// ocClient creates an oc client
+func ocClient() (*occlient.Client, error) {
 	client, err := occlient.New()
 	if err != nil {
 		return nil, err

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -210,7 +210,7 @@ func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error)
 // newContext creates a new context based on the command flags, creating missing app when requested
 func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingConfiguration bool) (*Context, error) {
 	// Create a new occlient
-	client, err := client(command)
+	client, err := client()
 	if err != nil {
 		return nil, err
 	}
@@ -280,11 +280,11 @@ func newDevfileContext(command *cobra.Command, createAppIfNeeded bool) (*Context
 	if !pushtarget.IsPushTargetDocker() {
 
 		// Create a new kubernetes client
-		internalCxt.KClient, err = kClient(command)
+		internalCxt.KClient, err = kClient()
 		if err != nil {
 			return nil, err
 		}
-		internalCxt.Client, err = client(command)
+		internalCxt.Client, err = client()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -210,7 +210,7 @@ func UpdatedContext(context *Context) (*Context, *config.LocalConfigInfo, error)
 // newContext creates a new context based on the command flags, creating missing app when requested
 func newContext(command *cobra.Command, createAppIfNeeded bool, ignoreMissingConfiguration bool) (*Context, error) {
 	// Create a new occlient
-	client, err := client()
+	client, err := ocClient()
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func newDevfileContext(command *cobra.Command, createAppIfNeeded bool) (*Context
 		if err != nil {
 			return nil, err
 		}
-		internalCxt.Client, err = client()
+		internalCxt.Client, err = ocClient()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does does this PR do / why we need it**:

It also removes unused parameters from some functions.

**Which issue(s) this PR fixes**:

Fixes #4507 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Open the kubeconfig and edit the `server: ` values to a invalid value.
- `odo create` should pass.