### PR TITLE
Updating docs and changelog script for updated release process

### DIFF
--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -166,14 +166,14 @@ To release a new version on GitHub:
 
 There is a helper script link:/scripts/bump-version.sh[scripts/bump-version.sh] that changes version number in all the files listed above.
 
-Also, ensure you cut the version in the link:Changelog.md['Changelog.md'] i.e create a new version on top of current version.
+Also, ensure you add the next version on top of the current one in the link:/Changelog.md['Changelog.md'] so that it is clear that future changelog updates happen under next version.
 
 . Merge the above PR.
 . Once the PR is merged create and push the new git tag for the version.
 . Create a new release using the GitHub site (this must be a proper release and NOT a draft).
 +
 
-. Update the release description (changelog) on GitHub. Run the script below to get the baseline template of release changelog and then copy and paste the content from the link:Changelog.md['Changelog.md'] into appropriately marked location in generated `/tmp/changelog.md`.
+. Update the release description (changelog) on GitHub. Run the script below to get the baseline template of release changelog and then copy and paste the content from the link:/Changelog.md['Changelog.md'] into appropriately marked location in generated `/tmp/changelog.md`.
 +
 ----
 $ export GITHUB_TOKEN=yoursupersecretgithubtoken

--- a/docs/dev/development.adoc
+++ b/docs/dev/development.adoc
@@ -166,12 +166,14 @@ To release a new version on GitHub:
 
 There is a helper script link:/scripts/bump-version.sh[scripts/bump-version.sh] that changes version number in all the files listed above.
 
+Also, ensure you cut the version in the link:Changelog.md['Changelog.md'] i.e create a new version on top of current version.
+
 . Merge the above PR.
 . Once the PR is merged create and push the new git tag for the version.
 . Create a new release using the GitHub site (this must be a proper release and NOT a draft).
 +
 
-. Update the release description (changelog) on GitHub. To make things easier, a script was created to automatically generate a CHANGELOG and output to `/tmp/changelog`. This script will require a GitHub authentication token which will prompt you when running the script.
+. Update the release description (changelog) on GitHub. Run the script below to get the baseline template of release changelog and then copy and paste the content from the link:Changelog.md['Changelog.md'] into appropriately marked location in generated `/tmp/changelog.md`.
 +
 ----
 $ export GITHUB_TOKEN=yoursupersecretgithubtoken

--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -32,3 +32,6 @@ After each release, binaries are synced to [mirror.openshift.com]($MIRROR)" > /t
 
 echo "The changelog is located at: /tmp/changelog"
 echo ""
+echo "Contents of changelog : "
+cat /tmp/changelog
+echo ""

--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
-# This script uses github_changelog_generator to generate a changelog
-# by using the kind labels that we use..
-# 
-# Then outputs it to STDOUT. This helps generate a changelog when doing a release.
-
-# Get the variables we're going to use..
-#if [ -z "$GITHUB_TOKEN" ]
-#then
-#  echo -e "GITHUB_TOKEN environment variable is blank..\nGet your GitHub token and then:\nexport GITHUB_TOKEN=yourtoken"
-#  exit 1
-#fi
+# This script generates the baseline release notes without the changelog
+# User must copy contents of `Changelog.md` into appropriate location in
+# release notes
 
 if [ -z "$1" ]  || [ -z "$2" ]
 then

--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -6,11 +6,11 @@
 # Then outputs it to STDOUT. This helps generate a changelog when doing a release.
 
 # Get the variables we're going to use..
-if [ -z "$GITHUB_TOKEN" ]
-then
-  echo -e "GITHUB_TOKEN environment variable is blank..\nGet your GitHub token and then:\nexport GITHUB_TOKEN=yourtoken"
-  exit 1
-fi
+#if [ -z "$GITHUB_TOKEN" ]
+#then
+#  echo -e "GITHUB_TOKEN environment variable is blank..\nGet your GitHub token and then:\nexport GITHUB_TOKEN=yourtoken"
+#  exit 1
+#fi
 
 if [ -z "$1" ]  || [ -z "$2" ]
 then
@@ -20,42 +20,23 @@ fi
 
 MIRROR="https://mirror.openshift.com/pub/openshift-v4/clients/odo/$2/"
 INSTALLATION_GUIDE="https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html"
+GIT_TREE="https://github.com/openshift/odo/tree/$2"
+FULL_CHANGELOG="https://github.com/openshift/odo/compare/$1...$2"
 
-echo -e "# Installation of $2
+echo -e "
+# Release of $2
+
+## [$2]($GIT_TREE) ($(date '+%Y-%m-%d'))
+
+[Full Changelog]($FULL_CHANGELOG)
+
+-- COPY CONTENT FROM Changelog.md here --
+
+# Installation of $2
 
 To install odo, follow our installation guide at [docs.openshift.com]($INSTALLATION_GUIDE)
 
-After each release, binaries are synced to [mirror.openshift.com]($MIRROR)" > /tmp/base
+After each release, binaries are synced to [mirror.openshift.com]($MIRROR)" > /tmp/changelog
 
-github_changelog_generator \
---max-issues 500 \
---user openshift \
---project odo \
--t $GITHUB_TOKEN \
---since-tag $1 \
---future-release $2 \
---base /tmp/base \
---output /tmp/changelog \
---exclude-tags "lifecycle/rotten" \
---header-label "# Release of $2" \
---enhancement-label "**Code Refactoring:**" \
---enhancement-labels "kind/cleanup,kind/api-change,kind/code-refactoring" \
---breaking-label "**New features:**" \
---breaking-labels "kind/feature" \
---bugs-label "**Bugs:**" \
---bug-labels "kind/bug" \
---removed-label "**Tests:**" \
---removed-labels "kind/flake,kind/test,kind/failing-test" \
---security-label "**Documentation & Discussions:**" \
---security-labels "kind/docs,kind/documentation,kind/design,kind/discussion,kind/epic"
-
-RESULT=$?
-
-if [ $RESULT -eq 0 ]; then
-  echo ""
-  echo "The changelog is located at: /tmp/changelog"
-  echo ""
-else
-  echo -e "Unable to generate changelog using github_changelog_generator"
-  exit 1
-fi
+echo "The changelog is located at: /tmp/changelog"
+echo ""


### PR DESCRIPTION
Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>


**What does this PR do / why we need it**:
Updates dev docs with updated release process of using changelog.md instead of github changelog generator and updates script to generate baseline release notes


**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

```
❯ sh scripts/changelog-script.sh v2.1.0 v2.2.0
The changelog is located at: /tmp/changelog

❯ cat /tmp/changelog

# Release of v2.2.0

## [v2.2.0](https://github.com/openshift/odo/tree/v2.2.0) (2021-05-24)

[Full Changelog](https://github.com/openshift/odo/compare/v2.1.0...v2.2.0)

-- COPY CONTENT FROM Changelog.md here --

# Installation of v2.2.0

To install odo, follow our installation guide at [docs.openshift.com](https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html)

After each release, binaries are synced to [mirror.openshift.com](https://mirror.openshift.com/pub/openshift-v4/clients/odo/v2.2.0/)

```