### PR TITLE
add operator-hub tests to ci for s390x platform

### DIFF
--- a/scripts/configure-installer-tests-cluster-s390x.sh
+++ b/scripts/configure-installer-tests-cluster-s390x.sh
@@ -23,7 +23,7 @@ IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12 openjdk-11"
 ## Let developer user have access to the project
 ##oc adm policy add-role-to-user edit developer
 
-#sh $SETUP_OPERATORS
+sh $SETUP_OPERATORS
 # OperatorHub setup complete
 
 # Create the namespace for e2e image test apply pull secret to the namespace

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -39,6 +39,7 @@ if [ "${ARCH}" == "s390x" ]; then
     make test-integration-devfile
     make test-cmd-login-logout
     make test-cmd-project
+    make test-operator-hub
     # E2e tests
     make test-e2e-all
 elif  [ "${ARCH}" == "ppc64le" ]; then


### PR DESCRIPTION
For the operator-hub test cases, have verified supported on s390x.

**What type of PR is this?**

> /kind bug

**What does does this PR do / why we need it**:

make odo supported on s390x, and including operator-hub cases in ci

**Which issue(s) this PR fixes**:

Fixes #3672 

**PR acceptance criteria**:
- [x] operator hub test 

**How to test changes / Special notes to the reviewer**:
 just run the test script