### PR TITLE
Adds ability to link one devfile component to another

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -421,12 +421,6 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 		return err
 	}
 
-	deploymentObjectMeta, err := a.generateDeploymentObjectMeta(labels)
-	if err != nil {
-		return err
-	}
-
-	objectMeta := generator.GetObjectMeta(componentName, a.Client.Namespace, labels, nil)
 	supervisordInitContainer := kclient.GetBootstrapSupervisordInitContainer()
 	initContainers, err := utils.GetPreStartInitContainers(a.Devfile, containers)
 	if err != nil {
@@ -472,6 +466,11 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 		"component": componentName,
 	}
 
+	deploymentObjectMeta, err := a.generateDeploymentObjectMeta(labels)
+	if err != nil {
+		return err
+	}
+
 	deployParams := generator.DeploymentParams{
 		TypeMeta:          generator.GetTypeMeta(kclient.DeploymentKind, kclient.DeploymentAPIVersion),
 		ObjectMeta:        deploymentObjectMeta,
@@ -489,11 +488,18 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 		deployment.Annotations["app.openshift.io/vcs-uri"] = vcsUri
 	}
 
+	// add the annotations to the service for linking
+	serviceAnnotations := make(map[string]string)
+	serviceAnnotations["service.binding/backend_ip"] = "path={.spec.clusterIP}"
+	serviceAnnotations["service.binding/backend_port"] = "path={.spec.ports},elementType=sliceOfMaps,sourceKey=name,sourceValue=port"
+
+	serviceObjectMeta := generator.GetObjectMeta(componentName, a.Client.Namespace, labels, serviceAnnotations)
 	serviceParams := generator.ServiceParams{
-		ObjectMeta:     objectMeta,
+		ObjectMeta:     serviceObjectMeta,
 		SelectorLabels: selectorLabels,
 	}
 	svc, err := generator.GetService(a.Devfile, serviceParams, parsercommon.DevfileOptions{})
+
 	if err != nil {
 		return err
 	}

--- a/pkg/kclient/services.go
+++ b/pkg/kclient/services.go
@@ -8,6 +8,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetService retrieves the service with the given name
+func (c *Client) GetService(name string) (*corev1.Service, error) {
+	service, err := c.KubeClient.CoreV1().Services(c.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get the Service with name %q", name)
+	}
+	return service, err
+}
+
 // CreateService generates and creates the service
 // commonObjectMeta is the ObjectMeta for the service
 func (c *Client) CreateService(svc corev1.Service) (*corev1.Service, error) {

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -424,9 +424,7 @@ func (o *commonLinkOptions) validateForOperator() (err error) {
 				Namespace: &o.KClient.Namespace,
 			},
 		}
-	}
-
-	if !o.isTargetAService {
+	} else {
 		service = servicebinding.Service{
 			NamespacedRef: servicebinding.NamespacedRef{
 				Ref: servicebinding.Ref{

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -110,7 +110,7 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 							Skip("This is a OpenShift specific scenario, skipping")
 						}
 						stdOut := helper.CmdShouldFail("odo", "link", "EtcdCluster/example")
-						Expect(stdOut).To(ContainSubstring("Couldn't find service named %q", "EtcdCluster/example"))
+						Expect(stdOut).To(ContainSubstring("couldn't find service named %q", "EtcdCluster/example"))
 					})
 				})
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -472,67 +472,64 @@ spec:
 			})
 		})
 
