### PR TITLE
skip centos7 image test on s390x

### DIFF
--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -93,6 +93,16 @@ var _ = Describe("odo supported images e2e tests", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", "rhoar-nodejs/nodejs-10:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("rhoar-nodejs/nodejs-10:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
+
+		It("Should be able to verify the nodejs-10-centos7 image", func() {
+			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+		})
+
+		It("Should be able to verify the nodejs-12-centos7 image", func() {
+			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
+		})
 	})
 
 	Context("odo supported images deployment", func() {
@@ -104,16 +114,6 @@ var _ = Describe("odo supported images e2e tests", func() {
 		It("Should be able to verify the nodejs-10-rhel7 image", func() {
 			oc.ImportImageFromRegistry("registry.access.redhat.com", "rhscl/nodejs-10-rhel7:latest", "nodejs:latest", commonVar.Project)
 			verifySupportedImage("rhscl/nodejs-10-rhel7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
-		})
-
-		It("Should be able to verify the nodejs-10-centos7 image", func() {
-			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-10-centos7:latest", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos7/nodejs-10-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
-		})
-
-		It("Should be able to verify the nodejs-12-centos7 image", func() {
-			oc.ImportImageFromRegistry("quay.io", "centos7/nodejs-12-centos7:latest", "nodejs:latest", commonVar.Project)
-			verifySupportedImage("centos7/nodejs-12-centos7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

> [skip ci]

**What does this PR do / why we need it**:
#4518 move two centos cases from only arm64 to all platform, but s390x doesn't support and don't have the centos7 s390x arch image. So we need skip the cases on s390x platform, I reverted the related move changes for #4518.

**Which issue(s) this PR fixes**:

Fixes #4518 ?

**PR acceptance criteria**:
skip two cases for s390x 

**How to test changes / Special notes to the reviewer**:
 just run the test script
