### PR TITLE
Swap login/logout calls from using odo to oc directly

### DIFF
--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -21,7 +21,7 @@ chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # Login as developer
-odo login -u developer -p password@123
+oc login -u developer -p password@123
 
 # Check login user name for debugging purpose
 oc whoami
@@ -38,4 +38,4 @@ make test-e2e-all
 
 cp -r reports $ARTIFACT_DIR 
 
-odo logout
+oc logout

--- a/scripts/openshiftci-presubmit-all-tests-old.sh
+++ b/scripts/openshiftci-presubmit-all-tests-old.sh
@@ -28,7 +28,7 @@ chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # Login as developer
-odo login -u developer -p password@123
+oc login -u developer -p password@123
 
 # Check login user name for debugging purpose
 oc whoami
@@ -66,4 +66,4 @@ fi
 
 cp -r reports $ARTIFACT_DIR
 
-odo logout
+oc logout

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -28,7 +28,7 @@ chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
 # Login as developer
-odo login -u developer -p password@123
+oc login -u developer -p password@123
 
 # Check login user name for debugging purpose
 oc whoami
@@ -68,4 +68,4 @@ fi
 
 cp -r reports $ARTIFACT_DIR
 
-odo logout
+oc logout


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does does this PR do / why we need it**:
The telemetry prompt popped up during a test due to the call to `odo
login`. Swap that to use `oc` directly and avoid the prompt.

**Which issue(s) this PR fixes**:

Fixes #4568

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
