### PR TITLE
[WIP] Apply ocp global secrets to project created during tests

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1459,12 +1459,3 @@ func GetCommandStringFromEnvs(envVars []v1alpha2.EnvVar) string {
 	}
 	return setEnvVariable
 }
-
-//GetEnvWithDefault gets value of specified env if it is set, otherwise, it returns default value
-func GetEnvWithDefault(key string, defaultval string) string {
-	val := os.Getenv(key)
-	if val == "" {
-		return defaultval
-	}
-	return val
-}

--- a/scripts/configure-installer-tests-cluster.sh
+++ b/scripts/configure-installer-tests-cluster.sh
@@ -10,9 +10,6 @@ KUBEADMIN_SCRIPT="$LIBCOMMON/kubeconfigandadmin.sh"
 
 CI_OPERATOR_HUB_PROJECT="ci-operator-hub-project"
 
-# list of namespace to create
-IMAGE_TEST_NAMESPACES="openjdk-11-rhel8 nodejs-12-rhel7 nodejs-12 openjdk-11 nodejs-14"
-
 . $KUBEADMIN_SCRIPT
 
 # Setup the cluster for Operator tests
@@ -24,16 +21,6 @@ oc adm policy add-role-to-user edit developer
 
 sh $SETUP_OPERATORS
 # OperatorHub setup complete
-
-# Create the namespace for e2e image test apply pull secret to the namespace
-for i in `echo $IMAGE_TEST_NAMESPACES`; do
-    # create the namespace
-    oc new-project $i
-    # Applying pull secret to the namespace which will be used for pulling images from authenticated registry
-    oc get secret pull-secret -n openshift-config -o yaml | sed "s/openshift-config/$i/g" | oc apply -f -
-    # Let developer user have access to the project
-    oc adm policy add-role-to-user edit developer
-done
 
 # Workarounds - Note we should find better soulutions asap
 # Missing wildfly in OpenShift Adding it manually to cluster Please remove once wildfly is again visible

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -27,9 +27,6 @@ cp $KUBECONFIG $TMP_DIR/kubeconfig
 chmod 640 $TMP_DIR/kubeconfig
 export KUBECONFIG=$TMP_DIR/kubeconfig
 
-# Login as developer
-oc login -u developer -p password@123
-
 # Check login user name for debugging purpose
 oc whoami
 

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -82,23 +82,6 @@ for i in $(oc projects -q); do
     fi
 done
 
-# Generate random project names to some tests
-export REDHAT_OPENJDK11_RHEL8_PROJECT="${SCRIPT_IDENTITY}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)"
-export REDHAT_OPENJDK11_UBI8_PROJECT="${SCRIPT_IDENTITY}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)"
-export REDHAT_NODEJS12_RHEL7_PROJECT="${SCRIPT_IDENTITY}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)"
-export REDHAT_NODEJS12_UBI8_PROJECT="${SCRIPT_IDENTITY}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)"
-export REDHAT_NODEJS14_UBI8_PROJECT="${SCRIPT_IDENTITY}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)"
-
-# Create the namespace for e2e image test apply pull secret to the namespace
-for i in `echo "$REDHAT_OPENJDK11_RHEL8_PROJECT $REDHAT_NODEJS12_RHEL7_PROJECT $REDHAT_NODEJS12_UBI8_PROJECT $REDHAT_OPENJDK11_UBI8_PROJECT $REDHAT_NODEJS14_UBI8_PROJECT"`; do
-    # create the namespace
-    oc new-project $i
-    # Applying pull secret to the namespace which will be used for pulling images from authenticated registry
-    oc get secret pull-secret -n openshift-config -o yaml | sed "s/openshift-config/$i/g" | oc apply -f -
-    # Let developer user have access to the project
-    oc adm policy add-role-to-user edit developer
-done
-
 shout "Logging into 4x cluster as developer (logs hidden)"
 set +x
 oc login -u developer -p ${OCP4X_DEVELOPER_PASSWORD} --insecure-skip-tls-verify ${OCP4X_API_URL}

--- a/tests/e2escenarios/e2e_images_test.go
+++ b/tests/e2escenarios/e2e_images_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/pkg/devfile/convert"
-	"github.com/openshift/odo/pkg/util"
 	"github.com/openshift/odo/tests/helper"
 	"github.com/openshift/odo/tests/integration/devfile/utils"
 )
