### PR TITLE
Update devfile tests with OCI-based registry

### DIFF
--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("odo devfile catalog command tests", func() {
 	const registryName string = "RegistryName"
 	// Use staging OCI-based registry for tests to avoid overload
-	const addRegistryURL string = "https://registry.devfile.io"
+	const addRegistryURL string = "https://registry.stage.devfile.io"
 
 	var commonVar helper.CommonVar
 

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -10,7 +10,9 @@ import (
 
 var _ = Describe("odo devfile catalog command tests", func() {
 	const registryName string = "RegistryName"
-	const addRegistryURL string = "https://github.com/odo-devfiles/registry"
+	// Use staging OCI-based registry for tests to avoid overload
+	const addRegistryURL string = "https://registry.devfile.io"
+
 	var commonVar helper.CommonVar
 
 	// This is run before every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("odo devfile registry command tests", func() {
 	const registryName string = "RegistryName"
-	const addRegistryURL string = "https://github.com/odo-devfiles/registry"
+	const addRegistryURL string = "https://registry.devfile.io"
 
 	const updateRegistryURL string = "http://www.example.com/update"
 	var commonVar helper.CommonVar

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -7,7 +7,8 @@ import (
 
 var _ = Describe("odo devfile registry command tests", func() {
 	const registryName string = "RegistryName"
-	const addRegistryURL string = "https://registry.devfile.io"
+	// Use staging OCI-based registry for tests to avoid overload
+	const addRegistryURL string = "https://registry.stage.devfile.io"
 
 	const updateRegistryURL string = "http://www.example.com/update"
 	var commonVar helper.CommonVar


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup
 
**What does this PR do / why we need it**:
After moving to use OCI-based registry (https://github.com/openshift/odo/pull/4525), devfile tests should be using OCI-based registry as well. 

**Which issue(s) this PR fixes**:

Related issues:
https://github.com/devfile/api/issues/367
https://github.com/openshift/odo/issues/4504
https://github.com/openshift/odo/pull/4525

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
This PR is for changing test codes.  
