### PR TITLE
Add doc to introduce using devfiles on IBM Z & Power.

### DIFF
--- a/docs/public/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.adoc
+++ b/docs/public/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.adoc
@@ -1,0 +1,93 @@
+== Using odo on IBM-Z and Power
+=== Introduction to devfile
+
+What is a devfile?
+
+A https://redhat-developer.github.io/devfile/[devfile] is a portable file that describes your development environment. It allows reproducing a _portable_ development environment without the need of reconfiguration.
+
+With a devfile you can describe:
+
+* Development components such as container definition for build and application runtimes
+* A list of pre-defined commands that can be run
+* Projects to initially clone
+
+odo takes this devfile and uses it to create a workspace of multiple containers running on Kubernetes or OpenShift.
+
+Devfiles are YAML files with a defined https://devfile.github.io/devfile/_attachments/api-reference.html[schema].
+
+=== odo and devfile
+
+odo can now create components from devfiles as recorded in registries. odo automatically consults the https://github.com/odo-devfiles/registry[default registry] but users can also add their own registries. Devfiles contribute new component types that users can pull to begin development immediately.
+
+An example deployment scenario:
+
+. `odo create` will consult the recorded devfile registries to offer the user a selection of available component types and pull down the associated `devfile.yaml` file
+. `odo push` parses and then deploys the component in the following order:
+ .. Parses and validates the YAML file
+ .. Deploys the development environment to your Kubernetes or OpenShift cluster
+ .. Synchronizes your source code to the containers
+ .. Executes any prerequisite commands
+
+=== Deploying your first devfile on IBM Z & Power
+Since the DefaultDevfileRegistry doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry , please check the doc link:https://github.com/openshift/odo/blob/main/docs/public/secure-registry.adoc[secure registry].
+
+The images can be used for devfiles on IBM Z & Power
+[options="header"]
+|===
+|Language | Devfile Name | Description | Image Source | Supported Platform
+
+| Java
+| java-maven
+| Upstream Maven and OpenJDK 11
+| registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8
+| s390x, ppc64le
+
+| Java
+| java-openliberty
+| Open Liberty microservice in Java
+| registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8
+| s390x, ppc64le
+
+| Java
+| java-quarkus
+| Upstream Quarkus with Java+GraalVM
+| registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8
+| s390x, ppc64le
+
+| Java
+| java-springboot
+| Spring Boot® using Java
+| registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8
+| s390x, ppc64le
+
+| Vert.x Java
+| java-vertx
+| Upstream Vert.x using Java
+| registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8
+| s390x, ppc64le
+
+| Node.JS
+| nodejs
+| Stack with NodeJS 12
+| registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8
+| s390x, ppc64le
+
+| Python
+| python
+| Python Stack with Python 3.7
+| registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8
+| s390x, ppc64le
+
+| Django
+| python-django
+| Python3.7 with Django
+| registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8
+| s390x, ppc64le
+
+|===
+[NOTE]
+====
+Access to the Red Hat registry is required to use these images on IBM Power Systems & IBM Z.
+====
+
+Steps to use devfiles can be found in the doc link:https://github.com/openshift/odo/blob/main/docs/public/deploying-a-devfile-using-odo.adoc#deploying-your-first-devfile[deploy your first devfile].


### PR DESCRIPTION
 /kind documentation
[skip ci]

**What does this PR do / why we need it**:
Since the DefaultDevfileRegistry don't support IBM Z & Power now, we give this doc to show how to use devfile on IBM Z & Power for clients.