### PR TITLE
OCI-based devfile reigstry support patch

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -866,7 +866,7 @@ func (co *CreateOptions) devfileRun() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "unable to save devfile to %s", DevfilePath)
 	}
-	if co.devfileMetadata.devfilePath.value == "" && !devfileExist {
+	if co.devfileMetadata.devfilePath.value == "" && !devfileExist && !strings.Contains(co.devfileMetadata.devfileRegistry.URL, "github") {
 		err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -773,6 +773,7 @@ func (co *CreateOptions) s2iRun() (err error) {
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) devfileRun() (err error) {
 	var devfileData []byte
+	devfileExist := util.CheckPathExists(DevfilePath)
 	// Use existing devfile directly from --devfile flag
 	if co.devfileMetadata.devfilePath.value != "" {
 		if co.devfileMetadata.devfilePath.protocol == "http(s)" {
@@ -792,7 +793,7 @@ func (co *CreateOptions) devfileRun() (err error) {
 			}
 		}
 	} else {
-		if util.CheckPathExists(DevfilePath) {
+		if devfileExist {
 			// if local devfile already exists read that
 			// odo create command was expected in a directory already containing devfile
 			devfileData, err = ioutil.ReadFile(DevfilePath)
@@ -865,7 +866,7 @@ func (co *CreateOptions) devfileRun() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "unable to save devfile to %s", DevfilePath)
 	}
-	if co.devfileMetadata.devfilePath.value == "" && !util.CheckPathExists(DevfilePath) {
+	if co.devfileMetadata.devfilePath.value == "" && !devfileExist {
 		err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
 		if err != nil {
 			return err

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -859,11 +859,15 @@ func (co *CreateOptions) devfileRun() (err error) {
 		return errors.Wrap(err, "failed to download project for devfile component")
 	}
 
-	// save devfile
+	// save devfile and corresponding resources if possible
 	// use original devfileData to persist original formatting of the devfile file
 	err = ioutil.WriteFile(DevfilePath, devfileData, 0644) // #nosec G306
 	if err != nil {
 		return errors.Wrapf(err, "unable to save devfile to %s", DevfilePath)
+	}
+	err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+	if err != nil {
+		return err
 	}
 
 	// Generate env file

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -865,9 +865,11 @@ func (co *CreateOptions) devfileRun() (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "unable to save devfile to %s", DevfilePath)
 	}
-	err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
-	if err != nil {
-		return err
+	if co.devfileMetadata.devfilePath.value == "" && !util.CheckPathExists(DevfilePath) {
+		err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Generate env file


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR fixes the issue that starter project overrides the devfile stack additional resources in the project root directory. The issue only happens on the case where the devfile stack has additional resources (eg. icon, outer loop configuration). 

**Which issue(s) this PR fixes**:

Related issues:
1. https://github.com/openshift/odo/issues/4504
2. https://github.com/devfile/api/issues/367

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. Run `odo create nodejs --registry DefaultDevfileRegistry --starter` then verify the nodejs devfile and corresponding resources and starter project can be downloaded from OCI-based public devfile registry.
