### PR TITLE
Add test-integration-devfile tests for ppc64le

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -43,6 +43,7 @@ if [ "${ARCH}" == "s390x" ]; then
 elif  [ "${ARCH}" == "ppc64le" ]; then
     # Integration tests
     make test-integration
+    make test-integration-devfile
     make test-cmd-login-logout
     make test-cmd-project
     # E2e tests


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does does this PR do / why we need it**:
This change enables ODO test-suite to enable devfile integration tests on Power.

**Which issue(s) this PR fixes**:

Fixes #4290 

**PR acceptance criteria**:

- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
Run the test script (scripts/openshiftci-presubmit-all-tests.sh)

> /area system-PZ