### PR TITLE
Changes to prefix projectNames with test_file_name and line number

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -329,12 +329,11 @@ func GjsonMatcher(values []gjson.Result, expected []string) bool {
 	return matched == numVars
 }
 
-//SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters 
+//SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
 func SetProjectName() string {
-		//Get current test filename and remove file path, file extension and replace undescores with hyphens
-		currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
-		currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
-		projectName := currGinkgoTestFileName + currGinkgoTestLineNum + RandString(3)
-		return projectName
+	//Get current test filename and remove file path, file extension and replace undescores with hyphens
+	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
+	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
+	projectName := currGinkgoTestFileName + currGinkgoTestLineNum + RandString(3)
+	return projectName
 }
-

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -327,3 +328,13 @@ func GjsonMatcher(values []gjson.Result, expected []string) bool {
 	numVars := len(expected)
 	return matched == numVars
 }
+
+//SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters 
+func SetProjectName() string {
+		//Get current test filename and remove file path, file extension and replace undescores with hyphens
+		currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
+		currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
+		projectName := currGinkgoTestFileName + currGinkgoTestLineNum + RandString(3)
+		return projectName
+}
+

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -138,7 +138,7 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 	return output
 }
 
-// CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
+// CreateRandNamespaceProject create new project
 func (kubectl KubectlRunner) CreateRandNamespaceProject() string {
 	projectName := SetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -141,10 +140,7 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 
 // CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
 func (kubectl KubectlRunner) CreateRandNamespaceProject() string {
-	//Get current test filename and remove file path, file extension and replace undescores with hyphens  
-	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
-	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
-	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)
+	projectName := SetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	CmdShouldPass("kubectl", "create", "namespace", projectName)
 	CmdShouldPass("kubectl", "config", "set-context", "--current", "--namespace", projectName)

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -139,8 +139,9 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 	return output
 }
 
-// CreateRandNamespaceProject create new project with random name in kubernetes cluster (10 letters)
+// CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
 func (kubectl KubectlRunner) CreateRandNamespaceProject() string {
+	//Get current test filename and remove file path, file extension and replace undescores with hyphens  
 	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
 	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
 	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -140,7 +141,9 @@ func (kubectl KubectlRunner) GetServices(namespace string) string {
 
 // CreateRandNamespaceProject create new project with random name in kubernetes cluster (10 letters)
 func (kubectl KubectlRunner) CreateRandNamespaceProject() string {
-	projectName := RandString(10)
+	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
+	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
+	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	CmdShouldPass("kubectl", "create", "namespace", projectName)
 	CmdShouldPass("kubectl", "config", "set-context", "--current", "--namespace", projectName)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -562,7 +562,7 @@ func (oc OcRunner) VerifyResourceDeleted(resourceType, resourceName, namespace s
 	Expect(output).NotTo(ContainSubstring(resourceName))
 }
 
-// CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
+// CreateRandNamespaceProject create new project
 func (oc OcRunner) CreateRandNamespaceProject() string {
 	projectName := SetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -562,9 +563,11 @@ func (oc OcRunner) VerifyResourceDeleted(resourceType, resourceName, namespace s
 	Expect(output).NotTo(ContainSubstring(resourceName))
 }
 
-// CreateRandNamespaceProject create new project with random name in oc cluster (10 letters)
+// CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
 func (oc OcRunner) CreateRandNamespaceProject() string {
-	projectName := RandString(10)
+	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
+	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
+	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	session := CmdShouldPass("odo", "project", "create", projectName, "-w", "-v4")
 	Expect(session).To(ContainSubstring("New project created"))

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -565,6 +565,7 @@ func (oc OcRunner) VerifyResourceDeleted(resourceType, resourceName, namespace s
 
 // CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
 func (oc OcRunner) CreateRandNamespaceProject() string {
+	//Get current test filename and remove file path, file extension and replace undescores with hyphens
 	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
 	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
 	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -565,10 +564,7 @@ func (oc OcRunner) VerifyResourceDeleted(resourceType, resourceName, namespace s
 
 // CreateRandNamespaceProject create new project with test file name, line number and 10 random letters
 func (oc OcRunner) CreateRandNamespaceProject() string {
-	//Get current test filename and remove file path, file extension and replace undescores with hyphens
-	currGinkgoTestFileName := strings.Replace(CurrentGinkgoTestDescription().FileName[strings.LastIndex(CurrentGinkgoTestDescription().FileName, "/")+1:strings.LastIndex(CurrentGinkgoTestDescription().FileName, ".")], "_", "-", -1)
-	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
-	projectName := currGinkgoTestFileName + "-lnum-" + currGinkgoTestLineNum + "-" + RandString(10)
+	projectName := SetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	session := CmdShouldPass("odo", "project", "create", projectName, "-w", "-v4")
 	Expect(session).To(ContainSubstring("New project created"))

--- a/tests/helper/odo_utils.go
+++ b/tests/helper/odo_utils.go
@@ -74,7 +74,7 @@ func routeURL(context string) string {
 // CreateRandProject create new project with random name (10 letters)
 // without writing to the config file (without switching project)
 func CreateRandProject() string {
-	projectName := RandString(10)
+	projectName := SetProjectName()
 	fmt.Fprintf(GinkgoWriter, "Creating a new project: %s\n", projectName)
 	session := CmdShouldPass("odo", "project", "create", projectName, "-w", "-v4")
 	Expect(session).To(ContainSubstring("New project created"))

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -110,7 +110,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 		})
 
 		It("should start a debug session and run debug info on a running debug session", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp-"+commonVar.Project, "--project", commonVar.Project, "--context", projectDirPath)
+			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp", "--project", commonVar.Project, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
 			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
@@ -130,7 +130,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.HttpWaitForWithStatus("http://localhost:"+freePort, "WebSockets request was expected", 12, 5, 400)
 			runningString := helper.CmdShouldPass("odo", "debug", "info", "--context", projectDirPath)
 			Expect(runningString).To(ContainSubstring(freePort))
-			Expect(helper.ListFilesInDir(os.TempDir())).To(ContainElement(commonVar.Project + "-nodejs-cmp-" + commonVar.Project + "-odo-debug.json"))
+			Expect(helper.ListFilesInDir(os.TempDir())).To(ContainElement(commonVar.Project + "-nodejs-cmp-odo-debug.json"))
 			stopChannel <- true
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What does does this PR do / why we need it**:
To assist in resolution of  we are prefixing projectNames with the test filename and line number of the test in progress, this way we can identify which tests are leaving projects behind (not getting cleaned up)

**Which issue(s) this PR fixes**:

Fixes [#4215](https://github.com/openshift/odo/issues/4502) 

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
make test-integration
during execution check that projects created in the target cluster are prefixed with the test filename and line number