### PR TITLE
Increase Run time for minikube job

### DIFF
--- a/scripts/minici-presubmit-all-tests.sh
+++ b/scripts/minici-presubmit-all-tests.sh
@@ -20,7 +20,7 @@ case $1 in
         export EXCHANGE="amqp.ci.exchange.minikube.send"
         export SETUP_SCRIPT="scripts/minikube-minishift-setup-env.sh minikube"
         export RUN_SCRIPT="scripts/minikube-minishift-all-tests.sh minikube"
-        export TIMEOUT="2h15m"
+        export TIMEOUT="4h00m"
         ;;
     minishift)
         export JOB_NAME="odo-minishift-pr-tests"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
Minikube jobs are not able to run whole test suite within 2h15min. So increasing the timeout.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
