### PR TITLE
Revert java import changes for s390x

### DIFF
--- a/scripts/configure-installer-tests-cluster-s390x.sh
+++ b/scripts/configure-installer-tests-cluster-s390x.sh
@@ -41,9 +41,9 @@ oc --request-timeout 5m apply -n openshift -f https://raw.githubusercontent.com/
 oc --request-timeout 5m delete istag nodejs:latest -n openshift
 oc --request-timeout 5m import-image nodejs:latest --from=registry.redhat.io/rhscl/nodejs-12-rhel7 --confirm -n openshift
 oc annotate istag/nodejs:latest tags=builder -n openshift --overwrite
-oc --request-timeout 5m import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
+oc --request-timeout 5m import-image java:8 --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
 oc annotate istag/java:8 --namespace=openshift tags=builder --overwrite
-oc --request-timeout 5m import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8 --confirm
+oc --request-timeout 5m import-image java:latest --namespace=openshift --from=registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --confirm
 oc annotate istag/java:latest --namespace=openshift tags=builder --overwrite
 oc --request-timeout 5m apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/s390x/official/ruby/imagestreams/ruby-rhel.json
 oc annotate istag/ruby:latest --namespace=openshift tags=builder --overwrite


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
Reverting back changes in https://github.com/openshift/odo/pull/4602 as `registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest` has been fixed.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
It should run successfully on s390x arch.