### PR TITLE
[skip ci] Update links to devfile registry in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,31 +57,31 @@ Devfiles describe your development environment link. link:https://odo.dev/docs/d
 | Java
 | java-maven
 | Upstream Maven and OpenJDK 11
-| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-maven/devfile.yaml[java-maven/devfile.yaml]
+| link:https://github.com/devfile/registry/blob/master/stacks/java-maven/devfile.yaml[java-maven/devfile.yaml]
 | amd64
 
 | Java
 | java-openliberty
 | Open Liberty microservice in Java      
-| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-openliberty/devfile.yaml[java-openliberty/devfile.yaml]
+| link:https://github.com/devfile/registry/blob/master/stacks/java-openliberty/devfile.yaml[java-openliberty/devfile.yaml]
 | amd64
 
 | Java
 | java-quarkus
 | Upstream Quarkus with Java+GraalVM
-| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-quarkus/devfile.yaml[java-quarkus/devfile.yaml]
+| link:https://github.com/devfile/registry/blob/master/stacks/java-quarkus/devfile.yaml[java-quarkus/devfile.yaml]
 | amd64
 
 | Java
 | java-springboot
 | Spring Boot® using Java 
-| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/java-springboot/devfile.yaml[java-springboot/devfile.yaml]
+| link:https://github.com/devfile/registry/blob/master/stacks/java-springboot/devfile.yaml[java-springboot/devfile.yaml]
 | amd64
 
 | Node.JS
 | nodejs
 | Stack with NodeJS 12
-| link:https://github.com/odo-devfiles/registry/blob/master/devfiles/nodejs/devfile.yaml[nodejs/devfile.yaml]
+| link:https://github.com/devfile/registry/blob/master/stacks/nodejs/devfile.yaml[nodejs/devfile.yaml]
 | amd64, s390x, ppc64le
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ Devfiles describe your development environment link. link:https://odo.dev/docs/d
 
 [NOTE]
 ====
-The list of available Devfiles is sourced from the official link:https://github.com/odo-devfiles/registry[odo registry] as well as any other registries added via `odo registry add`.
+The list of available Devfiles is sourced from the official link:https://github.com/devfile/registry[devfile registry] as well as any other registries added via `odo registry add`.
 ====
 
 To list the available Devfiles:


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation
[skip ci]

**What does this PR do / why we need it**:
Updates the devfile registry link in the readme from [odo-devfiles/registry](https://github.com/odo-devfiles/registry) to [devfile/registry](https://github.com/devfile/registry), now that the former is no longer used and is archived.

While the registry is hosted at https://registry.devfile.io, I opted to link to the repository instead, as that's the source repository for the devfiles.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)
