### PR TITLE
Log info about sending usage data

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/version"
 	"github.com/pborman/uuid"
@@ -61,6 +62,7 @@ func newCustomClient(preference *preference.PreferenceInfo, telemetryFilePath st
 
 // Close client connection and send the data
 func (c *Client) Close() error {
+	log.Info("Sending usage data. Please wait...")
 	return c.SegmentClient.Close()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
[skip ci]

**What does this PR do / why we need it**:
This PR adds a note about usage data being sent.

**Which issue(s) this PR fixes**:
Partly Fixes #4462

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Run a command with `ConsentTelemetry` preference set to true and see if this log appears.