### PR TITLE
update java image import for s390x platform

### DIFF
--- a/scripts/configure-installer-tests-cluster-s390x.sh
+++ b/scripts/configure-installer-tests-cluster-s390x.sh
@@ -41,11 +41,9 @@ oc --request-timeout 5m apply -n openshift -f https://raw.githubusercontent.com/
 oc --request-timeout 5m delete istag nodejs:latest -n openshift
 oc --request-timeout 5m import-image nodejs:latest --from=registry.redhat.io/rhscl/nodejs-12-rhel7 --confirm -n openshift
 oc annotate istag/nodejs:latest tags=builder -n openshift --overwrite
-oc --request-timeout 5m delete istag java:8 -n openshift
-oc --request-timeout 5m import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
+oc --request-timeout 5m import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
 oc annotate istag/java:8 --namespace=openshift tags=builder --overwrite
-oc --request-timeout 5m delete istag java:latest -n openshift
-oc --request-timeout 5m import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
+oc --request-timeout 5m import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
 oc annotate istag/java:latest --namespace=openshift tags=builder --overwrite
 oc --request-timeout 5m apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/s390x/official/ruby/imagestreams/ruby-rhel.json
 oc annotate istag/ruby:latest --namespace=openshift tags=builder --overwrite


### PR DESCRIPTION
For the java image used in s390x CI script, also need to change refer to #4569.

**What type of PR is this?**

> /kind bug

**What does does this PR do / why we need it**:

Update java image import for s390x platform, change the tag in the oc import-image command.

**Which issue(s) this PR fixes**:

Fixes #4569 

**PR acceptance criteria**:
configure test cluster for s390x 

**How to test changes / Special notes to the reviewer**:
 just run the test script