### PR TITLE
Fix minikube failures on pr

### DIFF
--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -25,8 +25,7 @@ make bin
 cp -avrf ./odo $GOBIN/
 
 setup_kubeconfig() {
-    export ORIGINAL_KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
-    export KUBECONFIG=$ORIGINAL_KUBECONFIG
+    export KUBECONFIG=$HOME/.kube/config
     if [[ ! -f $KUBECONFIG ]]; then
         echo "Could not find kubeconfig file"
         exit 1

--- a/scripts/minikube-minishift-setup-env.sh
+++ b/scripts/minikube-minishift-setup-env.sh
@@ -56,9 +56,7 @@ case ${1} in
             setup_kubeconfig
             kubectl config use-context minikube
         else
-            if [[ "$mkStatus" == *"host: Running"* ]] && [[ "$mkStatus" != *"kubelet: Running"* ]]; then
-                minikube delete
-            fi
+            minikube delete
             shout "| Start minikube"
             minikube start --vm-driver=docker --container-runtime=docker
             setup_kubeconfig


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
We have some failure on minikube. Might be due to `kubelet` stopped working so often. However `minikube status` results on vm and pr runs contradict.
Minikube status on prs:
```
minikube status

[ssh:Fedora-32-minikube] ++ mkStatus='* There is no local cluster named "minikube"

++ minikube start --vm-driver=docker --container-runtime=docker

[ssh:Fedora-32-minikube] * minikube 1.21.0 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.21.0

[ssh:Fedora-32-minikube] * To disable this notice, run: 'minikube config set WantUpdateNotification false'

Unable to restart cluster, will reset it: getting k8s client: client config: client config: context "minikube" does not exist
```

Minikube status on vm:
```
$ minikube status
minikube
type: Control Plane
host: Running
kubelet: Stopped
apiserver: Stopped
kubeconfig: Configured
```
I suspect somehow minikube is not deleted properly and hence its poping up. Making `minikube delete` as generic might solve the problem


**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
