### PR TITLE
add integration tests for devfile 2.1.0 and refactor devfile push tests

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -59,6 +59,10 @@ func ParseFromURL(url string) (parser.DevfileObj, error) {
 }
 
 func variableWarning(section string, variable string, messages []string) string {
-	return fmt.Sprintf("Variable %q in %q section was not successfully substituted. Reason: %q", section, variable, strings.Join(messages, ", "))
+	quotedVars := []string{}
+	for _, v := range messages {
+		quotedVars = append(quotedVars, fmt.Sprintf("%q", v))
+	}
+	return fmt.Sprintf("Invalid variable(s) %s in %q section with name %q. ", strings.Join(quotedVars, ","), section, variable)
 
 }

--- a/tests/examples/source/devfiles/nodejs/devfile-variables.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-variables.yaml
@@ -1,0 +1,35 @@
+schemaVersion: 2.1.0
+metadata:
+  name: nodejs
+variables:
+  VARIABLE_TEST: FOO
+  VALUE_TEST: bar
+components:
+  - name: runtime
+    container:
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      memoryLimit: 100Mi
+      endpoints:
+        - name: "3000-tcp"
+          targetPort: 3000
+      mountSources: true
+      env:
+        - name: "{{VARIABLE_TEST}}"
+          value: "{{VALUE_TEST}}"
+commands:
+  - id: build
+    exec:
+      component: runtime
+      commandLine: "npm install"
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: runtime
+      commandLine: npm start
+      workingDir: ${PROJECTS_ROOT}
+      group:
+        kind: run
+        isDefault: true

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -36,7 +36,7 @@ var _ = Describe("odo devfile create command tests", func() {
 
 	Context("when .gitignore file exists", func() {
 		It("checks that .odo/env exists in gitignore", func() {
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
 
 			ignoreFilePath := filepath.Join(commonVar.Context, ".gitignore")
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -34,6 +34,17 @@ var _ = Describe("odo devfile create command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
+	Context("when .gitignore file exists", func() {
+		It("checks that .odo/env exists in gitignore", func() {
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+			ignoreFilePath := filepath.Join(commonVar.Context, ".gitignore")
+
+			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "env"))
+
+		})
+	})
+
 	Context("When executing odo create with devfile component type argument", func() {
 		It("should successfully create the devfile component with valid component name", func() {
 			helper.Cmd("odo", "create", "java-openliberty", cmpName).ShouldPass()

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -30,15 +30,15 @@ var _ = Describe("odo list with devfile", func() {
 		It("should correctly output component information", func() {
 
 			// component created in "app" application
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
 			By("checking that component correctly shows as 'NotPushed'")
-			output := helper.CmdShouldPass("odo", "list")
+			output := helper.Cmd("odo", "list").ShouldPass().Out()
 			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
 
-			output = helper.CmdShouldPass("odo", "push")
+			output = helper.Cmd("odo", "push").ShouldPass().Out()
 			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
 			// component created in different application
@@ -46,19 +46,19 @@ var _ = Describe("odo list with devfile", func() {
 			cmpName2 := helper.RandString(6)
 			appName := helper.RandString(6)
 
-			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2)
+			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2).ShouldPass()
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
 
 			By("checking that second component correctly shows as 'NotPushed'")
-			output = helper.CmdShouldPass("odo", "list", "--context", context2)
+			output = helper.Cmd("odo", "list", "--context", context2).ShouldPass().Out()
 			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", appName, cmpName2, commonVar.Project, "nodejs"))))
 
-			output2 := helper.CmdShouldPass("odo", "push", "--context", context2)
+			output2 := helper.Cmd("odo", "push", "--context", context2).ShouldPass().Out()
 			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
 
 			By("checking listing components in the current application in 'Pushed' state")
-			output = helper.CmdShouldPass("odo", "list", "--project", commonVar.Project)
+			output = helper.Cmd("odo", "list", "--project", commonVar.Project).ShouldPass().Out()
 			// this test makes sure that a devfile component doesn't show up as an s2i component as well
 			Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
 			Devfile Components:
@@ -67,7 +67,7 @@ var _ = Describe("odo list with devfile", func() {
 			`, cmpName, commonVar.Project))))
 
 			By("checking that it shows components in all applications")
-			output = helper.CmdShouldPass("odo", "list", "--all-apps", "--project", commonVar.Project)
+			output = helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
 			Expect(output).To(ContainSubstring(cmpName))
 			Expect(output).To(ContainSubstring(cmpName2))
 

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -1,0 +1,79 @@
+package devfile
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/openshift/odo/tests/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo list with devfile", func() {
+	var cmpName string
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		commonVar = helper.CommonBeforeEach()
+		cmpName = helper.RandString(6)
+		helper.Chdir(commonVar.Context)
+	})
+
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("two components in different applications", func() {
+		It("should correctly output component information", func() {
+
+			// component created in "app" application
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+			By("checking that component correctly shows as 'NotPushed'")
+			output := helper.CmdShouldPass("odo", "list")
+			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
+
+			output = helper.CmdShouldPass("odo", "push")
+			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+			// component created in different application
+			context2 := helper.CreateNewContext()
+			cmpName2 := helper.RandString(6)
+			appName := helper.RandString(6)
+
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2)
+			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+
+			By("checking that second component correctly shows as 'NotPushed'")
+			output = helper.CmdShouldPass("odo", "list", "--context", context2)
+			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", appName, cmpName2, commonVar.Project, "nodejs"))))
+
+			output2 := helper.CmdShouldPass("odo", "push", "--context", context2)
+			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
+
+			By("checking listing components in the current application in 'Pushed' state")
+			output = helper.CmdShouldPass("odo", "list", "--project", commonVar.Project)
+			// this test makes sure that a devfile component doesn't show up as an s2i component as well
+			Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
+			Devfile Components:
+			APP        NAME       PROJECT        TYPE       STATE
+			app        %[1]s     %[2]s           nodejs     Pushed
+			`, cmpName, commonVar.Project))))
+
+			By("checking that it shows components in all applications")
+			output = helper.CmdShouldPass("odo", "list", "--all-apps", "--project", commonVar.Project)
+			Expect(output).To(ContainSubstring(cmpName))
+			Expect(output).To(ContainSubstring(cmpName2))
+
+			helper.DeleteDir(context2)
+		})
+
+	})
+
+})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -800,13 +800,13 @@ var _ = Describe("odo devfile push command tests", func() {
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
 
-				_, output := helper.CmdShouldPassIncludeErrStream("odo", "push")
+				_, output := helper.Cmd("odo", "push").ShouldFail().OutAndErr()
 				helper.MatchAllInOutput(output, []string{
 					"exited with error status within 1 sec",
 					"Did you mean one of these?",
 				})
 
-				_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "-f", "--run-command", "run")
+				_, output = helper.Cmd("odo", "push", "-f", "--run-command", "run").ShouldFail().OutAndErr()
 				helper.MatchAllInOutput(output, []string{
 					"exited with error status within 1 sec",
 					"Did you mean one of these?",

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -795,18 +795,18 @@ var _ = Describe("odo devfile push command tests", func() {
 
 		When("the run command throws an error", func() {
 			It("should wait and error out with some log", func() {
-				helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project)
+				helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project).ShouldPass()
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
 
-				_, output := helper.Cmd("odo", "push").ShouldFail().OutAndErr()
+				_, output := helper.Cmd("odo", "push").ShouldPass().OutAndErr()
 				helper.MatchAllInOutput(output, []string{
 					"exited with error status within 1 sec",
 					"Did you mean one of these?",
 				})
 
-				_, output = helper.Cmd("odo", "push", "-f", "--run-command", "run").ShouldFail().OutAndErr()
+				_, output = helper.Cmd("odo", "push", "-f", "--run-command", "run").ShouldPass().OutAndErr()
 				helper.MatchAllInOutput(output, []string{
 					"exited with error status within 1 sec",
 					"Did you mean one of these?",

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -119,10 +119,10 @@ var _ = Describe("odo devfile push command tests", func() {
 
 				output := helper.CmdShouldPass("odo", "push")
 				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-				routeURL := helper.DetermineRouteURL(commonVar.Context)
 
-				// Ping said URL
-				helper.HttpWaitFor(routeURL, "Hello from Node.js", 10, 5)
+				envVars := commonVar.CliRunner.GetEnvsDevFileDeployment(cmpName, "app", commonVar.Project)
+				// check if the env variable has a correct value. This value was substituted from in devfile from variable
+				Expect(envVars["FOO"]).To(Equal("bar"))
 
 			})
 		})

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -110,6 +110,23 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
 		})
 
+		When("Devfile 2.1.0 is used", func() {
+			It("should work with devfile variables", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-variables.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push")
+				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+				routeURL := helper.DetermineRouteURL(commonVar.Context)
+
+				// Ping said URL
+				helper.HttpWaitFor(routeURL, "Hello from Node.js", 10, 5)
+
+			})
+		})
+
 		It("checks that odo push works with a devfile with sourcemapping set", func() {
 			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
 

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -2,11 +2,9 @@ package devfile
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/openshift/odo/pkg/util"
@@ -34,53 +32,7 @@ var _ = Describe("odo devfile push command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	Context("Pushing devfile without an .odo folder", func() {
-
-		It("should be able to push based on metadata.name in devfile WITH a dash in the name", func() {
-			// This is the name that's contained within `devfile-with-metadataname-foobar.yaml`
-			name := "foobar"
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile-with-metadataname-foobar.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Executing devfile commands for component " + name))
-		})
-
-		It("should be able to push based on name passed", func() {
-			name := "springboot"
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project, name).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Executing devfile commands for component " + name))
-		})
-
-		It("should error out on devfile flag", func() {
-			helper.Cmd("odo", "push", "--project", commonVar.Project, "--devfile", "invalid.yaml").ShouldFail()
-		})
-
-	})
-
-	Context("Verify devfile push works", func() {
-
-		It("should have no errors when no endpoints within the devfile, should create a service when devfile has endpoints", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-no-endpoints.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
-			output := commonVar.CliRunner.GetServices(commonVar.Project)
-			Expect(output).NotTo(ContainSubstring(cmpName))
-
-			helper.RenameFile("devfile-old.yaml", "devfile.yaml")
-			output = helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-			output = commonVar.CliRunner.GetServices(commonVar.Project)
-			Expect(output).To(ContainSubstring(cmpName))
-		})
+	Context("verify devfile push works", func() {
 
 		It("checks that odo push works with a devfile", func() {
 			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
@@ -110,8 +62,59 @@ var _ = Describe("odo devfile push command tests", func() {
 			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
 		})
 
+		When("JSON output is requested", func() {
+			It("should display output in JSON format", func() {
+
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push", "-o", "json", "--project", commonVar.Project)
+				utils.AnalyzePushConsoleOutput(output)
+
+				// update devfile and push again
+				helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
+				output = helper.CmdShouldPass("odo", "push", "-o", "json", "--project", commonVar.Project)
+				utils.AnalyzePushConsoleOutput(output)
+
+			})
+		})
+
+		When("pushing devfile without an .odo folder", func() {
+
+			It("should be able to push based on name passed", func() {
+				helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "springboot")
+				Expect(output).To(ContainSubstring("Executing devfile commands for component springboot"))
+			})
+
+			It("should error out on devfile flag", func() {
+				helper.CmdShouldFail("odo", "push", "--project", commonVar.Project, "--devfile", "invalid.yaml")
+			})
+
+		})
+
+		When("not in context directory", func() {
+			It("should push correct component based on --context flag", func() {
+				newContext := helper.CreateNewContext()
+				defer helper.DeleteDir(newContext)
+				helper.Chdir(newContext)
+
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), newContext)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(newContext, "devfile.yaml"))
+
+				helper.Chdir(commonVar.Context)
+				output := helper.CmdShouldPass("odo", "push", "--context", newContext)
+				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+			})
+		})
+
 		When("Devfile 2.1.0 is used", func() {
-			It("should work with devfile variables", func() {
+			It("devfile variables should work", func() {
 				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
@@ -126,467 +129,253 @@ var _ = Describe("odo devfile push command tests", func() {
 
 			})
 		})
+	})
 
-		It("checks that odo push works with a devfile with sourcemapping set", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileSourceMapping.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// Verify source code was synced to /test instead of /projects
-			var statErr error
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"runtime",
-				commonVar.Project,
-				[]string{"stat", "/test/server.js"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-		})
-
-		It("checks that odo push works with a devfile with composite commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Executing mkdir command"))
-
-			// Verify the command executed successfully
-			var statErr error
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"runtime",
-				commonVar.Project,
-				[]string{"stat", "/projects/testfolder"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-		})
-
-		It("checks that odo push works with a devfile with parallel composite commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommandsParallel.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--build-command", "buildandmkdir").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Executing mkdir command"))
-
-			// Verify the command executed successfully
-			var statErr error
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"runtime",
-				commonVar.Project,
-				[]string{"stat", "/projects/testfolder"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-		})
-
-		It("checks that odo push works with a devfile with nested composite commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// Verify nested command was executed
-			output := helper.Cmd("odo", "push").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Executing mkdir command"))
-
-			// Verify the command executed successfully
-			var statErr error
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"runtime",
-				commonVar.Project,
-				[]string{"stat", "/projects/testfolder"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-		})
-
-		It("should throw a validation error for composite run commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// Verify odo push failed
-			output := helper.Cmd("odo", "push").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("not supported currently"))
-		})
-
-		It("should throw a validation error for composite command referencing non-existent commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeNonExistent.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// Verify odo push failed
-			output := helper.Cmd("odo", "push").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("does not exist in the devfile"))
-		})
-
-		It("should throw a validation error for composite command indirectly referencing itself", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileIndirectNesting.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// Verify odo push failed
-			output := helper.Cmd("odo", "push").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("cannot indirectly reference itself"))
-		})
-
-		It("should throw a validation error for composite command that has invalid exec subcommand", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeInvalidComponent.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// Verify odo push failed
-			output := helper.Cmd("odo", "push").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("command does not map to a container component"))
-		})
-
-		It("checks that odo push works outside of the context directory", func() {
-			newContext := helper.CreateNewContext()
-			defer helper.DeleteDir(newContext)
-			helper.Chdir(newContext)
-
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), newContext)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(newContext, "devfile.yaml"))
-
-			helper.Chdir(commonVar.Context)
-			output := helper.Cmd("odo", "push", "--context", newContext).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-		})
+	Context("verify files are correctly synced", func() {
 
 		It("should not build when no changes are detected in the directory and build when a file change is detected", func() {
 			utils.ExecPushToTestFileChanges(commonVar.Context, cmpName, commonVar.Project)
 		})
 
-		It("checks that odo push with -o json displays machine readable JSON event output", func() {
+		When("local files are created and deleted ", func() {
+			It("should correctly propagate changes to the container", func() {
+				newFilePath := filepath.Join(commonVar.Context, "foobar.txt")
+				newDirPath := filepath.Join(commonVar.Context, "testdir")
+				utils.ExecPushWithNewFileAndDir(commonVar.Context, cmpName, commonVar.Project, newFilePath, newDirPath)
 
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
+				// Check to see if it's been pushed (foobar.txt abd directory testdir)
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				stdOut := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+				helper.MatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
 
-			output := helper.Cmd("odo", "push", "-o", "json", "--project", commonVar.Project).ShouldPass().Out()
-			utils.AnalyzePushConsoleOutput(output)
+				// Now we delete the file and dir and push
+				helper.DeleteDir(newFilePath)
+				helper.DeleteDir(newDirPath)
+				helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-v4")
 
-			// update devfile and push again
-			helper.ReplaceString("devfile.yaml", "name: FOO", "name: BAR")
-			output = helper.Cmd("odo", "push", "-o", "json", "--project", commonVar.Project).ShouldPass().Out()
-			utils.AnalyzePushConsoleOutput(output)
-
+				// Then check to see if it's truly been deleted
+				stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+				helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
+			})
 		})
 
-		It("should be able to create a file, push, delete, then push again propagating the deletions", func() {
-			newFilePath := filepath.Join(commonVar.Context, "foobar.txt")
-			newDirPath := filepath.Join(commonVar.Context, "testdir")
-			utils.ExecPushWithNewFileAndDir(commonVar.Context, cmpName, commonVar.Project, newFilePath, newDirPath)
+		When("devfile is modified", func() {
+			// Tests https://github.com/openshift/odo/issues/3838
+			ensureFilesSyncedTest := func(namespace string, shouldForcePush bool) {
+				helper.CmdShouldPass("odo", "create", "java-springboot", "--project", commonVar.Project, cmpName)
+				helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
 
-			// Check to see if it's been pushed (foobar.txt abd directory testdir)
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				fmt.Fprintf(GinkgoWriter, "Testing with force push %v", shouldForcePush)
 
-			stdOut := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.MatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
+				// 1) Push a standard spring boot project
+				output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
+				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-			// Now we delete the file and dir and push
-			helper.DeleteDir(newFilePath)
-			helper.DeleteDir(newDirPath)
-			helper.Cmd("odo", "push", "--project", commonVar.Project, "-v4").ShouldPass()
+				// 2) Update the devfile.yaml, causing push to redeploy the component
+				helper.ReplaceString("devfile.yaml", "memoryLimit: 768Mi", "memoryLimit: 769Mi")
+				commands := []string{"push", "-v", "4", "--project", commonVar.Project}
+				if shouldForcePush {
+					// Test both w/ and w/o '-f'
+					commands = append(commands, "-f")
+				}
 
-			// Then check to see if it's truly been deleted
-			stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.DontMatchAllInOutput(stdOut, []string{"foobar.txt", "testdir"})
+				// 3) Ensure the build passes, indicating that all files were correctly synced to the new pod
+				output = helper.CmdShouldPass("odo", commands...)
+				Expect(output).To(ContainSubstring("BUILD SUCCESS"))
+
+				// 4) Acquire files from remote container, filtering out target/* and .*
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, namespace)
+				output = commonVar.CliRunner.Exec(podName, namespace, "find", sourcePath)
+				remoteFiles := []string{}
+				outputArr := strings.Split(output, "\n")
+				for _, line := range outputArr {
+
+					if !strings.HasPrefix(line, sourcePath+"/") || strings.Contains(line, "lost+found") {
+						continue
+					}
+
+					newLine, err := filepath.Rel(sourcePath, line)
+					Expect(err).ToNot(HaveOccurred())
+
+					newLine = filepath.ToSlash(newLine)
+					if strings.HasPrefix(newLine, "target/") || newLine == "target" || strings.HasPrefix(newLine, ".") {
+						continue
+					}
+
+					remoteFiles = append(remoteFiles, newLine)
+				}
+
+				// 5) Acquire file from local context, filtering out .*
+				localFiles := []string{}
+				err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+
+					newPath := filepath.ToSlash(path)
+
+					if strings.HasPrefix(newPath, ".") {
+						return nil
+					}
+
+					localFiles = append(localFiles, newPath)
+					return nil
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				// 6) Sort and compare the local and remote files; they should match
+				sort.Strings(localFiles)
+				sort.Strings(remoteFiles)
+				Expect(localFiles).To(Equal(remoteFiles))
+			}
+
+			When("odo push -f is executed", func() {
+
+				It("should correctly sync files after pod redeploy", func() {
+					ensureFilesSyncedTest(commonVar.Project, true)
+				})
+			})
+			When("odo push (without -f) is executed", func() {
+
+				It("should correctly sync files after pod redeploy", func() {
+					ensureFilesSyncedTest(commonVar.Project, false)
+				})
+			})
 		})
 
-		It("should delete the files from the container if its removed locally", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
+		When("run command has dev.odo.push.path attribute", func() {
+			It("should push only the mentioned files at the appropriate remote destination", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-remote-attributes.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
+				// create a folder and file which shouldn't be pushed
+				helper.MakeDir(filepath.Join(commonVar.Context, "views"))
+				_, _ = helper.CreateSimpleFile(filepath.Join(commonVar.Context, "views"), "view", ".html")
 
-			// Check to see if it's been pushed (foobar.txt abd directory testdir)
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				helper.ReplaceString("package.json", "node server.js", "node server/server.js")
+				helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
 
-			var statErr error
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"",
-				commonVar.Project,
-				[]string{"stat", "/projects/server.js"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-			Expect(os.Remove(filepath.Join(commonVar.Context, "server.js"))).NotTo(HaveOccurred())
-			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				stdOut := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+				helper.MatchAllInOutput(stdOut, []string{"package.json", "server"})
+				helper.DontMatchAllInOutput(stdOut, []string{"test", "views", "devfile.yaml"})
 
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"",
-				commonVar.Project,
-				[]string{"stat", "/projects/server.js"},
-				func(cmdOp string, err error) bool {
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).To(HaveOccurred())
-			Expect(statErr.Error()).To(ContainSubstring("cannot stat '/projects/server.js': No such file or directory"))
+				stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath+"/server")
+				helper.MatchAllInOutput(stdOut, []string{"server.js", "test"})
+
+				stdOut = helper.CmdShouldPass("odo", "push", "--context", commonVar.Context)
+				Expect(stdOut).To(ContainSubstring("No file changes detected"))
+			})
 		})
 
-		It("should build when no changes are detected in the directory and force flag is enabled", func() {
-			utils.ExecPushWithForceFlag(commonVar.Context, cmpName, commonVar.Project)
-		})
+		When("devfile has sourcemappings", func() {
+			It("should sync files to the correct location", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 
-		It("should execute the default build and run command groups if present", func() {
-			utils.ExecDefaultDevfileCommands(commonVar.Context, cmpName, commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileSourceMapping.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			// Check to see if it's been pushed (foobar.txt abd directory testdir)
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
+				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
 
-			var statErr error
-			var cmdOutput string
-			commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-				podName,
-				"runtime",
-				commonVar.Project,
-				[]string{"ps", "-ef"},
-				func(cmdOp string, err error) bool {
-					cmdOutput = cmdOp
-					statErr = err
-					return err == nil
-				},
-			)
-			Expect(statErr).ToNot(HaveOccurred())
-			Expect(cmdOutput).To(ContainSubstring("spring-boot:run"))
-		})
-
-		It("should execute PreStart commands if present during pod startup", func() {
-			// expectedInitContainers := []string{"tools-myprestart-1", "tools-myprestart-2", "runtime-secondprestart-3"}
-
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-preStart.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			// This is expected to fail for now.
-			// see https://github.com/openshift/odo/issues/4187 for more info
-			helper.MatchAllInOutput(output, []string{"myprestart should either map to an apply command or a composite command with apply commands\n"})
-
-			/*
-				helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
-
-				firstPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-
-				firstPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
-				// 3 preStart events + 1 supervisord init containers
-				Expect(len(firstPushInitContainers)).To(Equal(4))
-				helper.MatchAllInOutput(strings.Join(firstPushInitContainers, ","), expectedInitContainers)
-
-				// Need to force so build and run get triggered again with the component already created.
-				output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-f")
-				helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
-
-				secondPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-
-				secondPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
-				// 3 preStart events + 1 supervisord init containers
-				Expect(len(secondPushInitContainers)).To(Equal(4))
-				helper.MatchAllInOutput(strings.Join(secondPushInitContainers, ","), expectedInitContainers)
-
-				Expect(firstPushPodName).To(Equal(secondPushPodName))
-				Expect(firstPushInitContainers).To(Equal(secondPushInitContainers))
-
+				// Verify source code was synced to /test instead of /projects
 				var statErr error
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
 				commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
-					firstPushPodName,
+					podName,
 					"runtime",
 					commonVar.Project,
-					[]string{"cat", "/projects/test.txt"},
+					[]string{"stat", "/test/server.js"},
 					func(cmdOp string, err error) bool {
-						if err != nil {
-							statErr = err
-						} else if cmdOp == "" {
-							statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got empty string")
-						} else {
-							fileContents := strings.Split(cmdOp, "\n")
-							if len(fileContents)-1 != 3 {
-								statErr = fmt.Errorf("prestart event action count error, expected: 3 strings, got %d strings: %s", len(fileContents), strings.Join(fileContents, ","))
-							} else if cmdOp != "hello test2\nhello test2\nhello test\n" {
-								statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got: %s", cmdOp)
-							}
-						}
-
-						return true
+						statErr = err
+						return err == nil
 					},
 				)
 				Expect(statErr).ToNot(HaveOccurred())
-			*/
-		})
-
-		It("should execute PostStart commands if present and not execute when component already exists", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})
-
-			// Need to force so build and run get triggered again with the component already created.
-			output = helper.Cmd("odo", "push", "--project", commonVar.Project, "-f").ShouldPass().Out()
-			helper.DontMatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})
-			helper.MatchAllInOutput(output, []string{
-				"Executing devbuild command",
-				"Executing devrun command",
 			})
 		})
 
-		It("should err out on an event not mentioned in the devfile commands", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
+		When("project and clonePath is present", func() {
+			It("should sync to the correct dir in container", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-invalid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				// devfile with clonePath set in project field
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			helper.MatchAllInOutput(output, []string{"does not map to a valid devfile command"})
-		})
+				helper.CmdShouldPass("odo", "push", "--v", "5")
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				// source code is synced to $PROJECTS_ROOT/clonePath
+				// $PROJECTS_ROOT is /projects by default, if sourceMapping is set it is same as sourceMapping
+				// for devfile-with-projects.yaml, sourceMapping is apps and clonePath is webapp
+				// so source code would be synced to /apps/webapp
+				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/apps/webapp")
+				helper.MatchAllInOutput(output, []string{"package.json"})
 
-		It("should err out on an event command not mapping to a devfile container component", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.ReplaceString("devfile.yaml", "runtime #wrongruntime", "wrongruntime")
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			helper.MatchAllInOutput(output, []string{"does not map to a container component"})
-		})
-
-		It("should err out on an event composite command mentioning an invalid child command", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.ReplaceString("devfile.yaml", "secondprestop #secondprestopiswrong", "secondprestopiswrong")
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			helper.MatchAllInOutput(output, []string{"does not exist in the devfile"})
-		})
-
-		It("should be able to handle a missing build command group", func() {
-			utils.ExecWithMissingBuildCommand(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should error out on a missing run command group", func() {
-			utils.ExecWithMissingRunCommand(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should be able to push using the custom commands", func() {
-			utils.ExecWithCustomCommand(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should error out on a wrong custom commands", func() {
-			utils.ExecWithWrongCustomCommand(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should error out on multiple or no default commands", func() {
-			utils.ExecWithMultipleOrNoDefaults(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should execute commands with flags if the command has no group kind", func() {
-			utils.ExecCommandWithoutGroupUsingFlags(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should error out if the devfile has an invalid command group", func() {
-			utils.ExecWithInvalidCommandGroup(commonVar.Context, cmpName, commonVar.Project)
-		})
-
-		It("should restart the application if it is not hot reload capable", func() {
-			utils.ExecWithHotReload(commonVar.Context, cmpName, commonVar.Project, false)
-		})
-
-		It("should not restart the application if it is hot reload capable", func() {
-			utils.ExecWithHotReload(commonVar.Context, cmpName, commonVar.Project, true)
-		})
-
-		It("should restart the application if run mode is changed, regardless of hotReloadCapable value", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-hotReload.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
-
-			stdOut := helper.Cmd("odo", "push", "--debug", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(stdOut).To(Not(ContainSubstring("No file changes detected, skipping build")))
-
-			logs := helper.Cmd("odo", "log").ShouldPass().Out()
-
-			helper.MatchAllInOutput(logs, []string{
-				"\"stop the program\" program=debugrun",
-				"\"stop the program\" program=devrun",
+				// Verify the sync env variables are correct
+				utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/apps/webapp", "/apps", commonVar.CliRunner)
 			})
-
 		})
 
-		It("should run odo push successfully after odo push --debug", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
+		When("devfile project field is present", func() {
+			It("should sync to the correct dir in container", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				// reset clonePath and change the workdir accordingly, it should sync to project name
+				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "clonePath: webapp/", "# clonePath: webapp/")
 
-			output := helper.Cmd("odo", "push", "--debug", "--project", commonVar.Project).ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{
-				"Executing devbuild command",
-				"Executing debugrun command",
+				helper.CmdShouldPass("odo", "push")
+
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/apps/nodeshift")
+				helper.MatchAllInOutput(output, []string{"package.json"})
+
+				// Verify the sync env variables are correct
+				utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/apps/nodeshift", "/apps", commonVar.CliRunner)
 			})
-
-			output = helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{
-				"Executing devbuild command",
-				"Executing devrun command",
-			})
-
 		})
+
+		When("multiple project is present", func() {
+			It("should sync to the correct dir in container", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CmdShouldPass("odo", "push")
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				// for devfile-with-multiple-projects.yaml source mapping is not set so $PROJECTS_ROOT is /projects
+				// multiple projects, so source code would sync to the first project /projects/webapp
+				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects/webapp")
+				helper.MatchAllInOutput(output, []string{"package.json"})
+
+				// Verify the sync env variables are correct
+				utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/projects/webapp", "/projects", commonVar.CliRunner)
+			})
+		})
+
+		When("no project is present", func() {
+			It("should sync to the correct dir in container", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CmdShouldPass("odo", "push")
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
+				helper.MatchAllInOutput(output, []string{"package.json"})
+
+				// Verify the sync env variables are correct
+				utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/projects", "/projects", commonVar.CliRunner)
+			})
+		})
+	})
+
+	Context("verify devfile volume components work", func() {
 
 		It("should create pvc and reuse if it shares the same devfile volume name", func() {
 			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
@@ -650,151 +439,8 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(volumesMatched).To(Equal(true))
 		})
 
-		It("Ensure that push -f correctly removes local deleted files from the remote target sync folder", func() {
-
-			// 1) Push a generic Java project
-			helper.Cmd("odo", "create", "java-springboot", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// 2) Rename the pom.xml, which should cause the build to fail if sync is working as expected
-			err := os.Rename(filepath.Join(commonVar.Context, "pom.xml"), filepath.Join(commonVar.Context, "pom.xml.renamed"))
-			Expect(err).NotTo(HaveOccurred())
-
-			// 3) Ensure that the build fails due to missing 'pom.xml', which ensures that the sync operation
-			// correctly renamed pom.xml to pom.xml.renamed.
-			output = helper.Cmd("odo", "push", "-f", "--project", commonVar.Project).ShouldFail().Err()
-			helper.MatchAllInOutput(output, []string{"no POM in this directory"})
-		})
-
-	})
-
-	Context("Verify files are correctly synced", func() {
-
-		// Tests https://github.com/openshift/odo/issues/3838
-		ensureFilesSyncedTest := func(namespace string, shouldForcePush bool) {
-			helper.Cmd("odo", "create", "java-springboot", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-
-			fmt.Fprintf(GinkgoWriter, "Testing with force push %v", shouldForcePush)
-
-			// 1) Push a standard spring boot project
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// 2) Update the devfile.yaml, causing push to redeploy the component
-			helper.ReplaceString("devfile.yaml", "memoryLimit: 768Mi", "memoryLimit: 769Mi")
-			commands := []string{"push", "-v", "4", "--project", commonVar.Project}
-			if shouldForcePush {
-				// Test both w/ and w/o '-f'
-				commands = append(commands, "-f")
-			}
-
-			// 3) Ensure the build passes, indicating that all files were correctly synced to the new pod
-			output = helper.Cmd("odo", commands...).ShouldPass().Out()
-			Expect(output).To(ContainSubstring("BUILD SUCCESS"))
-
-			// 4) Acquire files from remote container, filtering out target/* and .*
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, namespace)
-			output = commonVar.CliRunner.Exec(podName, namespace, "find", sourcePath)
-			remoteFiles := []string{}
-			outputArr := strings.Split(output, "\n")
-			for _, line := range outputArr {
-
-				if !strings.HasPrefix(line, sourcePath+"/") || strings.Contains(line, "lost+found") {
-					continue
-				}
-
-				newLine, err := filepath.Rel(sourcePath, line)
-				Expect(err).ToNot(HaveOccurred())
-
-				newLine = filepath.ToSlash(newLine)
-				if strings.HasPrefix(newLine, "target/") || newLine == "target" || strings.HasPrefix(newLine, ".") {
-					continue
-				}
-
-				remoteFiles = append(remoteFiles, newLine)
-			}
-
-			// 5) Acquire file from local context, filtering out .*
-			localFiles := []string{}
-			err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				newPath := filepath.ToSlash(path)
-
-				if strings.HasPrefix(newPath, ".") {
-					return nil
-				}
-
-				localFiles = append(localFiles, newPath)
-				return nil
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			// 6) Sort and compare the local and remote files; they should match
-			sort.Strings(localFiles)
-			sort.Strings(remoteFiles)
-			Expect(localFiles).To(Equal(remoteFiles))
-		}
-
-		It("Should ensure that files are correctly synced on pod redeploy, with force push specified", func() {
-			ensureFilesSyncedTest(commonVar.Project, true)
-		})
-
-		It("Should ensure that files are correctly synced on pod redeploy, without force push specified", func() {
-			ensureFilesSyncedTest(commonVar.Project, false)
-		})
-
-	})
-
-	Context("Verify devfile volume components work", func() {
-
-		It("should error out when duplicate volume components exist", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.ReplaceString("devfile.yaml", "secondvol", "firstvol")
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			Expect(output).To(ContainSubstring("duplicate key: firstvol"))
-		})
-
-		It("should error out when a wrong volume size is used", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.ReplaceString("devfile.yaml", "3Gi", "3Garbage")
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			Expect(output).To(ContainSubstring("quantities must match the regular expression"))
-		})
-
-		It("should error out if a container component has volume mount that does not refer a valid volume component", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-invalid-volmount.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldFail().Err()
-			helper.MatchAllInOutput(output, []string{"unable to find the following volume mounts", "invalidvol1", "invalidvol2"})
-		})
-
 		It("should successfully use the volume components in container components", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
+			helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.RenameFile("devfile.yaml", "devfile-old.yaml")
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-volume-components.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
@@ -813,398 +459,446 @@ var _ = Describe("odo devfile push command tests", func() {
 			Expect(storageSize).To(ContainSubstring("3Gi"))
 		})
 
-		It("should throw a validation error for v1 devfiles", func() {
-			helper.Cmd("odo", "create", "java-springboot", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.ReplaceString("devfile.yaml", "schemaVersion: 2.0.0", "apiVersion: 1.0.0")
-
-			// Verify odo push failed
-			output := helper.Cmd("odo", "push").ShouldFail().Err()
-			Expect(output).To(ContainSubstring("schemaVersion not present in devfile"))
-		})
-
 	})
 
-	Context("when .gitignore file exists", func() {
-		It("checks that .odo/env exists in gitignore", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
+	Context("verify command executions", func() {
+
+		When("odo push --debug is executed", func() {
+			It("should execute debug commands", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-debugrun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
+				helper.MatchAllInOutput(output, []string{
+					"Executing devbuild command",
+					"Executing debugrun command",
+				})
+
+				output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
+				helper.MatchAllInOutput(output, []string{
+					"Executing devbuild command",
+					"Executing devrun command",
+				})
 
-			ignoreFilePath := filepath.Join(commonVar.Context, ".gitignore")
-
-			helper.FileShouldContainSubstring(ignoreFilePath, filepath.Join(".odo", "env"))
-
-		})
-	})
-
-	Context("exec commands with environment variables", func() {
-		It("Should be able to exec command with single environment variable", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.Cmd("odo", "push", "--build-command", "buildwithenv", "--run-command", "singleenv").ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{"mkdir $ENV1", "mkdir $BUILD_ENV1"})
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.MatchAllInOutput(output, []string{"test_env_variable", "test_build_env_variable"})
-
-		})
-
-		It("Should be able to exec command with multiple environment variables", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.Cmd("odo", "push", "--build-command", "buildwithmultipleenv", "--run-command", "multipleenv").ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{"mkdir $ENV1 $ENV2", "mkdir $BUILD_ENV1 $BUILD_ENV2"})
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.MatchAllInOutput(output, []string{"test_build_env_variable1", "test_build_env_variable2", "test_env_variable1", "test_env_variable2"})
-
-		})
-
-		It("Should be able to exec command with environment variable with spaces", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.Cmd("odo", "push", "--build-command", "buildenvwithspace", "--run-command", "envwithspace").ShouldPass().Out()
-			helper.MatchAllInOutput(output, []string{"mkdir \\\"$ENV1\\\"", "mkdir \\\"$BUILD_ENV1\\\""})
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.MatchAllInOutput(output, []string{"build env variable with space", "env with space"})
-
-		})
-	})
-
-	Context("Verify source code sync location", func() {
-
-		It("Should sync to the correct dir in container if project and clonePath is present", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-
-			// devfile with clonePath set in project field
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			helper.Cmd("odo", "push", "--v", "5").ShouldPass()
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			// source code is synced to $PROJECTS_ROOT/clonePath
-			// $PROJECTS_ROOT is /projects by default, if sourceMapping is set it is same as sourceMapping
-			// for devfile-with-projects.yaml, sourceMapping is apps and clonePath is webapp
-			// so source code would be synced to /apps/webapp
-			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/apps/webapp")
-			helper.MatchAllInOutput(output, []string{"package.json"})
-
-			// Verify the sync env variables are correct
-			utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/apps/webapp", "/apps", commonVar.CliRunner)
-		})
-
-		It("Should sync to the correct dir in container if project present", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// reset clonePath and change the workdir accordingly, it should sync to project name
-			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "clonePath: webapp/", "# clonePath: webapp/")
-
-			helper.Cmd("odo", "push").ShouldPass()
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/apps/nodeshift")
-			helper.MatchAllInOutput(output, []string{"package.json"})
-
-			// Verify the sync env variables are correct
-			utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/apps/nodeshift", "/apps", commonVar.CliRunner)
-		})
-
-		It("Should sync to the correct dir in container if multiple project is present", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-multiple-projects.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "push").ShouldPass()
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			// for devfile-with-multiple-projects.yaml source mapping is not set so $PROJECTS_ROOT is /projects
-			// multiple projects, so source code would sync to the first project /projects/webapp
-			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects/webapp")
-			helper.MatchAllInOutput(output, []string{"package.json"})
-
-			// Verify the sync env variables are correct
-			utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/projects/webapp", "/projects", commonVar.CliRunner)
-		})
-
-		It("Should sync to the correct dir in container if no project is present", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "push").ShouldPass()
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			output := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
-			helper.MatchAllInOutput(output, []string{"package.json"})
-
-			// Verify the sync env variables are correct
-			utils.VerifyContainerSyncEnv(podName, "runtime", commonVar.Project, "/projects", "/projects", commonVar.CliRunner)
-		})
-
-	})
-
-	Context("push with listing the devfile component", func() {
-		It("checks components in a specific app and all apps", func() {
-
-			// component created in "app" application
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			output := helper.Cmd("odo", "list").ShouldPass().Out()
-			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
-
-			output = helper.Cmd("odo", "push").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// component created in different application
-			context2 := helper.CreateNewContext()
-			cmpName2 := helper.RandString(6)
-			appName := helper.RandString(6)
-
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
-
-			output = helper.Cmd("odo", "list", "--context", context2).ShouldPass().Out()
-			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", appName, cmpName2, commonVar.Project, "nodejs"))))
-			output2 := helper.Cmd("odo", "push", "--context", context2).ShouldPass().Out()
-			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
-
-			output = helper.Cmd("odo", "list", "--project", commonVar.Project).ShouldPass().Out()
-			// this test makes sure that a devfile component doesn't show up as an s2i component as well
-			Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
-			Devfile Components:
-			APP        NAME       PROJECT        TYPE       STATE
-			app        %[1]s     %[2]s           nodejs     Pushed
-			`, cmpName, commonVar.Project))))
-
-			output = helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
-
-			Expect(output).To(ContainSubstring(cmpName))
-			Expect(output).To(ContainSubstring(cmpName2))
-
-			helper.DeleteDir(context2)
-
-		})
-
-		It("checks devfile and s2i components together", func() {
-			if os.Getenv("KUBERNETES") == "true" {
-				Skip("Skipping test because s2i image is not supported on Kubernetes cluster")
-			}
-
-			// component created in "app" application
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			output := helper.Cmd("odo", "list").ShouldPass().Out()
-			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
-
-			output = helper.Cmd("odo", "push").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// component created in different application
-			context2 := helper.CreateNewContext()
-			cmpName2 := helper.RandString(6)
-			appName := helper.RandString(6)
-			helper.CopyExample(filepath.Join("source", "nodejs"), context2)
-			helper.Cmd("odo", "create", "--s2i", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2).ShouldPass()
-
-			output2 := helper.Cmd("odo", "push", "--context", context2).ShouldPass().Out()
-			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
-
-			output = helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
-
-			Expect(output).To(ContainSubstring(cmpName))
-			Expect(output).To(ContainSubstring(cmpName2))
-
-			output = helper.Cmd("odo", "list", "--app", appName, "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(Not(ContainSubstring(cmpName))) // cmpName component hasn't been created under appName
-			Expect(output).To(ContainSubstring(cmpName2))
-
-			helper.DeleteDir(context2)
-		})
-
-	})
-
-	Context("Handle devfiles with parent", func() {
-		var server *http.Server
-		var freePort int
-		var parentTmpFolder string
-
-		var _ = BeforeEach(func() {
-			// get a free port
-			var err error
-			freePort, err = util.HTTPGetFreePort()
-			Expect(err).NotTo(HaveOccurred())
-
-			// move the parent devfiles to a tmp folder
-			parentTmpFolder = helper.CreateNewContext()
-			helper.CopyExample(filepath.Join("source", "devfiles", "parentSupport"), parentTmpFolder)
-			// update the port in the required devfile with the free port
-			helper.ReplaceString(filepath.Join(parentTmpFolder, "devfile-middle-layer.yaml"), "(-1)", strconv.Itoa(freePort))
-
-			// start the server and serve from the tmp folder of the devfiles
-			server = helper.HttpFileServer(freePort, parentTmpFolder)
-
-			// wait for the server to be respond with the desired result
-			helper.HttpWaitFor("http://localhost:"+strconv.Itoa(freePort), "devfile", 10, 1)
-		})
-
-		var _ = AfterEach(func() {
-			helper.DeleteDir(parentTmpFolder)
-			err := server.Close()
-			Expect(err).To(BeNil())
-		})
-
-		It("should handle a devfile with a parent and add a extra command", func() {
-			utils.ExecPushToTestParent(commonVar.Context, cmpName, commonVar.Project)
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			listDir := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/project/")
-			Expect(listDir).To(ContainSubstring("blah.js"))
-		})
-
-		It("should handle a devfile with a parent and override a composite command", func() {
-			utils.ExecPushWithCompositeOverride(commonVar.Context, cmpName, commonVar.Project, freePort)
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			listDir := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/projects")
-			Expect(listDir).To(ContainSubstring("testfile"))
-		})
-
-		It("should handle a parent and override/append it's envs", func() {
-			utils.ExecPushWithParentOverride(commonVar.Context, cmpName, "app", commonVar.Project, freePort)
-
-			envMap := commonVar.CliRunner.GetEnvsDevFileDeployment(cmpName, "app", commonVar.Project)
-
-			value, ok := envMap["ODO_TEST_ENV_0"]
-			Expect(ok).To(BeTrue())
-			Expect(value).To(Equal("ENV_VALUE_0"))
-
-			value, ok = envMap["ODO_TEST_ENV_1"]
-			Expect(ok).To(BeTrue())
-			Expect(value).To(Equal("ENV_VALUE_1_1"))
-		})
-
-		It("should handle a multi layer parent", func() {
-			utils.ExecPushWithMultiLayerParent(commonVar.Context, cmpName, "app", commonVar.Project, freePort)
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			listDir := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, "/project")
-			helper.MatchAllInOutput(listDir, []string{"blah.js", "new-blah.js"})
-
-			envMap := commonVar.CliRunner.GetEnvsDevFileDeployment(cmpName, "app", commonVar.Project)
-
-			value, ok := envMap["ODO_TEST_ENV_1"]
-			Expect(ok).To(BeTrue())
-			Expect(value).To(Equal("ENV_VALUE_1_1"))
-
-			value, ok = envMap["ODO_TEST_ENV_2"]
-			Expect(ok).To(BeTrue())
-			Expect(value).To(Equal("ENV_VALUE_2"))
-
-			value, ok = envMap["ODO_TEST_ENV_3"]
-			Expect(ok).To(BeTrue())
-			Expect(value).To(Equal("ENV_VALUE_3"))
-
-		})
-	})
-
-	Context("when the run command throws an error", func() {
-		It("should wait and error out with some log", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
-
-			_, output := helper.Cmd("odo", "push").ShouldPass().OutAndErr()
-			helper.MatchAllInOutput(output, []string{
-				"exited with error status within 1 sec",
-				"Did you mean one of these?",
-			})
-
-			_, output = helper.Cmd("odo", "push", "-f", "--run-command", "run").ShouldPass().OutAndErr()
-			helper.MatchAllInOutput(output, []string{
-				"exited with error status within 1 sec",
-				"Did you mean one of these?",
 			})
 		})
+
+		When("odo push -f is executed", func() {
+			It("should build even when no changes are detected", func() {
+				utils.ExecPushWithForceFlag(commonVar.Context, cmpName, commonVar.Project)
+			})
+		})
+
+		When("default build and run commands are defined", func() {
+			It("should execute correct commands", func() {
+				utils.ExecDefaultDevfileCommands(commonVar.Context, cmpName, commonVar.Project)
+
+				// Check to see if it's been pushed (foobar.txt abd directory testdir)
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+
+				var statErr error
+				var cmdOutput string
+				commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+					podName,
+					"runtime",
+					commonVar.Project,
+					[]string{"ps", "-ef"},
+					func(cmdOp string, err error) bool {
+						cmdOutput = cmdOp
+						statErr = err
+						return err == nil
+					},
+				)
+				Expect(statErr).ToNot(HaveOccurred())
+				Expect(cmdOutput).To(ContainSubstring("spring-boot:run"))
+			})
+		})
+
+		When("run command is not marked as hotReloadCapable", func() {
+			It("should restart the application", func() {
+				// TODO: this is almost the same test as one below
+				helper.CmdShouldPass("odo", "create", "nodejs", cmpName, "--project", commonVar.Project)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push")
+				Expect(output).To(ContainSubstring("Executing devrun command \"npm start\""))
+
+				helper.CmdShouldPass("odo", "push", "-f")
+
+				logs := helper.CmdShouldPass("odo", "log")
+				Expect(logs).To(ContainSubstring("stop the program"))
+
+			})
+		})
+
+		When("run command is marked as hotReloadCapable:true", func() {
+			It("should not restart the application", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", cmpName, "--project", commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-hotReload.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push")
+				Expect(output).To(ContainSubstring("Executing devrun command \"npm start\""))
+
+				helper.CmdShouldPass("odo", "push", "-f")
+
+				logs := helper.CmdShouldPass("odo", "log")
+				Expect(logs).To(ContainSubstring("Don't start program again, program is already started"))
+
+			})
+
+			When("run mode is changed to debug", func() {
+				It("should restart the application regardless of hotReloadCapable value", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-hotReload.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+					helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
+
+					stdOut := helper.CmdShouldPass("odo", "push", "--debug", "--project", commonVar.Project)
+					Expect(stdOut).To(Not(ContainSubstring("No file changes detected, skipping build")))
+
+					logs := helper.CmdShouldPass("odo", "log")
+
+					helper.MatchAllInOutput(logs, []string{
+						"\"stop the program\" program=debugrun",
+						"\"stop the program\" program=devrun",
+					})
+
+				})
+			})
+		})
+
+		When("devfile with composite command", func() {
+			It("should execute all commands in composite commmand", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push")
+				Expect(output).To(ContainSubstring("Executing mkdir command"))
+
+				// Verify the command executed successfully
+				var statErr error
+				podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+				commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+					podName,
+					"runtime",
+					commonVar.Project,
+					[]string{"stat", "/projects/testfolder"},
+					func(cmdOp string, err error) bool {
+						statErr = err
+						return err == nil
+					},
+				)
+				Expect(statErr).ToNot(HaveOccurred())
+			})
+
+			When("composite command is marked as paralell:true ", func() {
+				It("should execute all commands in composite commmand", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeCommandsParallel.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+					output := helper.CmdShouldPass("odo", "push", "--build-command", "buildandmkdir")
+					Expect(output).To(ContainSubstring("Executing mkdir command"))
+
+					// Verify the command executed successfully
+					var statErr error
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+					commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+						podName,
+						"runtime",
+						commonVar.Project,
+						[]string{"stat", "/projects/testfolder"},
+						func(cmdOp string, err error) bool {
+							statErr = err
+							return err == nil
+						},
+					)
+					Expect(statErr).ToNot(HaveOccurred())
+				})
+			})
+
+			When("composite command are nested", func() {
+				It("should execute all commands in composite commmand", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+					// Verify nested command was executed
+					output := helper.CmdShouldPass("odo", "push")
+					Expect(output).To(ContainSubstring("Executing mkdir command"))
+
+					// Verify the command executed successfully
+					var statErr error
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+					commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+						podName,
+						"runtime",
+						commonVar.Project,
+						[]string{"stat", "/projects/testfolder"},
+						func(cmdOp string, err error) bool {
+							statErr = err
+							return err == nil
+						},
+					)
+					Expect(statErr).ToNot(HaveOccurred())
+				})
+			})
+			When("composite command is used as a run command", func() {
+				It("should throw a validation error for composite run commands", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileCompositeRun.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+					// Verify odo push failed
+					output := helper.CmdShouldFail("odo", "push")
+					Expect(output).To(ContainSubstring("not supported currently"))
+				})
+			})
+		})
+
+		When("events are defined", func() {
+
+			It("should correctly execute PreStart commands", func() {
+				// expectedInitContainers := []string{"tools-myprestart-1", "tools-myprestart-2", "runtime-secondprestart-3"}
+
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-preStart.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldFail("odo", "push", "--project", commonVar.Project)
+				// This is expected to fail for now.
+				// see https://github.com/openshift/odo/issues/4187 for more info
+				helper.MatchAllInOutput(output, []string{"myprestart should either map to an apply command or a composite command with apply commands\n"})
+
+				/*
+					helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
+
+					firstPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+
+					firstPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
+					// 3 preStart events + 1 supervisord init containers
+					Expect(len(firstPushInitContainers)).To(Equal(4))
+					helper.MatchAllInOutput(strings.Join(firstPushInitContainers, ","), expectedInitContainers)
+
+					// Need to force so build and run get triggered again with the component already created.
+					output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-f")
+					helper.MatchAllInOutput(output, []string{"PreStart commands have been added to the component"})
+
+					secondPushPodName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+
+					secondPushInitContainers := commonVar.CliRunner.GetPodInitContainers(cmpName, commonVar.Project)
+
+					Expect(len(secondPushInitContainers)).To(Equal(4))
+					helper.MatchAllInOutput(strings.Join(secondPushInitContainers, ","), expectedInitContainers)
+
+					Expect(firstPushPodName).To(Equal(secondPushPodName))
+					Expect(firstPushInitContainers).To(Equal(secondPushInitContainers))
+
+					var statErr error
+					commonVar.CliRunner.CheckCmdOpInRemoteDevfilePod(
+						firstPushPodName,
+						"runtime",
+						commonVar.Project,
+						[]string{"cat", "/projects/test.txt"},
+						func(cmdOp string, err error) bool {
+							if err != nil {
+								statErr = err
+							} else if cmdOp == "" {
+								statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got empty string")
+							} else {
+								fileContents := strings.Split(cmdOp, "\n")
+								if len(fileContents)-1 != 3 {
+									statErr = fmt.Errorf("prestart event action count error, expected: 3 strings, got %d strings: %s", len(fileContents), strings.Join(fileContents, ","))
+								} else if cmdOp != "hello test2\nhello test2\nhello test\n" {
+									statErr = fmt.Errorf("prestart event action error, expected: hello test2\nhello test2\nhello test\n, got: %s", cmdOp)
+								}
+							}
+
+							return true
+						},
+					)
+					Expect(statErr).ToNot(HaveOccurred())
+				*/
+			})
+
+			It("should correctly execute PostStart commands", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-valid-events.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+
+				output := helper.CmdShouldPass("odo", "push", "--project", commonVar.Project)
+				helper.MatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})
+
+				// Need to force so build and run get triggered again with the component already created.
+				output = helper.CmdShouldPass("odo", "push", "--project", commonVar.Project, "-f")
+				helper.DontMatchAllInOutput(output, []string{"Executing mypoststart command \"echo I am a PostStart\"", "Executing secondpoststart command \"echo I am also a PostStart\""})
+				helper.MatchAllInOutput(output, []string{
+					"Executing devbuild command",
+					"Executing devrun command",
+				})
+			})
+		})
+
+		When("using custom commands (specified by flags)", func() {
+			It("should push successfully", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Project)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				output := helper.CmdShouldPass("odo", "push", "--build-command", "build", "--run-command", "run")
+				helper.MatchAllInOutput(output, []string{
+					"Executing build command \"npm install\"",
+					"Executing run command \"npm start\"",
+				})
+
+			})
+
+			It("should error out on a wrong custom commands", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", cmpName, "--project", commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				output := helper.CmdShouldFail("odo", "push", "--build-command", "buildgarbage")
+				Expect(output).NotTo(ContainSubstring("Executing buildgarbage command"))
+				Expect(output).To(ContainSubstring("the command \"%v\" is not found in the devfile", "buildgarbage"))
+			})
+
+		})
+
+		When("command has no group kind", func() {
+			It("should execute commands with flags", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", cmpName, "--project", commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-no-group-kind.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				output := helper.CmdShouldPass("odo", "push", "--build-command", "devbuild", "--run-command", "devrun")
+				helper.MatchAllInOutput(output, []string{
+					"Executing devbuild command \"npm install\"",
+					"Executing devrun command \"npm start\"",
+				})
+
+			})
+		})
+
+		When("the run command throws an error", func() {
+			It("should wait and error out with some log", func() {
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project)
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.ReplaceString(filepath.Join(commonVar.Context, "devfile.yaml"), "npm start", "npm starts")
+
+				_, output := helper.CmdShouldPassIncludeErrStream("odo", "push")
+				helper.MatchAllInOutput(output, []string{
+					"exited with error status within 1 sec",
+					"Did you mean one of these?",
+				})
+
+				_, output = helper.CmdShouldPassIncludeErrStream("odo", "push", "-f", "--run-command", "run")
+				helper.MatchAllInOutput(output, []string{
+					"exited with error status within 1 sec",
+					"Did you mean one of these?",
+				})
+			})
+		})
+
+		When("commands specify have env variables", func() {
+			When("sigle env var is set", func() {
+				It("should be able to exec command", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+					output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithenv", "--run-command", "singleenv")
+					helper.MatchAllInOutput(output, []string{"mkdir $ENV1", "mkdir $BUILD_ENV1"})
+
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+					output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+					helper.MatchAllInOutput(output, []string{"test_env_variable", "test_build_env_variable"})
+				})
+			})
+			When("multiple env variables are set", func() {
+				It("should be able to exec command", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+					output := helper.CmdShouldPass("odo", "push", "--build-command", "buildwithmultipleenv", "--run-command", "multipleenv")
+					helper.MatchAllInOutput(output, []string{"mkdir $ENV1 $ENV2", "mkdir $BUILD_ENV1 $BUILD_ENV2"})
+
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+					output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+					helper.MatchAllInOutput(output, []string{"test_build_env_variable1", "test_build_env_variable2", "test_env_variable1", "test_env_variable2"})
+				})
+			})
+			When("there is a env variable with spaces", func() {
+				It("should be able to exec command", func() {
+					helper.CmdShouldPass("odo", "create", "nodejs", "--project", commonVar.Project, cmpName)
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-command-envs.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+					output := helper.CmdShouldPass("odo", "push", "--build-command", "buildenvwithspace", "--run-command", "envwithspace")
+					helper.MatchAllInOutput(output, []string{"mkdir \\\"$ENV1\\\"", "mkdir \\\"$BUILD_ENV1\\\""})
+
+					podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
+					output = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
+					helper.MatchAllInOutput(output, []string{"build env variable with space", "env with space"})
+
+				})
+			})
+		})
 	})
 
-	Context("Testing Push for OpenShift specific scenarios", func() {
+	Context("using OpenShift cluster", func() {
 		JustBeforeEach(func() {
 			if os.Getenv("KUBERNETES") == "true" {
 				Skip("This is a OpenShift specific scenario, skipping")
 			}
 		})
+		When("project with with 'default' name is used", func() {
+			It("should throw an error", func() {
+				componentName := helper.RandString(6)
+				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", "default", componentName)
 
-		It("throw an error when the project value is default", func() {
-			componentName := helper.RandString(6)
-			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.Cmd("odo", "create", "nodejs", "--project", "default", componentName).ShouldPass()
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			stdout := helper.Cmd("odo", "push").ShouldFail().Err()
-			helper.MatchAllInOutput(stdout, []string{"odo may not work as expected in the default project, please run the odo component in a non-default project"})
+				stdout := helper.CmdShouldFail("odo", "push")
+				helper.MatchAllInOutput(stdout, []string{"odo may not work as expected in the default project, please run the odo component in a non-default project"})
+			})
 		})
 	})
 
-	Context("Testing Push for Kubernetes specific scenarios", func() {
+	Context("using Kubernetes cluster", func() {
 		JustBeforeEach(func() {
 			if os.Getenv("KUBERNETES") != "true" {
 				Skip("This is a Kubernetes specific scenario, skipping")
 			}
 		})
+		When("project with with 'default' name is used", func() {
 
-		It("should push successfully project value is default", func() {
-			componentName := helper.RandString(6)
-			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.Cmd("odo", "create", "nodejs", "--project", "default", componentName).ShouldPass()
+			It("should push successfully", func() {
+				componentName := helper.RandString(6)
+				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+				helper.CmdShouldPass("odo", "create", "nodejs", "--project", "default", componentName)
 
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			stdout := helper.Cmd("odo", "push").ShouldPass().Out()
-			helper.DontMatchAllInOutput(stdout, []string{"odo may not work as expected in the default project"})
+				stdout := helper.CmdShouldPass("odo", "push")
+				helper.DontMatchAllInOutput(stdout, []string{"odo may not work as expected in the default project"})
+			})
 		})
 	})
 
-	Context("Testing Push with remote attributes", func() {
-		It("should push only the mentioned files at the appropriate remote destination", func() {
-			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-			helper.Cmd("odo", "create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project).ShouldPass()
-
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-remote-attributes.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
-
-			// create a folder and file which shouldn't be pushed
-			helper.MakeDir(filepath.Join(commonVar.Context, "views"))
-			_, _ = helper.CreateSimpleFile(filepath.Join(commonVar.Context, "views"), "view", ".html")
-
-			helper.ReplaceString("package.json", "node server.js", "node server/server.js")
-			helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass()
-
-			podName := commonVar.CliRunner.GetRunningPodNameByComponent(cmpName, commonVar.Project)
-			stdOut := commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath)
-			helper.MatchAllInOutput(stdOut, []string{"package.json", "server"})
-			helper.DontMatchAllInOutput(stdOut, []string{"test", "views", "devfile.yaml"})
-
-			stdOut = commonVar.CliRunner.ExecListDir(podName, commonVar.Project, sourcePath+"/server")
-			helper.MatchAllInOutput(stdOut, []string{"server.js", "test"})
-
-			stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
-			Expect(stdOut).To(ContainSubstring("No file changes detected"))
-		})
-	})
 })

--- a/tests/integration/devfile/utils/utils.go
+++ b/tests/integration/devfile/utils/utils.go
@@ -84,38 +84,10 @@ func ExecWithMissingRunCommand(projectDirPath, cmpName, namespace string) {
 
 // ExecWithCustomCommand executes odo push with a custom command
 func ExecWithCustomCommand(projectDirPath, cmpName, namespace string) {
-	args := []string{"create", "nodejs", cmpName}
-	args = useProjectIfAvailable(args, namespace)
-	helper.Cmd("odo", args...).ShouldPass()
-
-	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
-	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
-
-	args = []string{"push", "--build-command", "build", "--run-command", "run"}
-	args = useProjectIfAvailable(args, namespace)
-	output := helper.Cmd("odo", args...).ShouldPass().Out()
-	helper.MatchAllInOutput(output, []string{
-		"Executing build command \"npm install\"",
-		"Executing run command \"npm start\"",
-	})
 }
 
 // ExecWithWrongCustomCommand executes odo push with a wrong custom command
 func ExecWithWrongCustomCommand(projectDirPath, cmpName, namespace string) {
-	garbageCommand := "buildgarbage"
-
-	args := []string{"create", "nodejs", cmpName}
-	args = useProjectIfAvailable(args, namespace)
-	helper.Cmd("odo", args...).ShouldPass()
-
-	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
-	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
-
-	args = []string{"push", "--build-command", garbageCommand}
-	args = useProjectIfAvailable(args, namespace)
-	output := helper.Cmd("odo", args...).ShouldFail().Err()
-	Expect(output).NotTo(ContainSubstring("Executing buildgarbage command"))
-	Expect(output).To(ContainSubstring("the command \"%v\" is not found in the devfile", garbageCommand))
 }
 
 // ExecWithMultipleOrNoDefaults executes odo push with multiple or no default commands
@@ -150,20 +122,6 @@ func ExecWithMultipleOrNoDefaults(projectDirPath, cmpName, namespace string) {
 
 // ExecCommandWithoutGroupUsingFlags executes odo push with no command group using flags
 func ExecCommandWithoutGroupUsingFlags(projectDirPath, cmpName, namespace string) {
-	args := []string{"create", "nodejs", cmpName}
-	args = useProjectIfAvailable(args, namespace)
-	helper.Cmd("odo", args...).ShouldPass()
-
-	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
-	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-no-group-kind.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
-
-	args = []string{"push", "--build-command", "devbuild", "--run-command", "devrun"}
-	args = useProjectIfAvailable(args, namespace)
-	output := helper.Cmd("odo", args...).ShouldPass().Out()
-	helper.MatchAllInOutput(output, []string{
-		"Executing devbuild command \"npm install\"",
-		"Executing devrun command \"npm start\"",
-	})
 }
 
 // ExecWithInvalidCommandGroup executes odo push with an invalid command group
@@ -325,34 +283,6 @@ func ExecPushWithNewFileAndDir(projectDirPath, cmpName, namespace, newFilePath, 
 
 // ExecWithHotReload executes odo push with hot reload true
 func ExecWithHotReload(projectDirPath, cmpName, namespace string, hotReload bool) {
-	args := []string{"create", "nodejs", cmpName}
-	args = useProjectIfAvailable(args, namespace)
-	helper.Cmd("odo", args...).ShouldPass()
-
-	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), projectDirPath)
-
-	if hotReload {
-		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-hotReload.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
-	} else {
-		helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(projectDirPath, "devfile.yaml"))
-	}
-
-	args = []string{"push"}
-	args = useProjectIfAvailable(args, namespace)
-	output := helper.Cmd("odo", args...).ShouldPass().Out()
-	Expect(output).To(ContainSubstring("Executing devrun command \"npm start\""))
-
-	args = []string{"push", "-f"}
-	args = useProjectIfAvailable(args, namespace)
-	helper.Cmd("odo", args...).ShouldPass()
-
-	args = useProjectIfAvailable([]string{"log"}, namespace)
-	logs := helper.Cmd("odo", args...).ShouldPass().Out()
-	if hotReload {
-		Expect(logs).To(ContainSubstring("Don't start program again, program is already started"))
-	} else {
-		Expect(logs).To(ContainSubstring("stop the program"))
-	}
 }
 
 type OdoV1Watch struct {


### PR DESCRIPTION
**What type of PR is this?**

/area testing


**What does this PR do / why we need it**:
add integration test to verify that variables have been added in devfile 2.1.0 are working properly 


This also updates structure of devfile push tests.
At a core level, there are 6 main test groups
- verify devfile push works  - generic tests, that don't fit other categories
- verify files are correctly synced
- verify devfile volume components work
- verify command executions
- using OpenShift cluster
- using Kubernetes cluster


**Which issue(s) this PR fixes**:

Fixes #4589

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`cmd_devfile_push_test.go` diff is pretty much unreadable. 
When reviewing it might be easier to check the whole file here https://github.com/kadel/odo/blob/devfile21-tests/tests/integration/devfile/cmd_devfile_push_test.go

