### PR TITLE
Use staging registry for devfile debug suite test

### DIFF
--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -3,9 +3,18 @@ package debug
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDebug(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Debug Suite")
 }
+
+var _ = BeforeSuite(func() {
+	const registryName string = "DefaultDevfileRegistry"
+	const addRegistryURL string = "https://registry.stage.devfile.io"
+
+	// Use staging OCI-based registry for tests to avoid a potential overload
+	helper.CmdShouldPass("odo", "registry", "update", registryName, addRegistryURL)
+})


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What does this PR do / why we need it**:
Use staging devfile registry for devfile debug suite test similar to https://github.com/openshift/odo/pull/4752

**Which issue(s) this PR fixes**:

Fixes #4639

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
