### PR TITLE
Adds the annotation app.openshift.io/vcs-uri to deployments

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -468,6 +468,12 @@ func (a Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSpe
 	}
 
 	deployment := generator.GetDeployment(deployParams)
+	if vcsUri := util.GetGitOriginPath(a.Context); vcsUri != "" {
+		if deployment.Annotations == nil {
+			deployment.Annotations = make(map[string]string)
+		}
+		deployment.Annotations["app.openshift.io/vcs-uri"] = vcsUri
+	}
 
 	serviceParams := generator.ServiceParams{
 		ObjectMeta:     objectMeta,

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -112,7 +112,7 @@ func (po *PushOptions) devfilePushInner() (err error) {
 	}
 	platformContext = kc
 
-	devfileHandler, err := adapters.NewComponentAdapter(componentName, po.componentContext, po.Application, devObj, platformContext)
+	devfileHandler, err := adapters.NewComponentAdapter(componentName, po.sourcePath, po.Application, devObj, platformContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/fatih/color"
+	"github.com/go-git/go-git/v5"
 	"github.com/gobwas/glob"
 	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/diskcache"
@@ -1023,7 +1024,7 @@ func DownloadFileInMemory(params HTTPRequestParams) ([]byte, error) {
 	return data, nil
 }
 
-// DownloadFileInMemory uses the url to download the file and return bytes
+// DownloadFileInMemoryWithCache uses the url to download the file and return bytes
 func DownloadFileInMemoryWithCache(params HTTPRequestParams, cacheFor int) ([]byte, error) {
 	data, err := HTTPGetRequest(params, cacheFor)
 
@@ -1504,4 +1505,29 @@ func IsValidKubeConfigPath() bool {
 		return false
 	}
 	return true
+}
+
+// GetGitOriginPath gets the remote fetch URL from the given git repo
+// if the repo is not a git repo, the error is ignored
+func GetGitOriginPath(path string) string {
+	open, err := git.PlainOpen(path)
+	if err != nil {
+		return ""
+	}
+
+	remotes, err := open.Remotes()
+	if err != nil {
+		return ""
+	}
+
+	for _, remote := range remotes {
+		if remote.Config().Name == "origin" {
+			if len(remote.Config().URLs) > 0 {
+				// https://github.com/go-git/go-git/blob/db4233e9e8b3b2e37259ed4e7952faaed16218b9/config/config.go#L549-L550
+				// the first URL is the fetch URL
+				return remote.Config().URLs[0]
+			}
+		}
+	}
+	return ""
 }

--- a/tests/helper/helper_cli.go
+++ b/tests/helper/helper_cli.go
@@ -25,4 +25,5 @@ type CliRunner interface {
 	WaitAndCheckForTerminatingState(resourceType, namespace string, timeoutMinutes int) bool
 	VerifyResourceDeleted(ri ResourceInfo)
 	VerifyResourceToBeDeleted(ri ResourceInfo)
+	GetAnnotationsDeployment(cmpName, appName, projectName string) map[string]string
 }

--- a/tests/helper/helper_kubectl.go
+++ b/tests/helper/helper_kubectl.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	applabels "github.com/openshift/odo/pkg/application/labels"
-	"github.com/openshift/odo/pkg/component/labels"
 )
 
 const (
@@ -241,21 +239,5 @@ func (kubectl KubectlRunner) VerifyResourceToBeDeleted(ri ResourceInfo) {
 // GetAnnotationsDeployment gets the annotations from the deployment
 // belonging to the given component, app and project
 func (kubectl KubectlRunner) GetAnnotationsDeployment(componentName, appName, projectName string) map[string]string {
-	var mapOutput = make(map[string]string)
-
-	selector := fmt.Sprintf("--selector=%s=%s,%s=%s", labels.ComponentLabel, componentName, applabels.ApplicationLabel, appName)
-	output := CmdShouldPass(kubectl.path, "get", "deployment", selector, "--namespace", projectName,
-		"-o", "go-template='{{ range $k, $v := (index .items 0).metadata.annotations}}{{$k}}:{{$v}}{{\"\\n\"}}{{end}}'")
-
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimPrefix(line, "'")
-		splits := strings.Split(line, ":")
-		if len(splits) < 2 {
-			continue
-		}
-		name := splits[0]
-		value := strings.Join(splits[1:], ":")
-		mapOutput[name] = value
-	}
-	return mapOutput
+	return GetAnnotationsDeployment(kubectl.path, componentName, appName, projectName)
 }

--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -10,8 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	applabels "github.com/openshift/odo/pkg/application/labels"
-	"github.com/openshift/odo/pkg/component/labels"
 )
 
 const (
@@ -614,7 +612,7 @@ func (oc OcRunner) CreateRandNamespaceProject() string {
 	return projectName
 }
 
-// CreateRandNamespaceProject creates a new project with name of length i
+// CreateRandNamespaceProjectOfLength creates a new project with name of length i
 func (oc OcRunner) CreateRandNamespaceProjectOfLength(i int) string {
 	projectName := RandString(i)
 	oc.createRandNamespaceProject(projectName)
@@ -692,21 +690,5 @@ func (oc OcRunner) WaitAndCheckForTerminatingState(resourceType, namespace strin
 // GetAnnotationsDeployment gets the annotations from the deployment
 // belonging to the given component, app and project
 func (oc OcRunner) GetAnnotationsDeployment(componentName, appName, projectName string) map[string]string {
-	var mapOutput = make(map[string]string)
-
-	selector := fmt.Sprintf("--selector=%s=%s,%s=%s", labels.ComponentLabel, componentName, applabels.ApplicationLabel, appName)
-	output := CmdShouldPass(oc.path, "get", "deployment", selector, "--namespace", projectName,
-		"-o", "go-template='{{ range $k, $v := (index .items 0).metadata.annotations}}{{$k}}:{{$v}}{{\"\\n\"}}{{end}}'")
-
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimPrefix(line, "'")
-		splits := strings.Split(line, ":")
-		if len(splits) < 2 {
-			continue
-		}
-		name := splits[0]
-		value := strings.Join(splits[1:], ":")
-		mapOutput[name] = value
-	}
-	return mapOutput
+	return GetAnnotationsDeployment(oc.path, componentName, appName, projectName)
 }

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -88,8 +88,22 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
+			helper.CmdShouldPass("git", "init")
+			remote := "origin"
+			remoteURL := "https://github.com/odo-devfiles/nodejs-ex"
+			helper.CmdShouldPass("git", "remote", "add", remote, remoteURL)
+
 			output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			annotations := commonVar.CliRunner.GetAnnotationsDeployment(cmpName, "app", commonVar.Project)
+			var valueFound bool
+			for key, value := range annotations {
+				if key == "app.openshift.io/vcs-uri" && value == remoteURL {
+					valueFound = true
+				}
+			}
+			Expect(valueFound).To(BeTrue())
 
 			// update devfile and push again
 			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does this PR do / why we need it**:

It adds the annotation `app.openshift.io/vcs-uri` to the deployment.

**Which issue(s) this PR fixes**:

Fixes #4544 

**PR acceptance criteria**:

- [X] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create a component using `odo create` and trigger `odo push` on a directory in which `git` has been initialized and a remote named `origin` is present.
- Check if the annotation `app.openshift.io/vcs-uri` is present with the value which is to the fetch URL of the `origin` remote.
- If the directory is not a `git` directory, the above annotation should be empty.