### PR TITLE
ginkgo checksum error on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ GINKGO_FLAGS_SERIAL = $(GINKGO_FLAGS_ALL) -nodes=1
 GINKGO_FLAGS=$(GINKGO_FLAGS_ALL) -nodes=$(TEST_EXEC_NODES)
 
 
-RUN_GINKGO = go run $(COMMON_GOFLAGS) github.com/onsi/ginkgo/ginkgo
+RUN_GINKGO = GOFLAGS='-mod=vendor' go run $(COMMON_GOFLAGS) github.com/onsi/ginkgo/ginkgo
 
 default: bin
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind failing-test

**What does this PR do / why we need it**:

When running ginkgo on CI, we want to use vendor dependencies instead of trying to download the dependencies.

Because ginkgo is building itself the tests suite from source, we need to pass it `-mod=vendor` flag, or it will try to build the tests suite by downloading deps.

In `v4.7-integration-e2e` environment, we get the error:

```
ginkgo  -mod=vendor -randomizeAllSpecs -slowSpecThreshold=120 -timeout 14400s -nodes=2 tests/integration/ 
Failed to compile integration:               
go test: mod flag may be set only once       
```

This error happens when running the previous command with `GOFLAGS="-mod=vendor"`:

```
$ GOFLAGS="-mod=vendor" go run -mod=vendor github.com/onsi/ginkgo/ginkgo tests/integration/
# OK

$ GOFLAGS="-mod=vendor" go run -mod=vendor github.com/onsi/ginkgo/ginkgo -mod=vendor tests/integration/
Failed to compile integration:

go test: mod flag may be set only once
```

**Which issue(s) this PR fixes**:

Fixes #4726 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
