### PR TITLE
Use ParseDevfileAndValidate instead of ParseAndValidate

### DIFF
--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/devfile/library/pkg/devfile/parser"
+
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/validate"
@@ -82,7 +84,7 @@ func (po *PushOptions) DevfilePush() error {
 func (po *PushOptions) devfilePushInner() (err error) {
 
 	// Parse devfile and validate
-	devObj, err := devfile.ParseAndValidate(po.DevfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: po.DevfilePath})
 
 	if err != nil {
 		return err
@@ -159,7 +161,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 // DevfileComponentLog fetch and display log from devfile components
 func (lo LogOptions) DevfileComponentLog() error {
 	// Parse devfile
-	devObj, err := devfile.ParseAndValidate(lo.devfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: lo.devfilePath})
 	if err != nil {
 		return err
 	}
@@ -219,7 +221,7 @@ func (lo LogOptions) DevfileComponentLog() error {
 // DevfileComponentDelete deletes the devfile component
 func (do *DeleteOptions) DevfileComponentDelete() error {
 	// Parse devfile and validate
-	devObj, err := devfile.ParseAndValidate(do.devfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: do.devfilePath})
 	if err != nil {
 		return err
 	}
@@ -293,7 +295,7 @@ func warnIfURLSInvalid(url []localConfigProvider.LocalURL) {
 // DevfileComponentExec executes the given user command inside the component
 func (eo *ExecOptions) DevfileComponentExec(command []string) error {
 	// Parse devfile
-	devObj, err := devfile.ParseAndValidate(eo.devfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: eo.devfilePath})
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/devfile/library/pkg/devfile/parser"
+
 	"github.com/devfile/library/pkg/devfile"
 	"github.com/openshift/odo/pkg/application"
 	"github.com/openshift/odo/pkg/devfile/validate"
@@ -69,7 +71,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		if err != nil {
 			return err
 		}
-		devObj, err := devfile.ParseAndValidate(lo.devfilePath)
+		devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: lo.devfilePath})
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -90,10 +90,9 @@ func (po *PushOptions) GetComponentContext() string {
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.CompleteDevfilePath()
 
-	// if experimental mode is enabled and devfile is present
 	if util.CheckPathExists(po.DevfilePath) {
 
-		po.Devfile, err = devfile.ParseAndValidate(po.DevfilePath)
+		po.Devfile, err = devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: po.DevfilePath})
 		if err != nil {
 			return errors.Wrap(err, "unable to parse devfile")
 		}

--- a/pkg/odo/cli/component/status.go
+++ b/pkg/odo/cli/component/status.go
@@ -82,7 +82,7 @@ func (so *StatusOptions) Complete(name string, cmd *cobra.Command, args []string
 		so.componentName = so.EnvSpecificInfo.GetName()
 
 		// Parse devfile
-		devObj, err := devfile.ParseAndValidate(so.devfilePath)
+		devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: so.devfilePath})
 		if err != nil {
 			return err
 		}

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -61,7 +61,7 @@ func (to *TestOptions) Validate() (err error) {
 		return fmt.Errorf("unable to find devfile, odo test command is only supported by devfile components")
 	}
 
-	devObj, err := devfile.ParseAndValidate(to.devfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(devfileParser.ParserArgs{Path: to.devfilePath})
 	if err != nil {
 		return errors.Wrap(err, "fail to parse devfile")
 	}

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/devfile/library/pkg/devfile/parser"
+
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/validate"
 	"github.com/openshift/odo/pkg/envinfo"
@@ -100,7 +102,7 @@ func (wo *WatchOptions) Complete(name string, cmd *cobra.Command, args []string)
 		wo.componentName = wo.EnvSpecificInfo.GetName()
 
 		// Parse devfile and validate
-		devObj, err := devfile.ParseAndValidate(wo.devfilePath)
+		devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: wo.devfilePath})
 		if err != nil {
 			return err
 		}
@@ -324,7 +326,7 @@ func (wo *WatchOptions) regenerateAdapterAndPush(pushParams common.PushParameter
 func (wo *WatchOptions) regenerateComponentAdapterFromWatchParams(parameters watch.WatchParameters) (common.ComponentAdapter, error) {
 
 	// Parse devfile and validate
-	devObj, err := devfile.ParseAndValidate(wo.devfilePath)
+	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: wo.devfilePath})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse and validate '%s'", wo.devfilePath)
 	}

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/devfile/library/pkg/devfile/parser"
+
 	"github.com/devfile/library/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/validate"
 	"github.com/openshift/odo/pkg/localConfigProvider"
@@ -77,7 +79,7 @@ func New(parameters CreateParameters, toggles ...bool) (context *Context, err er
 		}
 
 		// Parse devfile and validate
-		devObj, err := devfile.ParseAndValidate(parameters.DevfilePath)
+		devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: parameters.DevfilePath})
 		if err != nil {
 			return context, fmt.Errorf("failed to parse the devfile %s, with error: %s", parameters.DevfilePath, err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
ParseAndValidate has been deprecated in favour of
ParseDevfileAndValidate

**Which issue(s) this PR fixes**:

Fixes NA

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Test should pass