### PR TITLE
Fixes the storage list integration test for kubernetes clusters

### DIFF
--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -22,4 +22,5 @@ type CliRunner interface {
 	GetAllPVCNames(namespace string) []string
 	GetPodInitContainers(compName, namespace string) []string
 	GetContainerEnv(podName, containerName, namespace string) string
+	WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -201,27 +201,5 @@ func (kubectl KubectlRunner) DeletePod(podName string, namespace string) {
 // WaitAndCheckForTerminatingState waits for the given interval
 // and checks if the given resource type has been deleted on the cluster or is in the terminating state
 func (kubectl KubectlRunner) WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool {
-	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)
-	// this is a test package so time.Tick() is acceptable
-	// nolint
-	tick := time.Tick(time.Second)
-	for {
-		select {
-		case <-pingTimeout:
-			Fail(fmt.Sprintf("Timeout after %d minutes", timeoutMinutes))
-
-		case <-tick:
-			session := CmdRunner(kubectl.path, "get", resourceType, "--namespace", namespace)
-			Eventually(session).Should(gexec.Exit(0))
-			// https://github.com/kubernetes/kubectl/issues/847
-			outputStdErr := string(session.Wait().Err.Contents())
-			outputStdOut := string(session.Wait().Out.Contents())
-
-			// if the resource gets deleted before the check, we won't get the `terminating` state output
-			// thus we also check and exit when the resource has been deleted on the cluster.
-			if strings.Contains(strings.ToLower(outputStdErr), "no resources found") || strings.Contains(strings.ToLower(outputStdOut), "terminating") {
-				return true
-			}
-		}
-	}
+	return WaitAndCheckForTerminatingState(kubectl.path, resourceType, namespace, timeoutMinutes)
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -197,3 +197,31 @@ func (kubectl KubectlRunner) GetAllPVCNames(namespace string) []string {
 func (kubectl KubectlRunner) DeletePod(podName string, namespace string) {
 	CmdShouldPass(kubectl.path, "delete", "pod", "--namespace", namespace, podName)
 }
+
+// WaitAndCheckForTerminatingState waits for the given interval
+// and checks if the given resource type has been deleted on the cluster or is in the terminating state
+func (kubectl KubectlRunner) WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool {
+	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)
+	// this is a test package so time.Tick() is acceptable
+	// nolint
+	tick := time.Tick(time.Second)
+	for {
+		select {
+		case <-pingTimeout:
+			Fail(fmt.Sprintf("Timeout after %d minutes", timeoutMinutes))
+
+		case <-tick:
+			session := CmdRunner(kubectl.path, "get", resourceType, "--namespace", namespace)
+			Eventually(session).Should(gexec.Exit(0))
+			// https://github.com/kubernetes/kubectl/issues/847
+			outputStdErr := string(session.Wait().Err.Contents())
+			outputStdOut := string(session.Wait().Out.Contents())
+
+			// if the resource gets deleted before the check, we won't get the `terminating` state output
+			// thus we also check and exit when the resource has been deleted on the cluster.
+			if strings.Contains(strings.ToLower(outputStdErr), "no resources found") || strings.Contains(strings.ToLower(outputStdOut), "terminating") {
+				return true
+			}
+		}
+	}
+}

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -664,27 +664,5 @@ func (oc OcRunner) StatFileInPod(cmpName, appName, project, filepath string) str
 // WaitAndCheckForTerminatingState waits for the given interval
 // and checks if the given resource type has been deleted on the cluster or is in the terminating state
 func (oc OcRunner) WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool {
-	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)
-	// this is a test package so time.Tick() is acceptable
-	// nolint
-	tick := time.Tick(time.Second)
-	for {
-		select {
-		case <-pingTimeout:
-			Fail(fmt.Sprintf("Timeout after %d minutes", timeoutMinutes))
-
-		case <-tick:
-			session := CmdRunner(oc.path, "get", resourceType, "--namespace", namespace)
-			Eventually(session).Should(gexec.Exit(0))
-			// https://github.com/kubernetes/kubectl/issues/847
-			outputStdErr := string(session.Wait().Err.Contents())
-			outputStdOut := string(session.Wait().Out.Contents())
-
-			// if the resource gets deleted before the check, we won't get the `terminating` state output
-			// thus we also check and exit when the resource has been deleted on the cluster.
-			if strings.Contains(strings.ToLower(outputStdErr), "no resources found") || strings.Contains(strings.ToLower(outputStdOut), "terminating") {
-				return true
-			}
-		}
-	}
+	return WaitAndCheckForTerminatingState(oc.path, resourceType, namespace, timeoutMinutes)
 }

--- a/tests/helper/helper_run.go
+++ b/tests/helper/helper_run.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -121,4 +122,33 @@ func WaitForOutputToContain(substring string, timeoutInSeconds int, intervalInSe
 		return contents
 	}, timeoutInSeconds, intervalInSeconds).Should(ContainSubstring(substring))
 
+}
+
+// WaitAndCheckForTerminatingState waits for the given interval
+// and checks if the given resource type has been deleted on the cluster or is in the terminating state
+// path is the path to the program's binary
+func WaitAndCheckForTerminatingState(path, resourceType, namespace string, timeoutMinutes int) bool {
+	pingTimeout := time.After(time.Duration(timeoutMinutes) * time.Minute)
+	// this is a test package so time.Tick() is acceptable
+	// nolint
+	tick := time.Tick(time.Second)
+	for {
+		select {
+		case <-pingTimeout:
+			Fail(fmt.Sprintf("Timeout after %d minutes", timeoutMinutes))
+
+		case <-tick:
+			session := CmdRunner(path, "get", resourceType, "--namespace", namespace)
+			Eventually(session).Should(gexec.Exit(0))
+			// https://github.com/kubernetes/kubectl/issues/847
+			outputStdErr := string(session.Wait().Err.Contents())
+			outputStdOut := string(session.Wait().Out.Contents())
+
+			// if the resource gets deleted before the check, we won't get the `terminating` state output
+			// thus we also check and exit when the resource has been deleted on the cluster.
+			if strings.Contains(strings.ToLower(outputStdErr), "no resources found") || strings.Contains(strings.ToLower(outputStdOut), "terminating") {
+				return true
+			}
+		}
+	}
 }

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -209,10 +209,7 @@ var _ = Describe("odo devfile storage command tests", func() {
 
 			// since we don't have `wait` for `odo delete` at this moment
 			// we need to wait for the pod to be in the terminating state or it has been deleted from the cluster
-			ocArgs := []string{"get", "pod", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Terminating") || strings.Contains(output, "No resources")
-			})
+			commonVar.CliRunner.WaitAndCheckForTerminatingState("pods", commonVar.Project, 1)
 
 			stdOut = helper.CmdShouldPass("odo", "storage", "list", "--context", commonVar.Context)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:

It fixes the storage list integration test for kubernetes clusters.

**Which issue(s) this PR fixes**:

Fixes https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_odo/4660/pull-ci-openshift-odo-main-psi-kubernetes-integration-e2e/1388053768792182784#1:build-log.txt%3A601

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Tests should pass on kuberenetes clusters.