### PR TITLE
Make preference commands errors pretty and fix typos with test

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -307,7 +307,7 @@ func (c *PreferenceInfo) RegistryHandler(operation string, registryName string, 
 	c.OdoSettings.RegistryList = &registryList
 	err = util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to write the configuration of %s operation to preference file", operation)
+		return errors.Errorf("unable to write the configuration of %q operation to preference file", operation)
 	}
 
 	return nil
@@ -325,10 +325,10 @@ func handleWithoutRegistryExist(registryList []Registry, operation string, regis
 		registryList = append(registryList, registry)
 
 	case "update":
-		return nil, errors.Errorf("failed to update registry: registry %s doesn't exist", registryName)
+		return nil, errors.Errorf("failed to update registry: registry %q doesn't exist", registryName)
 
 	case "delete":
-		return nil, errors.Errorf("failed to delete registry: registry %s doesn't exist", registryName)
+		return nil, errors.Errorf("failed to delete registry: registry %q doesn't exist", registryName)
 	}
 
 	return registryList, nil
@@ -338,11 +338,11 @@ func handleWithRegistryExist(index int, registryList []Registry, operation strin
 	switch operation {
 
 	case "add":
-		return nil, errors.Errorf("failed to add registry: registry %s already exists", registryName)
+		return nil, errors.Errorf("failed to add registry: registry %q already exists", registryName)
 
 	case "update":
 		if !forceFlag {
-			if !ui.Proceed(fmt.Sprintf("Are you sure you want to update registry %s", registryName)) {
+			if !ui.Proceed(fmt.Sprintf("Are you sure you want to update registry %q", registryName)) {
 				log.Info("Aborted by the user")
 				return registryList, nil
 			}
@@ -354,7 +354,7 @@ func handleWithRegistryExist(index int, registryList []Registry, operation strin
 
 	case "delete":
 		if !forceFlag {
-			if !ui.Proceed(fmt.Sprintf("Are you sure you want to delete registry %s", registryName)) {
+			if !ui.Proceed(fmt.Sprintf("Are you sure you want to delete registry %q", registryName)) {
 				log.Info("Aborted by the user")
 				return registryList, nil
 			}
@@ -380,7 +380,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "timeout":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s", parameter, value)
+				return errors.Errorf("unable to set %q to %q", parameter, value)
 			}
 			if typedval < 0 {
 				return errors.Errorf("cannot set timeout to less than 0")
@@ -390,7 +390,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "buildtimeout":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be an integer", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
 			}
 			if typedval < 0 {
 				return errors.Errorf("cannot set timeout to less than 0")
@@ -400,7 +400,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "pushtimeout":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be an integer", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
 			}
 			if typedval < 0 {
 				return errors.Errorf("cannot set timeout to less than 0")
@@ -410,7 +410,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "registrycachetime":
 			typedval, err := strconv.Atoi(value)
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be an integer", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be an integer", parameter, value)
 			}
 			if typedval < 0 {
 				return errors.Errorf("cannot set timeout to less than 0")
@@ -420,7 +420,7 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "updatenotification":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be a boolean", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.UpdateNotification = &val
 
@@ -431,38 +431,38 @@ func (c *PreferenceInfo) SetConfiguration(parameter string, value string) error 
 		case "experimental":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be a boolean", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.Experimental = &val
 
 		case "ephemeral":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Errorf("unable to set %s to %s, value must be a boolean", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.Ephemeral = &val
 
 		case "pushtarget":
 			val := strings.ToLower(value)
 			if val != DockerPushTarget && val != KubePushTarget {
-				return errors.Errorf("cannot set pushtarget to values other than '%s' or '%s'", DockerPushTarget, KubePushTarget)
+				return errors.Errorf("cannot set pushtarget to values other than %q or %q", DockerPushTarget, KubePushTarget)
 			}
 			c.OdoSettings.PushTarget = &val
 
 		case "consenttelemetry":
 			val, err := strconv.ParseBool(strings.ToLower(value))
 			if err != nil {
-				return errors.Wrapf(err, "unable to set %s to %s", parameter, value)
+				return errors.Errorf("unable to set %q to %q, value must be a boolean", parameter, value)
 			}
 			c.OdoSettings.ConsentTelemetry = &val
 		}
 	} else {
-		return errors.Errorf("unknown parameter :'%s' is not a parameter in odo preference, run help to see list of available parameters", parameter)
+		return errors.Errorf("unknown parameter : %q is not a parameter in odo preference, run help to see list of available parameters", parameter)
 	}
 
 	err := util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to set %s, something is wrong with odo, kindly raise an issue at https://github.com/openshift/odo/issues/new?template=Bug.md", parameter)
+		return errors.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/openshift/odo/issues/new?template=Bug.md", parameter)
 	}
 	return nil
 }
@@ -477,12 +477,12 @@ func (c *PreferenceInfo) DeleteConfiguration(parameter string) error {
 			return err
 		}
 	} else {
-		return errors.Errorf("unknown parameter :'%s' is not a parameter in the odo preference", parameter)
+		return errors.Errorf("unknown parameter :%q is not a parameter in the odo preference", parameter)
 	}
 
 	err := util.WriteToFile(&c.Preference, c.Filename)
 	if err != nil {
-		return errors.Errorf("unable to set %s, something is wrong with odo, kindly raise an issue at https://github.com/openshift/odo/issues/new?template=Bug.md", parameter)
+		return errors.Errorf("unable to set %q, something is wrong with odo, kindly raise an issue at https://github.com/openshift/odo/issues/new?template=Bug.md", parameter)
 	}
 	return nil
 }

--- a/pkg/preference/preference_test.go
+++ b/pkg/preference/preference_test.go
@@ -120,7 +120,7 @@ func TestGetBuildTimeout(t *testing.T) {
 
 			output := cfg.GetBuildTimeout()
 			if output != tt.want {
-				t.Errorf("GetBuildTimeout returned unexpeced value expected \ngot: %d \nexpected: %d\n", output, tt.want)
+				t.Errorf("GetBuildTimeout returned unexpected value expected \ngot: %d \nexpected: %d\n", output, tt.want)
 			}
 		})
 	}
