### PR TITLE
add --jenkinsProject in PSI test script 

### DIFF
--- a/scripts/minici-presubmit-all-tests.sh
+++ b/scripts/minici-presubmit-all-tests.sh
@@ -52,4 +52,4 @@ set -x
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --timeout $TIMEOUT --mainbranch main
+./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --jenkinsProject $JENKINS_PROJECT --timeout $TIMEOUT --mainbranch main

--- a/scripts/minici-presubmit-all-tests.sh
+++ b/scripts/minici-presubmit-all-tests.sh
@@ -52,4 +52,4 @@ set -x
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --jenkinsProject $JENKINS_PROJECT --timeout $TIMEOUT --mainbranch main
+./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --jenkinsproject $JENKINS_PROJECT --timeout $TIMEOUT --mainbranch main

--- a/scripts/minici-presubmit-all-tests.sh
+++ b/scripts/minici-presubmit-all-tests.sh
@@ -52,4 +52,4 @@ set -x
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --jenkinsproject $JENKINS_PROJECT --timeout $TIMEOUT --mainbranch main
+./ci-firewall request --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $EXCHANGE --setupscript "$SETUP_SCRIPT" --runscript "$RUN_SCRIPT" --jenkinsproject $JOB_NAME --timeout $TIMEOUT --mainbranch main

--- a/scripts/openshiftci-e2e-4x-psi-tests.sh
+++ b/scripts/openshiftci-e2e-4x-psi-tests.sh
@@ -32,5 +32,5 @@ echo "Getting ci-firewall, see https://github.com,/mohammedzee1000/ci-firewall"
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsProject $JENKINS_PROJECT --runscript $RUNSCRIPT  --timeout 4h00m 
+./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsproject $JENKINS_PROJECT --runscript $RUNSCRIPT  --timeout 4h00m 
 

--- a/scripts/openshiftci-e2e-4x-psi-tests.sh
+++ b/scripts/openshiftci-e2e-4x-psi-tests.sh
@@ -32,5 +32,5 @@ echo "Getting ci-firewall, see https://github.com,/mohammedzee1000/ci-firewall"
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT  --runscript $RUNSCRIPT  --timeout 4h00m
+./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsProject $JENKINS_PROJECT --runscript $RUNSCRIPT  --timeout 4h00m 
 

--- a/scripts/openshiftci-e2e-4x-psi-tests.sh
+++ b/scripts/openshiftci-e2e-4x-psi-tests.sh
@@ -32,5 +32,5 @@ echo "Getting ci-firewall, see https://github.com,/mohammedzee1000/ci-firewall"
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsproject $JENKINS_PROJECT --runscript $RUNSCRIPT  --timeout 4h00m 
+./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsproject $JOB_NAME --runscript $RUNSCRIPT  --timeout 4h00m 
 

--- a/scripts/openshiftci-unit-psi-tests_win_mac.sh
+++ b/scripts/openshiftci-unit-psi-tests_win_mac.sh
@@ -8,7 +8,7 @@ case $1 in
     export SENDTOPIC=amqp.ci.topic.win.unit.send
     export SETUPSCRIPT="scripts/setup_script_unit.sh"
     export RUNSCRIPT="scripts/run_script_unit.sh"
-    export JOBNAME=odo-windows-unit-pr-build
+    export JOB_NAME=odo-windows-unit-pr-build
     export SENDEXCHANGE=amqp.ci.exchange.win.unit.send 
     ;;
 


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this?**
kind /failingtest

**What does this PR do / why we need it**:
This PR adds commands to debug failure experienced in release repo and adds a flag to use jenkinsProject 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)