@@ -126,33 +125,28 @@ var _ = Describe("odo supported images e2e tests", func() {
 		})
 
 		It("Should be able to verify the nodejs-12 image", func() {
-			redhatNodejs12UBI8Project := util.GetEnvWithDefault("REDHAT_NODEJS12_UBI8_PROJECT", "nodejs-12")
-			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/nodejs-12:latest", "nodejs:latest", redhatNodejs12UBI8Project)
-			verifySupportedImage("ubi8/nodejs-12:latest", "nodejs", "nodejs:latest", redhatNodejs12UBI8Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/nodejs-12:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("ubi8/nodejs-12:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-12-rhel7 image", func() {
-			redhatNodejs12RHEL7Project := util.GetEnvWithDefault("REDHAT_NODEJS12_RHEL7_PROJECT", "nodejs-12-rhel7")
-			oc.ImportImageFromRegistry("registry.redhat.io", "rhscl/nodejs-12-rhel7:latest", "nodejs:latest", redhatNodejs12RHEL7Project)
-			verifySupportedImage("rhscl/nodejs-12-rhel7:latest", "nodejs", "nodejs:latest", redhatNodejs12RHEL7Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("registry.redhat.io", "rhscl/nodejs-12-rhel7:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("rhscl/nodejs-12-rhel7:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the openjdk-11 image", func() {
-			redhatOpenjdk11UBI8Project := util.GetEnvWithDefault("REDHAT_OPENJDK11_UBI8_PROJECT", "openjdk-11")
-			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/openjdk-11:latest", "java:8", redhatOpenjdk11UBI8Project)
-			verifySupportedImage("ubi8/openjdk-11:latest", "openjdk", "java:8", redhatOpenjdk11UBI8Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/openjdk-11:latest", "java:8", commonVar.Project)
+			verifySupportedImage("ubi8/openjdk-11:latest", "openjdk", "java:8", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the openjdk-11-rhel8 image", func() {
-			redhatOpenjdk12RHEL8Project := util.GetEnvWithDefault("REDHAT_OPENJDK11_RHEL8_PROJECT", "openjdk-11-rhel8")
-			oc.ImportImageFromRegistry("registry.redhat.io", "openjdk/openjdk-11-rhel8:latest", "java:8", redhatOpenjdk12RHEL8Project)
-			verifySupportedImage("openjdk/openjdk-11-rhel8:latest", "openjdk", "java:8", redhatOpenjdk12RHEL8Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("registry.redhat.io", "openjdk/openjdk-11-rhel8:latest", "java:8", commonVar.Project)
+			verifySupportedImage("openjdk/openjdk-11-rhel8:latest", "openjdk", "java:8", commonVar.Project, appName, commonVar.Context)
 		})
 
 		It("Should be able to verify the nodejs-14 image", func() {
-			redhatNodeJS14UBI8Project := util.GetEnvWithDefault("REDHAT_NODEJS14_UBI8_PROJECT", "nodejs-14")
-			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/nodejs-14:latest", "nodejs:latest", redhatNodeJS14UBI8Project)
-			verifySupportedImage("ubi8/nodejs-14:latest", "nodejs", "nodejs:latest", redhatNodeJS14UBI8Project, appName, commonVar.Context)
+			oc.ImportImageFromRegistry("registry.redhat.io", "ubi8/nodejs-14:latest", "nodejs:latest", commonVar.Project)
+			verifySupportedImage("ubi8/nodejs-14:latest", "nodejs", "nodejs:latest", commonVar.Project, appName, commonVar.Context)
 		})
 	})
 

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -24,4 +24,5 @@ type CliRunner interface {
 	GetContainerEnv(podName, containerName, namespace string) string
 	WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool
 	VerifyResourceDeleted(ri ResourceInfo)
+	ApplyClusterSecrets(secretName, SourceNS, DestinationNS string)
 }

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -296,6 +296,9 @@ func CommonBeforeEach() CommonVar {
 	commonVar.CliRunner = GetCliRunner()
 	LocalKubeconfigSet(commonVar.Context)
 	commonVar.Project = commonVar.CliRunner.CreateRandNamespaceProject()
+	if os.Getenv("CI") == "openshift" {
+		commonVar.CliRunner.ApplyClusterSecrets("pull-secret", "openshift-config", commonVar.Project)
+	}
 	commonVar.OriginalWorkingDirectory = Getwd()
 	os.Setenv("GLOBALODOCONFIG", filepath.Join(commonVar.Context, "preference.yaml"))
 	// Set ConsentTelemetry to false so that it does not prompt to set a preference value

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -291,14 +291,15 @@ func CommonBeforeEach() CommonVar {
 	SetDefaultConsistentlyDuration(30 * time.Second)
 
 	commonVar := CommonVar{}
-	commonVar.Context = CreateNewContext()
 	commonVar.OriginalKubeconfig = os.Getenv("KUBECONFIG")
 	commonVar.CliRunner = GetCliRunner()
-	LocalKubeconfigSet(commonVar.Context)
 	commonVar.Project = commonVar.CliRunner.CreateRandNamespaceProject()
 	if os.Getenv("CI") == "openshift" {
 		commonVar.CliRunner.ApplyClusterSecrets("pull-secret", "openshift-config", commonVar.Project)
+		CmdShouldPass("oc", "login", "-u", "developer", "-p", "password@123")
 	}
+	commonVar.Context = CreateNewContext()
+	LocalKubeconfigSet(commonVar.Context)
 	commonVar.OriginalWorkingDirectory = Getwd()
 	os.Setenv("GLOBALODOCONFIG", filepath.Join(commonVar.Context, "preference.yaml"))
 	// Set ConsentTelemetry to false so that it does not prompt to set a preference value

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -220,5 +220,5 @@ func (kubectl KubectlRunner) VerifyResourceDeleted(ri ResourceInfo) {
 
 // ApplyClusterSecrets applying pull secret to the namespace which will be used for pulling images from authenticated registry
 func (kubectl KubectlRunner) ApplyClusterSecrets(secretName, SourceNS, DestinationNS string) {
-	CmdShouldPass(kubectl.path, "get", "secret", secretName, "-n", SourceNS, "-o", "yaml | sed 's/"+SourceNS+"/"+DestinationNS+"/g' | kubectl apply -n "+DestinationNS+" -f -")
+	CmdShouldPass(kubectl.path, "get", "secret/"+secretName, "-n", SourceNS, "-o", "yaml | sed 's/"+SourceNS+"/"+DestinationNS+"/g' | kubectl apply -n "+DestinationNS+" -f -")
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -217,3 +217,8 @@ func (kubectl KubectlRunner) VerifyResourceDeleted(ri ResourceInfo) {
 	output := string(session.Wait().Out.Contents())
 	Expect(output).NotTo(ContainSubstring(ri.ResourceName))
 }
+
+// ApplyClusterSecrets applying pull secret to the namespace which will be used for pulling images from authenticated registry
+func (kubectl KubectlRunner) ApplyClusterSecrets(secretName, SourceNS, DestinationNS string) {
+	CmdShouldPass(kubectl.path, "get", "secret", secretName, "-n", SourceNS, "-o", "yaml | sed 's/"+SourceNS+"/"+DestinationNS+"/g' | kubectl apply -n "+DestinationNS+" -f -")
+}

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -674,7 +674,7 @@ func (oc OcRunner) WaitAndCheckForTerminatingState(resourceType, namespace strin
 
 // ApplyClusterSecrets applying pull secret to the namespace which will be used for pulling images from authenticated registry
 func (oc OcRunner) ApplyClusterSecrets(secretName, SourceNS, DestinationNS string) {
-	CmdShouldPass(oc.path, "get", "secret", secretName, "-n", SourceNS, "-o", "yaml | sed 's/"+SourceNS+"/"+DestinationNS+"/g' | oc apply -f -")
+	CmdShouldPass(oc.path, "get", "secret/"+secretName, "-n", SourceNS, "-o", "yaml", "|", "sed", "'s/"+SourceNS+"/"+DestinationNS+"/g'", "|", "oc", "apply", "-f", "-")
 	// Let developer user have access to the project
-	CmdShouldPass(oc.path, "adm", "policy", "add-role-to-user", "edit developer")
+	CmdShouldPass(oc.path, "adm", "policy", "add-role-to-user", "edit", "developer")
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -671,3 +671,10 @@ func (oc OcRunner) StatFileInPod(cmpName, appName, project, filepath string) str
 func (oc OcRunner) WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool {
 	return WaitAndCheckForTerminatingState(oc.path, resourceType, namespace, timeoutMinutes)
 }
+
+// ApplyClusterSecrets applying pull secret to the namespace which will be used for pulling images from authenticated registry
+func (oc OcRunner) ApplyClusterSecrets(secretName, SourceNS, DestinationNS string) {
+	CmdShouldPass(oc.path, "get", "secret", secretName, "-n", SourceNS, "-o", "yaml | sed 's/"+SourceNS+"/"+DestinationNS+"/g' | oc apply -f -")
+	// Let developer user have access to the project
+	CmdShouldPass(oc.path, "adm", "policy", "add-role-to-user", "edit developer")
+}

--- a/tests/integration/loginlogout/loginlogout_suite_test.go
+++ b/tests/integration/loginlogout/loginlogout_suite_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestLoginlogout(t *testing.T) {
+	helper.CmdShouldPass("oc", "login", "-u", "developer", "-p", "password@123")
 	helper.RunTestSpecs(t, "Login Logout Suite")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind feature

**What does this PR do / why we need it**:
I have added `dockerhub` free account secrets to the psi clusters. This pr should enable the projects to use the account and import `docker.io` images. It should customise ocp secret configuration thing in proper way.

**Which issue(s) this PR fixes**:

Fixes #4739 
Fixes part - #4606 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

All the tests need secret should pass successfully on prow CI and psi