### PR TITLE
Separate out openshift specific tests

### DIFF
--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -191,9 +191,21 @@ var _ = Describe("odo devfile create command tests", func() {
 				helper.CmdShouldPass("odo", "create", "nodejs")
 				output := helper.CmdShouldFail("odo", "create", "nodejs")
 				Expect(output).To(ContainSubstring("this directory already contains a component"))
-				output = helper.CmdShouldFail("odo", "create", "nodejs", "--s2i")
-				Expect(output).To(ContainSubstring("this directory already contains a component"))
+			})
+		})
 
+		Context("Testing Create for OpenShift specific scenarios", func() {
+			JustBeforeEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+			})
+
+			It("should fail when we create the devfile or s2i component multiple times", func() {
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), filepath.Join(commonVar.Context, devfile))
+				helper.CmdShouldPass("odo", "create", "nodejs")
+				output := helper.CmdShouldFail("odo", "create", "nodejs", "--s2i")
+				Expect(output).To(ContainSubstring("this directory already contains a component"))
 			})
 		})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:

This will resolve test failure on kubernetes cluster

**Which issue(s) this PR fixes**:

Fixes #4577 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-cmd-devfile-create` should run successfully on openshift and kubernetes both.