### PR TITLE
Adds component labels to Operator backed services

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -182,8 +182,9 @@ func (a Adapter) Push(parameters common.PushParameters) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error while trying to fetch service(s) from devfile")
 	}
+	labels := componentlabels.GetLabels(a.ComponentName, a.AppName, true)
 	// create the Kubernetes objects from the manifest
-	services, err := service.CreateServiceFromKubernetesInlineComponents(a.Client.GetKubeClient(), k8sComponents)
+	services, err := service.CreateServiceFromKubernetesInlineComponents(a.Client.GetKubeClient(), k8sComponents, labels)
 	if err != nil {
 		return errors.Wrap(err, "failed to create service(s) associated with the component")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
Adds component labels to Operator backed services. We will need this for:
* `odo service list` - to list services that belong to a component. Refer https://github.com/openshift/odo/issues/4160#issuecomment-806678542 for more details.
* `odo service delete` - to delete services from cluster, we will compare the Kubernetes Inlined components in a devfile with the list of services belonging to the component on the cluster

**Which issue(s) this PR fixes**:

Fixes part of the scope mentioned in https://github.com/openshift/odo/issues/4160#issuecomment-809366184

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
*Notes*

* There's no integration test on this one because it's not a user facing change. Integration tests will be added in the PR for `odo sevice list` and `odo service delete` that use this PR.


*How to test*

* Create an operator backed service by doing `odo service create && odo push`. For example - `odo service create etcdoperator.v0.9.4-clusterwide/EtcdCluster myetcd && odo push`. You could edit the service manifest in `devfile.yaml` and add `labels` to it and see if appending the labels works.
* Check for labels - `kubectl get EtcdCluster/myetcd -o yaml | less` and check for `.metadata.labels`.