### PR TITLE
Use staging devfile registry for integration tests

### DIFF
--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -1008,7 +1008,7 @@ var _ = Describe("odo devfile push command tests", func() {
 		var freePort int
 		var parentTmpFolder string
 
-		var _ = BeforeSuite(func() {
+		var _ = BeforeEach(func() {
 			// get a free port
 			var err error
 			freePort, err = util.HTTPGetFreePort()
@@ -1027,7 +1027,7 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.HttpWaitFor("http://localhost:"+strconv.Itoa(freePort), "devfile", 10, 1)
 		})
 
-		var _ = AfterSuite(func() {
+		var _ = AfterEach(func() {
 			helper.DeleteDir(parentTmpFolder)
 			err := server.Close()
 			Expect(err).To(BeNil())

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	helper.RunTestSpecs(t, "Project Suite")
+	helper.RunTestSpecs(t, "Devfile Debug Suite")
 }

--- a/tests/integration/devfile/devfile_suite_test.go
+++ b/tests/integration/devfile/devfile_suite_test.go
@@ -3,9 +3,18 @@ package devfile
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDevfiles(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Suite")
 }
+
+var _ = BeforeSuite(func() {
+	const registryName string = "DefaultDevfileRegistry"
+	const addRegistryURL string = "https://registry.stage.devfile.io"
+
+	// Use staging OCI-based registry for tests to avoid a potential overload
+	helper.CmdShouldPass("odo", "registry", "update", registryName, addRegistryURL)
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What does this PR do / why we need it**:
Use staging devfile registry for integration test with devfile. Using a production registry would result in unnecessary overload.

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4639

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
