### PR TITLE
Fixes push when csv support is not present on the cluster

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -860,6 +860,12 @@ func (d *DynamicCRD) AddComponentLabelsToCRD(labels map[string]string) {
 // PushServiceFromKubernetesInlineComponents updates service(s) from Kubernetes Inlined component in a devfile by creating new ones or removing old ones
 func PushServiceFromKubernetesInlineComponents(client *kclient.Client, k8sComponents []devfile.Component, labels map[string]string) error {
 
+	// check csv support before proceeding
+	csvSupported, err := IsCSVSupported()
+	if err != nil || !csvSupported {
+		return err
+	}
+
 	created := []string{}
 	deleted := []string{}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

It fixes push on 3.11 clusters

**Which issue(s) this PR fixes**:

Fixes #4830 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

`odo push` should work on all supported cluster types including 3.11.