### PR TITLE
use filepath Join instead of / while constructing kubeconfig path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - Adding KUBECONFIG checks in odo catalog list components ([#4756](https://github.com/openshift/odo/pull/4756))
+- use filepath Join instead of / while constructing kubeconfig path ([#4765](https://github.com/openshift/odo/pull/4765))
 
 ### Tests
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog"
 )
 
@@ -1066,8 +1067,13 @@ func CheckKubeConfigExist() bool {
 	if os.Getenv("KUBECONFIG") != "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	} else {
-		home, _ := os.UserHomeDir()
-		kubeconfig = fmt.Sprintf("%s/.kube/config", home)
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfig = filepath.Join(home, ".kube", "config")
+			klog.V(4).Infof("using default kubeconfig path %s", kubeconfig)
+		} else {
+			klog.V(4).Infof("no KUBECONFIG provided and cannot fallback to default")
+			return false
+		}
 	}
 
 	if CheckPathExists(kubeconfig) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/util/homedir"
 	"math/big"
 	"net"
 	"net/http"
@@ -27,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/util/homedir"
+
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/fatih/color"
 	"github.com/gobwas/glob"
@@ -37,7 +38,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
 /kind bug

**What does this PR do / why we need it**:
We were using os specific method to join path for kubeconfig, using `filepath.Join` instead. Also we are not ignoring error from homedir function anymore also.

**Which issue(s) this PR fixes**:

No issue

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [X] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Tests should pass