### PR TITLE
Update changelog script

### DIFF
--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -49,6 +49,13 @@ github_changelog_generator \
 --security-label "**Documentation & Discussions:**" \
 --security-labels "kind/docs,kind/documentation,kind/design,kind/discussion,kind/epic"
 
-echo ""
-echo "The changelog is located at: /tmp/changelog"
-echo ""
+RESULT=$?
+
+if [ $RESULT -eq 0 ]; then
+  echo ""
+  echo "The changelog is located at: /tmp/changelog"
+  echo ""
+else
+  echo -e "Unable to generate changelog using github_changelog_generator"
+  exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

**What type of PR is this?**
 /kind cleanup


**What does this PR do / why we need it**:
if we didnt have the `github_changelog_generator` command:
```
Maysuns-MacBook-Pro:scripts maysun$ ./changelog-script.sh v1.0.0 v1.0.1
./changelog-script.sh: line 37: github_changelog_generator: command not found

The changelog is located at: /tmp/changelog
```

which does not exist

With this PR change:
```
Maysuns-MacBook-Pro:scripts maysun$ ./changelog-script.sh v1.0.0 v1.0.1
./changelog-script.sh: line 31: github_changelog_generator: command not found
Unable to generate changelog using github_changelog_generator
```

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
