### PR TITLE
Adds a check to ignore pods which are marked for deletion

### DIFF
--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -208,6 +208,11 @@ func (c *Client) GetOnePodFromSelector(selector string) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("multiple Pods exist for the selector: %v. Only one must be present", selector)
 	}
 
+	// check if the pod is in the terminating state
+	if pods.Items[0].DeletionTimestamp != nil {
+		return nil, &PodNotFoundError{Selector: selector}
+	}
+
 	return &pods.Items[0], nil
 }
 

--- a/pkg/kclient/pods_test.go
+++ b/pkg/kclient/pods_test.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,6 +100,11 @@ func TestGetOnePodFromSelector(t *testing.T) {
 	fakePod := FakePodStatus(corev1.PodRunning, "nodejs")
 	fakePod.Labels["component"] = "nodejs"
 
+	fakePodWithDeletionTimeStamp := FakePodStatus(corev1.PodRunning, "nodejs")
+	fakePodWithDeletionTimeStamp.Labels["component"] = "nodejs"
+	currentTime := metav1.NewTime(time.Now())
+	fakePodWithDeletionTimeStamp.DeletionTimestamp = &currentTime
+
 	type args struct {
 		selector string
 	}
@@ -136,6 +142,17 @@ func TestGetOnePodFromSelector(t *testing.T) {
 				Items: []corev1.Pod{
 					*fakePod,
 					*fakePod,
+				},
+			},
+			want:    &corev1.Pod{},
+			wantErr: true,
+		},
+		{
+			name: "pod is in the deletion state",
+			args: args{selector: fmt.Sprintf("component=%s", "nodejs")},
+			returnedPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					*fakePodWithDeletionTimeStamp,
 				},
 			},
 			want:    &corev1.Pod{},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

It adds a check to ignore pods which are marked for deletion.

**Which issue(s) this PR fixes**:

Fixes #4655 

**PR acceptance criteria**:

- [X] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create a storage and push the changes to the component `odo storage create && odo push`
- Delete the component and then list the storage `odo delete -f && odo storage list`.