### PR TITLE
Get SB secret name from SB

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -15,6 +15,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -391,8 +392,25 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		return err
 	}
 
+	// Get ServiceBinding Secret name for each Link
+	var sbSecrets []string
+	for _, link := range ei.GetLink() {
+		sb, err := a.Client.GetDynamicResource(kclient.ServiceBindingGroup, kclient.ServiceBindingVersion, kclient.ServiceBindingResource, link.Name)
+		if err != nil {
+			return err
+		}
+		secret, found, err := unstructured.NestedString(sb.Object, "status", "secret")
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("unable to find secret in ServiceBinding %s", link.Name)
+		}
+		sbSecrets = append(sbSecrets, secret)
+	}
+
 	// set EnvFrom to the container that's supposed to have link to the Operator backed service
-	containers, err = utils.UpdateContainerWithEnvFrom(containers, a.Devfile, a.devfileRunCmd, ei)
+	containers, err = utils.UpdateContainerWithEnvFromSecrets(containers, a.Devfile, a.devfileRunCmd, ei, sbSecrets)
 	if err != nil {
 		return err
 	}

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -27,6 +27,13 @@ const (
 	// TimedOutReason is added in a deployment when its newest replica set fails to show any progress
 	// within the given deadline (progressDeadlineSeconds).
 	timedOutReason = "ProgressDeadlineExceeded"
+
+	// Hardcoded variables since we can't install SBO on k8s using OLM
+	// (https://github.com/redhat-developer/service-binding-operator/issues/536)
+	ServiceBindingGroup    = "binding.operators.coreos.com"
+	ServiceBindingVersion  = "v1alpha1"
+	ServiceBindingKind     = "ServiceBinding"
+	ServiceBindingResource = "servicebindings"
 )
 
 // GetDeploymentByName gets a deployment by querying by name
@@ -239,6 +246,18 @@ func (c *Client) ListDynamicResource(group, version, resource string) (*unstruct
 	}
 
 	return list, nil
+}
+
+// GetDynamicResource returns an unstructured instances of a Custom
+// Resource currently deployed in the active namespace of the cluster
+func (c *Client) GetDynamicResource(group, version, resource, name string) (*unstructured.Unstructured, error) {
+	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	res, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // DeleteDynamicResource deletes an instance, specified by name, of a Custom Resource

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/odo/pkg/component"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/envinfo"
+	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -20,15 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
-)
-
-var (
-	// Hardcoded variables since we can't install SBO on k8s using OLM
-	// (https://github.com/redhat-developer/service-binding-operator/issues/536)
-	serviceBindingGroup    = "binding.operators.coreos.com"
-	serviceBindingVersion  = "v1alpha1"
-	serviceBindingKind     = "ServiceBinding"
-	serviceBindingResource = "servicebindings"
 )
 
 const unlink = "unlink"
@@ -111,8 +103,8 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 		componentName := o.EnvSpecificInfo.GetName()
 
 		// Assign static/hardcoded values to SBR
-		o.serviceBinding.Kind = serviceBindingKind
-		o.serviceBinding.APIVersion = strings.Join([]string{serviceBindingGroup, serviceBindingVersion}, "/")
+		o.serviceBinding.Kind = kclient.ServiceBindingKind
+		o.serviceBinding.APIVersion = strings.Join([]string{kclient.ServiceBindingGroup, kclient.ServiceBindingVersion}, "/")
 
 		// service binding request name will be like <component-name>-<service-type>-<service-name>. For example: nodejs-etcdcluster-example
 		o.serviceBinding.Name = getServiceBindingName(componentName, o.serviceType, o.serviceName)
@@ -142,7 +134,12 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 				Group:    deploymentSelfLinkSplit[2], // "apps" in above example output
 				Version:  deploymentSelfLinkSplit[3], // "v1" in above example output
 				Resource: deploymentSelfLinkSplit[6], // "deployments" in above example output
-			},
+			}
+		}
+
+		// Populate the application selector field in service binding request
+		o.serviceBinding.Spec.Application = &servicebinding.Application{
+			Ref: ref,
 		}
 		o.serviceBinding.Spec.Application.Name = componentName
 
@@ -208,7 +205,7 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 			}
 
 			// Verify if the underlying service binding request actually exists
-			serviceBindingSvcFullName := strings.Join([]string{serviceBindingKind, serviceBindingName}, "/")
+			serviceBindingSvcFullName := strings.Join([]string{kclient.ServiceBindingKind, serviceBindingName}, "/")
 			serviceBindingExists, err := svc.OperatorSvcExists(o.KClient, serviceBindingSvcFullName)
 			if err != nil {
 				return err
@@ -284,7 +281,7 @@ func (o *commonLinkOptions) run() (err error) {
 	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
 		if o.operationName == unlink {
 			serviceBindingName := getServiceBindingName(o.EnvSpecificInfo.GetName(), o.serviceType, o.serviceName)
-			svcFullName := getSvcFullName(serviceBindingKind, serviceBindingName)
+			svcFullName := getSvcFullName(kclient.ServiceBindingKind, serviceBindingName)
 			err = svc.DeleteServiceBindingRequest(o.KClient, svcFullName)
 			if err != nil {
 				return err
@@ -312,7 +309,7 @@ func (o *commonLinkOptions) run() (err error) {
 
 		// this creates a link by creating a service of type
 		// "ServiceBindingRequest" from the Operator "ServiceBindingOperator".
-		err = o.KClient.CreateDynamicResource(serviceBindingMap, serviceBindingGroup, serviceBindingVersion, serviceBindingResource)
+		err = o.KClient.CreateDynamicResource(serviceBindingMap, kclient.ServiceBindingGroup, kclient.ServiceBindingVersion, kclient.ServiceBindingResource)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				return fmt.Errorf("component %q is already linked with the service %q", o.Context.EnvSpecificInfo.GetName(), o.suppliedName)

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -134,13 +134,9 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 				Group:    deploymentSelfLinkSplit[2], // "apps" in above example output
 				Version:  deploymentSelfLinkSplit[3], // "v1" in above example output
 				Resource: deploymentSelfLinkSplit[6], // "deployments" in above example output
-			}
+			},
 		}
 
-		// Populate the application selector field in service binding request
-		o.serviceBinding.Spec.Application = &servicebinding.Application{
-			Ref: ref,
-		}
 		o.serviceBinding.Spec.Application.Name = componentName
 
 		return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does does this PR do / why we need it**:

Currently, odo assumes that  Secret created by SBO has the same name as ServiceBinding.
This is no longer valid. SBO Secrets have some kind of has as a suffix. 
This PR makes sure that odo detect the correct Secret name from SB definition. 

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
