### PR TITLE
Refactor OperatorHub integration tests

### DIFF
--- a/tests/helper/helper_oc.go
+++ b/tests/helper/helper_oc.go
@@ -696,3 +696,15 @@ func (oc OcRunner) WaitAndCheckForTerminatingState(resourceType, namespace strin
 func (oc OcRunner) GetAnnotationsDeployment(componentName, appName, projectName string) map[string]string {
 	return GetAnnotationsDeployment(oc.path, componentName, appName, projectName)
 }
+
+func (oc OcRunner) PodsShouldBeRunning(project string, regex string) {
+	// now verify if the pods for the operator have started
+	pods := oc.GetAllPodsInNs(project)
+	// Look for pods with specified regex
+	etcdPod := regexp.MustCompile(regex).FindString(pods)
+
+	ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", project}
+	WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+		return strings.Contains(output, "Running")
+	})
+}

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -33,7 +33,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 		var operators string
 		JustBeforeEach(func() {
-			// wait till oc can see the all operators installed by setup script in the namespace
+			// wait till odo can see that all operators installed by setup script in the namespace
 			odoArgs := []string{"catalog", "list", "services"}
 			operators := []string{"etcdoperator", "service-binding-operator"}
 			for _, operator := range operators {
@@ -52,11 +52,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			Expect(stdOut).To(ContainSubstring("service can be created/deleted from a valid component directory only"))
 		})
 
-		It("should list operators installed in the namespace", func() {
-			operators = helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(operators, []string{"Services available through Operators", "etcdoperator"})
-		})
-
 		Context("a specific operator is installed", func() {
 			var etcdOperator string
 			var etcdCluster string
@@ -65,9 +60,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
 				etcdOperator = regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
 				etcdCluster = fmt.Sprintf("%s/EtcdCluster", etcdOperator)
-			})
-
-			JustAfterEach(func() {
 			})
 
 			It("should describe the operator with human-readable output", func() {
@@ -82,7 +74,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 			})
 
-			It("should only output the definition of the CR that will be used to start service", func() {
+			It("should find the services by keyword", func() {
 				stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
 				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
@@ -93,7 +85,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
 			})
 
-			It("should list the operator", func() {
+			It("should list the operator in JSON output", func() {
 				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
 				helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
 			})
@@ -102,9 +94,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 				JustBeforeEach(func() {
 					helper.CmdShouldPass("odo", "create", "nodejs")
-				})
-
-				JustAfterEach(func() {
 				})
 
 				It("should fail for interactive mode", func() {
@@ -132,8 +121,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 						helper.CmdShouldPass("odo", "push")
 					})
 
-					JustAfterEach(func() {
-					})
 					It("should fail if the provided service doesn't exist in the namespace", func() {
 						if os.Getenv("KUBERNETES") == "true" {
 							Skip("This is a OpenShift specific scenario, skipping")
@@ -149,9 +136,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 					JustBeforeEach(func() {
 						stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", commonVar.Project)
-					})
-
-					JustAfterEach(func() {
 					})
 
 					It("should only output the definition of the CR that will be used to start service", func() {
@@ -186,9 +170,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 							When("odo push is executed", func() {
 								JustBeforeEach(func() {
 									helper.CmdShouldPass("odo", "push")
-								})
-
-								JustAfterEach(func() {
 								})
 
 								It("should create pods in running state", func() {
@@ -226,9 +207,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 									helper.CmdShouldPass("odo", "push")
 								})
 
-								JustAfterEach(func() {
-								})
-
 								It("should fail to create a service again with the same name", func() {
 									stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name, "--project", commonVar.Project)
 									Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
@@ -255,12 +233,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 					var stdOut string
 					JustBeforeEach(func() {
 						stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", commonVar.Project)
-					})
-
-					JustAfterEach(func() {
-					})
-
-					It("should create the EtcdCluster instance", func() {
 						Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
 					})
 
@@ -278,9 +250,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 						JustBeforeEach(func() {
 							helper.CmdShouldPass("odo", "push")
-						})
-
-						JustAfterEach(func() {
 						})
 
 						It("should create pods in running state", func() {
@@ -312,9 +281,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 								stdOut = helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
 							})
 
-							JustAfterEach(func() {
-							})
-
 							It("should display a successful message", func() {
 								if os.Getenv("KUBERNETES") == "true" {
 									Skip("This is a OpenShift specific scenario, skipping")
@@ -333,9 +299,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 							When("the link is deleted", func() {
 								JustBeforeEach(func() {
 									stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
-								})
-
-								JustAfterEach(func() {
 								})
 
 								It("should display a successful message", func() {
@@ -358,9 +321,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 						When("the service is deleted", func() {
 							JustBeforeEach(func() {
 								helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-							})
-
-							JustAfterEach(func() {
 							})
 
 							It("should delete service definition from devfile.yaml", func() {
@@ -414,9 +374,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 						JustBeforeEach(func() {
 							helper.CmdShouldPass("odo", "push")
-						})
-
-						JustAfterEach(func() {
 						})
 
 						It("should create pods in running state", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -29,486 +29,467 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	preSetup := func() {
-		// wait till oc can see the all operators installed by setup script in the namespace
-		odoArgs := []string{"catalog", "list", "services"}
-		operators := []string{"etcdoperator", "service-binding-operator"}
-		for _, operator := range operators {
-			helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
-				return strings.Contains(output, operator)
-			})
-		}
-	}
+	Context("Operators are installed in the cluster", func() {
 
-	cleanPreSetup := func() {
-		helper.DeleteProject(commonVar.Project)
-	}
-
-	Context("When Operators are installed in the cluster", func() {
-
+		var operators string
 		JustBeforeEach(func() {
-			preSetup()
+			// wait till oc can see the all operators installed by setup script in the namespace
+			odoArgs := []string{"catalog", "list", "services"}
+			operators := []string{"etcdoperator", "service-binding-operator"}
+			for _, operator := range operators {
+				helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
+					return strings.Contains(output, operator)
+				})
+			}
 		})
 
 		JustAfterEach(func() {
-			cleanPreSetup()
+			helper.DeleteProject(commonVar.Project)
+		})
+
+		It("should not allow creating service without valid context", func() {
+			stdOut := helper.CmdShouldFail("odo", "service", "create")
+			Expect(stdOut).To(ContainSubstring("service can be created/deleted from a valid component directory only"))
 		})
 
 		It("should list operators installed in the namespace", func() {
-			stdOut := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			helper.MatchAllInOutput(stdOut, []string{"Services available through Operators", "etcdoperator"})
+			operators = helper.CmdShouldPass("odo", "catalog", "list", "services")
+			helper.MatchAllInOutput(operators, []string{"Services available through Operators", "etcdoperator"})
 		})
 
-		It("should describe an installed operator with json output", func() {
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			etcdCluster := fmt.Sprintf("%s/EtcdCluster", etcdOperator)
+		Context("the etcd operator is installed", func() {
+			var etcdOperator string
+			var etcdCluster string
 
-			output := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster)
-			Expect(output).To(ContainSubstring("Kind: EtcdCluster"))
-			outputJSON := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster, "-o", "json")
-			values := gjson.GetMany(outputJSON, "spec.kind", "spec.displayName")
-			expected := []string{"EtcdCluster", "etcd Cluster"}
-			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
-		})
-
-		It("should not allow creating service without valid context, and fail for interactive mode", func() {
-			stdOut := helper.CmdShouldFail("odo", "service", "create")
-			Expect(stdOut).To(ContainSubstring("service can be created/deleted from a valid component directory only"))
-
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			stdOut = helper.CmdShouldFail("odo", "service", "create")
-			Expect(stdOut).To(ContainSubstring("odo doesn't support interactive mode for creating Operator backed service"))
-		})
-
-		It("should successfully push a second service after a first service is deployed", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-			// create a first service
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "myetcd1", "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
-
-			// deploy it
-			helper.CmdShouldPass("odo", "push")
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
-			Expect(stdOut).To(ContainSubstring("EtcdCluster/myetcd1"))
-
-			// create a second service
-			stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "myetcd2", "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
-
-			// deploy it
-			helper.CmdShouldPass("odo", "push")
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
-			// first service still here
-			Expect(stdOut).To(ContainSubstring("EtcdCluster/myetcd1"))
-			// second service created
-			Expect(stdOut).To(ContainSubstring("EtcdCluster/myetcd2"))
-		})
-	})
-
-	Context("When creating and deleting an operator backed service", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should be able to create, list and then delete EtcdCluster from its alm example", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
-
-			// read the devfile.yaml to check if service definition was rightly inserted
-			devfilePath := filepath.Join(commonVar.Context, "devfile.yaml")
-			content, err := ioutil.ReadFile(devfilePath)
-			Expect(err).To(BeNil())
-			matchInOutput := []string{"kubernetes", "inlined", "EtcdCluster", "example"}
-			helper.MatchAllInOutput(string(content), matchInOutput)
-
-			// now create the service on cluster and verify if the pods for the operator have started
-			helper.CmdShouldPass("odo", "push")
-			pods := oc.GetAllPodsInNs(commonVar.Project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustBeforeEach(func() {
+				operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
+				etcdOperator = regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				etcdCluster = fmt.Sprintf("%s/EtcdCluster", etcdOperator)
 			})
 
-			// now test listing of the service using odo
-			stdOut = helper.CmdShouldPass("odo", "service", "list")
-			Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
-
-			// now test the deletion of the service using odo
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-			// read the devfile.yaml to check if service definition was deleted
-			content, err = ioutil.ReadFile(devfilePath)
-			Expect(err).To(BeNil())
-			helper.DontMatchAllInOutput(string(content), matchInOutput)
-
-			// now try deleting the same service again. It should fail with error message
-			stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
-			Expect(stdOut).To(ContainSubstring("couldn't find service named"))
-		})
-
-		It("should be able to create service with name passed on CLI", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			name := helper.RandString(6)
-			svcFullName := strings.Join([]string{"EtcdCluster", name}, "/")
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", commonVar.Project)
-			helper.CmdShouldPass("odo", "push")
-
-			// now verify if the pods for the operator have started
-			pods := oc.GetAllPodsInNs(commonVar.Project)
-			// Look for pod with custom name because that's the name etcd will give to the pods.
-			compileString := name + `-.[a-z0-9]*`
-			etcdPod := regexp.MustCompile(compileString).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			JustAfterEach(func() {
 			})
 
-			// now try creating service with same name again. it should fail
-			stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
-
-			helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
-		})
-	})
-
-	Context("When using dry-run option to create operator backed service", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should only output the definition of the CR that will be used to start service", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", commonVar.Project)
-			helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
-		})
-	})
-
-	Context("Should be able to search from catalog", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should only output the definition of the CR that will be used to start service", func() {
-			stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
-			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-			stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
-			helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
-
-			stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
-			Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
-		})
-	})
-
-	Context("When using from-file option", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should be able to create a service", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", commonVar.Project)
-
-			// stdOut contains the yaml specification. Store it to a file
-			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join(os.TempDir(), randomFileName)
-			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
-
-			// now create operator backed service
-			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, "--project", commonVar.Project)
-			helper.CmdShouldPass("odo", "push")
-
-			// now verify if the pods for the operator have started
-			pods := oc.GetAllPodsInNs(commonVar.Project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+			It("should describe the etcd operator with human-readable output", func() {
+				output := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster)
+				Expect(output).To(ContainSubstring("Kind: EtcdCluster"))
 			})
 
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-		})
+			It("should describe the etcd operator with json output", func() {
+				outputJSON := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster, "-o", "json")
+				values := gjson.GetMany(outputJSON, "spec.kind", "spec.displayName")
+				expected := []string{"EtcdCluster", "etcd Cluster"}
+				Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
+			})
 
-		It("should be able to create a service with name passed on CLI", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
+			It("should only output the definition of the CR that will be used to start service", func() {
+				stdOut := helper.CmdShouldPass("odo", "catalog", "search", "service", "etcd")
+				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			name := helper.RandString(6)
-			// First let's grab the etcd operator's name from "odo catalog list services" output
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
+				stdOut = helper.CmdShouldPass("odo", "catalog", "search", "service", "EtcdCluster")
+				helper.MatchAllInOutput(stdOut, []string{"etcdoperator", "EtcdCluster"})
 
-			stdOut := helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", commonVar.Project)
+				stdOut = helper.CmdShouldFail("odo", "catalog", "search", "service", "dummy")
+				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
+			})
 
-			// stdOut contains the yaml specification. Store it to a file
-			randomFileName := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join(os.TempDir(), randomFileName)
-			if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
+			It("should list the etcd operator", func() {
+				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
+				helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
+			})
 
-			// now create operator backed service
-			helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name, "--project", commonVar.Project)
-			helper.CmdShouldPass("odo", "push")
+			When("a nodejs component is created", func() {
 
-			// Attempting to create service with same name should fail
-			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name, "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
-		})
-	})
+				JustBeforeEach(func() {
+					helper.CmdShouldPass("odo", "create", "nodejs")
+				})
 
-	Context("When using from-file option", func() {
+				JustAfterEach(func() {
+				})
 
-		var tmpContext string
+				It("should fail for interactive mode", func() {
+					stdOut := helper.CmdShouldFail("odo", "service", "create")
+					Expect(stdOut).To(ContainSubstring("odo doesn't support interactive mode for creating Operator backed service"))
+				})
 
-		JustBeforeEach(func() {
-			tmpContext = helper.CreateNewContext()
-			preSetup()
-		})
+				It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
+					if os.Getenv("KUBERNETES") == "true" {
+						Skip("This is a OpenShift specific scenario, skipping")
+					}
 
-		JustAfterEach(func() {
-			helper.DeleteDir(tmpContext)
-			cleanPreSetup()
-		})
+					stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
+					Expect(stdOut).To(ContainSubstring("invalid service name"))
 
-		It("should fail to create service if metadata doesn't exist or is invalid", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-			noMetadata := `
+					stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
+					Expect(stdOut).To(ContainSubstring("invalid service name"))
+
+					stdOut = helper.CmdShouldFail("odo", "link", "/example")
+					Expect(stdOut).To(ContainSubstring("invalid service name"))
+				})
+
+				When("odo push is executed", func() {
+					JustBeforeEach(func() {
+						helper.CmdShouldPass("odo", "push")
+					})
+
+					JustAfterEach(func() {
+					})
+					It("should fail if the provided service doesn't exist in the namespace", func() {
+						if os.Getenv("KUBERNETES") == "true" {
+							Skip("This is a OpenShift specific scenario, skipping")
+						}
+						stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+						Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
+					})
+				})
+
+				When("an EtcdCluster instance is created in dryRun mode", func() {
+
+					var stdOut string
+
+					JustBeforeEach(func() {
+						stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--dry-run", "--project", commonVar.Project)
+					})
+
+					JustAfterEach(func() {
+					})
+
+					It("should only output the definition of the CR that will be used to start service", func() {
+						helper.MatchAllInOutput(stdOut, []string{"apiVersion", "kind"})
+					})
+
+					When("the output of the command is stored in a file", func() {
+
+						var fileName string
+
+						JustBeforeEach(func() {
+							randomFileName := helper.RandString(6) + ".yaml"
+							fileName = filepath.Join(os.TempDir(), randomFileName)
+							if err := ioutil.WriteFile(fileName, []byte(stdOut), 0644); err != nil {
+								fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
+							}
+						})
+
+						JustAfterEach(func() {
+							// TODO delete file
+						})
+
+						When("a service is created from the output of the dryRun command with no name", func() {
+							JustBeforeEach(func() {
+								helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, "--project", commonVar.Project)
+							})
+
+							JustAfterEach(func() {
+								helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+							})
+
+							When("odo push is executed", func() {
+								JustBeforeEach(func() {
+									helper.CmdShouldPass("odo", "push")
+								})
+
+								JustAfterEach(func() {
+								})
+
+								It("should create pods in running state", func() {
+									// now verify if the pods for the operator have started
+									pods := oc.GetAllPodsInNs(commonVar.Project)
+									// Look for pod with example name because that's the name etcd will give to the pods.
+									etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+									ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
+									helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+										return strings.Contains(output, "Running")
+									})
+
+								})
+							})
+						})
+
+						When("a service is created from the output of the dryRun command with a specific name", func() {
+
+							var name string
+							var svcFullName string
+							JustBeforeEach(func() {
+								name = helper.RandString(6)
+								svcFullName = strings.Join([]string{"EtcdCluster", name}, "/")
+								helper.CmdShouldPass("odo", "service", "create", "--from-file", fileName, name, "--project", commonVar.Project)
+							})
+
+							JustAfterEach(func() {
+								helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
+							})
+
+							When("odo push is executed", func() {
+
+								JustBeforeEach(func() {
+									helper.CmdShouldPass("odo", "push")
+								})
+
+								JustAfterEach(func() {
+								})
+
+								It("should fail to create a service again with the same name", func() {
+									stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, name, "--project", commonVar.Project)
+									Expect(stdOut).To(ContainSubstring("please provide a different name or delete the existing service first"))
+								})
+
+								It("should create pods in running state", func() {
+									// now verify if the pods for the operator have started
+									pods := oc.GetAllPodsInNs(commonVar.Project)
+									// Look for pod with example name because that's the name etcd will give to the pods.
+									etcdPod := regexp.MustCompile(name + `-.[a-z0-9]*`).FindString(pods)
+
+									ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
+									helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+										return strings.Contains(output, "Running")
+									})
+
+								})
+							})
+						})
+					})
+				})
+
+				When("an EtcdCluster instance is created with no name", func() {
+					var stdOut string
+					JustBeforeEach(func() {
+						stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", commonVar.Project)
+					})
+
+					JustAfterEach(func() {
+					})
+
+					It("should create the EtcdCluster instance", func() {
+						Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
+					})
+
+					It("should insert service definition in devfile.yaml", func() {
+						devfilePath := filepath.Join(commonVar.Context, "devfile.yaml")
+						content, err := ioutil.ReadFile(devfilePath)
+						Expect(err).To(BeNil())
+						matchInOutput := []string{"kubernetes", "inlined", "EtcdCluster", "example"}
+						helper.MatchAllInOutput(string(content), matchInOutput)
+					})
+
+					When("odo push is executed", func() {
+
+						var etcdPod string
+
+						JustBeforeEach(func() {
+							helper.CmdShouldPass("odo", "push")
+						})
+
+						JustAfterEach(func() {
+						})
+
+						It("should create a pod in the namespace in Running state", func() {
+							// now create the service on cluster and verify if the pods for the operator have started
+							pods := oc.GetAllPodsInNs(commonVar.Project)
+							// Look for pod with example name because that's the name etcd will give to the pods.
+							etcdPod = regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
+
+							ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
+							helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+								return strings.Contains(output, "Running")
+							})
+						})
+
+						It("should list the service", func() {
+							// now test listing of the service using odo
+							stdOut := helper.CmdShouldPass("odo", "service", "list")
+							Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
+						})
+
+						It("should list the service in JSON format", func() {
+							jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
+							helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
+						})
+
+						When("a link is created with the service", func() {
+							var stdOut string
+							JustBeforeEach(func() {
+								stdOut = helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
+							})
+
+							JustAfterEach(func() {
+							})
+
+							It("should display a successful message", func() {
+								if os.Getenv("KUBERNETES") == "true" {
+									Skip("This is a OpenShift specific scenario, skipping")
+								}
+								Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
+							})
+
+							It("Should fail to link it again", func() {
+								if os.Getenv("KUBERNETES") == "true" {
+									Skip("This is a OpenShift specific scenario, skipping")
+								}
+								stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
+								Expect(stdOut).To(ContainSubstring("already linked with the service"))
+							})
+
+							When("the link is deleted", func() {
+								JustBeforeEach(func() {
+									stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
+								})
+
+								JustAfterEach(func() {
+								})
+
+								It("should display a successful message", func() {
+									if os.Getenv("KUBERNETES") == "true" {
+										Skip("This is a OpenShift specific scenario, skipping")
+									}
+									Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
+								})
+
+								It("should fail to delete it again", func() {
+									if os.Getenv("KUBERNETES") == "true" {
+										Skip("This is a OpenShift specific scenario, skipping")
+									}
+									stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
+									Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
+								})
+							})
+						})
+
+						When("the service is deleted", func() {
+							JustBeforeEach(func() {
+								helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
+							})
+
+							JustAfterEach(func() {
+							})
+
+							It("should delete service definition from devfile.yaml", func() {
+								// read the devfile.yaml to check if service definition was deleted
+								devfilePath := filepath.Join(commonVar.Context, "devfile.yaml")
+								content, err := ioutil.ReadFile(devfilePath)
+								Expect(err).To(BeNil())
+								matchInOutput := []string{"kubernetes", "inlined", "EtcdCluster", "example"}
+								helper.DontMatchAllInOutput(string(content), matchInOutput)
+							})
+
+							It("Should fail listing the services", func() {
+								out := helper.CmdShouldFail("odo", "service", "list")
+								msg := fmt.Sprintf("no operator backed services found in namespace: %s", commonVar.Project)
+								Expect(out).To(ContainSubstring(msg))
+							})
+
+							It("Should fail listing the services in JSON format", func() {
+								jsonOut := helper.CmdShouldFail("odo", "service", "list", "-o", "json")
+								msg := fmt.Sprintf("no operator backed services found in namespace: %s", commonVar.Project)
+								msgWithQuote := fmt.Sprintf("\"message\": \"no operator backed services found in namespace: %s\"", commonVar.Project)
+								helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
+							})
+
+							It("should fail to delete the service again", func() {
+								stdOut = helper.CmdShouldFail("odo", "service", "delete", "EtcdCluster/example", "-f")
+								Expect(stdOut).To(ContainSubstring("couldn't find service named"))
+							})
+						})
+					})
+				})
+
+				When("an EtcdCluster instance is created with a specific name", func() {
+
+					var name string
+					var svcFullName string
+
+					JustBeforeEach(func() {
+						name = helper.RandString(6)
+						svcFullName = strings.Join([]string{"EtcdCluster", name}, "/")
+						helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", commonVar.Project)
+					})
+
+					JustAfterEach(func() {
+						helper.CmdShouldPass("odo", "service", "delete", svcFullName, "-f")
+					})
+
+					When("odo push is executed", func() {
+
+						var etcdPod string
+
+						JustBeforeEach(func() {
+							helper.CmdShouldPass("odo", "push")
+						})
+
+						JustAfterEach(func() {
+						})
+
+						It("should create a pod in the namespace in Running state", func() {
+							pods := oc.GetAllPodsInNs(commonVar.Project)
+							compileString := name + `-.[a-z0-9]*`
+							etcdPod = regexp.MustCompile(compileString).FindString(pods)
+
+							ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
+							helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+								return strings.Contains(output, "Running")
+							})
+						})
+
+						It("should fail to create a service again with the same name", func() {
+							stdOut := helper.CmdShouldFail("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), name, "--project", commonVar.Project)
+							Expect(stdOut).To(ContainSubstring(fmt.Sprintf("service %q already exists", svcFullName)))
+						})
+					})
+				})
+
+				Context("Invalid service templates exist", func() {
+
+					var tmpContext string
+					var noMetaFileName string
+					var invalidFileName string
+
+					JustBeforeEach(func() {
+						tmpContext = helper.CreateNewContext()
+
+						// TODO write helpers to create such files
+						noMetadata := `
 apiVersion: etcd.database.coreos.com/v1beta2
 kind: EtcdCluster
 spec:
   size: 3
-  version: 3.2.13
-`
+  version: 3.2.13`
+						noMetaFile := helper.RandString(6) + ".yaml"
+						noMetaFileName = filepath.Join(tmpContext, noMetaFile)
+						if err := ioutil.WriteFile(noMetaFileName, []byte(noMetadata), 0644); err != nil {
+							fmt.Printf("Could not write yaml spec to file %s because of the error %v", noMetaFileName, err.Error())
+						}
 
-			invalidMetadata := `
+						invalidMetadata := `
 apiVersion: etcd.database.coreos.com/v1beta2
 kind: EtcdCluster
 metadata:
   noname: noname
 spec:
   size: 3
-  version: 3.2.13
-`
+  version: 3.2.13`
+						invalidMetaFile := helper.RandString(6) + ".yaml"
+						invalidFileName = filepath.Join(tmpContext, invalidMetaFile)
+						if err := ioutil.WriteFile(invalidFileName, []byte(invalidMetadata), 0644); err != nil {
+							fmt.Printf("Could not write yaml spec to file %s because of the error %v", invalidFileName, err.Error())
+						}
 
-			noMetaFile := helper.RandString(6) + ".yaml"
-			fileName := filepath.Join(tmpContext, noMetaFile)
-			if err := ioutil.WriteFile(fileName, []byte(noMetadata), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
+					})
 
-			// now create operator backed service
-			stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
+					JustAfterEach(func() {
+						helper.DeleteDir(tmpContext)
+					})
 
-			invalidMetaFile := helper.RandString(6) + ".yaml"
-			fileName = filepath.Join(tmpContext, invalidMetaFile)
-			if err := ioutil.WriteFile(fileName, []byte(invalidMetadata), 0644); err != nil {
-				fmt.Printf("Could not write yaml spec to file %s because of the error %v", fileName, err.Error())
-			}
+					It("should fail to create a service based on a template without metadata", func() {
+						stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", noMetaFileName, "--project", commonVar.Project)
+						Expect(stdOut).To(ContainSubstring("couldn't find \"metadata\" in the yaml"))
+					})
 
-			// now create operator backed service
-			stdOut = helper.CmdShouldFail("odo", "service", "create", "--from-file", fileName, "--project", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
-
-		})
-	})
-
-	Context("JSON output", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("listing catalog of services", func() {
-			jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
-		})
-	})
-
-	Context("When operator backed services are created", func() {
-
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should list the services if they exist", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs")
-
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", commonVar.Project)
-			helper.CmdShouldPass("odo", "push")
-
-			// now verify if the pods for the operator have started
-			pods := oc.GetAllPodsInNs(commonVar.Project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
+					It("should fail to create a service based on a template with invalid metadata", func() {
+						stdOut := helper.CmdShouldFail("odo", "service", "create", "--from-file", invalidFileName, "--project", commonVar.Project)
+						Expect(stdOut).To(ContainSubstring("couldn't find metadata.name in the yaml"))
+					})
+				})
 			})
-
-			stdOut := helper.CmdShouldPass("odo", "service", "list")
-			helper.MatchAllInOutput(stdOut, []string{"example", "EtcdCluster"})
-
-			// now check for json output
-			jsonOut := helper.CmdShouldPass("odo", "service", "list", "-o", "json")
-			helper.MatchAllInOutput(jsonOut, []string{"\"apiVersion\": \"etcd.database.coreos.com/v1beta2\"", "\"kind\": \"EtcdCluster\"", "\"name\": \"example\""})
-
-			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/example", "-f")
-
-			// Now let's check the output again to ensure expected behaviour
-			stdOut = helper.CmdShouldFail("odo", "service", "list")
-			jsonOut = helper.CmdShouldFail("odo", "service", "list", "-o", "json")
-
-			msg := fmt.Sprintf("no operator backed services found in namespace: %s", commonVar.Project)
-			msgWithQuote := fmt.Sprintf("\"message\": \"no operator backed services found in namespace: %s\"", commonVar.Project)
-			Expect(stdOut).To(ContainSubstring(msg))
-			helper.MatchAllInOutput(jsonOut, []string{msg, msgWithQuote})
-		})
-	})
-
-	Context("When linking devfile component with Operator backed service", func() {
-		JustBeforeEach(func() {
-			preSetup()
-		})
-
-		JustAfterEach(func() {
-			cleanPreSetup()
-		})
-
-		It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", componentName)
-
-			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster")
-			Expect(stdOut).To(ContainSubstring("invalid service name"))
-
-			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-			Expect(stdOut).To(ContainSubstring("invalid service name"))
-
-			stdOut = helper.CmdShouldFail("odo", "link", "/example")
-			Expect(stdOut).To(ContainSubstring("invalid service name"))
-		})
-
-		It("should fail if the provided service doesn't exist in the namespace", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", componentName)
-			helper.CmdShouldPass("odo", "push")
-
-			stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
-		})
-
-		It("should successfully connect and disconnect a component with an existing service", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			componentName := helper.RandString(6)
-			helper.CmdShouldPass("odo", "create", "nodejs", componentName)
-			helper.CmdShouldPass("odo", "push")
-
-			// start the Operator backed service first
-			operators := helper.CmdShouldPass("odo", "catalog", "list", "services")
-			etcdOperator := regexp.MustCompile(`etcdoperator\.*[a-z][0-9]\.[0-9]\.[0-9]-clusterwide`).FindString(operators)
-			helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "--project", commonVar.Project)
-			helper.CmdShouldPass("odo", "push")
-
-			// now verify if the pods for the operator have started
-			pods := oc.GetAllPodsInNs(commonVar.Project)
-			// Look for pod with example name because that's the name etcd will give to the pods.
-			etcdPod := regexp.MustCompile(`example-.[a-z0-9]*`).FindString(pods)
-
-			ocArgs := []string{"get", "pods", etcdPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
-			})
-
-			stdOut := helper.CmdShouldPass("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Successfully created link between component"))
-			helper.CmdShouldPass("odo", "push")
-			stdOut = helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("already linked with the service"))
-
-			// Before running "odo unlink" checks, wait for the pod to come up from "odo push" done after "odo link"
-			pods = oc.GetAllPodsInNs(commonVar.Project)
-			componentPod := regexp.MustCompile(fmt.Sprintf(`%s-.[a-z0-9]*-.[a-z0-9\-]*`, componentName)).FindString(pods)
-			ocArgs = []string{"get", "pods", componentPod, "-o", "template=\"{{.status.phase}}\"", "-n", commonVar.Project}
-			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-				return strings.Contains(output, "Running")
-			})
-
-			stdOut = helper.CmdShouldPass("odo", "unlink", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("Successfully unlinked component"))
-			helper.CmdShouldPass("odo", "push")
-
-			// verify that sbr is deleted
-			stdOut = helper.CmdShouldFail("odo", "unlink", "EtcdCluster/example")
-			Expect(stdOut).To(ContainSubstring("failed to unlink the service"))
 		})
 
 		It("should successfully link the component to the etcd service with a specific name", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -315,6 +315,27 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 								Expect(stdOut).To(ContainSubstring("couldn't find service named"))
 							})
 						})
