### PR TITLE
introduce ODO_DISABLE_TELEMETRY and skip telemetry question when there is no tty

### DIFF
--- a/USAGE_DATA.adoc
+++ b/USAGE_DATA.adoc
@@ -29,3 +29,4 @@ Disable::
 Note: If earlier the `ConsentTelemetry` preference was enabled, then the data will be collected about the disabling of the preference.
 
 Alternatively you can disable telemetry by setting `ODO_DISABLE_TELEMETRY` environment variable to `true`.
+This environment can override `ConsentTelemetry` value set by `odo preference`. 

--- a/USAGE_DATA.adoc
+++ b/USAGE_DATA.adoc
@@ -28,4 +28,4 @@ Disable::
 
 Note: If earlier the `ConsentTelemetry` preference was enabled, then the data will be collected about the disabling of the preference.
 
-Alternatively you can disable telemetry by setting `ODO_DISABLE_TELEMETRY` environment variable to `false`.
+Alternatively you can disable telemetry by setting `ODO_DISABLE_TELEMETRY` environment variable to `true`.

--- a/USAGE_DATA.adoc
+++ b/USAGE_DATA.adoc
@@ -27,3 +27,5 @@ Disable::
 `odo preference set ConsentTelemetry false`
 
 Note: If earlier the `ConsentTelemetry` preference was enabled, then the data will be collected about the disabling of the preference.
