### PR TITLE
Modifies newKubernetesAdapter() and others 

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -595,24 +595,13 @@ func ensureAndLogProperResourceUsage(resourceMin, resourceMax *string, resourceN
 // ApplyConfig applies the component config onto component dc
 // Parameters:
 //	client: occlient instance
-//	kClient: kclient instance
 //	componentConfig: Component configuration
 //	envSpecificInfo: Component environment specific information, available if uses devfile
 //  cmpExist: true if components exists in the cluster
 //  isS2I: Legacy option. Set as true if you want to use the old S2I method as it differentiates slightly.
 // Returns:
 //	err: Errors if any else nil
-func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool, isS2I bool) (err error) {
-
-	if client == nil {
-		var err error
-		client, err = occlient.New()
-		if err != nil {
-			return err
-		}
-		// new client created to support route URLs for devfile components should use the same namespace as kClient's
-		client.Namespace = kClient.Namespace
-	}
+func ApplyConfig(client *occlient.Client, componentConfig config.LocalConfigInfo, envSpecificInfo envinfo.EnvSpecificInfo, stdout io.Writer, cmpExist bool, isS2I bool) (err error) {
 
 	var configProvider localConfigProvider.LocalConfigProvider
 	if isS2I {
@@ -624,7 +613,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 		}
 	}
 
-	if isS2I || kClient == nil {
+	if isS2I {
 		configProvider = &componentConfig
 	} else {
 		configProvider = &envSpecificInfo
@@ -642,7 +631,7 @@ func ApplyConfig(client *occlient.Client, kClient *kclient.Client, componentConf
 		LocalConfigProvider: configProvider,
 	})
 
-	return urlpkg.Push(client, kClient, urlpkg.PushParameters{
+	return urlpkg.Push(client, urlpkg.PushParameters{
 		LocalConfig:      configProvider,
 		URLClient:        urlClient,
 		IsRouteSupported: isRouteSupported,

--- a/pkg/devfile/adapters/helper.go
+++ b/pkg/devfile/adapters/helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/lclient"
+	"github.com/openshift/odo/pkg/occlient"
 	"github.com/openshift/odo/pkg/odo/util/pushtarget"
 )
 
@@ -36,10 +37,16 @@ func NewComponentAdapter(componentName string, context string, appName string, d
 }
 
 func createKubernetesAdapter(adapterContext common.AdapterContext, namespace string) (common.ComponentAdapter, error) {
-	client, err := kclient.New()
+	client, err := occlient.New()
 	if err != nil {
 		return nil, err
 	}
+
+	kClient, err := kclient.New()
+	if err != nil {
+		return nil, err
+	}
+	client.SetKubeClient(kClient)
 
 	// If a namespace was passed in
 	if namespace != "" {
@@ -48,7 +55,7 @@ func createKubernetesAdapter(adapterContext common.AdapterContext, namespace str
 	return newKubernetesAdapter(adapterContext, *client)
 }
 
-func newKubernetesAdapter(adapterContext common.AdapterContext, client kclient.Client) (common.ComponentAdapter, error) {
+func newKubernetesAdapter(adapterContext common.AdapterContext, client occlient.Client) (common.ComponentAdapter, error) {
 	// Feed the common metadata to the platform-specific adapter
 	kubernetesAdapter := kubernetes.New(adapterContext, client)
 

--- a/pkg/devfile/adapters/helper_test.go
+++ b/pkg/devfile/adapters/helper_test.go
@@ -8,7 +8,7 @@ import (
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/testingutil"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
-	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/occlient"
 )
 
 func TestNewPlatformAdapter(t *testing.T) {
@@ -39,7 +39,7 @@ func TestNewPlatformAdapter(t *testing.T) {
 				ComponentName: tt.componentName,
 				Devfile:       devObj,
 			}
-			fkclient, _ := kclient.FakeNew()
+			fkclient, _ := occlient.FakeNew()
 			adapter, err := newKubernetesAdapter(adapterContext, *fkclient)
 			if err != nil {
 				t.Errorf("unexpected error: '%v'", err)

--- a/pkg/devfile/adapters/kubernetes/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/adapter.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/component"
-	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/occlient"
 	"github.com/pkg/errors"
 )
 
@@ -22,7 +22,7 @@ type KubernetesContext struct {
 }
 
 // New instantiates a kubernetes adapter
-func New(adapterContext common.AdapterContext, client kclient.Client) Adapter {
+func New(adapterContext common.AdapterContext, client occlient.Client) Adapter {
 
 	compAdapter := component.New(adapterContext, client)
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -41,7 +41,7 @@ import (
 const supervisorDStatusWaitTimeInterval = 1
 
 // New instantiates a component adapter
-func New(adapterContext common.AdapterContext, client kclient.Client) Adapter {
+func New(adapterContext common.AdapterContext, client occlient.Client) Adapter {
 
 	adapter := Adapter{Client: client}
 	adapter.GenericAdapter = common.NewGenericAdapter(&adapter, adapterContext)
@@ -56,7 +56,7 @@ func (a *Adapter) getPod(refresh bool) (*corev1.Pod, error) {
 		podSelector := fmt.Sprintf("component=%s", a.ComponentName)
 
 		// Wait for Pod to be in running state otherwise we can't sync data to it.
-		pod, err := a.Client.WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
+		pod, err := a.Client.GetKubeClient().WaitAndGetPodWithEvents(podSelector, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return nil, errors.Wrapf(err, "error while waiting for pod %s", podSelector)
 		}
@@ -94,7 +94,7 @@ func (a *Adapter) SupervisorComponentInfo(command devfilev1.Command) (common.Com
 
 // Adapter is a component adapter implementation for Kubernetes
 type Adapter struct {
-	Client kclient.Client
+	Client occlient.Client
 	*common.GenericAdapter
 
 	devfileBuildCmd  string
@@ -107,7 +107,7 @@ type Adapter struct {
 // Push updates the component if a matching component exists or creates one if it doesn't exist
 // Once the component has started, it will sync the source code to it.
 func (a Adapter) Push(parameters common.PushParameters) (err error) {
-	componentExists, err := utils.ComponentExists(a.Client, a.ComponentName)
+	componentExists, err := utils.ComponentExists(*a.Client.GetKubeClient(), a.ComponentName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to determine if component %s exists", a.ComponentName)
 	}
@@ -172,7 +172,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		return errors.Wrap(err, "unable to create or update component")
 	}
 
-	deployment, err := a.Client.WaitForDeploymentRollout(a.ComponentName)
+	deployment, err := a.Client.GetKubeClient().WaitForDeploymentRollout(a.ComponentName)
 	if err != nil {
 		return errors.Wrap(err, "error while waiting for deployment rollout")
 	}
@@ -184,7 +184,7 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	}
 
 	// list the latest state of the PVCs
-	pvcs, err := a.Client.ListPVCs(fmt.Sprintf("%v=%v", "component", a.ComponentName))
+	pvcs, err := a.Client.GetKubeClient().ListPVCs(fmt.Sprintf("%v=%v", "component", a.ComponentName))
 	if err != nil {
 		return err
 	}
@@ -194,14 +194,14 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 		if pvcs[i].OwnerReferences != nil || pvcs[i].DeletionTimestamp != nil {
 			continue
 		}
-		err = a.Client.UpdateStorageOwnerReference(&pvcs[i], generator.GetOwnerReference(deployment))
+		err = a.Client.GetKubeClient().UpdateStorageOwnerReference(&pvcs[i], generator.GetOwnerReference(deployment))
 		if err != nil {
 			return err
 		}
 	}
 
 	parameters.EnvSpecificInfo.SetDevfileObj(a.Devfile)
-	err = component.ApplyConfig(nil, &a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists, false)
+	err = component.ApplyConfig(&a.Client, config.LocalConfigInfo{}, parameters.EnvSpecificInfo, color.Output, componentExists, false)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}
@@ -317,7 +317,7 @@ func (a Adapter) CheckSupervisordCtlStatus(command devfilev1.Command) error {
 
 // Test runs the devfile test command
 func (a Adapter) Test(testCmd string, show bool) (err error) {
-	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
+	pod, err := a.Client.GetKubeClient().GetPodUsingComponentName(a.ComponentName)
 	if err != nil {
 		return fmt.Errorf("error occurred while getting the pod: %w", err)
 	}
@@ -340,24 +340,19 @@ func (a Adapter) Test(testCmd string, show bool) (err error) {
 
 // DoesComponentExist returns true if a component with the specified name exists, false otherwise
 func (a Adapter) DoesComponentExist(cmpName string) (bool, error) {
-	return utils.ComponentExists(a.Client, cmpName)
+	return utils.ComponentExists(*a.Client.GetKubeClient(), cmpName)
 }
 
 func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpecificInfo) (err error) {
 	ei.SetDevfileObj(a.Devfile)
-	ocClient, err := occlient.New()
-	if err != nil {
-		return err
-	}
-	ocClient.SetKubeClient(&a.Client)
 
 	storageClient := storagepkg.NewClient(storagepkg.ClientOptions{
-		OCClient:            *ocClient,
+		OCClient:            a.Client,
 		LocalConfigProvider: &ei,
 	})
 
 	// handle the ephemeral storage
-	err = storage.HandleEphemeralStorage(a.Client, storageClient, a.ComponentName)
+	err = storage.HandleEphemeralStorage(*a.Client.GetKubeClient(), storageClient, a.ComponentName)
 	if err != nil {
 		return err
 	}
@@ -395,7 +390,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	// Get ServiceBinding Secret name for each Link
 	var sbSecrets []string
 	for _, link := range ei.GetLink() {
-		sb, err := a.Client.GetDynamicResource(kclient.ServiceBindingGroup, kclient.ServiceBindingVersion, kclient.ServiceBindingResource, link.Name)
+		sb, err := a.Client.GetKubeClient().GetDynamicResource(kclient.ServiceBindingGroup, kclient.ServiceBindingVersion, kclient.ServiceBindingResource, link.Name)
 		if err != nil {
 			return err
 		}
@@ -433,7 +428,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	volumeNameToPVCName := make(map[string]string)
 
 	// list all the pvcs for the component
-	pvcs, err := a.Client.ListPVCs(fmt.Sprintf("%v=%v", "component", a.ComponentName))
+	pvcs, err := a.Client.GetKubeClient().ListPVCs(fmt.Sprintf("%v=%v", "component", a.ComponentName))
 	if err != nil {
 		return err
 	}
@@ -483,18 +478,18 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	if componentExists {
 		// If the component already exists, get the resource version of the deploy before updating
 		klog.V(2).Info("The component already exists, attempting to update it")
-		deployment, err = a.Client.UpdateDeployment(*deployment)
+		deployment, err = a.Client.GetKubeClient().UpdateDeployment(*deployment)
 		if err != nil {
 			return err
 		}
 		klog.V(2).Infof("Successfully updated component %v", componentName)
-		oldSvc, err := a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Get(componentName, metav1.GetOptions{})
+		oldSvc, err := a.Client.GetKubeClient().KubeClient.CoreV1().Services(a.Client.Namespace).Get(componentName, metav1.GetOptions{})
 		ownerReference := generator.GetOwnerReference(deployment)
 		service.OwnerReferences = append(service.OwnerReferences, ownerReference)
 		if err != nil {
 			// no old service was found, create a new one
 			if len(service.Spec.Ports) > 0 {
-				_, err = a.Client.CreateService(*service)
+				_, err = a.Client.GetKubeClient().CreateService(*service)
 				if err != nil {
 					return err
 				}
@@ -504,20 +499,20 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 			if len(service.Spec.Ports) > 0 {
 				service.Spec.ClusterIP = oldSvc.Spec.ClusterIP
 				service.ResourceVersion = oldSvc.GetResourceVersion()
-				_, err = a.Client.UpdateService(*service)
+				_, err = a.Client.GetKubeClient().UpdateService(*service)
 				if err != nil {
 					return err
 				}
 				klog.V(2).Infof("Successfully update Service for component %s", componentName)
 			} else {
-				err = a.Client.KubeClient.CoreV1().Services(a.Client.Namespace).Delete(componentName, &metav1.DeleteOptions{})
+				err = a.Client.GetKubeClient().KubeClient.CoreV1().Services(a.Client.Namespace).Delete(componentName, &metav1.DeleteOptions{})
 				if err != nil {
 					return err
 				}
 			}
 		}
 	} else {
-		deployment, err = a.Client.CreateDeployment(*deployment)
+		deployment, err = a.Client.GetKubeClient().CreateDeployment(*deployment)
 		if err != nil {
 			return err
 		}
@@ -525,7 +520,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		ownerReference := generator.GetOwnerReference(deployment)
 		service.OwnerReferences = append(service.OwnerReferences, ownerReference)
 		if len(service.Spec.Ports) > 0 {
-			_, err = a.Client.CreateService(*service)
+			_, err = a.Client.GetKubeClient().CreateService(*service)
 			if err != nil {
 				return err
 			}
@@ -561,7 +556,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 	podSpinner := log.Spinner("Checking status for component")
 	defer podSpinner.End(false)
 
-	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
+	pod, err := a.Client.GetKubeClient().GetPodUsingComponentName(a.ComponentName)
 	if kerrors.IsForbidden(err) {
 		klog.V(2).Infof("Resource for %s forbidden", a.ComponentName)
 		// log the error if it failed to determine if the component exists due to insufficient RBACs
@@ -595,7 +590,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 	spinner := log.Spinner("Deleting Kubernetes resources for component")
 	defer spinner.End(false)
 
-	err = a.Client.DeleteDeployment(labels)
+	err = a.Client.GetKubeClient().DeleteDeployment(labels)
 	if err != nil {
 		return err
 	}
@@ -608,7 +603,7 @@ func (a Adapter) Delete(labels map[string]string, show bool) error {
 // Log returns log from component
 func (a Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, error) {
 
-	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
+	pod, err := a.Client.GetKubeClient().GetPodUsingComponentName(a.ComponentName)
 	if err != nil {
 		return nil, errors.Errorf("the component %s doesn't exist on the cluster", a.ComponentName)
 	}
@@ -619,12 +614,12 @@ func (a Adapter) Log(follow bool, command devfilev1.Command) (io.ReadCloser, err
 
 	containerName := command.Exec.Component
 
-	return a.Client.GetPodLogs(pod.Name, containerName, follow)
+	return a.Client.GetKubeClient().GetPodLogs(pod.Name, containerName, follow)
 }
 
 // Exec executes a command in the component
 func (a Adapter) Exec(command []string) error {
-	exists, err := utils.ComponentExists(a.Client, a.ComponentName)
+	exists, err := utils.ComponentExists(*a.Client.GetKubeClient(), a.ComponentName)
 	if err != nil {
 		return err
 	}
@@ -640,7 +635,7 @@ func (a Adapter) Exec(command []string) error {
 	containerName := runCommand.Exec.Component
 
 	// get the pod
-	pod, err := a.Client.GetPodUsingComponentName(a.ComponentName)
+	pod, err := a.Client.GetKubeClient().GetPodUsingComponentName(a.ComponentName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
 	}
@@ -658,10 +653,10 @@ func (a Adapter) Exec(command []string) error {
 }
 
 func (a Adapter) ExecCMDInContainer(componentInfo common.ComponentInfo, cmd []string, stdout io.Writer, stderr io.Writer, stdin io.Reader, tty bool) error {
-	return a.Client.ExecCMDInContainer(componentInfo.ContainerName, componentInfo.PodName, cmd, stdout, stderr, stdin, tty)
+	return a.Client.GetKubeClient().ExecCMDInContainer(componentInfo.ContainerName, componentInfo.PodName, cmd, stdout, stderr, stdin, tty)
 }
 
 // ExtractProjectToComponent extracts the project archive(tar) to the target path from the reader stdin
 func (a Adapter) ExtractProjectToComponent(componentInfo common.ComponentInfo, targetPath string, stdin io.Reader) error {
-	return a.Client.ExtractProjectToComponent(componentInfo.ContainerName, componentInfo.PodName, targetPath, stdin)
+	return a.Client.GetKubeClient().ExtractProjectToComponent(componentInfo.ContainerName, componentInfo.PodName, targetPath, stdin)
 }

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devfile/library/pkg/testingutil"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/occlient"
 	odoTestingUtil "github.com/openshift/odo/pkg/testingutil"
 
 	v1 "k8s.io/api/apps/v1"
@@ -92,7 +93,7 @@ func TestCreateOrUpdateComponent(t *testing.T) {
 				Devfile:       devObj,
 			}
 
-			fkclient, fkclientset := kclient.FakeNew()
+			fkclient, fkclientset := occlient.FakeNew()
 
 			if tt.running {
 				fkclientset.Kubernetes.PrependReactor("update", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -270,7 +271,7 @@ func TestDoesComponentExist(t *testing.T) {
 				Devfile:       devObj,
 			}
 
-			fkclient, fkclientset := kclient.FakeNew()
+			fkclient, fkclientset := occlient.FakeNew()
 			fkWatch := watch.NewFake()
 
 			fkclientset.Kubernetes.PrependWatchReactor("pods", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
@@ -351,7 +352,7 @@ func TestWaitAndGetComponentPod(t *testing.T) {
 				Devfile:       devObj,
 			}
 
-			fkclient, fkclientset := kclient.FakeNew()
+			fkclient, fkclientset := occlient.FakeNew()
 			fkWatch := watch.NewFake()
 
 			// Change the status
@@ -478,7 +479,7 @@ func TestAdapterDelete(t *testing.T) {
 				adapterCtx.ComponentName = "doesNotExists"
 			}
 
-			fkclient, fkclientset := kclient.FakeNew()
+			fkclient, fkclientset := occlient.FakeNew()
 
 			a := New(adapterCtx, *fkclient)
 

--- a/pkg/devfile/adapters/kubernetes/component/podwatcher.go
+++ b/pkg/devfile/adapters/kubernetes/component/podwatcher.go
@@ -99,7 +99,7 @@ func (pw *podWatcher) startWatchThread(adapter *Adapter) {
 			klog.V(4).Infof("Attempting to acquire watch, attempt #%d", watchAttempts)
 
 			var err error
-			w, err = adapter.Client.KubeClient.CoreV1().Pods(adapter.Client.Namespace).Watch(metav1.ListOptions{})
+			w, err = adapter.Client.GetKubeClient().KubeClient.CoreV1().Pods(adapter.Client.Namespace).Watch(metav1.ListOptions{})
 
 			if err != nil || w == nil {
 

--- a/pkg/devfile/adapters/kubernetes/component/podwatcher_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/podwatcher_test.go
@@ -10,8 +10,8 @@ import (
 	devfileParser "github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/testingutil"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
-	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/machineoutput"
+	"github.com/openshift/odo/pkg/occlient"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -285,7 +285,7 @@ func TestStatusReconciler(t *testing.T) {
 				Devfile:       devObj,
 			}
 
-			fkclient, _ := kclient.FakeNew()
+			fkclient, _ := occlient.FakeNew()
 
 			adapter := New(adapterCtx, *fkclient)
 

--- a/pkg/devfile/adapters/kubernetes/component/status.go
+++ b/pkg/devfile/adapters/kubernetes/component/status.go
@@ -40,7 +40,7 @@ type KubernetesPodStatus struct {
 func (a Adapter) getDeploymentStatus() (*KubernetesDeploymentStatus, error) {
 
 	// 1) Retrieve the deployment
-	deployment, err := a.Client.KubeClient.AppsV1().Deployments(a.Client.Namespace).Get(a.ComponentName, metav1.GetOptions{})
+	deployment, err := a.Client.GetKubeClient().KubeClient.AppsV1().Deployments(a.Client.Namespace).Get(a.ComponentName, metav1.GetOptions{})
 	if err != nil {
 		klog.V(4).Infof("Unable to retrieve deployment %s in %s ", a.ComponentName, a.Client.Namespace)
 		return nil, err
@@ -53,7 +53,7 @@ func (a Adapter) getDeploymentStatus() (*KubernetesDeploymentStatus, error) {
 	deploymentUID := deployment.UID
 
 	// 2) Retrieve the replica set that is owned by the deployment; if multiple, go with one with largest generation
-	replicaSetList, err := a.Client.KubeClient.AppsV1().ReplicaSets(a.Client.Namespace).List(metav1.ListOptions{})
+	replicaSetList, err := a.Client.GetKubeClient().KubeClient.AppsV1().ReplicaSets(a.Client.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ outer:
 	replicaSetUID := matchingReplicaSets[0].UID
 
 	// 3) Retrieves the pods that are owned by the ReplicaSet and return
-	podList, err := a.Client.KubeClient.CoreV1().Pods(a.Client.Namespace).List(metav1.ListOptions{})
+	podList, err := a.Client.GetKubeClient().KubeClient.CoreV1().Pods(a.Client.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devfile/adapters/kubernetes/component/status_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devfile/library/pkg/testingutil"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/occlient"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -175,7 +176,7 @@ func TestGetDeploymentStatus(t *testing.T) {
 				Devfile:       devObj,
 			}
 
-			fkclient, fkclientset := kclient.FakeNew()
+			fkclient, fkclientset := occlient.FakeNew()
 
 			// Return test case's deployment, when requested
 			fkclientset.Kubernetes.PrependReactor("get", "*", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/odo/cli/component/common_push.go
+++ b/pkg/odo/cli/component/common_push.go
@@ -127,7 +127,7 @@ func (cpo *CommonPushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Wr
 		}
 	}
 	// Apply config
-	err := component.ApplyConfig(cpo.Context.Client, nil, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist, true)
+	err := component.ApplyConfig(cpo.Context.Client, *cpo.LocalConfigInfo, envinfo.EnvSpecificInfo{}, stdout, cpo.doesComponentExist, true)
 	if err != nil {
 		odoutil.LogErrorAndExit(err, "Failed to update config to component deployed.")
 	}

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -1384,6 +1384,8 @@ func TestPush(t *testing.T) {
 			fakeClient, fakeClientSet := occlient.FakeNew()
 			fakeKClient, fakeKClientSet := kclient.FakeNew()
 
+			fakeClient.SetKubeClient(fakeKClient)
+
 			fakeKClientSet.Kubernetes.PrependReactor("delete", "ingresses", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, nil
 			})
@@ -1407,7 +1409,7 @@ func TestPush(t *testing.T) {
 				return true, testingutil.CreateFakeDeployment(tt.componentName), nil
 			})
 
-			if err := Push(fakeClient, fakeKClient, PushParameters{
+			if err := Push(fakeClient, PushParameters{
 				LocalConfig:      mockLocalConfigProvider,
 				URLClient:        mockURLClient,
 				IsRouteSupported: tt.args.isRouteSupported,


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

It initializes the kubernetes adapter with a occlient instead of a kubeclient.

**Which issue(s) this PR fixes**:

Fixes #4562 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Running the tests with an invalid `KUBECONFIG` for the project should pass.
```
export KUBECONFIG=/tmp/test/asfdasdf
make test
```