### PR TITLE
Fix SB annotations since '.' no longer converted to '_'

### DIFF
--- a/docs/public/deploying-java-app-with-database.adoc
+++ b/docs/public/deploying-java-app-with-database.adoc
@@ -66,9 +66,9 @@ $ odo service create postgresql-operator.v0.1.1/Database --dry-run > db.yaml
 ----
   name: sampledatabase
   annotations:
-    service.binding/db.name: 'path={.spec.databaseName}'
-    service.binding/db.password: 'path={.spec.databasePassword}'
-    service.binding/db.user: 'path={.spec.databaseUser}'
+    service.binding/db_name: 'path={.spec.databaseName}'
+    service.binding/db_password: 'path={.spec.databasePassword}'
+    service.binding/db_user: 'path={.spec.databaseUser}'
 ----
 +
 This configuration ensures that when a database service is started using this file, appropriate annotations are added to it. Annotations help the Service Binding Operator in injecting those values into the application. Hence, the above configuration will help Service Binding Operator inject the values for `databaseName`, `databasePassword` and `databaseUser` into the application.


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

**What type of PR is this?**

/kind documentation
[skip ci]

**What does this PR do / why we need it**:

SBO behavior has changed and '.' in annotations are no longer converted  to "_" in the secret keys.

We _could_  mention specific versions in the doc but probably OK just to keep tracking the latest.

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ X] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)
