### PR TITLE
[skip ci] Fixed README typo for nodejs devfile version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ Devfiles describe your development environment link. link:https://odo.dev/docs/d
 
 | Node.JS
 | nodejs
-| Stack with NodeJS 12
+| Stack with NodeJS 14
 | link:https://github.com/devfile/registry/blob/master/stacks/nodejs/devfile.yaml[nodejs/devfile.yaml]
 | amd64, s390x, ppc64le
 
@@ -102,7 +102,7 @@ java-maven           Upstream Maven and OpenJDK 11          DefaultDevfileRegist
 java-openliberty     Open Liberty microservice in Java      DefaultDevfileRegistry
 java-quarkus         Upstream Quarkus with Java+GraalVM     DefaultDevfileRegistry
 java-springboot      Spring Boot® using Java                DefaultDevfileRegistry
-nodejs               Stack with NodeJS 12                   DefaultDevfileRegistry
+nodejs               Stack with NodeJS 14                   DefaultDevfileRegistry
 ----------------------------------------------------
 
 [[official-documentation]]


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
Wrong version for nodejs devfile stack.

**Which issue(s) this PR fixes**:
The image the devfile pulls for nodejs is version 14 and not version 12.
https://github.com/devfile/registry/pull/32
