### PR TITLE
add kubectl to ci test image

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -2,5 +2,9 @@
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.13
 
-RUN yum -y install make wget gcc git httpd-tools
+RUN yum -y install make wget gcc git httpd-tools curl
+
+# Download kubectl, a cli tool for accessing Kubernetes cluster
+RUN curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
 


### PR DESCRIPTION
Changes in this PR https://github.com/openshift/odo/pull/4518 requires the openshift CI to have kubectl present on the image