### PR TITLE
use default component name if user doesn't provide one in devfile mode

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -482,7 +482,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					return errors.Errorf("accepts between 0 and 1 arg when using existing devfile, received %d", len(args))
 				}
 
-				// If user can use existing devfile directly, we generate the Default Component name if only 1 arg is provided
+				// If user can use existing devfile directly, the first arg is component name instead of component type
 				if len(args) == 1 {
 					componentName = args[0]
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -484,16 +484,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 				// If user can use existing devfile directly, we generate the Default Component name if only 1 arg is provided
 				if len(args) == 1 {
-					var err error
-					componentName, err = createDefaultComponentName(
-						co.Context,
-						args[0],
-						config.LOCAL, // always local for devfile
-						co.componentContext,
-					)
-					if err != nil {
-						return err
-					}
+					componentName = args[0]
 
 				} else {
 					currentDirPath, err := os.Getwd()

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -482,9 +482,19 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					return errors.Errorf("accepts between 0 and 1 arg when using existing devfile, received %d", len(args))
 				}
 
-				// If user can use existing devfile directly, the first arg is component name instead of component type
+				// If user can use existing devfile directly, we generate the Default Component name if only 1 arg is provided
 				if len(args) == 1 {
-					componentName = args[0]
+					var err error
+					componentName, err = createDefaultComponentName(
+						co.Context,
+						args[0],
+						config.LOCAL, // always local for devfile
+						co.componentContext,
+					)
+					if err != nil {
+						return err
+					}
+
 				} else {
 					currentDirPath, err := os.Getwd()
 					if err != nil {
@@ -501,11 +511,20 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 				// Component type: Get from full command's first argument (mandatory in direct mode)
 				componentType = args[0]
 
-				// Component name: Get from full command's second argument (optional in direct mode), by default it is component type from first argument
+				// Component name: Get from full command's second argument (optional in direct mode), by default it is a generated name if second arg is not provided
 				if len(args) == 2 {
 					componentName = args[1]
 				} else {
-					componentName = args[0]
+					var err error
+					componentName, err = createDefaultComponentName(
+						co.Context,
+						componentType,
+						config.LOCAL, // always local for devfile
+						co.componentContext,
+					)
+					if err != nil {
+						return err
+					}
 				}
 
 				// Get available devfile components for checking devfile compatibility

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/tidwall/gjson"
 
@@ -101,6 +102,13 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--starter", "--context", newContext)
 			expectedFiles := []string{"package.json", "package-lock.json", "README.md", devfile}
 			Expect(helper.VerifyFilesExist(newContext, expectedFiles)).To(Equal(true))
+		})
+
+		It("should successfully create the devfile component with auto generated name", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--context", newContext)
+			output := helper.Cmd("odo", "env", "view", "--context", newContext, "-o", "json").ShouldPass().Out()
+			value := gjson.Get(output, "spec.name")
+			Expect(strings.TrimSpace(value.String())).To(ContainSubstring(strings.TrimSpace("nodejs-" + filepath.Base(strings.ToLower(newContext)))))
 		})
 
 		It("should successfully create the devfile component and show json output for working cluster", func() {

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -166,7 +166,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 	})
 
 	Context("when executing odo watch after odo push with debug flag", func() {
-		FIt("should be able to start a debug session after push with debug flag using odo watch and revert back after normal push", func() {
+		It("should be able to start a debug session after push with debug flag using odo watch and revert back after normal push", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "create", cmpName, "--project", commonVar.Project)

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -166,7 +166,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 	})
 
 	Context("when executing odo watch after odo push with debug flag", func() {
-		It("should be able to start a debug session after push with debug flag using odo watch and revert back after normal push", func() {
+		FIt("should be able to start a debug session after push with debug flag using odo watch and revert back after normal push", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "create", cmpName, "--project", commonVar.Project)

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -451,7 +451,7 @@ spec:
 
 			// Before running "odo unlink" checks, wait for the pod to come up from "odo push" done after "odo link"
 			pods = oc.GetAllPodsInNs(project)
-			componentPod := regexp.MustCompile(fmt.Sprintf(`%s-.[a-z0-9]*-.[a-z0-9]*`, componentName)).FindString(pods)
+			componentPod := regexp.MustCompile(fmt.Sprintf(`%s-.[a-z0-9]*-.[a-z0-9\-]*`, componentName)).FindString(pods)
 			ocArgs = []string{"get", "pods", componentPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
 			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
 				return strings.Contains(output, "Running")


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does does this PR do / why we need it**:
see $SUBJECT

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4112

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
mkdir hello
cd hello
odo create nodejs <- should create a component with name `nodejs-hello-<4randomChars>`

# again
odo create nodejs blah <- should create component with name blah

```