+
+						When("a second service is created", func() {
+							JustBeforeEach(func() {
+								stdOut = helper.CmdShouldPass("odo", "service", "create", fmt.Sprintf("%s/EtcdCluster", etcdOperator), "myetcd2", "--project", commonVar.Project)
+								Expect(stdOut).To(ContainSubstring("Successfully added service to the configuration"))
+							})
+
+							When("odo push is executed", func() {
+								JustBeforeEach(func() {
+									helper.CmdShouldPass("odo", "push")
+								})
+
+								It("should list both services", func() {
+									stdOut = helper.CmdShouldPass("odo", "service", "list")
+									// first service still here
+									Expect(stdOut).To(ContainSubstring("EtcdCluster/example"))
+									// second service created
+									Expect(stdOut).To(ContainSubstring("EtcdCluster/myetcd2"))
+								})
+							})
+						})
 					})
 				})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -57,7 +57,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			helper.MatchAllInOutput(operators, []string{"Services available through Operators", "etcdoperator"})
 		})
 
-		Context("the etcd operator is installed", func() {
+		Context("a specific operator is installed", func() {
 			var etcdOperator string
 			var etcdCluster string
 
@@ -70,12 +70,12 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			JustAfterEach(func() {
 			})
 
-			It("should describe the etcd operator with human-readable output", func() {
+			It("should describe the operator with human-readable output", func() {
 				output := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster)
 				Expect(output).To(ContainSubstring("Kind: EtcdCluster"))
 			})
 
-			It("should describe the etcd operator with json output", func() {
+			It("should describe the operator with json output", func() {
 				outputJSON := helper.CmdShouldPass("odo", "catalog", "describe", "service", etcdCluster, "-o", "json")
 				values := gjson.GetMany(outputJSON, "spec.kind", "spec.displayName")
 				expected := []string{"EtcdCluster", "etcd Cluster"}
@@ -93,7 +93,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 				Expect(stdOut).To(ContainSubstring("no service matched the query: dummy"))
 			})
 
-			It("should list the etcd operator", func() {
+			It("should list the operator", func() {
 				jsonOut := helper.CmdShouldPass("odo", "catalog", "list", "services", "-o", "json")
 				helper.MatchAllInOutput(jsonOut, []string{"etcdoperator"})
 			})
@@ -492,7 +492,7 @@ spec:
 			})
 		})
 
-		It("should successfully link the component to the etcd service with a specific name", func() {
+		It("should successfully link the component to the service with a specific name", func() {
 
 			// create a component and deploy it
 			helper.CmdShouldPass("odo", "create", "nodejs")
@@ -523,7 +523,7 @@ spec:
 			helper.CmdShouldPass("odo", "service", "delete", "EtcdCluster/etcd", "-f")
 		})
 
-		It("should successfully link the component to the etcd service with a specific name and activating bindAsFiles", func() {
+		It("should successfully link the component to the service with a specific name and activating bindAsFiles", func() {
 
 			// create a component and deploy it
 			helper.CmdShouldPass("odo", "create", "nodejs")

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -119,7 +119,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 							Skip("This is a OpenShift specific scenario, skipping")
 						}
 						stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-						Expect(stdOut).To(ContainSubstring("couldn't find service named %q", "EtcdCluster/example"))
+						Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
 					})
 				})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -283,7 +283,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 						JustAfterEach(func() {
 						})
 
-						It("should create a pod in the namespace in Running state", func() {
+						It("should create pods in running state", func() {
 							// now create the service on cluster and verify if the pods for the operator have started
 							pods := oc.GetAllPodsInNs(commonVar.Project)
 							// Look for pod with example name because that's the name etcd will give to the pods.
@@ -419,7 +419,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 						JustAfterEach(func() {
 						})
 
-						It("should create a pod in the namespace in Running state", func() {
+						It("should create pods in running state", func() {
 							pods := oc.GetAllPodsInNs(commonVar.Project)
 							compileString := name + `-.[a-z0-9]*`
 							etcdPod = regexp.MustCompile(compileString).FindString(pods)

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -31,7 +31,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 
 	Context("Operators are installed in the cluster", func() {
 
-		var operators string
 		JustBeforeEach(func() {
 			// wait till odo can see that all operators installed by setup script in the namespace
 			odoArgs := []string{"catalog", "list", "services"}


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does this PR do / why we need it**:

This PR refactors the code of the Operator Hub integration tests.

- `Context` describes a state of the cluster, and `JustBeforeEach` checks/wait that the state is ready
- `When` describes the execution of a command or other action **with side-effect** by the user, `JustBeforeEach` contains the execution of the command, `JustAfterEach` contains the counterpart of this command if necessary
- `It` checks the expectations after the last command executed. For readibility, `It` can contain commands executed by the user if these commands have no side-effect (commands failing, lists, describes, etc)

To add a test in this flow, a developer has to follow the Context/When tree to place its tests at the moment in the flow where (s)he wants to execute the test.

A plugin is available in VSCode to help browse the tree of Context/When/It (you will need ginkgo 1.15):

![ginkgo-test-explorer](https://user-images.githubusercontent.com/9973512/120604748-9ff39a00-c44d-11eb-8317-6a791acd01dc.png)

The output:

![ginkgo-plugin](https://user-images.githubusercontent.com/9973512/120604875-c3b6e000-c44d-11eb-8597-2f8354ea1d69.png)


**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