+
+Alternatively you can disable telemetry by setting `ODO_DISABLE_TELEMETRY` environment variable to `false`.

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -44,7 +44,9 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	// This prompt has been placed here so that it does not prompt the user when they call --help
 
 	if !cfg.IsSet(preference.ConsentTelemetrySetting) && cmd.Parent().Name() != "preference" {
-		if os.Getenv(disableTelemetryEnv) == "true" {
+		if !segment.RunningInTerminal() {
+			klog.V(4).Infof("Skipping telemetry question because there is no terminal (tty)\n")
+		} else if os.Getenv(disableTelemetryEnv) == "true" {
 			klog.V(4).Infof("Skipping telemetry question due to %s=%s\n", disableTelemetryEnv, os.Getenv(disableTelemetryEnv))
 		} else {
 			var consentTelemetry bool

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -38,6 +38,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	var err error
 	var startTime time.Time
 	cfg, _ := preference.New()
+	disableTelemetry := os.Getenv(disableTelemetryEnv)
 
 	// Prompt the user to consent for telemetry if a value is not set already
 	// Skip prompting if the preference command is called
@@ -46,8 +47,8 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	if !cfg.IsSet(preference.ConsentTelemetrySetting) && cmd.Parent().Name() != "preference" {
 		if !segment.RunningInTerminal() {
 			klog.V(4).Infof("Skipping telemetry question because there is no terminal (tty)\n")
-		} else if os.Getenv(disableTelemetryEnv) == "true" {
-			klog.V(4).Infof("Skipping telemetry question due to %s=%s\n", disableTelemetryEnv, os.Getenv(disableTelemetryEnv))
+		} else if disableTelemetry == "true" {
+			klog.V(4).Infof("Skipping telemetry question due to %s=%s\n", disableTelemetryEnv, disableTelemetry)
 		} else {
 			var consentTelemetry bool
 			prompt := &survey.Confirm{Message: "Help odo improve by allowing it to collect usage data. Read about our privacy statement: https://developers.redhat.com/article/tool-data-collection. You can change your preference later by changing the ConsentTelemetry preference.", Default: false}
@@ -62,8 +63,8 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	}
 	// Initiate the segment client if ConsentTelemetry preference is set to true
 	if cfg.GetConsentTelemetry() {
-		if os.Getenv(disableTelemetryEnv) == "true" {
-			log.Warningf("Sending telemetry disabled by %s=%s\n", disableTelemetryEnv, os.Getenv(disableTelemetryEnv))
+		if disableTelemetry == "true" {
+			log.Warningf("Sending telemetry disabled by %s=%s\n", disableTelemetryEnv, disableTelemetry)
 		} else {
 			if segmentClient, err = segment.NewClient(cfg); err != nil {
 				klog.V(4).Infof("Cannot create a segment client, will not send any data: %s", err.Error())

--- a/tests/e2escenarios/e2escenarios_suite_test.go
+++ b/tests/e2escenarios/e2escenarios_suite_test.go
@@ -3,12 +3,9 @@ package e2escenarios
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestE2eScenarios(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "odo e2e scenarios", []Reporter{reporter.JunitReport(t, "../../reports")})
+	helper.RunTestSpecs(t, "odo e2e scenarios")
 }

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -11,9 +11,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/openshift/odo/pkg/preference"
+	"github.com/openshift/odo/tests/helper/reporter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -341,4 +343,11 @@ func SetProjectName() string {
 	currGinkgoTestLineNum := strconv.Itoa(CurrentGinkgoTestDescription().LineNumber)
 	projectName := currGinkgoTestFileName + currGinkgoTestLineNum + RandString(3)
 	return projectName
+}
+
+// RunTestSpecs defines a common way how test specs in test suite are executed
+func RunTestSpecs(t *testing.T, description string) {
+	os.Setenv("ODO_DISABLE_TELEMETRY", "true")
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, description, []Reporter{reporter.JunitReport(t, "../../reports/")})
 }

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -360,10 +360,6 @@ var _ = Describe("odo preference and config command tests", func() {
 			output = helper.CmdShouldPass("odo", "preference", "unset", "buildtimeout", "-f")
 			Expect(output).ToNot(ContainSubstring(promtMessageSubString))
 		})
-		It("prompt should appear when non-preference command is run", func() {
-			output := helper.CmdShouldPass("odo", "create", "nodejs", "--context", commonVar.Context)
-			Expect(output).To(ContainSubstring(promtMessageSubString))
-		})
 	})
 
 	Context("Prompt should not appear when", func() {

--- a/tests/integration/debug/debug_suite_test.go
+++ b/tests/integration/debug/debug_suite_test.go
@@ -3,12 +3,9 @@ package debug
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDebug(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Debug Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Debug Suite")
 }

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -3,12 +3,9 @@ package debug
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDebug(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Project Suite")
 }

--- a/tests/integration/devfile/devfile_suite_test.go
+++ b/tests/integration/devfile/devfile_suite_test.go
@@ -3,12 +3,9 @@ package devfile
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDevfiles(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Devfile Suite")
 }

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -5,12 +5,9 @@ package integration
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestIntegration(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Integration Suite", []Reporter{reporter.JunitReport(t, "../../reports/")})
+	helper.RunTestSpecs(t, "Integration Suite")
 }

--- a/tests/integration/loginlogout/loginlogout_suite_test.go
+++ b/tests/integration/loginlogout/loginlogout_suite_test.go
@@ -3,12 +3,9 @@ package integration
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestLoginlogout(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Loginlogout Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Login Logout Suite")
 }

--- a/tests/integration/operatorhub/operatorhub_suite_test.go
+++ b/tests/integration/operatorhub/operatorhub_suite_test.go
@@ -3,11 +3,9 @@ package integration_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestOperatorhub(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Operatorhub Suite")
+	helper.RunTestSpecs(t, "Operatorhub Suite")
 }

--- a/tests/integration/project/project_suite_test.go
+++ b/tests/integration/project/project_suite_test.go
@@ -3,12 +3,9 @@ package project
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestProject(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Project Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Project Suite")
 }

--- a/tests/integration/servicecatalog/servicecatalog_suite_test.go
+++ b/tests/integration/servicecatalog/servicecatalog_suite_test.go
@@ -3,12 +3,9 @@ package integration
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openshift/odo/tests/helper/reporter"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestServicecatalog(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Servicecatalog Suite", []Reporter{reporter.JunitReport(t, "../../../reports")})
+	helper.RunTestSpecs(t, "Servicecatalog Suite")
 }

--- a/tests/template/template_suite_test.go
+++ b/tests/template/template_suite_test.go
@@ -3,11 +3,10 @@ package template
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/tests/helper"
 )
 
 func TestTemplate(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "TestTemplate Suite")
+	helper.RunTestSpecs(t, "TestTemplate Suite")
+
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind code-refactoring


**What does does this PR do / why we need it**:

- introduces `ODO_DISABLE_TELEMETRY ` env variable. When this is set to `true` odo will skip the telemetry question and it won't send any telemetry data out even if `odo preference set consentTelemetry true`.
- sets `ODO_DISABLE_TELEMETRY` in all ginkgo test suites to make sure that no data is sent to telemetry even by accident
- if odo is not executed in terminal (no tty) it won't ask user to consent with telemetry

**Which issue(s) this PR fixes**:

Partly Fixes #4462 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
