### PR TITLE
Fixing latest image import issue for java 8

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -107,7 +107,7 @@ var _ = Describe("odo supported images e2e tests", func() {
 
 	Context("odo supported images deployment", func() {
 		It("Should be able to verify the openjdk18-openshift image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", "redhat-openjdk-18/openjdk18-openshift:latest", "java:8", commonVar.Project)
+			oc.ImportImageFromRegistry("registry.access.redhat.com", "redhat-openjdk-18/openjdk18-openshift:1.8", "java:8", commonVar.Project)
 			verifySupportedImage("redhat-openjdk-18/openjdk18-openshift:latest", "openjdk", "java:8", commonVar.Project, appName, commonVar.Context)
 		})
 

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -319,13 +319,15 @@ func (oc OcRunner) ImportImageFromRegistry(registry, image, cmpType, project str
 // ImportJavaIS import the openjdk image which is used for jars
 func (oc OcRunner) ImportJavaIS(project string) {
 	// if ImageStream already exists, no need to do anything
-	if oc.checkForImageStream("java", "8") {
-		return
-	}
+
+	// Commenting as per the article https://access.redhat.com/articles/4301321
+	// if oc.checkForImageStream("java", "8") {
+	// 	return
+	// }
 
 	// we need to import the openjdk image which is used for jars because it's not available by default
 	CmdShouldPass(oc.path, "--request-timeout", "5m", "import-image", "java:8",
-		"--namespace="+project, "--from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.5",
+		"--namespace="+project, "--from=registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8",
 		"--confirm")
 	CmdShouldPass(oc.path, "annotate", "istag/java:8", "--namespace="+project,
 		"tags=builder", "--overwrite")


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

PR will fix the latest java:8 image import issue on CI.
```
Checking if "imagestreams" resource supported
[odo] I0330 18:55:13.516732   28620 imageStreams.go:98] Found exact image tag match for java:8
[odo]  ✗  unable to find tag 8 for image java
Deleting dir: /tmp/043054859
```
Log details: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_odo/4563/pull-ci-openshift-odo-master-v4.7-integration-e2e/1377069342159540224

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
All the tests related to java:8 should pass.