-	})
-
-	When("one component is deployed", func() {
-		var context0 string
-		var cmp0 string
-
-		JustBeforeEach(func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("This is a OpenShift specific scenario, skipping")
-			}
-
-			context0 = helper.CreateNewContext()
-			cmp0 = helper.RandString(5)
-
-			helper.CmdShouldPass("odo", "create", "nodejs", cmp0, "--context", context0)
-			helper.CmdShouldPass("odo", "push", "--context", context0)
-		})
-
-		JustAfterEach(func() {
-			helper.CmdShouldPass("odo", "delete", "-f", "--context", context0)
-			helper.DeleteDir(context0)
-			cleanPreSetup()
-		})
-
-		It("should fail when linking to itself", func() {
-			stdOut := helper.CmdShouldFail("odo", "link", cmp0, "--context", context0)
-			helper.MatchAllInOutput(stdOut, []string{cmp0, "cannot be linked with itself"})
-		})
-
-		When("another component is deployed", func() {
-			var context1 string
-			var cmp1 string
+		When("one component is deployed", func() {
+			var context0 string
+			var cmp0 string
 
 			JustBeforeEach(func() {
-				context1 = helper.CreateNewContext()
-				cmp1 = helper.RandString(5)
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
 
-				helper.CmdShouldPass("odo", "create", "nodejs", cmp1, "--context", context1)
-				helper.CmdShouldPass("odo", "push", "--context", context1)
+				context0 = helper.CreateNewContext()
+				cmp0 = helper.RandString(5)
+
+				helper.CmdShouldPass("odo", "create", "nodejs", cmp0, "--context", context0)
+				helper.CmdShouldPass("odo", "push", "--context", context0)
 			})
 
 			JustAfterEach(func() {
-				helper.CmdShouldPass("odo", "delete", "-f", "--context", context1)
-				helper.DeleteDir(context1)
-				cleanPreSetup()
+				helper.CmdShouldPass("odo", "delete", "-f", "--context", context0)
+				helper.DeleteDir(context0)
 			})
 
-			It("should link the two components successfully", func() {
+			It("should fail when linking to itself", func() {
+				stdOut := helper.CmdShouldFail("odo", "link", cmp0, "--context", context0)
+				helper.MatchAllInOutput(stdOut, []string{cmp0, "cannot be linked with itself"})
+			})
 
-				helper.CmdShouldPass("odo", "link", cmp1, "--context", context0)
+			When("another component is deployed", func() {
+				var context1 string
+				var cmp1 string
 
-				// check the link exists with the specific name
-				ocArgs := []string{"get", "servicebinding", strings.Join([]string{cmp0, cmp1}, "-"), "-o", "jsonpath='{.status.secret}'", "-n", commonVar.Project}
-				helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
-					return strings.Contains(output, strings.Join([]string{cmp0, cmp1}, "-"))
+				JustBeforeEach(func() {
+					context1 = helper.CreateNewContext()
+					cmp1 = helper.RandString(5)
+
+					helper.CmdShouldPass("odo", "create", "nodejs", cmp1, "--context", context1)
+					helper.CmdShouldPass("odo", "push", "--context", context1)
 				})
 
-				// delete the link
-				helper.CmdShouldPass("odo", "unlink", cmp1, "--context", context0)
+				JustAfterEach(func() {
+					helper.CmdShouldPass("odo", "delete", "-f", "--context", context1)
+					helper.DeleteDir(context1)
+				})
 
-				commonVar.CliRunner.WaitAndCheckForTerminatingState("servicebinding", commonVar.Project, 1)
+				It("should link the two components successfully", func() {
+
+					helper.CmdShouldPass("odo", "link", cmp1, "--context", context0)
+
+					// check the link exists with the specific name
+					ocArgs := []string{"get", "servicebinding", strings.Join([]string{cmp0, cmp1}, "-"), "-o", "jsonpath='{.status.secret}'", "-n", commonVar.Project}
+					helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+						return strings.Contains(output, strings.Join([]string{cmp0, cmp1}, "-"))
+					})
+
+					// delete the link
+					helper.CmdShouldPass("odo", "unlink", cmp1, "--context", context0)
+
+					commonVar.CliRunner.WaitAndCheckForTerminatingState("servicebinding", commonVar.Project, 1)
+				})
 			})
 		})
 	})

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -100,15 +100,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 					Expect(stdOut).To(ContainSubstring("odo doesn't support interactive mode for creating Operator backed service"))
 				})
 
