### PR TITLE
Set 4 nodes for ginkgo tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TIMEOUT ?= 14400s
 # TEST_EXEC_NODES=1, otherwise by default the specs are run in parallel on 4 ginkgo test node.
 # NOTE: Any TEST_EXEC_NODES value greater than one runs the spec in parallel
 # on the same number of ginkgo test nodes.
-TEST_EXEC_NODES ?= 2
+TEST_EXEC_NODES ?= 4
 
 # Slow spec threshold for ginkgo tests. After this time (in second), ginkgo marks test as slow
 SLOW_SPEC_THRESHOLD := 120


### PR DESCRIPTION
**What type of PR is this?**

Run the parallel ginkgo tests on 4 nodes (instead of 2 previously).

The non-parallel tests are still running on a single node.
