### PR TITLE
Fix OCI-based registry migration

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -68,6 +68,9 @@ const (
 	// DefaultDevfileRegistryURL is the URL of default devfile registry
 	DefaultDevfileRegistryURL = "https://registry.devfile.io"
 
+	// OldDefaultDevfileRegistryURL is the URL of old default devfile registry for registry migration purpose
+	OldDefaultDevfileRegistryURL = "https://github.com/odo-devfiles/registry"
+
 	// DefaultRegistryCacheTime is time (in minutes) for how long odo will cache information from Devfile registry
 	DefaultRegistryCacheTime = 15
 
@@ -252,7 +255,7 @@ func NewPreferenceInfo() (*PreferenceInfo, error) {
 	// Handle OCI-based default registry migration
 	if c.OdoSettings.RegistryList != nil {
 		for index, registry := range *c.OdoSettings.RegistryList {
-			if registry.Name == DefaultDevfileRegistryName && registry.URL != DefaultDevfileRegistryURL {
+			if registry.Name == DefaultDevfileRegistryName && registry.URL == OldDefaultDevfileRegistryURL {
 				registryList := *c.OdoSettings.RegistryList
 				registryList[index].URL = DefaultDevfileRegistryURL
 				break


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR ensures the OCI-based registry auto migration only migrates the old default registry.

**Which issue(s) this PR fixes**:
Related issue: https://github.com/openshift/odo/issues/4504

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
