### PR TITLE
Creates service on cluster upon "odo push"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.0.0
 	k8s.io/kubectl v0.0.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/odo/pkg/service"
+
 	"github.com/devfile/library/pkg/devfile/generator"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/envinfo"
@@ -170,6 +172,26 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	err = a.createOrUpdateComponent(componentExists, parameters.EnvSpecificInfo)
 	if err != nil {
 		return errors.Wrap(err, "unable to create or update component")
+	}
+
+	// fetch the "kubernetes inlined components" to create them on cluster
+	// from odo standpoint, these components contain yaml manifest of an odo service or an odo link
+	k8sComponents, err := a.Devfile.Data.GetComponents(parsercommon.DevfileOptions{
+		ComponentOptions: parsercommon.ComponentOptions{ComponentType: devfilev1.KubernetesComponentType},
+	})
+	if err != nil {
+		return errors.Wrap(err, "error while trying to fetch service(s) from devfile")
+	}
+	// create the Kubernetes objects from the manifest
+	services, err := service.CreateServiceFromKubernetesInlineComponents(a.Client.GetKubeClient(), k8sComponents)
+	if err != nil {
+		return errors.Wrap(err, "failed to create service(s) associated with the component")
+	}
+
+	if len(services) == 1 {
+		log.Infof("Created service %q on the cluster; refer %q to know how to link it to the component", services[0], "odo link -h")
+	} else if len(services) > 1 {
+		log.Infof("Created services %q on the cluster; refer %q to know how to link them to the component", strings.Join(services, ", "), "odo link -h")
 	}
 
 	deployment, err := a.Client.GetKubeClient().WaitForDeploymentRollout(a.ComponentName)
@@ -376,7 +398,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	}
 
 	if len(containers) == 0 {
-		return fmt.Errorf("No valid components found in the devfile")
+		return fmt.Errorf("no valid components found in the devfile")
 	}
 
 	// Add the project volume before generating init containers
@@ -471,7 +493,7 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		ObjectMeta:     objectMeta,
 		SelectorLabels: selectorLabels,
 	}
-	service, err := generator.GetService(a.Devfile, serviceParams, parsercommon.DevfileOptions{})
+	svc, err := generator.GetService(a.Devfile, serviceParams, parsercommon.DevfileOptions{})
 	if err != nil {
 		return err
 	}
@@ -488,21 +510,21 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		klog.V(2).Infof("Successfully updated component %v", componentName)
 		oldSvc, err := a.Client.GetKubeClient().KubeClient.CoreV1().Services(a.Client.Namespace).Get(componentName, metav1.GetOptions{})
 		ownerReference := generator.GetOwnerReference(deployment)
