### PR TITLE
Reducing timeout for windows and macOS unit test to 20m

### DIFF
--- a/scripts/openshiftci-e2e-4x-psi-tests.sh
+++ b/scripts/openshiftci-e2e-4x-psi-tests.sh
@@ -14,6 +14,7 @@ export SENDTOPIC=${SENDTOPIC:-"amqp.ci.topic.send"}
 export SETUPSCRIPT=${SETUPSCRIPT:-"scripts/setup_script_e2e.sh"}
 export RUNSCRIPT=${RUNSCRIPT:-"scripts/run_script_e2e.sh"}
 export SENDEXCHANGE=${SENDEXCHANGE:-"amqp.ci.exchange.send"}
+export TIMEOUT=${TIMEOUT:-"4h00m"}
 
 # show commands
 set -x
@@ -32,5 +33,5 @@ echo "Getting ci-firewall, see https://github.com,/mohammedzee1000/ci-firewall"
 curl -kLO https://github.com/mohammedzee1000/ci-firewall/releases/download/$CI_FIREWALL_VERSION/ci-firewall-linux-amd64.tar.gz
 tar -xzf ci-firewall-linux-amd64.tar.gz
 
-./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsproject $JOB_NAME --runscript $RUNSCRIPT  --timeout 4h00m 
+./ci-firewall request --mainbranch main --sendqueue $SENDQUEUE --sendtopic $SENDTOPIC --sendexchange $SENDEXCHANGE --setupscript $SETUPSCRIPT --jenkinsproject $JOB_NAME --runscript $RUNSCRIPT  --timeout $TIMEOUT 
 

--- a/scripts/openshiftci-unit-psi-tests_win_mac.sh
+++ b/scripts/openshiftci-unit-psi-tests_win_mac.sh
@@ -10,6 +10,7 @@ case $1 in
     export RUNSCRIPT="scripts/run_script_unit.sh"
     export JOB_NAME=odo-windows-unit-pr-build
     export SENDEXCHANGE=amqp.ci.exchange.win.unit.send 
+    export TIMEOUT="20m"
     ;;
 
   mac)
@@ -19,6 +20,7 @@ case $1 in
     export RUNSCRIPT="scripts/run_script_unit.sh"
     export JOB_NAME=odo-mac-unit-pr-build
     export SENDEXCHANGE=amqp.ci.exchange.mac.unit.send 
+    export TIMEOUT="20m"
     ;;
 esac
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
As the successful unit test takes usually 10 min, so waiting for more than 20min does not make sense.

**Which issue(s) this PR fixes**:

Fixes part of - #4789 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
unit test for windows and macOS should not wait more than 20 min if it is supposed to fail