-				It("should fail if service name doesn't adhere to <service-type>/<service-name> format", func() {
-					if os.Getenv("KUBERNETES") == "true" {
-						Skip("This is a OpenShift specific scenario, skipping")
-					}
-					helper.CmdShouldFail("odo", "link", "EtcdCluster")
-					helper.CmdShouldFail("odo", "link", "EtcdCluster/")
-					helper.CmdShouldFail("odo", "link", "/example")
-				})
-
 				When("odo push is executed", func() {
 					JustBeforeEach(func() {
 						helper.CmdShouldPass("odo", "push")
@@ -496,6 +487,15 @@ spec:
 			It("should fail when linking to itself", func() {
 				stdOut := helper.CmdShouldFail("odo", "link", cmp0, "--context", context0)
 				helper.MatchAllInOutput(stdOut, []string{cmp0, "cannot be linked with itself"})
+			})
+
+			It("should fail if the component doesn't exist and the service name doesn't adhere to the <service-type>/<service-name> format", func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+				helper.CmdShouldFail("odo", "link", "EtcdCluster")
+				helper.CmdShouldFail("odo", "link", "EtcdCluster/")
+				helper.CmdShouldFail("odo", "link", "/example")
 			})
 
 			When("another component is deployed", func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -473,4 +473,63 @@ spec:
 		})
 
 	})
+
+	Context("When linking devfile component with another component", func() {
+		var context0 string
+		var context1 string
+		var cmp0 string
+		var cmp1 string
+
+		JustBeforeEach(func() {
+			context0 = helper.CreateNewContext()
+			context1 = helper.CreateNewContext()
+
+			cmp0 = helper.RandString(5)
+			cmp1 = helper.RandString(5)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", cmp0, "--context", context0)
+			helper.CmdShouldPass("odo", "create", "nodejs", cmp1, "--context", context1)
+
+			helper.CmdShouldPass("odo", "push", "--context", context0)
+			helper.CmdShouldPass("odo", "push", "--context", context1)
+		})
+
+		JustAfterEach(func() {
+			helper.CmdShouldPass("odo", "delete", "-f", "--context", context0)
+			helper.CmdShouldPass("odo", "delete", "-f", "--context", context1)
+
+			helper.DeleteDir(context0)
+			helper.DeleteDir(context1)
+
+			cleanPreSetup()
+		})
+
+		It("should fail when component is getting linked with itself", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			stdOut := helper.CmdShouldFail("odo", "link", cmp0, "--context", context0)
+			helper.MatchAllInOutput(stdOut, []string{cmp0, "cannot be linked with itself"})
+		})
+
+		It("should successfully link and unlink a component with another", func() {
+			if os.Getenv("KUBERNETES") == "true" {
+				Skip("This is a OpenShift specific scenario, skipping")
+			}
+
+			helper.CmdShouldPass("odo", "link", cmp1, "--context", context0)
+
+			// check the link exists with the specific name
+			ocArgs := []string{"get", "servicebinding", strings.Join([]string{cmp0, cmp1}, "-"), "-o", "jsonpath='{.status.secret}'", "-n", commonVar.Project}
+			helper.WaitForCmdOut("oc", ocArgs, 1, true, func(output string) bool {
+				return strings.Contains(output, strings.Join([]string{cmp0, cmp1}, "-"))
+			})
+
+			// delete the link
+			helper.CmdShouldPass("odo", "unlink", cmp1, "--context", context0)
+
+			commonVar.CliRunner.WaitAndCheckForTerminatingState("servicebinding", commonVar.Project, 1)
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does this PR do / why we need it**:

It adds the ability to link one devfile component to another devfile component.

**Which issue(s) this PR fixes**:

Fixes #3423 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Create two devfile components. 
```
mkdir frontend-dir
mkdir backend-dir
odo create nodejs frontend --context frontend-dir
odo push --context frontend-dir
odo create nodejs backend --context backend-dir
odo push --context backend-dir
```
- Execute `odo link <component-name-1>` from the directory of `<component-name-0>`.
```
odo link backend --context frontend-dir
```
- Check if a `servicebinding` resource has been generated successfully or not.
- A secret should be mentioned in the `servicebinding` resource.
- Self linking of the component to itself should fail.