### PR TITLE
Adding deprecation warning for git based registries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 ### Feature/Enhancements
 
 - implement `odo catalog describe service` for operator backed services
+- add deprecation warning for old git style devfile registries ([#4707](https://github.com/openshift/odo/pull/4707))
 
 ### Bug Fixes
 

--- a/docs/public/git-registry-deprecation.adoc
+++ b/docs/public/git-registry-deprecation.adoc
@@ -1,0 +1,9 @@
+= Deprecation of git based Registries
+
+As we now have OCI based registries for devfiles, git based registries are being #deprecated#.
+
+You are hereby advised to move to OCI based registry at the earliest as support for git based will be dropped in future releases.
+
+OCI based registries can be setup on any kubernetes cluster using https://github.com/devfile/registry-operator[devfile registry operator].
+
+An example of a devfile registry can be seen in the new https://registry.devfile.io[default devfile registry].

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -643,3 +643,4 @@ func getAllNonHiddenTags(allTags []string, hiddenTags []string) []string {
 	}
 	return result
 }
+

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -643,4 +643,3 @@ func getAllNonHiddenTags(allTags []string, hiddenTags []string) []string {
 	}
 	return result
 }
-

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -214,8 +214,8 @@ func (s *Status) End(success bool) {
 
 // Namef will output the name of the component / application / project in a *bolded* manner
 func Namef(format string, a ...interface{}) {
-	bold := color.New(color.Bold).SprintFunc()
 	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
 	}
 }
