### PR TITLE
remove getInitContainer from odo

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -427,12 +427,13 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 	}
 
 	objectMeta := generator.GetObjectMeta(componentName, a.Client.Namespace, labels, nil)
-	supervisordInitContainer := kclient.GetBootstrapSupervisordInitContainer()
-	initContainers, err := utils.GetPreStartInitContainers(a.Devfile, containers)
-	if err != nil {
-		return err
-	}
-	initContainers = append(initContainers, supervisordInitContainer)
+	var initContainers []corev1.Container
+	initContainers = append(initContainers, kclient.GetBootstrapSupervisordInitContainer())
+
+	// odo currently does not support PreStart event or apply commands
+	// https://github.com/openshift/odo/issues/4187
+	// after odo support apply commands, should append result from generator.getInitContainers()
+	// initContainers := generator.GetInitContainers(a.Devfile)
 
 	var odoSourcePVCName string
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
This PR removes GetPreStartInitContainers from odo util:
1. should use generator from library to get initcontainers
2. odo currently does not support PreStart and apply commands
https://github.com/openshift/odo/blob/a54cfd86da993560768c7aae1a8fd1a1c017b833/pkg/devfile/validate/events.go#L5-L14

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
