### PR TITLE
Adds a document regarding the odo.dev.push.path attributes in the devfile

### DIFF
--- a/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
+++ b/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
@@ -1,15 +1,15 @@
 # Using the odo.dev.push.path related attributes
 
-`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only specific files and folders to the component. The format of the attribute is `odo.dev.push.path:<local_relative_path>:<remote_relative_path>`
+`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component. The format of the attribute is `"odo.dev.push.path:<local_relative_path>": "<remote_relative_path>"`
 
 ```yaml
 commands:
   - id: dev-run
     attributes:
-      "dev.odo.push.path:target/quarkus-app": "target/quarkus-app"
+      "dev.odo.push.path:target/quarkus-app": "remote-target/quarkus-app"
     exec:
       component: tools
-      commandLine: "java -jar target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
+      commandLine: "java -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
       hotReloadCapable: true
       group:
         kind: run
@@ -18,7 +18,7 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
+      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
       hotReloadCapable: true
       group:
         kind: debug

--- a/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
+++ b/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
@@ -1,0 +1,29 @@
+# Using the odo.dev.push.path related attributes
+
+`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only specific files and folders to the component. The format of the attribute is `odo.dev.push.path:<local_relative_path>:<remote_relative_path>`
+
+```yaml
+commands:
+  - id: dev-run
+    attributes:
+      "dev.odo.push.path:target/quarkus-app": "target/quarkus-app"
+    exec:
+      component: tools
+      commandLine: "java -jar target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
+      hotReloadCapable: true
+      group:
+        kind: run
+        isDefault: true
+      workingDir: $PROJECTS_ROOT
+  - id: dev-debug
+    exec:
+      component: tools
+      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
+      hotReloadCapable: true
+      group:
+        kind: debug
+        isDefault: true
+      workingDir: $PROJECTS_ROOT
+```
+
+In the above example the contents of the `quarkus-app` folder, which is inside the `target` folder, will be pushed to the remote location of `target/quarkus-app`. The local path is relative to the component's local folder. The remote location is relative to the folder containing the component's source code inside the container.

--- a/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
+++ b/docs/public/using-devfile-odo.dev.push.path-attribute.adoc
@@ -1,12 +1,13 @@
 # Using the odo.dev.push.path related attributes
 
-`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component. The format of the attribute is `"odo.dev.push.path:<local_relative_path>": "<remote_relative_path>"`
+`odo` uses the `odo.dev.push.path` related attribute from the devfile's run commands to push only the specified files and folders to the component. The format of the attribute is `"odo.dev.push.path:<local_relative_path>": "<remote_relative_path>"`. We can mention multiple such attributes in the run command's `attributes` section.
 
 ```yaml
 commands:
   - id: dev-run
     attributes:
       "dev.odo.push.path:target/quarkus-app": "remote-target/quarkus-app"
+      "dev.odo.push.path:README.txt": "docs/README.txt"
     exec:
       component: tools
       commandLine: "java -jar remote-target/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0"
@@ -26,4 +27,4 @@ commands:
       workingDir: $PROJECTS_ROOT
 ```
 
-In the above example the contents of the `quarkus-app` folder, which is inside the `target` folder, will be pushed to the remote location of `target/quarkus-app`. The local path is relative to the component's local folder. The remote location is relative to the folder containing the component's source code inside the container.
+In the above example the contents of the `quarkus-app` folder, which is inside the `target` folder, will be pushed to the remote location of `remote-target/quarkus-app` and the file `README.txt` will be pushed to `doc/README.txt`. The local path is relative to the component's local folder. The remote location is relative to the folder containing the component's source code inside the container. 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
[skip ci]

**What does this PR do / why we need it**:

It adds a document regarding the `odo.dev.push.path` related attributes for https://github.com/openshift/odo/pull/4588

**Which issue(s) this PR fixes**:

Fixes part of #3132 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [X] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- The doc should be valid.