### PR TITLE
Fix for java image import issue on ppc64le

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -30,6 +30,7 @@ const (
 
 var supportedImages = map[string]bool{
 	"redhat-openjdk-18/openjdk18-openshift:latest": true,
+	"redhat-openjdk-18/openjdk18-openshift:1.8":    true,
 	"openjdk/openjdk-11-rhel8:latest":              true,
 	"openjdk/openjdk-11-rhel7:latest":              true,
 	"ubi8/openjdk-11:latest":                       true,

--- a/scripts/configure-installer-tests-cluster-ppc64le.sh
+++ b/scripts/configure-installer-tests-cluster-ppc64le.sh
@@ -42,10 +42,10 @@ sleep 15
 oc import-image nodejs:latest --from=registry.redhat.io/rhscl/nodejs-12-rhel7 --confirm -n openshift
 sleep 15
 oc annotate istag/nodejs:latest tags=builder -n openshift --overwrite
-oc import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
+oc import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
 sleep 15
 oc annotate istag/java:8 --namespace=openshift tags=builder --overwrite
-oc import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
+oc import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
 sleep 15
 oc annotate istag/java:latest --namespace=openshift tags=builder --overwrite
 oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/ppc64le/official/ruby/imagestreams/ruby-rhel.json


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What does this PR do / why we need it**:
This will fix the issue with Java image import on ppc64le platform.

**Which issue(s) this PR fixes**:

Fixes #4569

**PR acceptance criteria**:

- [ ] Integration test 

**How to test changes / Special notes to the reviewer**:
This PR fix the issue observed with Java image import on Power Systems platform.

Changes in "pkg/catalog/catalog.go" are required to omit the below warning observed with odo:
`        Warning: java:latest is not fully supported by odo, and it is not guaranteed to work`