### PR TITLE
Fix kubeconfig issue when minikube already running on VM

### DIFF
--- a/scripts/minikube-minishift-all-tests.sh
+++ b/scripts/minikube-minishift-all-tests.sh
@@ -16,7 +16,7 @@ case ${1} in
         # Integration tests
         shout "| Running integration Tests on MiniKube"
         make test-cmd-project
-        # make test-integration-devfile
+        make test-integration-devfile
 
         shout "Cleaning up some leftover namespaces"
 

--- a/scripts/minikube-minishift-all-tests.sh
+++ b/scripts/minikube-minishift-all-tests.sh
@@ -16,7 +16,7 @@ case ${1} in
         # Integration tests
         shout "| Running integration Tests on MiniKube"
         make test-cmd-project
-        make test-integration-devfile
+        # make test-integration-devfile
 
         shout "Cleaning up some leftover namespaces"
 

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -42,12 +42,24 @@ case ${1} in
         sh .scripts/minishift-start-if-required.sh
         ;;
     minikube)
-        shout "| Start minikube"
-        # Delete minikube instance, if in anycase already exists
-        minikube delete
-        minikube start --vm-driver=docker --container-runtime=docker
+        mkStatus=$(minikube status)
+        shout "| Checking if Minikube needs to be started..."
+        if [[ "$mkStatus" == *"host: Running"* ]] then 
+            shout "| Copying kubeconfig to current directory"
+            touch $PWD/config
+            cp -avrf ~/.kube/config $PWD
+            chmod 640 $PWD/config
+            export KUBECONFIG=$PWD/config
+            kubectl config use-context minikube
+        else
+            shout "| Start minikube"
+            minikube start --vm-driver=docker --container-runtime=docker
+            cp -avrf ~/.kube/confg $PWD
+            chmod 640 $PWD/config
+            export KUBECONFIG=$PWD/config
+        fi
+        
         minikube version
-
         set +x
         # Get kubectl cluster info
         kubectl cluster-info

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -44,7 +44,7 @@ case ${1} in
     minikube)
         mkStatus=$(minikube status)
         shout "| Checking if Minikube needs to be started..."
-        if [[ "$mkStatus" == *"host: Running"* ]] then 
+        if [[ "$mkStatus" == *"host: Running"* ]]; then 
             shout "| Copying kubeconfig to current directory"
             touch $PWD/config
             cp -avrf ~/.kube/config $PWD

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -13,7 +13,7 @@ mkdir bin artifacts
 export GOBIN="`pwd`/bin"
 
 # Set kubeconfig to current dir. This ensures no clashes with other test runs
-export KUBECONFIG="`pwd`/config"
+export KUBECONFIG=$HOME/.kube/config
 export ARTIFACTS_DIR="`pwd`/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACT_DIR
 
@@ -29,8 +29,6 @@ make bin
 
 # copy built odo to GOBIN
 cp -avrf ./odo $GOBIN/
-shout "| Getting ginkgo"
-make goget-ginkgo
 
 case ${1} in
     minishift)
@@ -46,17 +44,18 @@ case ${1} in
         shout "| Checking if Minikube needs to be started..."
         if [[ "$mkStatus" == *"host: Running"* ]]; then 
             shout "| Copying kubeconfig to current directory"
-            touch $PWD/config
-            cp -avrf ~/.kube/config $PWD
-            chmod 640 $PWD/config
-            export KUBECONFIG=$PWD/config
+            set -x
+            touch "`pwd`/config"
+            cp $KUBECONFIG "`pwd`/config"
+            chmod 640 "`pwd`/config"
+            export KUBECONFIG="`pwd`/config"
             kubectl config use-context minikube
         else
             shout "| Start minikube"
             minikube start --vm-driver=docker --container-runtime=docker
-            cp -avrf ~/.kube/confg $PWD
-            chmod 640 $PWD/config
-            export KUBECONFIG=$PWD/config
+            cp $KUBECONFIG "`pwd`/config"
+            chmod 640 "`pwd`/config"
+            export KUBECONFIG="`pwd`/config"
         fi
         
         minikube version

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -11,8 +11,6 @@ mkdir bin artifacts
 # Change the default location of go's bin directory (without affecting GOPATH). This is where compiled binaries will end up by default
 # for eg go get ginkgo later on will produce ginkgo binary in GOBIN
 export GOBIN="`pwd`/bin"
-
-# Set kubeconfig to current dir. This ensures no clashes with other test runs
 export ARTIFACTS_DIR="`pwd`/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACT_DIR
 
@@ -29,6 +27,22 @@ make bin
 # copy built odo to GOBIN
 cp -avrf ./odo $GOBIN/
 
+setup_kubeconfig() {
+    export ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
+    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+    if [[ ! -f $KUBECONFIG ]]; then
+        echo "Could not find kubeconfig file"
+        exit 1
+    fi
+    if [[ ! -z $KUBECONFIG ]]; then
+        # Copy kubeconfig to current directory, to avoid clashes with other test runs
+        # Read and Write permission to current kubeconfig file
+        cp $KUBECONFIG "`pwd`/config"
+        chmod 640 "`pwd`/config"
+        export KUBECONFIG="`pwd`/config"
+    fi
+}
+
 case ${1} in
     minishift)
         export MINISHIFT_ENABLE_EXPERIMENTAL=y 
@@ -42,22 +56,15 @@ case ${1} in
         mkStatus=$(minikube status)
         shout "| Checking if Minikube needs to be started..."
         if [[ "$mkStatus" == *"host: Running"* ]]; then 
-            minikube update-context
-            minikube status
-            export KUBECONFIG=$HOME/.kube/config
-            shout "| Copying kubeconfig to current directory"
-            set -x
-            touch "`pwd`/config"
-            cp $KUBECONFIG "`pwd`/config"
-            chmod 640 "`pwd`/config"
-            export KUBECONFIG="`pwd`/config"
+            if [[ "$mkStatus" == *"kubeconfig: Misconfigured"* ]]; then
+                minikube update-context
+            fi
+            setup_kubeconfig
             kubectl config use-context minikube
         else
             shout "| Start minikube"
             minikube start --vm-driver=docker --container-runtime=docker
-            cp $KUBECONFIG "`pwd`/config"
-            chmod 640 "`pwd`/config"
-            export KUBECONFIG="`pwd`/config"
+            setup_kubeconfig
         fi
         
         minikube version

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -13,7 +13,6 @@ mkdir bin artifacts
 export GOBIN="`pwd`/bin"
 
 # Set kubeconfig to current dir. This ensures no clashes with other test runs
-export KUBECONFIG=$HOME/.kube/config
 export ARTIFACTS_DIR="`pwd`/artifacts"
 export CUSTOM_HOMEDIR=$ARTIFACT_DIR
 
@@ -43,6 +42,9 @@ case ${1} in
         mkStatus=$(minikube status)
         shout "| Checking if Minikube needs to be started..."
         if [[ "$mkStatus" == *"host: Running"* ]]; then 
+            minikube update-context
+            minikube status
+            export KUBECONFIG=$HOME/.kube/config
             shout "| Copying kubeconfig to current directory"
             set -x
             touch "`pwd`/config"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
kubeconfig fails finding config file, if minikube is already running on the VM. And thats why we don't have long running minikube on VM. It also unblock us for executing concurrent builds on jenkins.

**Which issue(s) this PR fixes**:

Fixes #4826 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`minikube` job should run successfully.