@@ -229,24 +229,24 @@ func Progressf(format string, a ...interface{}) {
 
 // Success will output in an appropriate "success" manner
 func Success(a ...interface{}) {
-	green := color.New(color.FgGreen).SprintFunc()
 	if !IsJSON() {
+		green := color.New(color.FgGreen).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s%s%s%s", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintln(a...))
 	}
 }
 
 // Successf will output in an appropriate "progress" manner
 func Successf(format string, a ...interface{}) {
-	green := color.New(color.FgGreen).SprintFunc()
 	if !IsJSON() {
+		green := color.New(color.FgGreen).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s%s%s%s\n", prefixSpacing, green(getSuccessString()), suffixSpacing, fmt.Sprintf(format, a...))
 	}
 }
 
 // Warningf will output in an appropriate "warning" manner
 func Warningf(format string, a ...interface{}) {
-	yellow := color.New(color.FgYellow).SprintFunc()
 	if !IsJSON() {
+		yellow := color.New(color.FgYellow).SprintFunc()
 		fmt.Fprintf(GetStderr(), " %s%s%s\n", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
 	}
 }
@@ -258,8 +258,8 @@ func Swarningf(format string, a ...interface{}) string {
 }
 
 func Deprecate(what, nextAction string) {
-	yellow := color.New(color.FgYellow).SprintFunc()
 	if !IsJSON() {
+		yellow := color.New(color.FgYellow).SprintFunc()
 		msg1 := fmt.Sprintf("%s%s%s%s%s", yellow(getWarningString()), suffixSpacing, yellow(fmt.Sprintf("%s Deprecated", what)), suffixSpacing, nextAction)
 		fmt.Fprintf(GetStderr(), " %s\n", msg1)
 	}
@@ -267,40 +267,40 @@ func Deprecate(what, nextAction string) {
 
 // Experimental will output in an appropriate "progress" manner
 func Experimental(a ...interface{}) {
-	yellow := color.New(color.FgYellow).SprintFunc()
 	if !IsJSON() {
+		yellow := color.New(color.FgYellow).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s\n", yellow(fmt.Sprintln(a...)))
 	}
 }
 
 // Warning will output in an appropriate "progress" manner
 func Warning(a ...interface{}) {
-	yellow := color.New(color.FgYellow).SprintFunc()
 	if !IsJSON() {
+		yellow := color.New(color.FgYellow).SprintFunc()
 		fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, yellow(getWarningString()), suffixSpacing, fmt.Sprintln(a...))
 	}
 }
 
 // Errorf will output in an appropriate "progress" manner
 func Errorf(format string, a ...interface{}) {
-	red := color.New(color.FgRed).SprintFunc()
 	if !IsJSON() {
+		red := color.New(color.FgRed).SprintFunc()
 		fmt.Fprintf(GetStderr(), " %s%s%s\n", red(getErrString()), suffixSpacing, fmt.Sprintf(format, a...))
 	}
 }
 
 // Error will output in an appropriate "progress" manner
 func Error(a ...interface{}) {
-	red := color.New(color.FgRed).SprintFunc()
 	if !IsJSON() {
+		red := color.New(color.FgRed).SprintFunc()
 		fmt.Fprintf(GetStderr(), "%s%s%s%s", prefixSpacing, red(getErrString()), suffixSpacing, fmt.Sprintln(a...))
 	}
 }
 
 // Italic will simply print out information on a new italic line
 func Italic(a ...interface{}) {
-	italic := color.New(color.Italic).SprintFunc()
 	if !IsJSON() {
+		italic := color.New(color.Italic).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s", italic(fmt.Sprintln(a...)))
 	}
 }
@@ -308,8 +308,8 @@ func Italic(a ...interface{}) {
 // Italicf will simply print out information on a new italic line
 // this is **normally** used as a way to describe what's next within odo.
 func Italicf(format string, a ...interface{}) {
-	italic := color.New(color.Italic).SprintFunc()
 	if !IsJSON() {
+		italic := color.New(color.Italic).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s\n", italic(fmt.Sprintf(format, a...)))
 	}
 }
@@ -317,8 +317,8 @@ func Italicf(format string, a ...interface{}) {
 // Info will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Info(a ...interface{}) {
-	bold := color.New(color.Bold).SprintFunc()
 	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintln(a...)))
 	}
 }
@@ -326,8 +326,8 @@ func Info(a ...interface{}) {
 // Infof will simply print out information on a new (bolded) line
 // this is intended as information *after* something has been deployed
 func Infof(format string, a ...interface{}) {
-	bold := color.New(color.Bold).SprintFunc()
 	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s\n", bold(fmt.Sprintf(format, a...)))
 	}
 }
@@ -336,16 +336,16 @@ func Infof(format string, a ...interface{}) {
 // this is intended to be used with `odo describe` and other outputs that list
 // a lot of information
 func Describef(title string, format string, a ...interface{}) {
-	bold := color.New(color.Bold).SprintFunc()
 	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s%s\n", bold(title), fmt.Sprintf(format, a...))
 	}
 }
 
 // Askf will print out information, but in an "Ask" way (without newline)
 func Askf(format string, a ...interface{}) {
-	bold := color.New(color.Bold).SprintFunc()
 	if !IsJSON() {
+		bold := color.New(color.Bold).SprintFunc()
 		fmt.Fprintf(GetStdout(), "%s", bold(fmt.Sprintf(format, a...)))
 	}
 }

--- a/pkg/log/status.go
+++ b/pkg/log/status.go
@@ -257,6 +257,14 @@ func Swarningf(format string, a ...interface{}) string {
 	return fmt.Sprintf(" %s%s%s", yellow(getWarningString()), suffixSpacing, fmt.Sprintf(format, a...))
 }
 
+func Deprecate(what, nextAction string) {
+	yellow := color.New(color.FgYellow).SprintFunc()
+	if !IsJSON() {
+		msg1 := fmt.Sprintf("%s%s%s%s%s", yellow(getWarningString()), suffixSpacing, yellow(fmt.Sprintf("%s Deprecated", what)), suffixSpacing, nextAction)
+		fmt.Fprintf(GetStderr(), " %s\n", msg1)
+	}
+}
+
 // Experimental will output in an appropriate "progress" manner
 func Experimental(a ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintFunc()

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -621,7 +621,10 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		if co.devfileMetadata.devfileSupport && !co.forceS2i {
 			registrySpinner := log.Spinnerf("Creating a devfile component from registry: %s", co.devfileMetadata.devfileRegistry.Name)
-
+			// warn user of deprecation if registry is git based
+			if registryUtil.IsGitBasedRegistry(co.devfileMetadata.devfileRegistry.URL) {
+				registryUtil.PrintGitRegistryDeprecationWarning()
+			}
 			// Initialize envinfo
 			err = co.InitEnvInfoFromContext()
 			if err != nil {

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -621,7 +621,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		if co.devfileMetadata.devfileSupport && !co.forceS2i {
 			registrySpinner := log.Spinnerf("Creating a devfile component from registry: %s", co.devfileMetadata.devfileRegistry.Name)
-			// warn user of deprecation if registry is git based
 			if registryUtil.IsGitBasedRegistry(co.devfileMetadata.devfileRegistry.URL) {
 				registryUtil.PrintGitRegistryDeprecationWarning()
 			}

--- a/pkg/odo/cli/registry/add.go
+++ b/pkg/odo/cli/registry/add.go
@@ -3,6 +3,7 @@ package registry
 import (
 	// Built-in packages
 	"fmt"
+	util2 "github.com/openshift/odo/pkg/odo/cli/registry/util"
 
 	// Third-party packages
 	"github.com/pkg/errors"
@@ -60,7 +61,9 @@ func (o *AddOptions) Validate() (err error) {
 	if err != nil {
 		return err
 	}
-
+	if util2.IsGitBasedRegistry(o.registryURL) {
+		util2.PrintGitRegistryDeprecationWarning()
+	}
 	return
 }
 

--- a/pkg/odo/cli/registry/list.go
+++ b/pkg/odo/cli/registry/list.go
@@ -3,6 +3,7 @@ package registry
 import (
 	// Built-in packages
 	"fmt"
+	util2 "github.com/openshift/odo/pkg/odo/cli/registry/util"
 	"io"
 	"os"
 	"text/tabwriter"
@@ -32,11 +33,14 @@ var (
 
 // ListOptions encapsulates the options for "odo registry list" command
 type ListOptions struct {
+	printGitRegistryDeprecationWarning bool
 }
 
 // NewListOptions creates a new ListOptions instance
 func NewListOptions() *ListOptions {
-	return &ListOptions{}
+	return &ListOptions{
+		printGitRegistryDeprecationWarning: false,
+	}
 }
 
 // Complete completes ListOptions after they've been created
@@ -70,6 +74,9 @@ func (o *ListOptions) Run() (err error) {
 	fmt.Fprintln(w, "NAME", "\t", "URL", "\t", "SECURE")
 	o.printRegistryList(w, registryList)
 	w.Flush()
+	if o.printGitRegistryDeprecationWarning {
+		util2.PrintGitRegistryDeprecationWarning()
+	}
 	return
 }
 
@@ -87,6 +94,9 @@ func (o *ListOptions) printRegistryList(w io.Writer, registryList *[]preference.
 			secure = "Yes"
 		}
 		fmt.Fprintln(w, registry.Name, "\t", registry.URL, "\t", secure)
+		if util2.IsGitBasedRegistry(registry.URL) {
+			o.printGitRegistryDeprecationWarning = true
+		}
 	}
 }
 

--- a/pkg/odo/cli/registry/update.go
+++ b/pkg/odo/cli/registry/update.go
@@ -58,7 +58,9 @@ func (o *UpdateOptions) Validate() (err error) {
 	if err != nil {
 		return err
 	}
-
+	if registryUtil.IsGitBasedRegistry(o.registryURL) {
+		registryUtil.PrintGitRegistryDeprecationWarning()
+	}
 	return
 }
 

--- a/pkg/odo/cli/registry/util/util.go
+++ b/pkg/odo/cli/registry/util/util.go
@@ -37,7 +37,7 @@ func IsSecure(registryName string) bool {
 }
 
 func IsGitBasedRegistry(url string) bool {
-	return strings.Contains(url, "github.com")
+	return strings.Contains(url, "github.com") || strings.Contains(url, "raw.githubusercontent.com")
 }
 
 func PrintGitRegistryDeprecationWarning() {

--- a/pkg/odo/cli/registry/util/util.go
+++ b/pkg/odo/cli/registry/util/util.go
@@ -40,6 +40,6 @@ func IsGitBasedRegistry(url string) bool {
 	return strings.Contains(url, "github")
 }
 
-func PrintGitRegistryDeprecationWarning()  {
+func PrintGitRegistryDeprecationWarning() {
 	log.Deprecate("Git based registries", "Please see https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc")
 }

--- a/pkg/odo/cli/registry/util/util.go
+++ b/pkg/odo/cli/registry/util/util.go
@@ -4,6 +4,7 @@ import (
 	// odo packages
 
 	"os"
+	"strings"
 
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/preference"
@@ -33,4 +34,12 @@ func IsSecure(registryName string) bool {
 	}
 
 	return isSecure
+}
+
+func IsGitBasedRegistry(url string) bool {
+	return strings.Contains(url, "github")
+}
+
+func PrintGitRegistryDeprecationWarning()  {
+	log.Deprecate("Git based registries", "Please see https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc")
 }

--- a/pkg/odo/cli/registry/util/util.go
+++ b/pkg/odo/cli/registry/util/util.go
@@ -37,7 +37,7 @@ func IsSecure(registryName string) bool {
 }
 
 func IsGitBasedRegistry(url string) bool {
-	return strings.Contains(url, "github")
+	return strings.Contains(url, "github.com")
 }
 
 func PrintGitRegistryDeprecationWarning() {

--- a/pkg/odo/cli/registry/util/util_test.go
+++ b/pkg/odo/cli/registry/util/util_test.go
@@ -71,20 +71,20 @@ func TestIsSecure(t *testing.T) {
 }
 
 func TestIsGitBasedRegistry(t *testing.T) {
-	tests := []struct{
-		name string
+	tests := []struct {
+		name        string
 		registryURL string
-		want bool
-	} {
+		want        bool
+	}{
 		{
-			name: "Case 1: Returns true if URL contains github",
+			name:        "Case 1: Returns true if URL contains github",
 			registryURL: "https://github.com/odo-devfiles/registry",
-			want: true,
+			want:        true,
 		},
 		{
-			name: "Case 2: Returns false if URL does not contain github",
+			name:        "Case 2: Returns false if URL does not contain github",
 			registryURL: " https://registry.devfile.io",
-			want: false,
+			want:        false,
 		},
 	}
 

--- a/pkg/odo/cli/registry/util/util_test.go
+++ b/pkg/odo/cli/registry/util/util_test.go
@@ -86,6 +86,11 @@ func TestIsGitBasedRegistry(t *testing.T) {
 			registryURL: " https://registry.devfile.io",
 			want:        false,
 		},
+		{
+			name:        "Case 3: Returns false if URL git based on raw.githubusercontent",
+			registryURL: "https://raw.githubusercontent.com/odo-devfiles/registry",
+			want:        true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/odo/cli/registry/util/util_test.go
+++ b/pkg/odo/cli/registry/util/util_test.go
@@ -69,3 +69,30 @@ func TestIsSecure(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGitBasedRegistry(t *testing.T) {
+	tests := []struct{
+		name string
+		registryURL string
+		want bool
+	} {
+		{
+			name: "Case 1: Returns true if URL contains github",
+			registryURL: "https://github.com/odo-devfiles/registry",
+			want: true,
+		},
+		{
+			name: "Case 2: Returns false if URL does not contain github",
+			registryURL: " https://registry.devfile.io",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := IsGitBasedRegistry(tt.registryURL); actual != tt.want {
+				t.Errorf("failed checking if registry is git based, got %t want %t", actual, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -86,7 +86,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 	})
 
 	Context("when working with git based registries", func() {
-		It("should show deprecation warning when when the git based registry is used", func() {
+		It("should show deprecation warning when the git based registry is used", func() {
 			deprecated := "Deprecated"
 			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
 			outstr, errstr := helper.CmdShouldPassIncludeErrStream("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
@@ -99,7 +99,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 			co = fmt.Sprintln(outstr, errstr)
 			helper.MatchAllInOutput(co, []string{deprecated, docLink})
 		})
-		It("should not show deprecation warning if git based registry is not used", func() {
+		It("should not show deprecation warning if non-git-based registry is used", func() {
 			deprecated := "Deprecated"
 			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
 			_, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	"github.com/openshift/odo/tests/helper"
 )
@@ -88,12 +89,15 @@ var _ = Describe("odo devfile registry command tests", func() {
 		It("should show deprecation warning when when the git based registry is used", func() {
 			deprecated := "Deprecated"
 			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
-			_, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
-			helper.MatchAllInOutput(err, []string{deprecated, docLink})
-			_, err = helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
-			helper.MatchAllInOutput(err, []string{deprecated, docLink})
-			_, err = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "RegistryFromGitHub")
-			helper.MatchAllInOutput(err, []string{deprecated, docLink})
+			outstr, errstr := helper.CmdShouldPassIncludeErrStream("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
+			co := fmt.Sprintln(outstr, errstr)
+			helper.MatchAllInOutput(co, []string{deprecated, docLink})
+			outstr, errstr = helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
+			co = fmt.Sprintln(outstr, errstr)
+			helper.MatchAllInOutput(co, []string{deprecated, docLink})
+			outstr, errstr = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "RegistryFromGitHub")
+			co = fmt.Sprintln(outstr, errstr)
+			helper.MatchAllInOutput(co, []string{deprecated, docLink})
 		})
 		It("should not show deprecation warning if git based registry is not used", func() {
 			deprecated := "Deprecated"

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -41,6 +41,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 			helper.MatchAllInOutput(output, []string{"No devfile registries added to the configuration. Refer `odo registry add -h` to add one"})
 
 		})
+
 	})
 
 	Context("When executing registry commands with the registry is not present", func() {
@@ -81,6 +82,27 @@ var _ = Describe("odo devfile registry command tests", func() {
 			helper.CmdShouldPass("odo", "registry", "delete", registryName, "-f")
 			helper.CmdShouldFail("odo", "create", "java-maven", "--registry", registryName)
 		})
+	})
 
+	Context("when working with git based registries", func() {
+		It("should show deprecation warning when when the git based registry is used", func() {
+			deprecated := "Deprecated"
+			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
+			_, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
+			helper.MatchAllInOutput(err, []string{deprecated, docLink})
+			_, err = helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
+			helper.MatchAllInOutput(err, []string{deprecated, docLink})
+			_, err = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "RegistryFromGitHub")
+			helper.MatchAllInOutput(err, []string{deprecated, docLink})
+		})
+		It("should not show deprecation warning if git based registry is not used", func() {
+			deprecated := "Deprecated"
+			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
+			_, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
+			helper.DontMatchAllInOutput(err, []string{deprecated, docLink})
+			helper.CmdShouldPass("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
+			_, err = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "DefaultDevfileRegistry")
+			helper.DontMatchAllInOutput(err, []string{deprecated, docLink})
+		})
 	})
 })

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -86,9 +86,13 @@ var _ = Describe("odo devfile registry command tests", func() {
 	})
 
 	Context("when working with git based registries", func() {
+		var deprecated, docLink string
+		JustBeforeEach(func() {
+			deprecated = "Deprecated"
+			docLink = "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
+		})
 		It("should show deprecation warning when the git based registry is used", func() {
-			deprecated := "Deprecated"
-			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
+
 			outstr, errstr := helper.CmdShouldPassIncludeErrStream("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
 			co := fmt.Sprintln(outstr, errstr)
 			helper.MatchAllInOutput(co, []string{deprecated, docLink})
@@ -100,13 +104,11 @@ var _ = Describe("odo devfile registry command tests", func() {
 			helper.MatchAllInOutput(co, []string{deprecated, docLink})
 		})
 		It("should not show deprecation warning if non-git-based registry is used", func() {
-			deprecated := "Deprecated"
-			docLink := "https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc"
-			_, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
-			helper.DontMatchAllInOutput(err, []string{deprecated, docLink})
+			out, err := helper.CmdShouldPassIncludeErrStream("odo", "registry", "list")
+			helper.DontMatchAllInOutput(fmt.Sprintln(out, err), []string{deprecated, docLink})
 			helper.CmdShouldPass("odo", "registry", "add", "RegistryFromGitHub", "https://github.com/odo-devfiles/registry")
-			_, err = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "DefaultDevfileRegistry")
-			helper.DontMatchAllInOutput(err, []string{deprecated, docLink})
+			out, err = helper.CmdShouldPassIncludeErrStream("odo", "create", "nodejs", "--registry", "DefaultDevfileRegistry")
+			helper.DontMatchAllInOutput(fmt.Sprintln(out, err), []string{deprecated, docLink})
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

**What type of PR is this?**

/kind deprecation

**What does this PR do / why we need it**:
This PR adds deprecation warning for git based registries, whever they are created/listed/updated/used

**Which issue(s) this PR fixes**:

Fixes #4666 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
❯ odo registry list
NAME                       URL                             SECURE
DefaultDevfileRegistry     https://registry.devfile.io     No
❯ odo create nodejs
Devfile Object Validation
 ✓  Checking devfile existence [20878ns]
 ✓  Creating a devfile component from registry: DefaultDevfileRegistry [36812ns]
Validation
 ✓  Validating if devfile name is correct [46943ns]

Please use `odo push` command to create the component with source deployed
❯ rm -rf ./devfile.yaml ./.odo
❯ odo registry add RegistryFromGitHub https://github.com/odo-devfiles/registry
 ⚠  Git based registries Deprecated  Please see https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc
New registry successfully added
❯ odo registry list
NAME                       URL                                          SECURE
RegistryFromGitHub         https://github.com/odo-devfiles/registry     No
DefaultDevfileRegistry     https://registry.devfile.io                  No
 ⚠  Git based registries Deprecated  Please see https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc
❯ rm -rf ./devfile.yaml ./.odo
❯ odo create nodejs --registry DefaultDevfileRegistry
Devfile Object Validation
 ✓  Checking devfile existence [71165ns]
 ✓  Creating a devfile component from registry: DefaultDevfileRegistry [97543ns]
Validation
 ✓  Validating if devfile name is correct [125752ns]

Please use `odo push` command to create the component with source deployed
❯ odo create nodejs --registry RegistryFromGitHub
Devfile Object Validation
 ✓  Checking devfile existence [69482ns]
 ⚠  Git based registries Deprecated  Please see https://github.com/openshift/odo/tree/main/docs/public/git-registry-deprecation.adoc
 ✓  Creating a devfile component from registry: RegistryFromGitHub [220317ns]
Validation
 ✓  Validating if devfile name is correct [179669ns]

Please use `odo push` command to create the component with source deployed

```