### PR TITLE
Revert Java:8 image import to default

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -107,7 +107,7 @@ var _ = Describe("odo supported images e2e tests", func() {
 
 	Context("odo supported images deployment", func() {
 		It("Should be able to verify the openjdk18-openshift image", func() {
-			oc.ImportImageFromRegistry("registry.access.redhat.com", "redhat-openjdk-18/openjdk18-openshift:1.8", "java:8", commonVar.Project)
+			oc.ImportImageFromRegistry("registry.access.redhat.com", "redhat-openjdk-18/openjdk18-openshift:latest", "java:8", commonVar.Project)
 			verifySupportedImage("redhat-openjdk-18/openjdk18-openshift:latest", "openjdk", "java:8", commonVar.Project, appName, commonVar.Context)
 		})
 

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -319,11 +319,9 @@ func (oc OcRunner) ImportImageFromRegistry(registry, image, cmpType, project str
 // ImportJavaIS import the openjdk image which is used for jars
 func (oc OcRunner) ImportJavaIS(project string) {
 	// if ImageStream already exists, no need to do anything
-
-	// Commenting as per the article https://access.redhat.com/articles/4301321
-	// if oc.checkForImageStream("java", "8") {
-	// 	return
-	// }
+	if oc.checkForImageStream("java", "8") {
+		return
+	}
 
 	// we need to import the openjdk image which is used for jars because it's not available by default
 	CmdShouldPass(oc.path, "--request-timeout", "5m", "import-image", "java:8",


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does does this PR do / why we need it**:
As https://bugzilla.redhat.com/show_bug.cgi?id=1945281 has been fixed. Reverting java:8 image import to default.
```
$ docker pull registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest
latest: Pulling from redhat-openjdk-18/openjdk18-openshift
Digest: sha256:42567207376487246d144b3b06e7505cb912aaa0f0d1f0a093097e6cbccaa604
Status: Downloaded newer image for registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest
registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest
```

**Which issue(s) this PR fixes**:

Fixes #4598 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

All the tests related to java:8 should pass.