### PR TITLE
Fix minikube tests if kubelet gets stopped

### DIFF
--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -55,13 +55,16 @@ case ${1} in
     minikube)
         mkStatus=$(minikube status)
         shout "| Checking if Minikube needs to be started..."
-        if [[ "$mkStatus" == *"host: Running"* ]]; then 
+        if [[ "$mkStatus" == *"host: Running"* ]] && [[ "$mkStatus" == *"kubelet: Running"* ]]; then 
             if [[ "$mkStatus" == *"kubeconfig: Misconfigured"* ]]; then
                 minikube update-context
             fi
             setup_kubeconfig
             kubectl config use-context minikube
         else
+            if [[ "$mkStatus" == *"host: Running"* ]] && [[ "$mkStatus" != *"kubelet: Running"* ]]; then
+                minikube delete
+            fi
             shout "| Start minikube"
             minikube start --vm-driver=docker --container-runtime=docker
             setup_kubeconfig


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
Fix test failure if `kubelet` gets stopped somehow https://github.com/openshift/odo/pull/4661#issuecomment-864912787 
```
$ minikube status
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Stopped
kubeconfig: Configured
```


**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
minikube should run test successfully.