### PR TITLE
Fixes kClient namespace in createKubernetesAdapter()

### DIFF
--- a/pkg/devfile/adapters/helper.go
+++ b/pkg/devfile/adapters/helper.go
@@ -51,6 +51,7 @@ func createKubernetesAdapter(adapterContext common.AdapterContext, namespace str
 	// If a namespace was passed in
 	if namespace != "" {
 		client.Namespace = namespace
+		kClient.Namespace = namespace
 	}
 	return newKubernetesAdapter(adapterContext, *client)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

It fixes kClient namespace in createKubernetesAdapter()

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4609

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- The scenario mentioned in https://github.com/openshift/odo/issues/4609 should pass.