### PR TITLE
Decide GVR based on underlying cluster

### DIFF
--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -383,3 +383,31 @@ func (c *Client) GetDeploymentConfigsFromSelector(selector string) ([]appsv1.Dep
 	}
 	return dcList.Items, nil
 }
+
+// GetDeploymentAPIVersion returns a map with Group, Version, Resource information of Deployment objects
+// depending on the GVR supported by the cluster
+func (c *Client) GetDeploymentAPIVersion() (map[string]string, error) {
+	extV1Beta1, err := c.IsDeploymentExtensionsV1Beta1()
+	if err != nil {
+		return nil, err
+	}
+
+	if extV1Beta1 {
+		// this indicates we're running on OCP 3.11 cluster
+		return map[string]string{
+			"group":    "extensions",
+			"version":  "v1beta1",
+			"resource": "deployments",
+		}, nil
+	}
+
+	return map[string]string{
+		"group":    "apps",
+		"version":  "v1",
+		"resource": "deployments",
+	}, nil
+}
+
+func (c *Client) IsDeploymentExtensionsV1Beta1() (bool, error) {
+	return c.IsResourceSupported("extensions", "v1beta1", "deployments")
+}

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -386,25 +386,25 @@ func (c *Client) GetDeploymentConfigsFromSelector(selector string) ([]appsv1.Dep
 
 // GetDeploymentAPIVersion returns a map with Group, Version, Resource information of Deployment objects
 // depending on the GVR supported by the cluster
-func (c *Client) GetDeploymentAPIVersion() (map[string]string, error) {
+func (c *Client) GetDeploymentAPIVersion() (metav1.GroupVersionResource, error) {
 	extV1Beta1, err := c.IsDeploymentExtensionsV1Beta1()
 	if err != nil {
-		return nil, err
+		return metav1.GroupVersionResource{}, err
 	}
 
 	if extV1Beta1 {
 		// this indicates we're running on OCP 3.11 cluster
-		return map[string]string{
-			"group":    "extensions",
-			"version":  "v1beta1",
-			"resource": "deployments",
+		return metav1.GroupVersionResource{
+			Group:    "extensions",
+			Version:  "v1beta1",
+			Resource: "deployments",
 		}, nil
 	}
 
-	return map[string]string{
-		"group":    "apps",
-		"version":  "v1",
-		"resource": "deployments",
+	return metav1.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
 	}, nil
 }
 

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -120,20 +120,18 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 		// make this deployment the owner of the link we're creating so that link gets deleted upon doing "odo delete"
 		ownerReference := generator.GetOwnerReference(deployment)
 		o.serviceBinding.SetOwnerReferences(append(o.serviceBinding.GetOwnerReferences(), ownerReference))
+
+		deploymentGVR, err := o.KClient.GetDeploymentAPIVersion()
 		if err != nil {
 			return err
 		}
 
-		// This is a really hacky way to get group, version and resource info but I couldn't find better one.
-		// A sample "deploymentSelfLinkSplit" looks like: [ apis apps v1 namespaces myproject deployments nodejs ]
-		deploymentSelfLinkSplit := strings.Split(deployment.SelfLink, "/")
-
 		// Populate the application selector field in service binding request
 		o.serviceBinding.Spec.Application = &servicebinding.Application{
 			GroupVersionResource: metav1.GroupVersionResource{
-				Group:    deploymentSelfLinkSplit[2], // "apps" in above example output
-				Version:  deploymentSelfLinkSplit[3], // "v1" in above example output
-				Resource: deploymentSelfLinkSplit[6], // "deployments" in above example output
+				Group:    deploymentGVR["group"],
+				Version:  deploymentGVR["version"],
+				Resource: deploymentGVR["resource"],
 			},
 		}
 

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -129,9 +129,9 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 		// Populate the application selector field in service binding request
 		o.serviceBinding.Spec.Application = &servicebinding.Application{
 			GroupVersionResource: metav1.GroupVersionResource{
-				Group:    deploymentGVR["group"],
-				Version:  deploymentGVR["version"],
-				Resource: deploymentGVR["resource"],
+				Group:    deploymentGVR.Group,
+				Version:  deploymentGVR.Version,
+				Resource: deploymentGVR.Resource,
 			},
 		}
 

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -128,11 +128,7 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 
 		// Populate the application selector field in service binding request
 		o.serviceBinding.Spec.Application = &servicebinding.Application{
-			GroupVersionResource: metav1.GroupVersionResource{
-				Group:    deploymentGVR.Group,
-				Version:  deploymentGVR.Version,
-				Resource: deploymentGVR.Resource,
-			},
+			GroupVersionResource: deploymentGVR,
 		}
 
 		o.serviceBinding.Spec.Application.Name = componentName


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind bug

**What does this PR do / why we need it**:
Gets rid of the deprecated `SelfLink` attribute of a deployment and uses information available from the underlying cluster instead.

**Which issue(s) this PR fixes**:

Fixes #4431

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Along with OCP 4.6 and 4.7, `odo link` should work fine on OCP 4.8 and minikube started with `minikube start --kubernetes-version=v1.20.2`