### PR TITLE
Collect Component type for usage data

### DIFF
--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/preference"
+	"github.com/openshift/odo/pkg/segment"
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -65,7 +67,7 @@ func main() {
 		updateInfo := make(chan string)
 		go version.GetLatestReleaseInfo(updateInfo)
 
-		util.LogErrorAndExit(root.Execute(), "")
+		util.LogErrorAndExit(root.ExecuteContext(segment.NewContext(context.Background())), "")
 		select {
 		case message := <-updateInfo:
 			log.Italic(message)
@@ -73,7 +75,7 @@ func main() {
 			klog.V(4).Info("Could not get the latest release information in time. Never mind, exiting gracefully :)")
 		}
 	} else {
-		util.LogErrorAndExit(root.Execute(), "")
+		util.LogErrorAndExit(root.ExecuteContext(segment.NewContext(context.Background())), "")
 	}
 }
 

--- a/cmd/odo/odo.go
+++ b/cmd/odo/odo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/util"
 	"github.com/openshift/odo/pkg/odo/util/completion"
 	"github.com/openshift/odo/pkg/preference"
-	"github.com/openshift/odo/pkg/segment"
+	segment "github.com/openshift/odo/pkg/segment/context"
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/pkg/odo/cli/application/delete.go
+++ b/pkg/odo/cli/application/delete.go
@@ -72,7 +72,7 @@ func (o *DeleteOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo command
-func (o *DeleteOptions) Run() (err error) {
+func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	if log.IsJSON() {
 		err = application.Delete(o.Client, o.appName)
 		if err != nil {

--- a/pkg/odo/cli/application/describe.go
+++ b/pkg/odo/cli/application/describe.go
@@ -76,7 +76,7 @@ func (o *DescribeOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo command
-func (o *DescribeOptions) Run() (err error) {
+func (o *DescribeOptions) Run(cmd *cobra.Command) (err error) {
 	if log.IsJSON() {
 		appDef := application.GetMachineReadableFormat(o.Client, o.appName, o.Project)
 		machineoutput.OutputSuccess(appDef)

--- a/pkg/odo/cli/application/list.go
+++ b/pkg/odo/cli/application/list.go
@@ -52,7 +52,7 @@ func (o *ListOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo command
-func (o *ListOptions) Run() (err error) {
+func (o *ListOptions) Run(cmd *cobra.Command) (err error) {
 	apps, err := application.List(o.Client)
 	if err != nil {
 		return fmt.Errorf("unable to get list of applications: %v", err)

--- a/pkg/odo/cli/catalog/describe/component.go
+++ b/pkg/odo/cli/catalog/describe/component.go
@@ -113,7 +113,7 @@ type DevfileComponentDescription struct {
 }
 
 // Run contains the logic for the command associated with DescribeComponentOptions
-func (o *DescribeComponentOptions) Run() (err error) {
+func (o *DescribeComponentOptions) Run(cmd *cobra.Command) (err error) {
 	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 	if log.IsJSON() {
 		if len(o.devfileComponents) > 0 {

--- a/pkg/odo/cli/catalog/describe/service.go
+++ b/pkg/odo/cli/catalog/describe/service.go
@@ -71,7 +71,7 @@ func (o *DescribeServiceOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command associated with DescribeServiceOptions
-func (o *DescribeServiceOptions) Run() (err error) {
+func (o *DescribeServiceOptions) Run(cmd *cobra.Command) (err error) {
 	return o.backend.RunDescribeService(o)
 }
 

--- a/pkg/odo/cli/catalog/list/components.go
+++ b/pkg/odo/cli/catalog/list/components.go
@@ -93,7 +93,7 @@ type combinedCatalogList struct {
 }
 
 // Run contains the logic for the command associated with ListComponentsOptions
-func (o *ListComponentsOptions) Run() (err error) {
+func (o *ListComponentsOptions) Run(cmd *cobra.Command) (err error) {
 	if log.IsJSON() {
 		for i, image := range o.catalogList.Items {
 			// here we don't care about the unsupported tags (second return value)

--- a/pkg/odo/cli/catalog/list/services.go
+++ b/pkg/odo/cli/catalog/list/services.go
@@ -63,7 +63,7 @@ func (o *ServiceOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command associated with ListServicesOptions
-func (o *ServiceOptions) Run() (err error) {
+func (o *ServiceOptions) Run(cmd *cobra.Command) (err error) {
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(newCatalogListOutput(&o.services, o.csvs))
 	} else {

--- a/pkg/odo/cli/catalog/search/component.go
+++ b/pkg/odo/cli/catalog/search/component.go
@@ -49,7 +49,7 @@ func (o *SearchComponentOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command associated with SearchComponentOptions
-func (o *SearchComponentOptions) Run() (err error) {
+func (o *SearchComponentOptions) Run(cmd *cobra.Command) (err error) {
 	util.DisplayComponents(o.components)
 	return
 }

--- a/pkg/odo/cli/catalog/search/service.go
+++ b/pkg/odo/cli/catalog/search/service.go
@@ -76,7 +76,7 @@ func (o *SearchServiceOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command associated with SearchServiceOptions
-func (o *SearchServiceOptions) Run() (err error) {
+func (o *SearchServiceOptions) Run(cmd *cobra.Command) (err error) {
 	if len(o.csvs.Items) > 0 {
 		util.DisplayClusterServiceVersions(o.csvs)
 	}

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	segment "github.com/openshift/odo/pkg/segment/context"
+	scontext "github.com/openshift/odo/pkg/segment/context"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -908,7 +908,7 @@ func (co *CreateOptions) devfileRun() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
-	segment.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
+	scontext.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
 	// By default we run Devfile
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
 		err := co.devfileRun()

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo/pkg/segment"
+	segment "github.com/openshift/odo/pkg/segment/context"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -905,8 +907,8 @@ func (co *CreateOptions) devfileRun() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (co *CreateOptions) Run() (err error) {
-
+func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
+	segment.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
 	// By default we run Devfile
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
 		err := co.devfileRun()

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -130,7 +130,7 @@ func (do *DeleteOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (do *DeleteOptions) Run() (err error) {
+func (do *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	klog.V(4).Infof("component delete called")
 	klog.V(4).Infof("args: %#v", do)
 

--- a/pkg/odo/cli/component/describe.go
+++ b/pkg/odo/cli/component/describe.go
@@ -56,7 +56,7 @@ func (do *DescribeOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (do *DescribeOptions) Run() (err error) {
+func (do *DescribeOptions) Run(cmd *cobra.Command) (err error) {
 
 	cfd, err := component.NewComponentFullDescriptionFromClientAndLocalConfig(do.Context.Client, do.LocalConfigInfo, do.EnvSpecificInfo, do.componentName, do.Context.Application, do.Context.Project)
 	if err != nil {

--- a/pkg/odo/cli/component/exec.go
+++ b/pkg/odo/cli/component/exec.go
@@ -83,7 +83,7 @@ func (eo *ExecOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (eo *ExecOptions) Run() (err error) {
+func (eo *ExecOptions) Run(cmd *cobra.Command) (err error) {
 	return eo.DevfileComponentExec(eo.command)
 }
 

--- a/pkg/odo/cli/component/get.go
+++ b/pkg/odo/cli/component/get.go
@@ -48,7 +48,7 @@ func (gto *GetOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (gto *GetOptions) Run() (err error) {
+func (gto *GetOptions) Run(cmd *cobra.Command) (err error) {
 	klog.V(4).Infof("component get called")
 
 	if gto.componentShortFlag {

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -138,7 +138,7 @@ func (o *LinkOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo link command
-func (o *LinkOptions) Run() (err error) {
+func (o *LinkOptions) Run(cmd *cobra.Command) (err error) {
 	return o.run()
 }
 

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -139,7 +139,7 @@ func (lo *ListOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (lo *ListOptions) Run() (err error) {
+func (lo *ListOptions) Run(cmd *cobra.Command) (err error) {
 
 	// --path workflow
 

--- a/pkg/odo/cli/component/log.go
+++ b/pkg/odo/cli/component/log.go
@@ -61,7 +61,7 @@ func (lo *LogOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (lo *LogOptions) Run() (err error) {
+func (lo *LogOptions) Run(cmd *cobra.Command) (err error) {
 	stdout := os.Stdout
 
 	// If experimental mode is enabled, use devfile push

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -249,7 +249,7 @@ func (po *PushOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (po *PushOptions) Run() (err error) {
+func (po *PushOptions) Run(cmd *cobra.Command) (err error) {
 	// If experimental mode is enabled, use devfile push
 	if util.CheckPathExists(po.DevfilePath) {
 		// Return Devfile push

--- a/pkg/odo/cli/component/status.go
+++ b/pkg/odo/cli/component/status.go
@@ -123,7 +123,7 @@ func (so *StatusOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (so *StatusOptions) Run() (err error) {
+func (so *StatusOptions) Run(cmd *cobra.Command) (err error) {
 
 	if !so.isDevfile {
 		return errors.New("the status command is only supported for devfiles")

--- a/pkg/odo/cli/component/test.go
+++ b/pkg/odo/cli/component/test.go
@@ -74,7 +74,7 @@ func (to *TestOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo command
-func (to *TestOptions) Run() (err error) {
+func (to *TestOptions) Run(cmd *cobra.Command) (err error) {
 	return to.RunTestCommand()
 }
 

--- a/pkg/odo/cli/component/unlink.go
+++ b/pkg/odo/cli/component/unlink.go
@@ -79,7 +79,7 @@ func (o *UnlinkOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo link command
-func (o *UnlinkOptions) Run() (err error) {
+func (o *UnlinkOptions) Run(cmd *cobra.Command) (err error) {
 	return o.run()
 }
 

--- a/pkg/odo/cli/component/update.go
+++ b/pkg/odo/cli/component/update.go
@@ -168,7 +168,7 @@ func (uo *UpdateOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (uo *UpdateOptions) Run() (err error) {
+func (uo *UpdateOptions) Run(cmd *cobra.Command) (err error) {
 
 	// if devfile is present
 	if util.CheckPathExists(uo.devfilePath) {

--- a/pkg/odo/cli/component/watch.go
+++ b/pkg/odo/cli/component/watch.go
@@ -206,7 +206,7 @@ func (wo *WatchOptions) Validate() (err error) {
 }
 
 // Run has the logic to perform the required actions as part of command
-func (wo *WatchOptions) Run() (err error) {
+func (wo *WatchOptions) Run(cmd *cobra.Command) (err error) {
 	// if experimental mode is enabled and devfile is present
 	if util.CheckPathExists(wo.devfilePath) {
 

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -166,7 +166,7 @@ func (o *SetOptions) DevfileRun() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *SetOptions) Run() (err error) {
+func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 
 	if o.IsDevfile {
 		return o.DevfileRun()

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -149,7 +149,7 @@ func (o *UnsetOptions) DevfileRun() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *UnsetOptions) Run() (err error) {
+func (o *UnsetOptions) Run(cmd *cobra.Command) (err error) {
 
 	if o.IsDevfile {
 		return o.DevfileRun()

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -96,7 +96,7 @@ func (o *ViewOptions) DevfileRun() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *ViewOptions) Run() (err error) {
+func (o *ViewOptions) Run(cmd *cobra.Command) (err error) {
 
 	if o.IsDevfile {
 		return o.DevfileRun()

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -82,7 +82,7 @@ func (o InfoOptions) Validate() error {
 }
 
 // Run implements all the necessary functionality for port-forward cmd.
-func (o InfoOptions) Run() error {
+func (o InfoOptions) Run(cmd *cobra.Command) error {
 	if debugFileInfo, debugging := debug.GetDebugInfo(o.PortForwarder); debugging {
 		if log.IsJSON() {
 			machineoutput.OutputSuccess(debugFileInfo)

--- a/pkg/odo/cli/debug/portforward.go
+++ b/pkg/odo/cli/debug/portforward.go
@@ -145,7 +145,7 @@ func (o PortForwardOptions) Validate() error {
 }
 
 // Run implements all the necessary functionality for port-forward cmd.
-func (o PortForwardOptions) Run() error {
+func (o PortForwardOptions) Run(cmd *cobra.Command) error {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt,

--- a/pkg/odo/cli/env/set.go
+++ b/pkg/odo/cli/env/set.go
@@ -79,7 +79,7 @@ func (o *SetOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *SetOptions) Run() (err error) {
+func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 	if !o.forceFlag {
 		if isSet := o.cfg.IsSet(o.paramName); isSet {
 			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the environment", o.paramName)) {

--- a/pkg/odo/cli/env/unset.go
+++ b/pkg/odo/cli/env/unset.go
@@ -72,7 +72,7 @@ func (o *UnsetOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *UnsetOptions) Run() (err error) {
+func (o *UnsetOptions) Run(cmd *cobra.Command) (err error) {
 	if !o.forceFlag {
 		if isSet := o.cfg.IsSet(o.paramName); isSet {
 			if !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the environment", o.paramName)) {

--- a/pkg/odo/cli/env/view.go
+++ b/pkg/odo/cli/env/view.go
@@ -59,7 +59,7 @@ func (o *ViewOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *ViewOptions) Run() (err error) {
+func (o *ViewOptions) Run(cmd *cobra.Command) (err error) {
 	cs := o.cfg.GetComponentSettings()
 	if log.IsJSON() {
 		machineoutput.OutputSuccess(envinfo.WrapForJSONOutput(cs))

--- a/pkg/odo/cli/login/login.go
+++ b/pkg/odo/cli/login/login.go
@@ -56,7 +56,7 @@ func (o *LoginOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo command
-func (o *LoginOptions) Run() (err error) {
+func (o *LoginOptions) Run(cmd *cobra.Command) (err error) {
 	return auth.Login(o.server, o.userName, o.password, o.token, o.caAuth, o.skipTLS)
 }
 

--- a/pkg/odo/cli/logout/logout.go
+++ b/pkg/odo/cli/logout/logout.go
@@ -39,7 +39,7 @@ func (o *LogoutOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo logout command
-func (o *LogoutOptions) Run() (err error) {
+func (o *LogoutOptions) Run(cmd *cobra.Command) (err error) {
 	return o.Client.RunLogout(os.Stdout)
 }
 

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/openshift/odo/pkg/log"
 
 	"github.com/openshift/odo/pkg/odo/cli/ui"
@@ -50,7 +52,7 @@ func (o *SetOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *SetOptions) Run() (err error) {
+func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 
 	cfg, err := preference.New()
 
@@ -69,6 +71,7 @@ func (o *SetOptions) Run() (err error) {
 	}
 
 	err = cfg.SetConfiguration(strings.ToLower(o.paramName), o.paramValue)
+	segment.SetConfigurationKey(cmd.Context(), strings.ToLower(o.paramName))
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/preference/set.go
+++ b/pkg/odo/cli/preference/set.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/odo/pkg/segment"
-
 	"github.com/openshift/odo/pkg/log"
 
 	"github.com/openshift/odo/pkg/odo/cli/ui"
@@ -71,7 +69,6 @@ func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	err = cfg.SetConfiguration(strings.ToLower(o.paramName), o.paramValue)
-	segment.SetConfigurationKey(cmd.Context(), strings.ToLower(o.paramName))
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/preference/unset.go
+++ b/pkg/odo/cli/preference/unset.go
@@ -48,7 +48,7 @@ func (o *UnsetOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *UnsetOptions) Run() (err error) {
+func (o *UnsetOptions) Run(cmd *cobra.Command) (err error) {
 
 	cfg, err := preference.New()
 

--- a/pkg/odo/cli/preference/view.go
+++ b/pkg/odo/cli/preference/view.go
@@ -41,7 +41,7 @@ func (o *ViewOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *ViewOptions) Run() (err error) {
+func (o *ViewOptions) Run(cmd *cobra.Command) (err error) {
 
 	cfg, err := preference.New()
 

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -54,7 +54,7 @@ func (pco *ProjectCreateOptions) Validate() (err error) {
 }
 
 // Run runs the project create command
-func (pco *ProjectCreateOptions) Run() (err error) {
+func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
 
 	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)
 

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -66,7 +66,7 @@ func (pdo *ProjectDeleteOptions) Validate() (err error) {
 }
 
 // Run runs the project delete command
-func (pdo *ProjectDeleteOptions) Run() (err error) {
+func (pdo *ProjectDeleteOptions) Run(cmd *cobra.Command) (err error) {
 
 	// Create the "spinner"
 	s := &log.Status{}

--- a/pkg/odo/cli/project/get.go
+++ b/pkg/odo/cli/project/get.go
@@ -52,7 +52,7 @@ func (pgo *ProjectGetOptions) Validate() (err error) {
 }
 
 // Run runs the project get command
-func (pgo *ProjectGetOptions) Run() (err error) {
+func (pgo *ProjectGetOptions) Run(cmd *cobra.Command) (err error) {
 	currentProject := pgo.Context.Project
 
 	if pgo.projectShortFlag {

--- a/pkg/odo/cli/project/list.go
+++ b/pkg/odo/cli/project/list.go
@@ -46,7 +46,7 @@ func (plo *ProjectListOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo project list command
-func (plo *ProjectListOptions) Run() (err error) {
+func (plo *ProjectListOptions) Run(cmd *cobra.Command) (err error) {
 	projects, err := project.List(plo.Context)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -65,7 +65,7 @@ func (pso *ProjectSetOptions) Validate() (err error) {
 }
 
 // Run runs the project set command
-func (pso *ProjectSetOptions) Run() (err error) {
+func (pso *ProjectSetOptions) Run(cmd *cobra.Command) (err error) {
 	current := pso.Project
 	err = project.SetCurrent(pso.Context, pso.projectName)
 	if err != nil {

--- a/pkg/odo/cli/registry/add.go
+++ b/pkg/odo/cli/registry/add.go
@@ -65,7 +65,7 @@ func (o *AddOptions) Validate() (err error) {
 }
 
 // Run contains the logic for "odo registry add" command
-func (o *AddOptions) Run() (err error) {
+func (o *AddOptions) Run(cmd *cobra.Command) (err error) {
 	isSecure := false
 	if o.token != "" {
 		isSecure = true

--- a/pkg/odo/cli/registry/delete.go
+++ b/pkg/odo/cli/registry/delete.go
@@ -57,7 +57,7 @@ func (o *DeleteOptions) Validate() (err error) {
 }
 
 // Run contains the logic for "odo registry delete" command
-func (o *DeleteOptions) Run() (err error) {
+func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	isSecure := registryUtil.IsSecure(o.registryName)
 
 	cfg, err := preference.New()

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -50,7 +50,7 @@ func (o *ListOptions) Validate() (err error) {
 }
 
 // Run contains the logic for "odo registry list" command
-func (o *ListOptions) Run() (err error) {
+func (o *ListOptions) Run(cmd *cobra.Command) (err error) {
 	cfg, err := preference.New()
 	if err != nil {
 		util.LogErrorAndExit(err, "")

--- a/pkg/odo/cli/registry/update.go
+++ b/pkg/odo/cli/registry/update.go
@@ -63,7 +63,7 @@ func (o *UpdateOptions) Validate() (err error) {
 }
 
 // Run contains the logic for "odo registry update" command
-func (o *UpdateOptions) Run() (err error) {
+func (o *UpdateOptions) Run(cmd *cobra.Command) (err error) {
 	secureBeforeUpdate := false
 	secureAfterUpdate := false
 	if registryUtil.IsSecure(o.registryName) {

--- a/pkg/odo/cli/service/create.go
+++ b/pkg/odo/cli/service/create.go
@@ -137,7 +137,7 @@ func (o *CreateOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo service create command
-func (o *CreateOptions) Run() (err error) {
+func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 	err = o.Backend.RunServiceCreate(o)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/service/delete.go
+++ b/pkg/odo/cli/service/delete.go
@@ -78,7 +78,7 @@ func (o *DeleteOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo service delete command
-func (o *DeleteOptions) Run() (err error) {
+func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	if o.serviceForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v", o.serviceName)) {
 		s := log.Spinner("Waiting for service to be deleted")
 		defer s.End(false)

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -68,7 +68,7 @@ func (o *ServiceListOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo service list command
-func (o *ServiceListOptions) Run() (err error) {
+func (o *ServiceListOptions) Run(cmd *cobra.Command) (err error) {
 	if o.csvSupport {
 		// if cluster supports Operators, we list only operator backed services
 		// and not service catalog ones

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+
 	"github.com/openshift/odo/pkg/localConfigProvider"
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/machineoutput"
@@ -78,7 +79,7 @@ func (o *CreateOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo storage create command
-func (o *CreateOptions) Run() (err error) {
+func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 	err = o.Context.LocalConfigProvider.CreateStorage(o.storage)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -67,7 +67,7 @@ func (o *DeleteOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo storage delete command
-func (o *DeleteOptions) Run() (err error) {
+func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	mPath, err := o.Context.LocalConfigProvider.GetStorageMountPath(o.storageName)
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/list.go
+++ b/pkg/odo/cli/storage/list.go
@@ -67,7 +67,7 @@ func (o *ListOptions) Validate() (err error) {
 	return nil
 }
 
-func (o *ListOptions) Run() (err error) {
+func (o *ListOptions) Run(cmd *cobra.Command) (err error) {
 	storageList, err := o.client.List()
 	if err != nil {
 		return err

--- a/pkg/odo/cli/storage/mount.go
+++ b/pkg/odo/cli/storage/mount.go
@@ -59,7 +59,7 @@ func (o *StorageMountOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo storage mount command
-func (o *StorageMountOptions) Run() (err error) {
+func (o *StorageMountOptions) Run(cmd *cobra.Command) (err error) {
 	err = storage.Mount(o.Client, o.storagePath, o.storageName, o.Component(), o.Application)
 	if err != nil {
 		return

--- a/pkg/odo/cli/storage/unmount.go
+++ b/pkg/odo/cli/storage/unmount.go
@@ -76,7 +76,7 @@ func (o *StorageUnMountOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo storage unmount command
-func (o *StorageUnMountOptions) Run() (err error) {
+func (o *StorageUnMountOptions) Run(cmd *cobra.Command) (err error) {
 	err = storage.Unmount(o.Client, o.storageName, o.Component(), o.Application, true)
 	if err != nil {
 		return fmt.Errorf("unable to unmount storage %v from component %v", o.storageName, o.Component())

--- a/pkg/odo/cli/telemetry/telemetry.go
+++ b/pkg/odo/cli/telemetry/telemetry.go
@@ -31,7 +31,7 @@ func (o *TelemetryOptions) Validate() (err error) {
 	return err
 }
 
-func (o *TelemetryOptions) Run() (err error) {
+func (o *TelemetryOptions) Run(cmd *cobra.Command) (err error) {
 	cfg, err := preference.New()
 	if err != nil {
 		return errors.Wrapf(err, "unable to upload telemetry data")

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -176,7 +176,7 @@ func (o *CreateOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo url create command
-func (o *CreateOptions) Run() (err error) {
+func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 
 	// create the URL and write it to the local config
 	err = o.Context.LocalConfigProvider.CreateURL(o.url)

--- a/pkg/odo/cli/url/delete.go
+++ b/pkg/odo/cli/url/delete.go
@@ -83,7 +83,7 @@ func (o *DeleteOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo url delete command
-func (o *DeleteOptions) Run() (err error) {
+func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 	if o.urlForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete the url %v", o.urlName)) {
 		err := o.LocalConfigProvider.DeleteURL(o.urlName)
 		if err != nil {

--- a/pkg/odo/cli/url/list.go
+++ b/pkg/odo/cli/url/list.go
@@ -72,7 +72,7 @@ func (o *ListOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo url list command
-func (o *ListOptions) Run() (err error) {
+func (o *ListOptions) Run(cmd *cobra.Command) (err error) {
 	componentName := o.Context.LocalConfigProvider.GetName()
 	urls, err := o.client.List()
 	if err != nil {

--- a/pkg/odo/cli/utils/convert.go
+++ b/pkg/odo/cli/utils/convert.go
@@ -93,7 +93,7 @@ func (co *ConvertOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (co *ConvertOptions) Run() (err error) {
+func (co *ConvertOptions) Run(cmd *cobra.Command) (err error) {
 
 	/* NOTE: This data is not used in devfile currently so cannot be converted
 	   minMemory := context.LocalConfigInfo.GetMinMemory()

--- a/pkg/odo/cli/utils/terminal.go
+++ b/pkg/odo/cli/utils/terminal.go
@@ -87,7 +87,7 @@ func (o *TerminalOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the command
-func (o *TerminalOptions) Run() (err error) {
+func (o *TerminalOptions) Run(cmd *cobra.Command) (err error) {
 	// shell type is already validated so retrieval will work
 	_, err = os.Stdout.Write([]byte(supportedShells[o.shellType]))
 	return

--- a/pkg/odo/cli/version/version.go
+++ b/pkg/odo/cli/version/version.go
@@ -60,7 +60,7 @@ func (o *VersionOptions) Validate() (err error) {
 }
 
 // Run contains the logic for the odo service create command
-func (o *VersionOptions) Run() (err error) {
+func (o *VersionOptions) Run(cmd *cobra.Command) (err error) {
 	// If verbose mode is enabled, dump all KUBECLT_* env variables
 	// this is usefull for debuging oc plugin integration
 	for _, v := range os.Environ() {

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/openshift/odo/pkg/segment"
+	scontext "github.com/openshift/odo/pkg/segment/context"
 	"k8s.io/klog"
 
 	"github.com/openshift/odo/pkg/log"
@@ -96,7 +97,7 @@ func startTelemetry(cfg *preference.PreferenceInfo, cmd *cobra.Command, err erro
 				Success:       err == nil,
 				Tty:           segment.RunningInTerminal(),
 				Version:       fmt.Sprintf("odo %v (%v)", version.VERSION, version.GITCOMMIT),
-				CmdProperties: segment.GetContextProperties(cmd.Context()),
+				CmdProperties: scontext.GetContextProperties(cmd.Context()),
 			},
 		}
 		if err != nil {

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -28,7 +28,7 @@ import (
 type Runnable interface {
 	Complete(name string, cmd *cobra.Command, args []string) error
 	Validate() error
-	Run() error
+	Run(cmd *cobra.Command) error
 }
 
 func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
@@ -80,22 +80,23 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	}
 	util.LogErrorAndExit(err, "")
 
-	err = o.Run()
+	err = o.Run(cmd)
 	startTelemetry(cfg, cmd, err, startTime)
 	util.LogErrorAndExit(err, "")
 }
 
-// startTelemetry uploads the data to segment and logs the error
+// startTelemetry uploads the data to segment if user has consented to usage data collection and the command is not telemetry
 // TODO: move this function to a more suitable place, preferably pkg/segment
 func startTelemetry(cfg *preference.PreferenceInfo, cmd *cobra.Command, err error, startTime time.Time) {
 	if segment.IsTelemetryEnabled(cfg) && !strings.Contains(cmd.CommandPath(), "telemetry") {
 		uploadData := &segment.TelemetryData{
 			Event: cmd.CommandPath(),
 			Properties: segment.TelemetryProperties{
-				Duration: time.Since(startTime).Milliseconds(),
-				Success:  err == nil,
-				Tty:      segment.RunningInTerminal(),
-				Version:  fmt.Sprintf("odo %v (%v)", version.VERSION, version.GITCOMMIT),
+				Duration:      time.Since(startTime).Milliseconds(),
+				Success:       err == nil,
+				Tty:           segment.RunningInTerminal(),
+				Version:       fmt.Sprintf("odo %v (%v)", version.VERSION, version.GITCOMMIT),
+				CmdProperties: segment.GetContextProperties(cmd.Context()),
 			},
 		}
 		if err != nil {

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -1,0 +1,61 @@
+package context
+
+import (
+	"context"
+	"sync"
+)
+
+type contextKey struct{}
+
+var key = contextKey{}
+
+type properties struct {
+	lock    sync.Mutex
+	storage map[string]interface{}
+}
+
+func (p *properties) set(name string, value interface{}) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.storage[name] = value
+}
+
+func (p *properties) values() map[string]interface{} {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	ret := make(map[string]interface{})
+	for k, v := range p.storage {
+		ret[k] = v
+	}
+	return ret
+}
+
+// NewContext returns a context more specifically to be used for telemetry data collection
+func NewContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, &properties{storage: make(map[string]interface{})})
+}
+
+func propertiesFromContext(ctx context.Context) *properties {
+	value := ctx.Value(key)
+	if cast, ok := value.(*properties); ok {
+		return cast
+	}
+	return nil
+}
+
+// SetContextProperty sets the value of a key in given context for telemetry data
+func SetContextProperty(ctx context.Context, key string, value interface{}) {
+	properties := propertiesFromContext(ctx)
+	if properties != nil {
+		properties.set(key, value)
+	}
+}
+
+// GetContextProperties retrieves all the values set in a given context
+func GetContextProperties(ctx context.Context) map[string]interface{} {
+	properties := propertiesFromContext(ctx)
+	if properties == nil {
+		return make(map[string]interface{})
+	}
+	return properties.values()
+}

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -9,17 +9,39 @@ type contextKey struct{}
 
 var key = contextKey{}
 
+// properties is a struct used to store data in a context and it comes with locking mechanism
 type properties struct {
 	lock    sync.Mutex
 	storage map[string]interface{}
 }
 
+// NewContext returns a context more specifically to be used for telemetry data collection
+func NewContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, &properties{storage: make(map[string]interface{})})
+}
+
+// GetContextProperties retrieves all the values set in a given context
+func GetContextProperties(ctx context.Context) map[string]interface{} {
+	properties := propertiesFromContext(ctx)
+	if properties == nil {
+		return make(map[string]interface{})
+	}
+	return properties.values()
+}
+
+// SetComponentType sets componentType property for telemetry data when a new component is created
+func SetComponentType(ctx context.Context, value string) {
+	setContextProperty(ctx, "componentType", value)
+}
+
+// set safely sets value for a key in storage
 func (p *properties) set(name string, value interface{}) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.storage[name] = value
 }
 
+// values safely retrieves a deep copy of the storage
 func (p *properties) values() map[string]interface{} {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -30,11 +52,7 @@ func (p *properties) values() map[string]interface{} {
 	return ret
 }
 
-// NewContext returns a context more specifically to be used for telemetry data collection
-func NewContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, key, &properties{storage: make(map[string]interface{})})
-}
-
+// propertiesFromContext retrieves the properties instance from the context
 func propertiesFromContext(ctx context.Context) *properties {
 	value := ctx.Value(key)
 	if cast, ok := value.(*properties); ok {
@@ -43,19 +61,10 @@ func propertiesFromContext(ctx context.Context) *properties {
 	return nil
 }
 
-// SetContextProperty sets the value of a key in given context for telemetry data
-func SetContextProperty(ctx context.Context, key string, value interface{}) {
+// setContextProperty sets the value of a key in given context for telemetry data
+func setContextProperty(ctx context.Context, key string, value interface{}) {
 	properties := propertiesFromContext(ctx)
 	if properties != nil {
 		properties.set(key, value)
 	}
-}
-
-// GetContextProperties retrieves all the values set in a given context
-func GetContextProperties(ctx context.Context) map[string]interface{} {
-	properties := propertiesFromContext(ctx)
-	if properties == nil {
-		return make(map[string]interface{})
-	}
-	return properties.values()
 }

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -6,15 +6,25 @@ import (
 	"testing"
 )
 
-func TestSegmentContext(t *testing.T) {
-	key, value := "componentType", "java"
+func TestGetContextProperties(t *testing.T) {
+	key, value := "preferenceKey", "consenttelemetry"
 	ctx := NewContext(context.Background())
-	SetContextProperty(ctx, key, value)
+	setContextProperty(ctx, key, value)
 
 	got := GetContextProperties(ctx)
 	want := map[string]interface{}{key: value}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("want: %q got: %q", want, got)
+	}
+}
+
+func TestSetComponentType(t *testing.T) {
+	key, value := "componentType", "maven"
+	ctx := NewContext(context.Background())
+	SetComponentType(ctx, value)
+
+	if _, contains := GetContextProperties(ctx)[key]; !contains {
+		t.Errorf("component type was not set.")
 	}
 }

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -1,0 +1,20 @@
+package context
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestSegmentContext(t *testing.T) {
+	key, value := "componentType", "java"
+	ctx := NewContext(context.Background())
+	SetContextProperty(ctx, key, value)
+
+	got := GetContextProperties(ctx)
+	want := map[string]interface{}{key: value}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want: %q got: %q", want, got)
+	}
+}

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -1,7 +1,6 @@
 package segment
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -11,8 +10,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-
-	scontext "github.com/openshift/odo/pkg/segment/context"
 
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/pborman/uuid"
@@ -218,9 +215,4 @@ func IsTelemetryEnabled(cfg *preference.PreferenceInfo) bool {
 		return true
 	}
 	return false
-}
-
-// SetComponentType sets componentType property for telemetry data when a new component is created
-func SetComponentType(ctx context.Context, value string) {
-	scontext.SetContextProperty(ctx, "componentType", value)
 }

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -247,6 +247,7 @@ func (p *Properties) values() map[string]interface{} {
 func NewContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, key, &Properties{storage: make(map[string]interface{})})
 }
+
 func propertiesFromContext(ctx context.Context) *Properties {
 	value := ctx.Value(key)
 	if cast, ok := value.(*Properties); ok {
@@ -254,14 +255,12 @@ func propertiesFromContext(ctx context.Context) *Properties {
 	}
 	return nil
 }
+
 func setContextProperty(ctx context.Context, key string, value interface{}) {
 	properties := propertiesFromContext(ctx)
 	if properties != nil {
 		properties.set(key, value)
 	}
-}
-func SetConfigurationKey(ctx context.Context, value string) {
-	setContextProperty(ctx, "key", value)
 }
 
 func SetComponentType(ctx context.Context, value string) {

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,10 +30,11 @@ type segmentResponse struct {
 			OS string `json:"os"`
 		} `json:"traits"`
 		Properties struct {
-			Error     string `json:"error"`
-			ErrorType string `json:"error-type"`
-			Success   bool   `json:"success"`
-			Version   string `json:"version"`
+			Error         string `json:"error"`
+			ErrorType     string `json:"error-type"`
+			Success       bool   `json:"success"`
+			Version       string `json:"version"`
+			ComponentType string `json:"componentType"`
 		} `json:"properties"`
 		Type string `json:"type"`
 	} `json:"batch"`
@@ -71,12 +73,15 @@ func TestClientUploadWithoutConsent(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	defer c.Close()
 
 	testError := errors.New("error occurred")
-	uploadData := fakeTelemetryData("odo preference view", testError)
+	uploadData := fakeTelemetryData("odo preference view", testError, context.Background())
 	// run a command, odo preference view
 	if err = c.Upload(uploadData); err != nil {
+		t.Error(err)
+	}
+
+	if err = c.Close(); err != nil {
 		t.Error(err)
 	}
 
@@ -131,7 +136,7 @@ func TestClientUploadWithConsent(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			uploadData := fakeTelemetryData("odo create", tt.err)
+			uploadData := fakeTelemetryData("odo create", tt.err, context.Background())
 			// upload the data to Segment
 			if err = c.Upload(uploadData); err != nil {
 				t.Error(err)
@@ -309,6 +314,58 @@ func TestIsTelemetryEnabled(t *testing.T) {
 	}
 }
 
+func TestClientUploadWithContext(t *testing.T) {
+	var uploadData TelemetryData
+	body, server := mockServer()
+	defer server.Close()
+	defer close(body)
+	trueValue := true
+
+	cfg := &preference.PreferenceInfo{
+		Preference: preference.Preference{
+			OdoSettings: preference.OdoSettings{
+				ConsentTelemetry: &trueValue,
+			},
+		},
+	}
+	ctx := NewContext(context.Background())
+
+	for k, v := range map[string]string{"componentType": "nodejs"} {
+		switch k {
+		case "componentType":
+			SetComponentType(ctx, v)
+			uploadData = fakeTelemetryData("odo create", nil, ctx)
+		}
+		c, err := newCustomClient(cfg, createConfigDir(t), server.URL)
+		if err != nil {
+			t.Error(err)
+		}
+		// upload the data to Segment
+		if err = c.Upload(uploadData); err != nil {
+			t.Error(err)
+		}
+		if err = c.Close(); err != nil {
+			t.Error(err)
+		}
+		select {
+		case x := <-body:
+			s := segmentResponse{}
+			if err1 := json.Unmarshal(x, &s); err1 != nil {
+				t.Error(err1)
+			}
+			if s.Batch[1].Type == "identify" {
+				switch k {
+				case "componentType":
+					if s.Batch[1].Properties.ComponentType != v {
+						t.Errorf("componentType did not match. Want: %q Got: %q", v, s.Batch[1].Properties.ComponentType)
+					}
+
+				}
+			}
+		}
+	}
+}
+
 // createConfigDir creates a mock filesystem
 func createConfigDir(t *testing.T) string {
 	fs := filesystem.NewFakeFs()
@@ -320,16 +377,17 @@ func createConfigDir(t *testing.T) string {
 }
 
 // fakeTelemetryData returns fake data to test segment client Upload
-func fakeTelemetryData(cmd string, err error) TelemetryData {
+func fakeTelemetryData(cmd string, err error, ctx context.Context) TelemetryData {
 	return TelemetryData{
 		Event: cmd,
 		Properties: TelemetryProperties{
-			Duration:  time.Second.Milliseconds(),
-			Error:     SetError(err),
-			ErrorType: ErrorType(err),
-			Success:   err == nil,
-			Tty:       RunningInTerminal(),
-			Version:   version.VERSION,
+			Duration:      time.Second.Milliseconds(),
+			Error:         SetError(err),
+			ErrorType:     ErrorType(err),
+			Success:       err == nil,
+			Tty:           RunningInTerminal(),
+			Version:       version.VERSION,
+			CmdProperties: GetContextProperties(ctx),
 		},
 	}
 }

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/preference"
+	scontext "github.com/openshift/odo/pkg/segment/context"
 	"github.com/openshift/odo/pkg/version"
 )
 
@@ -328,7 +329,7 @@ func TestClientUploadWithContext(t *testing.T) {
 			},
 		},
 	}
-	ctx := NewContext(context.Background())
+	ctx := scontext.NewContext(context.Background())
 
 	for k, v := range map[string]string{"componentType": "nodejs"} {
 		switch k {
@@ -389,7 +390,7 @@ func fakeTelemetryData(cmd string, err error, ctx context.Context) TelemetryData
 			Success:       err == nil,
 			Tty:           RunningInTerminal(),
 			Version:       version.VERSION,
-			CmdProperties: GetContextProperties(ctx),
+			CmdProperties: scontext.GetContextProperties(ctx),
 		},
 	}
 }

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -362,6 +362,8 @@ func TestClientUploadWithContext(t *testing.T) {
 
 				}
 			}
+		default:
+			t.Error("Server should receive some data")
 		}
 	}
 }

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -334,7 +334,7 @@ func TestClientUploadWithContext(t *testing.T) {
 	for k, v := range map[string]string{"componentType": "nodejs"} {
 		switch k {
 		case "componentType":
-			SetComponentType(ctx, v)
+			scontext.SetComponentType(ctx, v)
 			uploadData = fakeTelemetryData("odo create", nil, ctx)
 		}
 		c, err := newCustomClient(cfg, createConfigDir(t), server.URL)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind code-refactoring

**What does this PR do / why we need it**:
This PR adds the component type to the telemetry data when the user creates a component.

**Which issue(s) this PR fixes**:

Fixes part of #4462

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
With telemetry enabled, run `odo create nodejs` and see if the data pops up on Segment.

A note: This PR is based off #4565.