-		service.OwnerReferences = append(service.OwnerReferences, ownerReference)
+		svc.OwnerReferences = append(svc.OwnerReferences, ownerReference)
 		if err != nil {
 			// no old service was found, create a new one
-			if len(service.Spec.Ports) > 0 {
-				_, err = a.Client.GetKubeClient().CreateService(*service)
+			if len(svc.Spec.Ports) > 0 {
+				_, err = a.Client.GetKubeClient().CreateService(*svc)
 				if err != nil {
 					return err
 				}
 				klog.V(2).Infof("Successfully created Service for component %s", componentName)
 			}
 		} else {
-			if len(service.Spec.Ports) > 0 {
-				service.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-				service.ResourceVersion = oldSvc.GetResourceVersion()
-				_, err = a.Client.GetKubeClient().UpdateService(*service)
+			if len(svc.Spec.Ports) > 0 {
+				svc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
+				svc.ResourceVersion = oldSvc.GetResourceVersion()
+				_, err = a.Client.GetKubeClient().UpdateService(*svc)
 				if err != nil {
 					return err
 				}
@@ -521,9 +543,9 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 		}
 		klog.V(2).Infof("Successfully created component %v", componentName)
 		ownerReference := generator.GetOwnerReference(deployment)
-		service.OwnerReferences = append(service.OwnerReferences, ownerReference)
-		if len(service.Spec.Ports) > 0 {
-			_, err = a.Client.GetKubeClient().CreateService(*service)
+		svc.OwnerReferences = append(svc.OwnerReferences, ownerReference)
+		if len(svc.Spec.Ports) > 0 {
+			_, err = a.Client.GetKubeClient().CreateService(*svc)
 			if err != nil {
 				return err
 			}
@@ -549,7 +571,7 @@ func getFirstContainerWithSourceVolume(containers []corev1.Container) (string, s
 		}
 	}
 
-	return "", "", fmt.Errorf("In order to sync files, odo requires at least one component in a devfile to set 'mountSources: true'")
+	return "", "", fmt.Errorf("in order to sync files, odo requires at least one component in a devfile to set 'mountSources: true'")
 }
 
 // Delete deletes the component

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -83,11 +83,11 @@ func (po *PushOptions) devfilePushInner() (err error) {
 
 	// Parse devfile and validate
 	devObj, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: po.DevfilePath})
-
 	if err != nil {
 		return err
 	}
 
+	// odo specific validations
 	err = validate.ValidateDevfileData(devObj.Data)
 	if err != nil {
 		return err
@@ -138,12 +138,12 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	// Start or update the component
 	err = devfileHandler.Push(pushParams)
 	if err != nil {
-		err = errors.Errorf("Failed to start component with name %s. Error: %v",
+		err = errors.Errorf("Failed to start component with name %q. Error: %v",
 			componentName,
 			err,
 		)
 	} else {
-		log.Infof("\nPushing devfile component %s", componentName)
+		log.Infof("\nPushing devfile component %q", componentName)
 		log.Success("Changes successfully pushed to component")
 	}
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/openshift/odo/pkg/component"
+	"github.com/openshift/odo/pkg/log"
+
 	"github.com/devfile/library/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/validate"
 	"github.com/openshift/odo/pkg/envinfo"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/devfile/library/pkg/devfile/parser"
-	"github.com/openshift/odo/pkg/component"
-	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/occlient"
 	projectCmd "github.com/openshift/odo/pkg/odo/cli/project"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -126,20 +126,6 @@ func (o *CreateOptions) Complete(name string, cmd *cobra.Command, args []string)
 	return o.Backend.CompleteServiceCreate(o, cmd, args)
 }
 
-// outputNonInteractiveEquivalent outputs the populated options as the equivalent command that would be used in non-interactive mode
-func (o *CreateOptions) outputNonInteractiveEquivalent() string {
-	if o.outputCLI {
-		var tpl bytes.Buffer
-		t := template.Must(template.New("service-create-cli").Parse(equivalentTemplate))
-		e := t.Execute(&tpl, o)
-		if e != nil {
-			panic(e) // shouldn't happen
-		}
-		return strings.TrimSpace(tpl.String())
-	}
-	return ""
-}
-
 // Validate validates the CreateOptions based on completed values
 func (o *CreateOptions) Validate() (err error) {
 	// if we are in interactive mode, all values are already valid
@@ -159,7 +145,7 @@ func (o *CreateOptions) Run() (err error) {
 
 	// Information on what to do next; don't do this if "--dry-run" was requested as it gets appended to the file
 	if !o.DryRun {
-		log.Infof("You can now link the service to a component using 'odo link'; check 'odo link -h'")
+		log.Info("Successfully added service to the configuration; do 'odo push' to create service on the cluster")
 	}
 
 	equivalent := o.outputNonInteractiveEquivalent()
@@ -167,6 +153,20 @@ func (o *CreateOptions) Run() (err error) {
 		log.Info("Equivalent command:\n" + ui.StyledOutput(equivalent, "cyan"))
 	}
 	return
+}
+
+// outputNonInteractiveEquivalent outputs the populated options as the equivalent command that would be used in non-interactive mode
+func (o *CreateOptions) outputNonInteractiveEquivalent() string {
+	if o.outputCLI {
+		var tpl bytes.Buffer
+		t := template.Must(template.New("service-create-cli").Parse(equivalentTemplate))
+		e := t.Execute(&tpl, o)
+		if e != nil {
+			panic(e) // shouldn't happen
+		}
+		return strings.TrimSpace(tpl.String())
+	}
+	return ""
 }
 
 // NewCmdServiceCreate implements the odo service create command.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ghodss/yaml"
+
 	devfile "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"github.com/openshift/odo/pkg/kclient"
@@ -97,7 +99,6 @@ func doesCRExist(kind string, csvs *olm.ClusterServiceVersionList) (olm.ClusterS
 		}
 	}
 	return olm.ClusterServiceVersion{}, errors.New("could not find the requested cluster resource")
-
 }
 
 // CreateOperatorService creates new service (actually a Deployment) from OperatorHub
@@ -484,9 +485,9 @@ func updateStatusIfMatchingDeploymentExists(dcs []appsv1.DeploymentConfig, secre
 	}
 }
 
-// IsValidOperatorServiceName checks if the provided name follows
+// IsOperatorServiceNameValid checks if the provided name follows
 // <service-type>/<service-name> format. For example: "EtcdCluster/example" is
-// a valid servicename but "EtcdCluster/", "EtcdCluster", "example" aren't.
+// a valid service name but "EtcdCluster/", "EtcdCluster", "example" aren't.
 func IsOperatorServiceNameValid(name string) (string, string, error) {
 	checkName := strings.SplitN(name, "/", 2)
 
@@ -737,4 +738,117 @@ func DeleteKubernetesComponentFromDevfile(name string, devfileObj parser.Devfile
 	}
 
 	return devfileObj.WriteYamlDevfile()
+}
+
+// DynamicCRD holds the original CR obtained from the Operator (a CSV), or user
+// (when they use --from-file flag), and few other attributes that are likely
+// to be used to validate a CRD before creating a service from it
+type DynamicCRD struct {
+	// contains the CR as obtained from CSV or user
+	OriginalCRD map[string]interface{}
+}
+
+func NewDynamicCRD() *DynamicCRD {
+	return &DynamicCRD{}
+}
+
+// ValidateMetadataInCRD validates if the CRD has metadata.name field and returns an error
+func (d *DynamicCRD) ValidateMetadataInCRD() error {
+	metadata, ok := d.OriginalCRD["metadata"].(map[string]interface{})
+	if !ok {
+		// this condition is satisfied if there's no metadata at all in the provided CRD
+		return fmt.Errorf("couldn't find \"metadata\" in the yaml; need metadata start the service")
+	}
+
+	if _, ok := metadata["name"].(string); ok {
+		// found the metadata.name; no error
+		return nil
+	}
+	return fmt.Errorf("couldn't find metadata.name in the yaml; provide a name for the service")
+}
+
+// SetServiceName modifies the CRD to contain user provided name on the CLI
+// instead of using the default one in almExample
+func (d *DynamicCRD) SetServiceName(name string) {
+	metaMap := d.OriginalCRD["metadata"].(map[string]interface{})
+
+	for k := range metaMap {
+		if k == "name" {
+			metaMap[k] = name
+			return
+		}
+		// if metadata doesn't have 'name' field, we set it up
+		metaMap["name"] = name
+	}
+}
+
+// GetServiceNameFromCRD fetches the service name from metadata.name field of the CRD
+func (d *DynamicCRD) GetServiceNameFromCRD() (string, error) {
+	metadata, ok := d.OriginalCRD["metadata"].(map[string]interface{})
+	if !ok {
+		// this condition is satisfied if there's no metadata at all in the provided CRD
+		return "", fmt.Errorf("couldn't find \"metadata\" in the yaml; need metadata.name to start the service")
+	}
+
+	if name, ok := metadata["name"].(string); ok {
+		// found the metadata.name; no error
+		return name, nil
+	}
+	return "", fmt.Errorf("couldn't find metadata.name in the yaml; provide a name for the service")
+}
+
+// CreateServiceFromKubernetesInlineComponents creates service(s) from Kubernetes Inlined component in a devfile
+func CreateServiceFromKubernetesInlineComponents(client *kclient.Client, k8sComponents []devfile.Component) ([]string, error) {
+	if len(k8sComponents) == 0 {
+		// if there's no Kubernetes Inlined component, there's nothing to do.
+		return []string{}, nil
+	}
+
+	// create an object on the kubernetes cluster for all the Kubernetes Inlined components
+	var services []string
+	for _, c := range k8sComponents {
+		// get the string representation of the YAML definition of a CRD
+		strCRD := c.Kubernetes.Inlined
+
+		// convert the YAML definition into map[string]interface{} since it's needed to create dynamic resource
+		d := NewDynamicCRD()
+		err := yaml.Unmarshal([]byte(strCRD), &d.OriginalCRD)
+		if err != nil {
+			return []string{}, err
+		}
+
+		cr, csv, err := GetCSV(client, d.OriginalCRD)
+		if err != nil {
+			return []string{}, err
+		}
+
+		var group, version, kind, resource string
+		for _, crd := range csv.Spec.CustomResourceDefinitions.Owned {
+			if crd.Kind == cr {
+				group, version, kind, resource, err = getGVKRFromCR(crd)
+				if err != nil {
+					return []string{}, err
+				}
+				break
+			}
+		}
+
+		// create the service on cluster
+		err = client.CreateDynamicResource(d.OriginalCRD, group, version, resource)
+		if err != nil {
+			if strings.Contains(err.Error(), "already exists") {
+				// this could be the case when "odo push" was executed after making change to code but there was no change to the service itself
+				// TODO: better way to handle this might be introduced by https://github.com/openshift/odo/issues/4553
+				err = nil
+				break // this ensures that services slice is not updated
+			} else {
+				return []string{}, err
+			}
+		}
+
+		name, _ := d.GetServiceNameFromCRD() // ignoring error because invalid yaml won't be inserted into devfile through odo
+		services = append(services, strings.Join([]string{kind, name}, "/"))
+	}
+
+	return services, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
This PR ensures that an Opreator backed service is created on the cluster only when user does `odo push` and not when they do `odo service create`.

**Which issue(s) this PR fixes**:

Fixes part of the scope mentioned in https://github.com/openshift/odo/issues/4160#issuecomment-809366184

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Notes:
* This PR is targeted only for `odo service create; odo push` workflow for Operator backed services. Adding labels to the service, deleting service upon doing `odo push` and Service Catalog related changes will come in subsequent PRs after this one is merged. Doing this to break big piece into smaller chunks.
* ~I need to add integration tests to the PR.~ Integration tests have been modified to use `odo push` to actually create service on the cluster. Can't think of a new scenario that needs to be added. Open to ideas.

How to test:
* For Operator backed services, `odo service create` and `odo push`. Subsequent `odo push` would silently pass without any service info (because the service already exists on cluster.)