@@ -176,7 +176,7 @@ func TestGetPushTimeout(t *testing.T) {
 
 			output := cfg.GetPushTimeout()
 			if output != tt.want {
-				t.Errorf("GetPushTimeout returned unexpeced value expected \ngot: %d \nexpected: %d\n", output, tt.want)
+				t.Errorf("GetPushTimeout returned unexpected value expected \ngot: %d \nexpected: %d\n", output, tt.want)
 			}
 		})
 	}
@@ -232,7 +232,7 @@ func TestGetTimeout(t *testing.T) {
 
 			output := cfg.GetTimeout()
 			if output != tt.want {
-				t.Errorf("GetTimeout returned unexpeced value expected \ngot: %d \nexpected: %d\n", output, tt.want)
+				t.Errorf("GetTimeout returned unexpected value expected \ngot: %d \nexpected: %d\n", output, tt.want)
 			}
 		})
 	}
@@ -508,23 +508,23 @@ func TestSetConfiguration(t *testing.T) {
 				switch tt.parameter {
 				case "updatenotification":
 					if *cfg.OdoSettings.UpdateNotification != tt.want {
-						t.Errorf("unexpeced value after execution of SetConfiguration \ngot: %t \nexpected: %t\n", *cfg.OdoSettings.UpdateNotification, tt.want)
+						t.Errorf("unexpected value after execution of SetConfiguration \ngot: %t \nexpected: %t\n", *cfg.OdoSettings.UpdateNotification, tt.want)
 					}
 				case "timeout":
 					if *cfg.OdoSettings.Timeout != tt.want {
-						t.Errorf("unexpeced value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.Timeout, tt.want)
+						t.Errorf("unexpected value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.Timeout, tt.want)
 					}
 				case "experimental":
 					if *cfg.OdoSettings.Experimental != tt.want {
-						t.Errorf("unexpeced value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.Experimental, tt.want)
+						t.Errorf("unexpected value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.Experimental, tt.want)
 					}
 				case "pushtarget":
 					if *cfg.OdoSettings.PushTarget != tt.want {
-						t.Errorf("unexpeced value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.PushTarget, tt.want)
+						t.Errorf("unexpected value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", cfg.OdoSettings.PushTarget, tt.want)
 					}
 				case "registrycachetime":
 					if *cfg.OdoSettings.RegistryCacheTime != tt.want {
-						t.Errorf("unexpeced value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", *cfg.OdoSettings.RegistryCacheTime, tt.want)
+						t.Errorf("unexpected value after execution of SetConfiguration \ngot: %v \nexpected: %d\n", *cfg.OdoSettings.RegistryCacheTime, tt.want)
 					}
 				}
 			} else if tt.wantErr && err != nil {
@@ -596,7 +596,7 @@ func TestGetupdateNotification(t *testing.T) {
 			output := cfg.GetUpdateNotification()
 
 			if output != tt.want {
-				t.Errorf("GetUpdateNotification returned unexpeced value expected \ngot: %t \nexpected: %t\n", output, tt.want)
+				t.Errorf("GetUpdateNotification returned unexpected value expected \ngot: %t \nexpected: %t\n", output, tt.want)
 			}
 
 		})
@@ -652,7 +652,7 @@ func TestGetExperimental(t *testing.T) {
 			output := cfg.GetExperimental()
 
 			if output != tt.want {
-				t.Errorf("GetExperimental returned unexpeced value expected \ngot: %t \nexpected: %t\n", output, tt.want)
+				t.Errorf("GetExperimental returned unexpected value expected \ngot: %t \nexpected: %t\n", output, tt.want)
 			}
 
 		})
@@ -708,7 +708,7 @@ func TestGetPushTarget(t *testing.T) {
 			output := cfg.GetPushTarget()
 
 			if output != tt.want {
-				t.Errorf("GetExperimental returned unexpeced value expected \ngot: %s \nexpected: %s\n", output, tt.want)
+				t.Errorf("GetExperimental returned unexpected value expected \ngot: %s \nexpected: %s\n", output, tt.want)
 			}
 
 		})
@@ -967,7 +967,7 @@ func TestGetConsentTelemetry(t *testing.T) {
 			output := cfg.GetConsentTelemetry()
 
 			if output != tt.want {
-				t.Errorf("GetConsentTelemetry returned unexpeced value expected \ngot: %t \nexpected: %t\n", output, tt.want)
+				t.Errorf("GetConsentTelemetry returned unexpected value expected \ngot: %t \nexpected: %t\n", output, tt.want)
 			}
 
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:
This PR just replaces `%s` with `%q` to make errors more readable, and fixes typos in tests.

**Which issue(s) this PR fixes**:

Fixes #4540

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
