### PR TITLE
Add test-integration-devfile tests for s390x

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -36,6 +36,7 @@ oc whoami
 if [ "${ARCH}" == "s390x" ]; then
     # Integration tests
     make test-integration
+    make test-integration-devfile
     make test-cmd-login-logout
     make test-cmd-project
     # E2e tests


### PR DESCRIPTION
For the test-integration-devfile, have verified supported on s390x.

**What type of PR is this?**

> /kind bug

**What does does this PR do / why we need it**:

make odo supported on s390x, and including more cases in ci

**Which issue(s) this PR fixes**:

Fixes #4290 

**Area**

system-PZ

**PR acceptance criteria**:
- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
 just run the test script