### PR TITLE
fix typo in unit-test job name for windows

### DIFF
--- a/scripts/openshiftci-unit-psi-tests_win_mac.sh
+++ b/scripts/openshiftci-unit-psi-tests_win_mac.sh
@@ -8,7 +8,7 @@ case $1 in
     export SENDTOPIC=amqp.ci.topic.win.unit.send
     export SETUPSCRIPT="scripts/setup_script_unit.sh"
     export RUNSCRIPT="scripts/run_script_unit.sh"
-    export JOBNAME=odo-mac-unit-pr-build
+    export JOBNAME=odo-windows-unit-pr-build
     export SENDEXCHANGE=amqp.ci.exchange.win.unit.send 
     ;;
 


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this?**
kind /failingtest
**What does this PR do / why we need it**:

It fix typo in windows jobs name for unit test


**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
N/A