### PR TITLE
Cleanup context in devfile integration tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 > /kind documentation
 > [skip ci]
 
-**What does does this PR do / why we need it**:
+**What does this PR do / why we need it**:
 
 **Which issue(s) this PR fixes**:
 

--- a/tests/integration/devfile/cmd_devfile_app_test.go
+++ b/tests/integration/devfile/cmd_devfile_app_test.go
@@ -17,7 +17,6 @@ var _ = Describe("odo devfile app command tests", func() {
 	// This is run before every Spec (It)
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
-		helper.Chdir(commonVar.Context)
 		namespace = commonVar.Project
 	})
 

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -31,7 +31,6 @@ var _ = Describe("odo devfile debug command tests", func() {
 
 	preSetup := func() {
 		helper.MakeDir(projectDirPath)
-		helper.Chdir(projectDirPath)
 	}
 
 	// This is run after every Spec (It)
@@ -48,7 +47,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
-			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
+			helper.RenameFile(filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--debug", "--context", projectDirPath)
 
 			httpPort, err := util.HTTPGetFreePort()
@@ -77,7 +76,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
-			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
+			helper.RenameFile(filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--context", projectDirPath)
 			helper.CmdShouldPass("odo", "push", "--debug", "--context", projectDirPath)
 
@@ -113,7 +112,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "nodejs-cmp", "--project", commonVar.Project, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
-			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
+			helper.RenameFile(filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--debug", "--context", projectDirPath)
 
 			httpPort, err := util.HTTPGetFreePort()
@@ -138,7 +137,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, componentName, "--context", projectDirPath)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"))
-			helper.RenameFile("devfile-with-debugrun.yaml", "devfile.yaml")
+			helper.RenameFile(filepath.Join(projectDirPath, "devfile-with-debugrun.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--debug", "--context", projectDirPath)
 
 			httpPort, err := util.HTTPGetFreePort()

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -47,10 +47,10 @@ var _ = Describe("odo devfile delete command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, componentName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.CmdShouldPass("odo", "url", "create", "example", "--host", "1.2.3.4.nip.io", "--port", "3000", "--ingress", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "url", "create", "example", "--host", "1.2.3.4.nip.io", "--port", "3000", "--ingress")
 
 			if os.Getenv("KUBERNETES") != "true" {
-				helper.CmdShouldPass("odo", "url", "create", "example-1", "--port", "3000", "--context", commonVar.Context)
+				helper.CmdShouldPass("odo", "url", "create", "example-1", "--port", "3000")
 				resourceTypes = append(resourceTypes, "routes")
 			}
 
@@ -69,7 +69,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 
-			helper.CmdShouldPass("odo", "url", "create", "example", "--host", "1.2.3.4.nip.io", "--port", "3000", "--ingress", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "url", "create", "example", "--host", "1.2.3.4.nip.io", "--port", "3000", "--ingress")
 
 			if os.Getenv("KUBERNETES") != "true" {
 				helper.CmdShouldPass("odo", "url", "create", "example-1", "--port", "3000")

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -29,6 +29,8 @@ var _ = Describe("odo devfile describe command tests", func() {
 	Context("When executing odo describe", func() {
 		JustAfterEach(func() {
 			// odo delete requires changing directory because it does not work as intended with --context
+			// TODO: Remove helper.Chdir after these issues are closed - https://github.com/openshift/odo/issues/4451
+			// TODO: and https://github.com/openshift/odo/issues/4135
 			helper.Chdir(commonVar.Context)
 			helper.CmdShouldPass("odo", "delete", "-f", "--all")
 		})

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -19,7 +19,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 		}
 
 		commonVar = helper.CommonBeforeEach()
-		helper.Chdir(commonVar.Context)
 	})
 
 	// This is run after every Spec (It)
@@ -28,6 +27,12 @@ var _ = Describe("odo devfile describe command tests", func() {
 	})
 
 	Context("When executing odo describe", func() {
+		JustAfterEach(func() {
+			// odo delete requires changing directory because it does not work as intended with --context
+			helper.Chdir(commonVar.Context)
+			helper.CmdShouldPass("odo", "delete", "-f", "--all")
+		})
+
 		It("should describe the component when it is not pushed", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing")
 			helper.CmdShouldPass("odo", "url", "create", "url-1", "--port", "3000", "--host", "example.com", "--context", commonVar.Context)
@@ -51,8 +56,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 			// odo should describe not pushed component if component name is given.
 			helper.CmdShouldPass("odo", "describe", "cmp-git", "--context", commonVar.Context)
 			Expect(cmpDescribe).To(ContainSubstring("cmp-git"))
-
-			helper.CmdShouldPass("odo", "delete", "-f", "--all", "--context", commonVar.Context)
 		})
 
 		It("should describe the component when it is pushed", func() {
@@ -79,8 +82,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 			// odo should describe not pushed component if component name is given.
 			helper.CmdShouldPass("odo", "describe", "cmp-git", "--context", commonVar.Context)
 			Expect(cmpDescribe).To(ContainSubstring("cmp-git"))
-
-			helper.CmdShouldPass("odo", "delete", "-f", "--all", "--context", commonVar.Context)
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("odo devfile log command tests", func() {
+var _ = FDescribe("odo devfile log command tests", func() {
 	var cmpName string
 	var commonVar helper.CommonVar
 
@@ -17,7 +17,6 @@ var _ = Describe("odo devfile log command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
-		helper.Chdir(commonVar.Context)
 	})
 
 	// This is run after every Spec (It)
@@ -54,9 +53,7 @@ var _ = Describe("odo devfile log command tests", func() {
 		})
 
 		It("should log debug command output", func() {
-
 			projectDir := filepath.Join(commonVar.Context, "projectDir")
-
 			helper.CopyExample(filepath.Join("source", "web-nodejs-sample"), projectDir)
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName, "--context", projectDir)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(projectDir, "devfile.yaml"))

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("odo devfile log command tests", func() {
+var _ = Describe("odo devfile log command tests", func() {
 	var cmpName string
 	var commonVar helper.CommonVar
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -920,7 +920,7 @@ var _ = Describe("odo devfile push command tests", func() {
 		It("checks components in a specific app and all apps", func() {
 
 			// component created in "app" application
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -127,7 +127,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push")
 			Expect(output).To(ContainSubstring("Executing mkdir command"))
 
 			// Verify the command executed successfully
@@ -152,7 +152,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommandsParallel.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildandmkdir", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildandmkdir")
 			Expect(output).To(ContainSubstring("Executing mkdir command"))
 
 			// Verify the command executed successfully
@@ -178,7 +178,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			// Verify nested command was executed
-			output := helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push")
 			Expect(output).To(ContainSubstring("Executing mkdir command"))
 
 			// Verify the command executed successfully
@@ -204,7 +204,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			// Verify odo push failed
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldFail("odo", "push")
 			Expect(output).To(ContainSubstring("not supported currently"))
 		})
 
@@ -215,7 +215,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeNonExistent.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			// Verify odo push failed
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldFail("odo", "push")
 			Expect(output).To(ContainSubstring("does not exist in the devfile"))
 		})
 
@@ -226,7 +226,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileIndirectNesting.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			// Verify odo push failed
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldFail("odo", "push")
 			Expect(output).To(ContainSubstring("cannot indirectly reference itself"))
 		})
 
@@ -237,19 +237,22 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeInvalidComponent.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			// Verify odo push failed
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldFail("odo", "push")
 			Expect(output).To(ContainSubstring("command does not map to a container component"))
 		})
 
 		It("checks that odo push works outside of the context directory", func() {
-			helper.Chdir(commonVar.OriginalWorkingDirectory)
+			newContext := helper.CreateNewContext()
+			defer helper.DeleteDir(newContext)
+			helper.Chdir(newContext)
 
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context, cmpName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), newContext)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(newContext, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			helper.Chdir(commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push", "--context", newContext)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 		})
 
@@ -783,7 +786,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.ReplaceString("devfile.yaml", "schemaVersion: 2.0.0", "apiVersion: 1.0.0")
 
 			// Verify odo push failed
-			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			output := helper.CmdShouldFail("odo", "push")
 			Expect(output).To(ContainSubstring("unable to find schema for version \"1.0.0\""))
 		})
 
@@ -805,7 +808,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithenv", "--run-command", "singleenv", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithenv", "--run-command", "singleenv")
 			helper.MatchAllInOutput(output, []string{"mkdir $ENV1", "mkdir $BUILD_ENV1"})
 
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
@@ -818,7 +821,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithmultipleenv", "--run-command", "multipleenv", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithmultipleenv", "--run-command", "multipleenv")
 			helper.MatchAllInOutput(output, []string{"mkdir $ENV1 $ENV2", "mkdir $BUILD_ENV1 $BUILD_ENV2"})
 
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
@@ -831,7 +834,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildenvwithspace", "--run-command", "envwithspace", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "push", "--build-command", "buildenvwithspace", "--run-command", "envwithspace")
 			helper.MatchAllInOutput(output, []string{"mkdir \\\"$ENV1\\\"", "mkdir \\\"$BUILD_ENV1\\\""})
 
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
@@ -850,7 +853,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			// devfile with clonePath set in project field
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context, "--v", "5")
+			helper.CmdShouldPass("odo", "push", "--v", "5")
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 			// source code is synced to $PROJECTS_ROOT/clonePath
 			// $PROJECTS_ROOT is /projects by default, if sourceMapping is set it is same as sourceMapping
@@ -871,7 +874,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			// reset clonePath and change the workdir accordingly, it should sync to project name
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "clonePath: webapp/", "# clonePath: webapp/")
 
-			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "push")
 
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/apps/nodeshift")
@@ -886,7 +889,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "push")
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 			// for devfile-with-multiple-projects.yaml source mapping is not set so $PROJECTS_ROOT is /projects
 			// multiple projects, so source code would sync to the first project /projects/webapp
@@ -902,7 +905,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "push")
 			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
 			helper.MatchAllInOutput(output, []string{"package.json"})
@@ -914,18 +917,17 @@ var _ = Describe("odo devfile push command tests", func() {
 	})
 
 	Context("push with listing the devfile component", func() {
-
 		It("checks components in a specific app and all apps", func() {
 
 			// component created in "app" application
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context, cmpName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.CmdShouldPass("odo", "list", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "list")
 			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
 
-			output = helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			output = helper.CmdShouldPass("odo", "push")
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			// component created in different application
@@ -966,15 +968,15 @@ var _ = Describe("odo devfile push command tests", func() {
 			}
 
 			// component created in "app" application
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context, cmpName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			output := helper.CmdShouldPass("odo", "list", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "list")
 			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
 
-			output = helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			output = helper.CmdShouldPass("odo", "push")
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			// component created in different application
@@ -1085,18 +1087,18 @@ var _ = Describe("odo devfile push command tests", func() {
 
 	Context("when the run command throws an error", func() {
 		It("should wait and error out with some log", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
 
-			_, output := helper.CmdShouldPassIncludeErrStream("odo", "push", "--context", commonVar.Context)
+			_, output := helper.CmdShouldPassIncludeErrStream("odo", "push")
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean one of these?",
 			})
 
-			_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "--context", commonVar.Context, "-f", "--run-command", "run")
+			_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "-f", "--run-command", "run")
 			helper.MatchAllInOutput(output, []string{
 				"exited with error status within 1 sec",
 				"Did you mean one of these?",
@@ -1114,12 +1116,12 @@ var _ = Describe("odo devfile push command tests", func() {
 		It("throw an error when the project value is default", func() {
 			componentName := helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", "default", componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", "default", componentName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			stdout := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
+			stdout := helper.CmdShouldFail("odo", "push")
 			helper.MatchAllInOutput(stdout, []string{"odo may not work as expected in the default project, please run the odo component in a non-default project"})
 		})
 	})
@@ -1134,12 +1136,12 @@ var _ = Describe("odo devfile push command tests", func() {
 		It("should push successfully project value is default", func() {
 			componentName := helper.RandString(6)
 			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", "default", componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", "default", componentName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			stdout := helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+			stdout := helper.CmdShouldPass("odo", "push")
 			helper.DontMatchAllInOutput(stdout, []string{"odo may not work as expected in the default project"})
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -1,10 +1,11 @@
 package devfile
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
-	"path/filepath"
 )
 
 var _ = Describe("odo devfile test command tests", func() {
@@ -16,7 +17,6 @@ var _ = Describe("odo devfile test command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
-		helper.Chdir(commonVar.Context)
 	})
 
 	// This is run after every Spec (It)
@@ -28,7 +28,7 @@ var _ = Describe("odo devfile test command tests", func() {
 
 		// used ";" as consolidating symbol as this spec covers multiple scenerios
 		It("should show error if component is not pushed; should error out if a non-existent command or a command from wrong group is specified", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName, "--context", commonVar.Context)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-testgroup.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
@@ -77,7 +77,7 @@ var _ = Describe("odo devfile test command tests", func() {
 		})
 
 		It("should error out on devfile flag", func() {
-			helper.CmdShouldFail("odo", "test", "--devfile", "invalid.yaml")
+			helper.CmdShouldFail("odo", "test", "--devfile", "invalid.yaml", "--context", commonVar.Context)
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -59,7 +59,7 @@ var _ = Describe("odo devfile test command tests", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-testgroup.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.ReplaceString("devfile.yaml", "isDefault: true", "")
+			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "isDefault: true", "")
 			output := helper.CmdShouldFail("odo", "push", "--context", commonVar.Context)
 			Expect(output).To(ContainSubstring("command group test error - there should be exactly one default command, currently there is no default command"))
 			output = helper.CmdShouldFail("odo", "test", "--context", commonVar.Context)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -62,19 +62,19 @@ var _ = Describe("odo devfile url command tests", func() {
 			url2 := helper.RandString(5)
 			host := helper.RandString(5) + ".com"
 
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", commonVar.Project, componentName)
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, componentName)
 
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "9090", "--host", host, "--secure", "--ingress", "--context", commonVar.Context)
-			helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
-			stdout := helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "9090", "--host", host, "--secure", "--ingress")
+			helper.CmdShouldPass("odo", "push")
+			stdout := helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "Pushed", "true", "ingress"})
 
-			helper.CmdShouldPass("odo", "url", "delete", url1, "-f", "--context", commonVar.Context)
-			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8080", "--host", host, "--ingress", "--context", commonVar.Context)
-			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			helper.CmdShouldPass("odo", "url", "delete", url1, "-f")
+			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8080", "--host", host, "--ingress")
+			stdout = helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", "true", "ingress"})
 			helper.MatchAllInOutput(stdout, []string{url2, "Not Pushed", "false", "ingress"})
 		})
@@ -148,7 +148,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress", "--context", commonVar.Context)
+			stdout = helper.CmdShouldPass("odo", "url", "create", url1, "--port", "3000", "--host", host, "--now", "--ingress")
 
 			// check the env for the runMode
 			envOutput, err := helper.ReadFile(filepath.Join(commonVar.Context, ".odo/env/env.yaml"))
@@ -156,7 +156,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			Expect(envOutput).To(ContainSubstring(" RunMode: run"))
 
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " created for component", "http:", url1 + "." + host})
-			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f", "--context", commonVar.Context)
+			stdout = helper.CmdShouldPass("odo", "url", "delete", url1, "--now", "-f")
 			helper.MatchAllInOutput(stdout, []string{"URL " + url1 + " successfully deleted", "Applying URL changes"})
 		})
 
@@ -304,13 +304,13 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.CmdShouldPass("odo", "url", "create", ingressurl, "--port", "8080", "--host", host, "--ingress")
 			helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8080")
-			stdout := helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			stdout := helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "Pushed", "true", "route"})
 			helper.MatchAllInOutput(stdout, []string{url2, "Not Pushed", "false", "route"})
 			helper.MatchAllInOutput(stdout, []string{ingressurl, "Pushed", "false", "ingress"})
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f")
-			stdout = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			stdout = helper.CmdShouldPass("odo", "url", "list")
 			helper.MatchAllInOutput(stdout, []string{url1, "Locally Deleted", "true", "route"})
 			helper.MatchAllInOutput(stdout, []string{url2, "Not Pushed", "false", "route"})
 			helper.MatchAllInOutput(stdout, []string{ingressurl, "Pushed", "false", "ingress"})
@@ -331,7 +331,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.DontMatchAllInOutput(pushStdOut, []string{"successfully deleted", "created"})
 			Expect(pushStdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 
-			output := helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "url", "list")
 			Expect(output).Should(ContainSubstring(url1))
 
 			helper.CmdShouldPass("odo", "url", "delete", url1, "-f")
@@ -340,7 +340,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			helper.DontMatchAllInOutput(pushStdOut, []string{"successfully deleted", "created"})
 			Expect(pushStdOut).To(ContainSubstring("URLs are synced with the cluster, no changes are required"))
 
-			output = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			output = helper.CmdShouldPass("odo", "url", "list")
 			Expect(output).ShouldNot(ContainSubstring(url1))
 		})
 
@@ -354,7 +354,7 @@ var _ = Describe("odo devfile url command tests", func() {
 			output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 			helper.MatchAllInOutput(output, []string{"URL 3000-tcp", "created"})
 
-			output = helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			output = helper.CmdShouldPass("odo", "url", "list")
 			Expect(output).Should(ContainSubstring("3000-tcp"))
 		})
 
@@ -370,24 +370,8 @@ var _ = Describe("odo devfile url command tests", func() {
 
 			helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 
-			output := helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
+			output := helper.CmdShouldPass("odo", "url", "list")
 			Expect(output).Should(ContainSubstring(url1))
-		})
-
-		// remove once https://github.com/openshift/odo/issues/3550 is resolved
-		It("should list URLs for s2i components", func() {
-			url1 := helper.RandString(5)
-			url2 := helper.RandString(5)
-
-			componentName := helper.RandString(6)
-			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context, "--project", commonVar.Project, componentName, "--s2i")
-
-			helper.CmdShouldPass("odo", "url", "create", url1, "--port", "8080", "--context", commonVar.Context)
-			helper.CmdShouldPass("odo", "url", "create", url2, "--port", "8080", "--context", commonVar.Context, "--ingress", "--host", "com")
-
-			stdout := helper.CmdShouldPass("odo", "url", "list", "--context", commonVar.Context)
-			helper.MatchAllInOutput(stdout, []string{url1, url2})
 		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -101,7 +101,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 			output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-			session := helper.CmdRunner("odo", "watch", "--context", commonVar.Context)
+			session := helper.CmdRunner("odo", "watch")
 			defer session.Kill()
 
 			helper.WaitForOutputToContain("Waiting for something to change", 180, 10, session)
@@ -128,7 +128,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 			fileAPath, fileAText := helper.CreateSimpleFile(commonVar.Context, "my-file-", ".txt")
 
 			// 3) Odo watch that project
-			session := helper.CmdRunner("odo", "watch", "--context", commonVar.Context)
+			session := helper.CmdRunner("odo", "watch")
 			defer session.Kill()
 
 			helper.WaitForOutputToContain("Waiting for something to change", 180, 10, session)
@@ -204,7 +204,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 			utils.OdoWatch(utils.OdoV1Watch{}, odoV2Watch, commonVar.Project, commonVar.Context, watchFlag, commonVar.CliRunner, "kube")
 
 			// check that the --debug-command fails when the component is not pushed using debug mode
-			output = helper.CmdShouldFailWithRetry(1, 1, "odo", "watch", "--context", commonVar.Context, "--debug-command", "debug")
+			output = helper.CmdShouldFailWithRetry(1, 1, "odo", "watch", "--debug-command", "debug")
 			Expect(output).To(ContainSubstring("please start the component in debug mode"))
 		})
 	})
@@ -245,7 +245,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// 2) Odo watch that project
-			session := helper.CmdRunner("odo", "watch", "--context", commonVar.Context)
+			session := helper.CmdRunner("odo", "watch")
 			defer session.Kill()
 
 			helper.WaitForOutputToContain("Waiting for something to change", 180, 10, session)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
This PR cleans up code that renders the use of `--context` useless.

**Which issue(s) this PR fixes**:

Fixes #3801

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Run the tests fixed by the PR.