### PR TITLE
Fix Operatorhub test to use CreateNewContext()

### DIFF
--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -285,7 +285,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			cleanPreSetup()
 		})
 
-		FIt("should fail to create service if metadata doesn't exist or is invalid", func() {
+		It("should fail to create service if metadata doesn't exist or is invalid", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs")
 			noMetadata := `
 apiVersion: etcd.database.coreos.com/v1beta2

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -277,11 +277,15 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 	Context("When using from-file option", func() {
 
+		var tmpContext string
+
 		JustBeforeEach(func() {
+			tmpContext = helper.CreateNewContext()
 			preSetup()
 		})
 
 		JustAfterEach(func() {
+			helper.DeleteDir(tmpContext)
 			cleanPreSetup()
 		})
 
@@ -306,7 +310,6 @@ spec:
 `
 
 			noMetaFile := helper.RandString(6) + ".yaml"
-			tmpContext := helper.CreateNewContext()
 			fileName := filepath.Join(tmpContext, noMetaFile)
 			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
 				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -285,7 +285,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			cleanPreSetup()
 		})
 
-		It("should fail to create service if metadata doesn't exist or is invalid", func() {
+		FIt("should fail to create service if metadata doesn't exist or is invalid", func() {
 			helper.CmdShouldPass("odo", "create", "nodejs")
 			noMetadata := `
 apiVersion: etcd.database.coreos.com/v1beta2
@@ -306,7 +306,8 @@ spec:
 `
 
 			noMetaFile := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join("/tmp", noMetaFile)
+			tmpContext := helper.CreateNewContext()
+			fileName := filepath.Join(tmpContext, noMetaFile)
 			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
 				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
 			}
@@ -316,7 +317,7 @@ spec:
 			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
 
 			invalidMetaFile := helper.RandString(6) + ".yaml"
-			fileName = filepath.Join("/tmp", invalidMetaFile)
+			fileName = filepath.Join(tmpContext, invalidMetaFile)
 			if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
 				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
 			}


### PR DESCRIPTION
**What type of PR is this?**

 /kind failing-test

**What does this PR do / why we need it**:
This PR fix Operatorhub test to uses CreateNewContext() in the test to compatible with windows.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4680

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-operator-hub`
