### PR TITLE
follow devfile like conventions in generated url name to keep url short for --s2i

### DIFF
--- a/pkg/devfile/convert/convert.go
+++ b/pkg/devfile/convert/convert.go
@@ -290,25 +290,25 @@ func setDevfileComponentsForS2I(d data.DevfileData, s2iImage string, localConfig
 	}
 	// convert s2i ports to devfile endpoints if there are no urls present
 	for _, port := range ports {
-		split_port := strings.Split(port, "/")
+		splitPort := strings.Split(port, "/")
 		protocol := "http"
 		//  protocol provided
-		if len(split_port) > 1 {
+		if len(splitPort) > 1 {
 			// technically tcp when exposed is by default using http
-			if strings.ToLower(split_port[1]) == "tcp" {
+			if strings.ToLower(splitPort[1]) == "tcp" {
 				protocol = "http"
 			} else {
-				protocol = strings.ToLower(split_port[1])
+				protocol = strings.ToLower(splitPort[1])
 			}
 		}
-		i_port, err := strconv.Atoi(split_port[0])
+		intPort, err := strconv.Atoi(splitPort[0])
 		// we dont fail if the ports are malformed
 		if err != nil {
 			continue
 		}
 		hasURL := false
 		for _, url := range urls {
-			if i_port == url.Port {
+			if intPort == url.Port {
 				hasURL = true
 			}
 		}
@@ -316,8 +316,8 @@ func setDevfileComponentsForS2I(d data.DevfileData, s2iImage string, localConfig
 		if !hasURL {
 			// every port is an exposed url for now
 			endpoint := devfilev1.Endpoint{
-				Name:       fmt.Sprintf("%s-%d", protocol, i_port),
-				TargetPort: i_port,
+				Name:       fmt.Sprintf("%s-%d", protocol, intPort),
+				TargetPort: intPort,
 				Secure:     false,
 			}
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -509,14 +509,13 @@ func componentTests(args ...string) {
 			helper.DeleteDir(contextNumeric)
 		})
 
-		// issue https://github.com/openshift/odo/issues/4621
-		// It("should create default named component in a directory with numeric name", func() {
-		// 	helper.CopyExample(filepath.Join("source", "nodejs"), contextNumeric)
-		// 	helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", commonVar.Project, "--context", contextNumeric, "--app", "testing")...)
-		// 	info := helper.LocalEnvInfo(contextNumeric)
-		// 	Expect(info.GetApplication(), "testing")
-		// 	helper.CmdShouldPass("odo", append(args, "push", "--context", contextNumeric, "-v4")...)
-		// })
+		It("should create default named component in a directory with numeric name", func() {
+			helper.CopyExample(filepath.Join("source", "nodejs"), contextNumeric)
+			helper.CmdShouldPass("odo", append(args, "create", "--s2i", "nodejs", "--project", commonVar.Project, "--context", contextNumeric, "--app", "testing")...)
+			info := helper.LocalEnvInfo(contextNumeric)
+			Expect(info.GetApplication(), "testing")
+			helper.CmdShouldPass("odo", append(args, "push", "--context", contextNumeric, "-v4")...)
+		})
 	})
 
 	Context("Creating component using symlink", func() {


### PR DESCRIPTION
**What type of PR is this?**
After this change the generated devfile would generate a very similar url as new devfiles

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4621

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
