### PR TITLE
Custom link names and bindAsFiles option for SB

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 ### Feature/Enhancements
 
+- Custom link name and bind-as-files option for `odo link` ([#4729](https://github.com/openshift/odo/pull/4729))
+
 ### Bug Fixes
 
 ### Tests

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -439,6 +439,16 @@ func (ei *EnvInfo) GetLink() []EnvInfoLink {
 	return *ei.componentSettings.Link
 }
 
+func (ei *EnvInfo) SearchLinkName(kind, name string) (string, error) {
+	links := ei.GetLink()
+	for _, link := range links {
+		if link.ServiceKind == kind && link.ServiceName == name {
+			return link.Name, nil
+		}
+	}
+	return "", errors.Errorf("Link with type %s and name %s not found", kind, name)
+}
+
 const (
 	// Name is the name of the setting controlling the component name
 	Name = "Name"

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -439,14 +439,16 @@ func (ei *EnvInfo) GetLink() []EnvInfoLink {
 	return *ei.componentSettings.Link
 }
 
-func (ei *EnvInfo) SearchLinkName(kind, name string) (string, error) {
+// SearchLinkName searches for a Link with given service kind and service name
+// and returns its name if found
+func (ei *EnvInfo) SearchLinkName(serviceKind, serviceName string) (string, bool) {
 	links := ei.GetLink()
 	for _, link := range links {
-		if link.ServiceKind == kind && link.ServiceName == name {
-			return link.Name, nil
+		if link.ServiceKind == serviceKind && link.ServiceName == serviceName {
+			return link.Name, true
 		}
 	}
-	return "", errors.Errorf("Link with type %s and name %s not found", kind, name)
+	return "", false
 }
 
 const (

--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -895,6 +895,7 @@ func TestRemoveEndpointInDevfile(t *testing.T) {
 
 func TestSearchLinkName(t *testing.T) {
 	tests := []struct {
+		name        string
 		ei          *EnvInfo
 		serviceKind string
 		serviceName string
@@ -902,6 +903,7 @@ func TestSearchLinkName(t *testing.T) {
 		wantFound   bool
 	}{
 		{
+			name: "Case 1: Existing link",
 			ei: &EnvInfo{
 				componentSettings: ComponentSettings{
 					Link: &[]EnvInfoLink{
@@ -924,6 +926,7 @@ func TestSearchLinkName(t *testing.T) {
 			wantFound:   true,
 		},
 		{
+			name: "Case 2: Non existing link",
 			ei: &EnvInfo{
 				componentSettings: ComponentSettings{
 					Link: &[]EnvInfoLink{
@@ -947,13 +950,15 @@ func TestSearchLinkName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, found := tt.ei.SearchLinkName(tt.serviceKind, tt.serviceName)
-		if found != tt.wantFound {
-			t.Errorf("Expected found %v, got %v", tt.wantFound, found)
-		}
-		if found && result != tt.want {
-			t.Errorf("Expected %q, got %q", tt.want, result)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			result, found := tt.ei.SearchLinkName(tt.serviceKind, tt.serviceName)
+			if found != tt.wantFound {
+				t.Errorf("Expected found %v, got %v", tt.wantFound, found)
+			}
+			if found && result != tt.want {
+				t.Errorf("Expected %q, got %q", tt.want, result)
+			}
+		})
 	}
 }
 

--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -893,6 +893,70 @@ func TestRemoveEndpointInDevfile(t *testing.T) {
 	}
 }
 
+func TestSearchLinkName(t *testing.T) {
+	tests := []struct {
+		ei          *EnvInfo
+		serviceKind string
+		serviceName string
+		want        string
+		wantFound   bool
+	}{
+		{
+			ei: &EnvInfo{
+				componentSettings: ComponentSettings{
+					Link: &[]EnvInfoLink{
+						{
+							Name:        "a first name",
+							ServiceKind: "a first kind",
+							ServiceName: "a first service name",
+						},
+						{
+							Name:        "a name",
+							ServiceKind: "a kind",
+							ServiceName: "a service name",
+						},
+					},
+				},
+			},
+			serviceKind: "a kind",
+			serviceName: "a service name",
+			want:        "a name",
+			wantFound:   true,
+		},
+		{
+			ei: &EnvInfo{
+				componentSettings: ComponentSettings{
+					Link: &[]EnvInfoLink{
+						{
+							Name:        "a first name",
+							ServiceKind: "a first kind",
+							ServiceName: "a first service name",
+						},
+						{
+							Name:        "a name",
+							ServiceKind: "a kind",
+							ServiceName: "a service name",
+						},
+					},
+				},
+			},
+			serviceKind: "an unknown kind",
+			serviceName: "a service name",
+			wantFound:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		result, found := tt.ei.SearchLinkName(tt.serviceKind, tt.serviceName)
+		if found != tt.wantFound {
+			t.Errorf("Expected found %v, got %v", tt.wantFound, found)
+		}
+		if found && result != tt.want {
+			t.Errorf("Expected %q, got %q", tt.want, result)
+		}
+	}
+}
+
 func createDirectoryAndFile(create bool, fs filesystem.Filesystem, odoDir string) error {
 	if !create {
 		return nil

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -442,14 +442,3 @@ func (o *commonLinkOptions) getServiceBindingName(componentName string) string {
 func getSvcFullName(serviceType, serviceName string) string {
 	return strings.Join([]string{serviceType, serviceName}, "/")
 }
-
-// isComponentLinked checks if link with "serviceBindingName" exists in the component's
-// config. It confirms if the component is linked with the service
-func isComponentLinked(serviceBindingName string, links []envinfo.EnvInfoLink) bool {
-	for _, link := range links {
-		if link.Name == serviceBindingName {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -191,8 +191,8 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 		}
 
 		if o.operationName == unlink {
-			serviceBindingName, err := o.EnvSpecificInfo.SearchLinkName(o.serviceType, o.serviceName)
-			if err != nil {
+			serviceBindingName, found := o.EnvSpecificInfo.SearchLinkName(o.serviceType, o.serviceName)
+			if !found {
 				return fmt.Errorf("failed to unlink the service %q since no link found in env file", svcFullName)
 			}
 
@@ -274,10 +274,9 @@ func (o *commonLinkOptions) validate(wait bool) (err error) {
 func (o *commonLinkOptions) run() (err error) {
 	if o.csvSupport && o.Context.EnvSpecificInfo != nil {
 		if o.operationName == unlink {
-			var serviceBindingName string
-			serviceBindingName, err = o.EnvSpecificInfo.SearchLinkName(o.serviceType, o.serviceName)
-			if err != nil {
-				return err
+			serviceBindingName, found := o.EnvSpecificInfo.SearchLinkName(o.serviceType, o.serviceName)
+			if !found {
+				return fmt.Errorf("failed to unlink the service %q of type %q since no link found in env file", o.serviceName, o.serviceType)
 			}
 			svcFullName := getSvcFullName(kclient.ServiceBindingKind, serviceBindingName)
 			err = svc.DeleteServiceBindingRequest(o.KClient, svcFullName)

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -31,6 +31,7 @@ type commonLinkOptions struct {
 	secretName       string
 	isTargetAService bool
 	name             string
+	bindAsFiles      bool
 
 	devfilePath string
 
@@ -127,7 +128,7 @@ func (o *commonLinkOptions) complete(name string, cmd *cobra.Command, args []str
 			},
 			Spec: servicebinding.ServiceBindingSpec{
 				DetectBindingResources: true,
-				BindAsFiles:            false,
+				BindAsFiles:            o.bindAsFiles,
 				Application: &servicebinding.Application{
 					Ref: servicebinding.Ref{
 						Name:     componentName,

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -162,6 +162,7 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 	linkCmd.PersistentFlags().StringVar(&o.name, "name", "", "Name of the created ServiceBinding resource")
+	linkCmd.PersistentFlags().BoolVar(&o.bindAsFiles, "bindAsFiles", false, "If enabled, configuration values will be mounted as files, instead of declared as environment variables")
 	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--project` flag

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -161,7 +161,7 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().StringVar(&o.port, "port", "", "Port of the backend to which to link")
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
-
+	linkCmd.PersistentFlags().StringVar(&o.name, "name", "", "Name of the created ServiceBinding resource")
 	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--project` flag

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -42,7 +42,7 @@ var (
 
 # Link the current component to the 'EtcdCluster' named 'myetcd'
 # and make the secrets accessible as files in the '/bindings/etcd/' directory
-%[1]s EtcdCluster/myetcd  --bindAsFiles --name etcd`)
+%[1]s EtcdCluster/myetcd  --bind-as-files --name etcd`)
 
 	linkLongDesc = `Link component to a service (backed by an Operator or Service Catalog) or component (works only with s2i components)
 
@@ -50,7 +50,7 @@ If the source component is not provided, the current active component is assumed
 In both use cases, link adds the appropriate secret to the environment of the source component. 
 The source component can then consume the entries of the secret as environment variables.
 
-Using the '--bindAsFiles' flag, secrets will be accessible as files instead of environment variables.
+Using the '--bind-as-files' flag, secrets will be accessible as files instead of environment variables.
 The value of the '--name' flag indicates the name of the directory under '/bindings/' containing the secrets files.
 
 For example:
@@ -169,7 +169,7 @@ func NewCmdLink(name, fullName string) *cobra.Command {
 	linkCmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "If enabled the link will return only when the component is fully running after the link is created")
 	linkCmd.PersistentFlags().BoolVar(&o.waitForTarget, "wait-for-target", false, "If enabled, the link command will wait for the service to be provisioned (has no effect when linking to a component)")
 	linkCmd.PersistentFlags().StringVar(&o.name, "name", "", "Name of the created ServiceBinding resource")
-	linkCmd.PersistentFlags().BoolVar(&o.bindAsFiles, "bindAsFiles", false, "If enabled, configuration values will be mounted as files, instead of declared as environment variables")
+	linkCmd.PersistentFlags().BoolVar(&o.bindAsFiles, "bind-as-files", false, "If enabled, configuration values will be mounted as files, instead of declared as environment variables")
 	linkCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
 	//Adding `--project` flag

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -38,13 +38,20 @@ var (
 %[1]s backend --component nodejs
 
 # Link current component to port 8080 of the 'backend' component (backend must have port 8080 exposed) 
-%[1]s backend --port 8080`)
+%[1]s backend --port 8080
+
+# Link the current component to the 'EtcdCluster' named 'myetcd'
+# and make the secrets accessible as files in the '/bindings/etcd/' directory
+%[1]s EtcdCluster/myetcd  --bindAsFiles --name etcd`)
 
 	linkLongDesc = `Link component to a service (backed by an Operator or Service Catalog) or component (works only with s2i components)
 
 If the source component is not provided, the current active component is assumed.
 In both use cases, link adds the appropriate secret to the environment of the source component. 
 The source component can then consume the entries of the secret as environment variables.
+
+Using the '--bindAsFiles' flag, secrets will be accessible as files instead of environment variables.
+The value of the '--name' flag indicates the name of the directory under '/bindings/' containing the secrets files.
 
 For example:
 

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -134,8 +134,8 @@ var _ = Describe("odo link and unlink command tests", func() {
 			// deploy the component and service
 			helper.CmdShouldPass("odo", "push")
 
-			// create the link with a specific name and with bindAsFiles
-			helper.CmdShouldPass("odo", "link", "EtcdCluster/etcd", "--name", "etcd-config", "--bindAsFiles")
+			// create the link with a specific name and with bind-as-files
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/etcd", "--name", "etcd-config", "--bind-as-files")
 
 			// for the moment, odo push is not necessary
 

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -1,6 +1,10 @@
 package integration
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -21,6 +25,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	var _ = BeforeEach(func() {
 		// oc = helper.NewOcRunner("oc")
 		commonVar = helper.CommonBeforeEach()
+		helper.Chdir(commonVar.Context)
 	})
 
 	// Clean up after the test
@@ -28,6 +33,17 @@ var _ = Describe("odo link and unlink command tests", func() {
 	var _ = AfterEach(func() {
 		helper.CommonAfterEach(commonVar)
 	})
+
+	preSetup := func() {
+		// wait till oc can see the all operators installed by setup script in the namespace
+		odoArgs := []string{"catalog", "list", "services"}
+		operators := []string{"etcdoperator", "service-binding-operator"}
+		for _, operator := range operators {
+			helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
+				return strings.Contains(output, operator)
+			})
+		}
+	}
 
 	Context("when running help for link and unlink command", func() {
 		It("should display the help", func() {
@@ -38,6 +54,104 @@ var _ = Describe("odo link and unlink command tests", func() {
 		})
 	})
 
+	Context("When running an etcd operator backed service", func() {
+
+		JustBeforeEach(func() {
+			preSetup()
+		})
+
+		It("should be able to link the component to the etcd service", func() {
+
+			// create a component and deploy it
+			helper.CmdShouldPass("odo", "create", "nodejs")
+
+			// create an etcd service
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "etcd")
+
+			// deploy the component and service
+			helper.CmdShouldPass("odo", "push")
+
+			// create the link
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/etcd")
+
+			// for the moment, odo push is not necessary
+
+			// check the link exists
+			ocArgs := []string{"get", "servicebinding", "-n", commonVar.Project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "etcdcluster-etcd")
+			})
+
+			helper.CmdShouldPass("odo", "unlink", "EtcdCluster/etcd")
+
+			// delete the service using odo
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/etcd", "-f")
+		})
+
+		It("should be able to link the component to the etcd service with a specific name", func() {
+
+			// create a component and deploy it
+			helper.CmdShouldPass("odo", "create", "nodejs")
+
+			// create an etcd service
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "etcd")
+
+			// deploy the component and service
+			helper.CmdShouldPass("odo", "push")
+
+			// create the link with a specific name
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/etcd", "--name", "etcd-config")
+
+			// for the moment, odo push is not necessary
+
+			// check the link exists with the specific name
+			ocArgs := []string{"get", "servicebinding", "etcd-config", "-n", commonVar.Project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "etcd-config")
+			})
+
+			// delete the link
+			helper.CmdShouldPass("odo", "unlink", "EtcdCluster/etcd")
+
+			// delete the etcd service
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/etcd", "-f")
+		})
+
+		It("should be able to link the component to the etcd service with a specific name and activating bindAsFiles", func() {
+
+			// create a component and deploy it
+			helper.CmdShouldPass("odo", "create", "nodejs")
+
+			// create an etcd service
+			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "etcd")
+
+			// deploy the component and service
+			helper.CmdShouldPass("odo", "push")
+
+			// create the link with a specific name and with bindAsFiles
+			helper.CmdShouldPass("odo", "link", "EtcdCluster/etcd", "--name", "etcd-config", "--bindAsFiles")
+
+			// for the moment, odo push is not necessary
+
+			// check the link exists with the specific name
+			ocArgs := []string{"get", "servicebinding", "etcd-config", "-o", "jsonpath='{.spec.bindAsFiles}'", "-n", commonVar.Project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, "true")
+			})
+
+			// delete the link
+			helper.CmdShouldPass("odo", "unlink", "EtcdCluster/etcd")
+
+			// delete the etcd service
+			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/etcd", "-f")
+		})
+	})
 	/*
 		Context("When link between components using wrong port", func() {
 			JustBeforeEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind feature

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4693 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**TODO**
- [x] rebase after #4713 is merged

**How to test changes / Special notes to the reviewer**:

On a cluster with some Operator backed services installed (for example etcdoperator.v0.9.4-clusterwide):
```
$ odo create nodejs 
$ odo service create etcdoperator.v0.9.4-clusterwide/EtcdCluster myetcd
$ odo push
$ odo link EtcdCluster/myetcd --name myetcd-config
$ oc get servicebinding myetcd-config
# myetcd-config should exist

$ odo unlink EtcdCluster/myetcd
$ odo link EtcdCluster/myetcd --name myetcd-config --bind-as-files
$ oc get servicebinding myetcd-config -o jsonpath='{.spec.bindAsFiles}'
# should output "true"

# cleanup
$ odo unlink EtcdCluster/myetcd
$ odo service delete EtcdCluster/myetcd
