### PR TITLE
Updating create, delete and get to newer networking v1 extension v1 union functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- Completely move to using networking v1 and extensions v1 ingresses based on cluster support as extensions v1 ingress is deprecated ([#4853](https://github.com/openshift/odo/pull/4853))
+
 ### Tests
 
 ### Documentation

--- a/pkg/kclient/fakeclient.go
+++ b/pkg/kclient/fakeclient.go
@@ -38,6 +38,7 @@ func FakeNewWithIngressSupports(networkingv1Supported, extensionV1Supported bool
 	client.appsClient = fkclientset.Kubernetes.AppsV1()
 	client.isExtensionV1Beta1IngressSupported = extensionV1Supported
 	client.isNetworkingV1IngressSupported = networkingv1Supported
+	client.checkIngressSupports = false
 	client.SetDiscoveryInterface(NewKubernetesFakedDiscovery(true, true))
 
 	return &client, &fkclientset

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -75,6 +75,10 @@ func (c *Client) CreateIngress(ingress unions.KubernetesIngress) (*unions.Kubern
 	if !ingress.IsGenerated() {
 		return nil, fmt.Errorf("create ingress should get a generated ingress. If you are hiting this, contact the developer")
 	}
+	err = c.checkIngressSupport()
+	if err != nil {
+		return nil, err
+	}
 	created := false
 	kubernetesIngress := unions.NewNonGeneratedKubernetesIngress()
 	if c.isNetworkingV1IngressSupported {
@@ -98,6 +102,10 @@ func (c *Client) CreateIngress(ingress unions.KubernetesIngress) (*unions.Kubern
 
 func (c *Client) DeleteIngress(name string) error {
 	var err error
+	err = c.checkIngressSupport()
+	if err != nil {
+		return err
+	}
 	if c.isNetworkingV1IngressSupported {
 		err = c.KubeClient.NetworkingV1().Ingresses(c.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 		if err != nil {
@@ -115,6 +123,11 @@ func (c *Client) DeleteIngress(name string) error {
 //ListIngresses lists all the ingresses based on given label selector
 func (c *Client) ListIngresses(labelSelector string) (*unions.KubernetesIngressList, error) {
 	kubernetesIngressList := unions.NewEmptyKubernetesIngressList()
+	var err error
+	err = c.checkIngressSupport()
+	if err != nil {
+		return nil, err
+	}
 	// if networking v1 ingress is supported then extension v1 ingress are automatically wrapped
 	// by net v1 ingresses
 	if c.isNetworkingV1IngressSupported {

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -123,8 +123,7 @@ func (c *Client) DeleteIngress(name string) error {
 //ListIngresses lists all the ingresses based on given label selector
 func (c *Client) ListIngresses(labelSelector string) (*unions.KubernetesIngressList, error) {
 	kubernetesIngressList := unions.NewEmptyKubernetesIngressList()
-	var err error
-	err = c.checkIngressSupport()
+	err := c.checkIngressSupport()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -32,33 +32,21 @@ func (c *Client) DeleteIngressExtensionV1(name string) error {
 	return nil
 }
 
-// ListIngressesExtensionV1 lists all the ingresses based on the given label selector
-func (c *Client) ListIngressesExtensionV1(labelSelector string) ([]extensionsv1.Ingress, error) {
-	ingressList, err := c.KubeClient.ExtensionsV1beta1().Ingresses(c.Namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get ingress list")
-	}
-
-	return ingressList.Items, nil
-}
-
 // GetOneIngressFromSelector gets one ingress with the given selector
 // if no or multiple ingresses are found with the given selector, it throws an error
-func (c *Client) GetOneIngressFromSelector(selector string) (*extensionsv1.Ingress, error) {
-	ingresses, err := c.ListIngressesExtensionV1(selector)
+func (c *Client) GetOneIngressFromSelector(selector string) (*unions.KubernetesIngress, error) {
+	ingresses, err := c.ListIngresses(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	if num := len(ingresses); num == 0 {
+	if num := len(ingresses.Items); num == 0 {
 		return nil, fmt.Errorf("no ingress was found for the selector: %v", selector)
 	} else if num > 1 {
 		return nil, fmt.Errorf("multiple ingresses exist for the selector: %v. Only one must be present", selector)
 	}
 
-	return &ingresses[0], nil
+	return ingresses.Items[0], nil
 }
 
 // GetIngressExtensionV1 gets an ingress based on the given name

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -49,12 +49,6 @@ func (c *Client) GetOneIngressFromSelector(selector string) (*unions.KubernetesI
 	return ingresses.Items[0], nil
 }
 
-// GetIngressExtensionV1 gets an ingress based on the given name
-func (c *Client) GetIngressExtensionV1(name string) (*extensionsv1.Ingress, error) {
-	ingress, err := c.KubeClient.ExtensionsV1beta1().Ingresses(c.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	return ingress, err
-}
-
 //CreateIngress creates a specified Kubernetes Ingress as a networking v1 or extensions v1beta1 ingress depending on what
 //is supported, with preference for networking v1 ingress. The passed ingress MUST be a generated one, i.e it must
 //have been created using unions.NewKubernetesIngressFromParams

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -113,8 +113,8 @@ func (c *Client) DeleteIngress(name string) error {
 }
 
 //ListIngresses lists all the ingresses based on given label selector
-func (c *Client) ListIngresses(labelSelector string) ([]*unions.KubernetesIngress, error) {
-	var kubernetesIngressList []*unions.KubernetesIngress
+func (c *Client) ListIngresses(labelSelector string) (*unions.KubernetesIngressList, error) {
+	kubernetesIngressList := unions.NewEmptyKubernetesIngressList()
 	// if networking v1 ingress is supported then extension v1 ingress are automatically wrapped
 	// by net v1 ingresses
 	if c.isNetworkingV1IngressSupported {
@@ -127,7 +127,7 @@ func (c *Client) ListIngresses(labelSelector string) ([]*unions.KubernetesIngres
 			for k := range ingressList.Items {
 				ki := unions.NewNonGeneratedKubernetesIngress()
 				ki.NetworkingV1Ingress = &ingressList.Items[k]
-				kubernetesIngressList = append(kubernetesIngressList, ki)
+				kubernetesIngressList.Items = append(kubernetesIngressList.Items, ki)
 			}
 		}
 	} else if c.isExtensionV1Beta1IngressSupported {
@@ -140,7 +140,7 @@ func (c *Client) ListIngresses(labelSelector string) ([]*unions.KubernetesIngres
 			for k := range ingressList.Items {
 				ki := unions.NewNonGeneratedKubernetesIngress()
 				ki.ExtensionV1Beta1Ingress = &ingressList.Items[k]
-				kubernetesIngressList = append(kubernetesIngressList, ki)
+				kubernetesIngressList.Items = append(kubernetesIngressList.Items, ki)
 			}
 		}
 	}

--- a/pkg/kclient/ingress.go
+++ b/pkg/kclient/ingress.go
@@ -5,32 +5,8 @@ import (
 	"fmt"
 	"github.com/openshift/odo/pkg/unions"
 
-	"github.com/pkg/errors"
-
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// CreateIngressExtensionV1 creates an ingress object for the given service and with the given labels
-func (c *Client) CreateIngressExtensionV1(ingress extensionsv1.Ingress) (*extensionsv1.Ingress, error) {
-	if ingress.GetName() == "" {
-		return nil, fmt.Errorf("ingress name is empty")
-	}
-	ingressObj, err := c.KubeClient.ExtensionsV1beta1().Ingresses(c.Namespace).Create(context.TODO(), &ingress, metav1.CreateOptions{FieldManager: FieldManager})
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating ingress")
-	}
-	return ingressObj, nil
-}
-
-// DeleteIngressExtensionV1 deletes the given ingress
-func (c *Client) DeleteIngressExtensionV1(name string) error {
-	err := c.KubeClient.ExtensionsV1beta1().Ingresses(c.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
-	if err != nil {
-		return errors.Wrap(err, "unable to delete ingress")
-	}
-	return nil
-}
 
 // GetOneIngressFromSelector gets one ingress with the given selector
 // if no or multiple ingresses are found with the given selector, it throws an error
@@ -56,6 +32,9 @@ func (c *Client) CreateIngress(ingress unions.KubernetesIngress) (*unions.Kubern
 	var err error
 	if !ingress.IsGenerated() {
 		return nil, fmt.Errorf("create ingress should get a generated ingress. If you are hiting this, contact the developer")
+	}
+	if ingress.GetName() == "" {
+		return nil, fmt.Errorf("cannot create an ingress without a name")
 	}
 	err = c.checkIngressSupport()
 	if err != nil {
@@ -124,6 +103,7 @@ func (c *Client) ListIngresses(labelSelector string) (*unions.KubernetesIngressL
 				kubernetesIngressList.Items = append(kubernetesIngressList.Items, ki)
 			}
 		}
+		return kubernetesIngressList, nil
 	} else if c.isExtensionV1Beta1IngressSupported {
 		ingressList, err := c.KubeClient.ExtensionsV1beta1().Ingresses(c.Namespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: labelSelector,
@@ -137,8 +117,9 @@ func (c *Client) ListIngresses(labelSelector string) (*unions.KubernetesIngressL
 				kubernetesIngressList.Items = append(kubernetesIngressList.Items, ki)
 			}
 		}
+		return kubernetesIngressList, nil
 	}
-	return kubernetesIngressList, nil
+	return kubernetesIngressList, fmt.Errorf("ingresses on cluster are not supported")
 }
 
 func (c *Client) GetIngress(name string) (*unions.KubernetesIngress, error) {

--- a/pkg/kclient/ingress_test.go
+++ b/pkg/kclient/ingress_test.go
@@ -14,6 +14,17 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
+func ingressNameMatchError(expected, got []string) string {
+	if len(expected) != len(got) {
+		return "invalid error string format expected and got length should be the same"
+	}
+	val := "ingress name does not match the expected name"
+	for i := 0; i < len(expected); i++ {
+		val = fmt.Sprintf("%s, expected %s, got %s", val, expected[i], got[i])
+	}
+	return fmt.Sprintf("ingress name does not match the expected name, expected: %s, got %s", expected, got)
+}
+
 func TestCreateIngress(t *testing.T) {
 
 	tests := []struct {
@@ -83,7 +94,7 @@ func TestCreateIngress(t *testing.T) {
 					t.Errorf("expected 1 action, got: %v", fkclientset.Kubernetes.Actions())
 				} else {
 					if createdIngress.GetName() != tt.ingressName {
-						t.Errorf("ingress name does not match the expected name, expected: %s, got %s", tt.ingressName, createdIngress.GetName())
+						t.Errorf(ingressNameMatchError([]string{tt.ingressName}, []string{createdIngress.GetName()}))
 					}
 				}
 			}
@@ -221,9 +232,9 @@ func TestListIngresses(t *testing.T) {
 					if len(tt.wantIngress.Items) != len(ingresses.Items) {
 						t.Errorf("IngressList length is different, expected %v, got %v", len(tt.wantIngress.Items), len(ingresses.Items))
 					} else if len(ingresses.Items) == 1 && ingresses.Items[0].GetName() != tt.wantIngress.Items[0].GetName() {
-						t.Errorf("ingress name does not match the expected name, expected: %s, got %s", tt.wantIngress.Items[0].GetName(), ingresses.Items[0].GetName())
+						t.Errorf(ingressNameMatchError([]string{tt.wantIngress.Items[0].GetName()}, []string{ingresses.Items[0].GetName()}))
 					} else if len(ingresses.Items) == 2 && (ingresses.Items[0].GetName() != tt.wantIngress.Items[0].GetName() || ingresses.Items[1].GetName() != tt.wantIngress.Items[1].GetName()) {
-						t.Errorf("ingress name does not match the expected name, expected: %s and %s, got %s and %s", tt.wantIngress.Items[0].GetName(), tt.wantIngress.Items[1].GetName(), ingresses.Items[0].GetName(), ingresses.Items[1].GetName())
+						t.Errorf(ingressNameMatchError([]string{tt.wantIngress.Items[0].GetName(), tt.wantIngress.Items[1].GetName()}, []string{ingresses.Items[0].GetName(), ingresses.Items[1].GetName()}))
 					}
 				}
 			}
@@ -365,7 +376,7 @@ func TestGetIngresses(t *testing.T) {
 					t.Errorf("expected 1 action, got: %v", fkclientset.Kubernetes.Actions())
 				} else {
 					if ingress.GetName() != tt.ingressName {
-						t.Errorf("ingress name does not match the expected name, expected: %s, got %s", tt.ingressName, ingress.GetName())
+						t.Errorf(ingressNameMatchError([]string{tt.ingressName}, []string{ingress.GetName()}))
 					}
 				}
 			}

--- a/pkg/kclient/ingress_test.go
+++ b/pkg/kclient/ingress_test.go
@@ -76,7 +76,7 @@ func TestListIngresses(t *testing.T) {
 			name:          "Case: one ingress",
 			labelSelector: fmt.Sprintf("%v=%v", componentLabel, componentName),
 			wantIngress: []extensionsv1.Ingress{
-				extensionsv1.Ingress{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "testIngress1",
 						Labels: map[string]string{
@@ -90,7 +90,7 @@ func TestListIngresses(t *testing.T) {
 			name:          "Case: two ingresses",
 			labelSelector: fmt.Sprintf("%v=%v", componentLabel, componentName),
 			wantIngress: []extensionsv1.Ingress{
-				extensionsv1.Ingress{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "testIngress1",
 						Labels: map[string]string{
@@ -98,7 +98,7 @@ func TestListIngresses(t *testing.T) {
 						},
 					},
 				},
-				extensionsv1.Ingress{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "testIngress2",
 						Labels: map[string]string{

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -54,7 +54,9 @@ type Client struct {
 	supportedResources map[string]bool
 	// Is server side apply supported by cluster
 	// Use IsSSASupported()
-	isSSASupported                     *bool
+	isSSASupported *bool
+	// checkIngressSupports is used to check ingress support
+	//(used to prevent duplicate checks and disable check in UTs)
 	checkIngressSupports               bool
 	isNetworkingV1IngressSupported     bool
 	isExtensionV1Beta1IngressSupported bool
@@ -288,6 +290,7 @@ func (c *Client) checkIngressSupport() error {
 		if err != nil {
 			return fmt.Errorf("failed to check extensions v1beta1 ingress support %w", err)
 		}
+		c.checkIngressSupports = false
 	}
 	return nil
 }

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -55,6 +55,7 @@ type Client struct {
 	// Is server side apply supported by cluster
 	// Use IsSSASupported()
 	isSSASupported                     *bool
+	checkIngressSupports               bool
 	isNetworkingV1IngressSupported     bool
 	isExtensionV1Beta1IngressSupported bool
 }
@@ -116,10 +117,7 @@ func NewForConfig(config clientcmd.ClientConfig) (client *Client, err error) {
 		return nil, err
 	}
 
-	err = client.checkIngressSupport()
-	if err != nil {
-		return nil, err
-	}
+	client.checkIngressSupports = true
 
 	return client, nil
 }
@@ -281,13 +279,15 @@ func (c *Client) IsSSASupported() bool {
 
 func (c *Client) checkIngressSupport() error {
 	var err error
-	c.isNetworkingV1IngressSupported, err = c.IsResourceSupported("networking.k8s.io", "v1", "ingresses")
-	if err != nil {
-		return fmt.Errorf("failed to check networking v1 ingress support %w", err)
-	}
-	c.isExtensionV1Beta1IngressSupported, err = c.IsResourceSupported("extensions", "v1beta1", "ingresses")
-	if err != nil {
-		return fmt.Errorf("failed to check extensions v1beta1 ingress support %w", err)
+	if c.checkIngressSupports {
+		c.isNetworkingV1IngressSupported, err = c.IsResourceSupported("networking.k8s.io", "v1", "ingresses")
+		if err != nil {
+			return fmt.Errorf("failed to check networking v1 ingress support %w", err)
+		}
+		c.isExtensionV1Beta1IngressSupported, err = c.IsResourceSupported("extensions", "v1beta1", "ingresses")
+		if err != nil {
+			return fmt.Errorf("failed to check extensions v1beta1 ingress support %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/odogenerator/ingressgenerator.go
+++ b/pkg/odogenerator/ingressgenerator.go
@@ -1,7 +1,6 @@
 package odogenerator
 
 import (
-	"fmt"
 	"github.com/devfile/library/pkg/devfile/generator"
 	"k8s.io/api/networking/v1"
 )
@@ -10,6 +9,7 @@ import (
 // getNetworkingV1IngressSpec gets an networking v1 ingress spec
 func getNetworkingV1IngressSpec(ingressSpecParams generator.IngressSpecParams) *v1.IngressSpec {
 	path := "/"
+	pathType := v1.PathTypeImplementationSpecific
 	if ingressSpecParams.Path != "" {
 		path = ingressSpecParams.Path
 	}
@@ -26,12 +26,15 @@ func getNetworkingV1IngressSpec(ingressSpecParams generator.IngressSpecParams) *
 									Service: &v1.IngressServiceBackend{
 										Name: ingressSpecParams.ServiceName,
 										Port: v1.ServiceBackendPort{
-											Name:   fmt.Sprintf("%s%d", ingressSpecParams.ServiceName, ingressSpecParams.PortNumber.IntVal),
+											//Looks like we can either set name or number. going with number as it is more important
+											//Name:   fmt.Sprintf("%s%d", ingressSpecParams.ServiceName, ingressSpecParams.PortNumber.IntVal),
 											Number: ingressSpecParams.PortNumber.IntVal,
 										},
 									},
 									Resource: nil,
 								},
+								//this field is compulsory
+								PathType: &pathType,
 							},
 						},
 					},

--- a/pkg/odogenerator/ingressgenerator.go
+++ b/pkg/odogenerator/ingressgenerator.go
@@ -27,7 +27,6 @@ func getNetworkingV1IngressSpec(ingressSpecParams generator.IngressSpecParams) *
 										Name: ingressSpecParams.ServiceName,
 										Port: v1.ServiceBackendPort{
 											//Looks like we can either set name or number. going with number as it is more important
-											//Name:   fmt.Sprintf("%s%d", ingressSpecParams.ServiceName, ingressSpecParams.PortNumber.IntVal),
 											Number: ingressSpecParams.PortNumber.IntVal,
 										},
 									},

--- a/pkg/odogenerator/ingressgenerator.go
+++ b/pkg/odogenerator/ingressgenerator.go
@@ -26,13 +26,11 @@ func getNetworkingV1IngressSpec(ingressSpecParams generator.IngressSpecParams) *
 									Service: &v1.IngressServiceBackend{
 										Name: ingressSpecParams.ServiceName,
 										Port: v1.ServiceBackendPort{
-											//Looks like we can either set name or number. going with number as it is more important
 											Number: ingressSpecParams.PortNumber.IntVal,
 										},
 									},
 									Resource: nil,
 								},
-								//this field is compulsory
 								PathType: &pathType,
 							},
 						},

--- a/pkg/unions/kubernetes_ingress.go
+++ b/pkg/unions/kubernetes_ingress.go
@@ -1,6 +1,7 @@
 package unions
 
 import (
+	"fmt"
 	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/openshift/odo/pkg/odogenerator"
 	"k8s.io/api/extensions/v1beta1"
@@ -42,4 +43,65 @@ func NewKubernetesIngressFromParams(ingressParams generator.IngressParams) *Kube
 //IsGenerated returns true if ths KubernetesIngress was generated using generators
 func (ki *KubernetesIngress) IsGenerated() bool {
 	return ki.isGenerated
+}
+
+func (ki *KubernetesIngress) GetName() string {
+	if ki.NetworkingV1Ingress != nil {
+		return ki.NetworkingV1Ingress.GetName()
+	} else if ki.ExtensionV1Beta1Ingress != nil {
+		return ki.ExtensionV1Beta1Ingress.GetName()
+	}
+	return ""
+}
+
+func (ki *KubernetesIngress) GetProtocol() string {
+	if (ki.NetworkingV1Ingress != nil && len(ki.NetworkingV1Ingress.Spec.TLS) > 0) || (ki.ExtensionV1Beta1Ingress != nil && len(ki.ExtensionV1Beta1Ingress.Spec.TLS) > 0) {
+		return "https"
+	}
+	return "http"
+}
+
+func (ki *KubernetesIngress) GetHost() string {
+	if ki.NetworkingV1Ingress != nil {
+		return ki.NetworkingV1Ingress.Spec.Rules[0].Host
+	} else if ki.ExtensionV1Beta1Ingress != nil {
+		return ki.ExtensionV1Beta1Ingress.Spec.Rules[0].Host
+	}
+	return ""
+}
+
+func (ki *KubernetesIngress) GetURLString() string {
+	return fmt.Sprintf("%v://%v", ki.GetProtocol(), ki.GetHost())
+}
+
+type KubernetesIngressList struct {
+	Items []*KubernetesIngress
+}
+
+func NewEmptyKubernetesIngressList() *KubernetesIngressList {
+	return &KubernetesIngressList{}
+}
+
+func (kil *KubernetesIngressList) GetNetworkingV1IngressList(skipIfExtensionV1Set bool) *v1.IngressList {
+	il := v1.IngressList{}
+	for _, it := range kil.Items {
+		if !skipIfExtensionV1Set || (skipIfExtensionV1Set && it.ExtensionV1Beta1Ingress == nil) {
+			if it.NetworkingV1Ingress != nil {
+				il.Items = append(il.Items, *it.NetworkingV1Ingress)
+			}
+		}
+	}
+	return &il
+}
+
+func (kil *KubernetesIngressList) GetExtensionV1Beta1IngresList(skipIfNetworkingV1Set bool) *v1beta1.IngressList {
+	il := v1beta1.IngressList{}
+	for _, it := range kil.Items {
+		if !skipIfNetworkingV1Set || (skipIfNetworkingV1Set && it.NetworkingV1Ingress == nil) {
+			if it.ExtensionV1Beta1Ingress != nil {
+				il.Items = append(il.Items, *it.ExtensionV1Beta1Ingress)
+			}
+		}
+	}
+	return &il
 }

--- a/pkg/unions/kubernetes_ingress.go
+++ b/pkg/unions/kubernetes_ingress.go
@@ -45,6 +45,7 @@ func (ki *KubernetesIngress) IsGenerated() bool {
 	return ki.isGenerated
 }
 
+//GetName returns the name of underlying networking v1 or extensions v1 ingress
 func (ki *KubernetesIngress) GetName() string {
 	if ki.NetworkingV1Ingress != nil {
 		return ki.NetworkingV1Ingress.GetName()
@@ -54,6 +55,7 @@ func (ki *KubernetesIngress) GetName() string {
 	return ""
 }
 
+//GetProtocol returns `https` if tls is configured on either networking v1 or extensions v1 ingress, else `http`
 func (ki *KubernetesIngress) GetProtocol() string {
 	if (ki.NetworkingV1Ingress != nil && len(ki.NetworkingV1Ingress.Spec.TLS) > 0) || (ki.ExtensionV1Beta1Ingress != nil && len(ki.ExtensionV1Beta1Ingress.Spec.TLS) > 0) {
 		return "https"
@@ -61,6 +63,7 @@ func (ki *KubernetesIngress) GetProtocol() string {
 	return "http"
 }
 
+//GetHost returns the host of underlying networking v1 or extensions v1 ingress
 func (ki *KubernetesIngress) GetHost() string {
 	if ki.NetworkingV1Ingress != nil {
 		return ki.NetworkingV1Ingress.Spec.Rules[0].Host
@@ -70,6 +73,7 @@ func (ki *KubernetesIngress) GetHost() string {
 	return ""
 }
 
+//GetURLString returns the fully formed url of the form `GetProtocol()://GetHost()`
 func (ki *KubernetesIngress) GetURLString() string {
 	return fmt.Sprintf("%v://%v", ki.GetProtocol(), ki.GetHost())
 }
@@ -82,6 +86,9 @@ func NewEmptyKubernetesIngressList() *KubernetesIngressList {
 	return &KubernetesIngressList{}
 }
 
+//GetNetworkingV1IngressList returns a v1.IngressList populated by networking v1 ingresses
+//if skipIfExtensionV1Set it true, then if both networking v1 and extension v1 are set for
+//specific KubernetesIngress, then it will be skipped form the returned list
 func (kil *KubernetesIngressList) GetNetworkingV1IngressList(skipIfExtensionV1Set bool) *v1.IngressList {
 	il := v1.IngressList{}
 	for _, it := range kil.Items {
@@ -94,6 +101,9 @@ func (kil *KubernetesIngressList) GetNetworkingV1IngressList(skipIfExtensionV1Se
 	return &il
 }
 
+//GetExtensionV1Beta1IngresList returns a v1beta1.IngressList populated by extensions v1 beta1 ingresses
+//if skipIfNetworkingV1Set it true, then if both networking v1 and extension v1 are set for
+//specific KubernetesIngress, then it will be skipped form the returned list
 func (kil *KubernetesIngressList) GetExtensionV1Beta1IngresList(skipIfNetworkingV1Set bool) *v1beta1.IngressList {
 	il := v1beta1.IngressList{}
 	for _, it := range kil.Items {

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -143,7 +143,7 @@ func (k kubernetesClient) Delete(name string, kind localConfigProvider.URLKind) 
 		if err != nil {
 			return err
 		}
-		return k.client.GetKubeClient().DeleteIngressExtensionV1(ingress.Name)
+		return k.client.GetKubeClient().DeleteIngressExtensionV1(ingress.GetName())
 	case localConfigProvider.ROUTE:
 		route, err := k.client.GetOneRouteFromSelector(selector)
 		if err != nil {

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -263,7 +263,7 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 	if err != nil {
 		return "", fmt.Errorf("unable to create ingress %w", err)
 	}
-	return GetURLString(i.GetProtocol(), "", ingressDomain, false), nil
+	return i.GetURLString(), nil
 }
 
 // createRoute creates a route for the given URL with the given labels

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"fmt"
+	"github.com/openshift/odo/pkg/unions"
 	"sort"
 
 	"github.com/devfile/library/pkg/devfile/generator"
@@ -143,7 +144,7 @@ func (k kubernetesClient) Delete(name string, kind localConfigProvider.URLKind) 
 		if err != nil {
 			return err
 		}
-		return k.client.GetKubeClient().DeleteIngressExtensionV1(ingress.GetName())
+		return k.client.GetKubeClient().DeleteIngress(ingress.GetName())
 	case localConfigProvider.ROUTE:
 		route, err := k.client.GetOneRouteFromSelector(selector)
 		if err != nil {
@@ -256,13 +257,13 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 			Path:          url.Spec.Path,
 		},
 	}
-	ingress := generator.GetIngress(ingressParam)
+	ingress := unions.NewKubernetesIngressFromParams(ingressParam)
 	// Pass in the namespace name, link to the service (componentName) and labels to create a ingress
-	i, err := k.client.GetKubeClient().CreateIngressExtensionV1(*ingress)
+	i, err := k.client.GetKubeClient().CreateIngress(*ingress)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to create ingress")
+		return "", fmt.Errorf("unable to create ingress %w", err)
 	}
-	return GetURLString(GetProtocol(routev1.Route{}, *i), "", ingressDomain, false), nil
+	return GetURLString(i.GetProtocol(), "", ingressDomain, false), nil
 }
 
 // createRoute creates a route for the given URL with the given labels

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -46,9 +46,7 @@ func (k kubernetesClient) ListFromCluster() (URLList, error) {
 	}
 
 	var clusterURLs []URL
-	for _, i := range ingresses {
-		clusterURLs = append(clusterURLs, NewURLFromKubernetesIngress(i))
-	}
+	clusterURLs = append(clusterURLs, NewURLsFromKubernetesIngressList(ingresses)...)
 	for _, r := range routes {
 		// ignore the routes created by ingresses
 		if r.OwnerReferences != nil && r.OwnerReferences[0].Kind == "Ingress" {

--- a/pkg/url/types.go
+++ b/pkg/url/types.go
@@ -52,6 +52,14 @@ const (
 	StateTypeLocallyDeleted = "Locally Deleted"
 )
 
+func NewURLsFromKubernetesIngressList(kil *unions.KubernetesIngressList) []URL {
+	var ul []URL
+	for _, it := range kil.Items {
+		ul = append(ul, NewURLFromKubernetesIngress(it))
+	}
+	return ul
+}
+
 func NewURLFromKubernetesIngress(ki *unions.KubernetesIngress) URL {
 	if ki.IsGenerated() {
 		return URL{}

--- a/pkg/url/types.go
+++ b/pkg/url/types.go
@@ -6,6 +6,7 @@ import (
 	urlLabels "github.com/openshift/odo/pkg/url/labels"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 )
 
 // URL is
@@ -53,11 +54,14 @@ const (
 )
 
 func NewURLsFromKubernetesIngressList(kil *unions.KubernetesIngressList) []URL {
-	var ul []URL
-	for _, it := range kil.Items {
-		ul = append(ul, NewURLFromKubernetesIngress(it))
+	var urlList []URL
+	for _, item := range kil.Items {
+		urlItem := NewURLFromKubernetesIngress(item)
+		if !reflect.DeepEqual(urlItem, URL{}) {
+			urlList = append(urlList, urlItem)
+		}
 	}
-	return ul
+	return urlList
 }
 
 func NewURLFromKubernetesIngress(ki *unions.KubernetesIngress) URL {

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -72,10 +72,7 @@ func ListPushedIngress(client *kclient.Client, componentName string) (URLList, e
 	}
 
 	var urls []URL
-	for _, i := range ingresses {
-		urls = append(urls, NewURLFromKubernetesIngress(i))
-	}
-
+	urls = append(urls, NewURLsFromKubernetesIngressList(ingresses)...)
 	urlList := getMachineReadableFormatForList(urls)
 	return urlList, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind task

**What does this PR do / why we need it**:
This is part 2 of the move from extensions v1beta1 ingress to networking v1 ingress

**Which issue(s) this PR fixes**:

Fixes #4592 

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```bash
> odo create nodejs
Devfile Object Validation
 ✓  Checking devfile existence [93840ns]
 ✓  Creating a devfile component from registry: DefaultDevfileRegistry [159109ns]
Validation
 ✓  Validating if devfile name is correct [137914ns]

Please use `odo push` command to create the component with source deployed
> odo url create ingress-3001 --port 3001 --host com --protocol https --ingress --secure
 ✓  URL ingress-3001 created for component: nodejs-nodejs-ex-kfga

To apply the URL configuration changes, please use `odo push`
> odo url create ingress-3002 --port 3002 --host com --protocol http --ingress
 ✓  URL ingress-3002 created for component: nodejs-nodejs-ex-kfga

To apply the URL configuration changes, please use `odo push`
> odo url list
Found the following URLs for component nodejs-nodejs-ex-kfga
NAME             STATE          URL                          PORT     SECURE     KIND
http-3000        Not Pushed     <provided by cluster>        3000     false      route
ingress-3001     Not Pushed     https://ingress-3001.com     3001     true       ingress
ingress-3002     Not Pushed     http://ingress-3002.com      3002     false      ingress
There are local changes. Please run 'odo push'.
> odo push

Validation
 ✓  Validating the devfile [147584ns]

Creating Kubernetes resources for component nodejs-nodejs-ex-kfga
 ✓  Waiting for component to start [2s]
 ✓  Waiting for component to start [454ms]

Applying URL changes
 ✓  URL http-3000: http://http-3000-nodejs-nodejs-ex-kfga-uv.apps.testocp47.psiodo.net/ created
 ✓  URL ingress-3001: https://ingress-3001.com/ created
 ✓  URL ingress-3002: http://ingress-3002.com/ created

Syncing to component nodejs-nodejs-ex-kfga
 ✓  Checking files for pushing [10ms]
 ✓  Syncing files to the component [10s]

Executing devfile commands for component nodejs-nodejs-ex-kfga
 ✓  Waiting for component to start [460ms]
 ✓  Executing install command "npm install" [10s]
 ✓  Executing run command "npm start" [3s]

Pushing devfile component "nodejs-nodejs-ex-kfga"
 ✓  Changes successfully pushed to component
> odo url list
Found the following URLs for component nodejs-nodejs-ex-kfga
NAME             STATE      URL                                                                     PORT     SECURE     KIND
http-3000        Pushed     http://http-3000-nodejs-nodejs-ex-kfga-uv.apps.testocp47.psiodo.net     3000     false      route
ingress-3001     Pushed     https://ingress-3001.com                                                3001     true       ingress
ingress-3002     Pushed     http://ingress-3002.com                                                 3002     false      ingress
> odo url delete ingress-3002
? Are you sure you want to delete the url ingress-3002 Yes
 ✓  URL ingress-3002 removed from component nodejs-nodejs-ex-kfga
> odo url list
Found the following URLs for component nodejs-nodejs-ex-kfga
NAME             STATE               URL                                                                     PORT     SECURE     KIND
http-3000        Pushed              http://http-3000-nodejs-nodejs-ex-kfga-uv.apps.testocp47.psiodo.net     3000     false      route
ingress-3001     Pushed              https://ingress-3001.com                                                3001     true       ingress
ingress-3002     Locally Deleted     http://ingress-3002.com                                                 3002     false      ingress
There are local changes. Please run 'odo push'.
> odo push
 ✓  Waiting for component to start [539ms]

Validation
 ✓  Validating the devfile [170418ns]

Creating Kubernetes resources for component nodejs-nodejs-ex-kfga
 ✓  Waiting for component to start [13s]
 ✓  Waiting for component to start [409ms]

Applying URL changes
 ✓  URL ingress-3002 successfully deleted

Syncing to component nodejs-nodejs-ex-kfga
 ✓  Checking file changes for pushing [3ms]
 ✓  Syncing files to the component [14s]

Executing devfile commands for component nodejs-nodejs-ex-kfga
 ✓  Waiting for component to start [505ms]
 ✓  Executing install command "npm install" [12s]
 ✓  Executing run command "npm start" [4s]

Pushing devfile component "nodejs-nodejs-ex-kfga"
 ✓  Changes successfully pushed to component
> odo url list
Found the following URLs for component nodejs-nodejs-ex-kfga
NAME             STATE      URL                                                                     PORT     SECURE     KIND
http-3000        Pushed     http://http-3000-nodejs-nodejs-ex-kfga-uv.apps.testocp47.psiodo.net     3000     false      route
ingress-3001     Pushed     https://ingress-3001.com                                                3001     true       ingress

> odo list
Devfile Components: 
APP     NAME                      PROJECT     TYPE       STATE
app     nodejs-nodejs-ex-kfga     uv          nodejs     Pushed

> odo list -o json
{
	"kind": "List",
	"apiVersion": "odo.dev/v1alpha1",
	"metadata": {},
	"s2iComponents": [],
	"devfileComponents": [
		{
			"kind": "Component",
			"apiVersion": "odo.dev/v1alpha1",
			"metadata": {
				"name": "nodejs-nodejs-ex-kfga",
				"namespace": "uv",
				"creationTimestamp": null
			},
			"spec": {
				"app": "app",
				"type": "nodejs",
				"sourceType": "local",
				"url": [
					"http-3000",
					"ingress-3001"
				],
				"env": [
					{
						"name": "PROJECTS_ROOT",
						"value": "/project"
					},
					{
						"name": "PROJECT_SOURCE",
						"value": "/project"
					},
					{
						"name": "DEBUG_PORT",
						"value": "5858"
					}
				]
			},
			"status": {
				"state": "Pushed"
			}
		}
	],
	"otherComponents": []
}

> odo version
odo v2.2.2 (8b135744e)

Server: https://api.testocp47.psiodo.net:6443
Kubernetes: v1.20.0+bafe72f
> time odo version
odo v2.2.2 (8b135744e)

Server: https://api.testocp47.psiodo.net:6443
Kubernetes: v1.20.0+bafe72f
odo version  0.22s user 0.04s system 9% cpu 2.749 total
> odo version -v 9
I0701 16:31:15.994282  113297 preference.go:220] The path for preference file is /home/mzee1000/.odo/preference.yaml
I0701 16:31:15.994436  113297 util.go:761] HTTPGetRequest: https://raw.githubusercontent.com/openshift/odo/master/build/VERSION
I0701 16:31:15.994606  113297 util.go:782] Response will be cached in /tmp/odohttpcache for 1h0m0s
I0701 16:31:15.995124  113297 util.go:795] Cached response used.
I0701 16:31:16.003994  113297 preference.go:220] The path for preference file is /home/mzee1000/.odo/preference.yaml
I0701 16:31:16.004236  113297 occlient.go:337] Trying to connect to server api.testocp47.psiodo.net:6443
I0701 16:31:16.367498  113297 occlient.go:344] Server https://api.testocp47.psiodo.net:6443 is up
I0701 16:31:17.961146  113297 occlient.go:1202] Unable to get OpenShift Version - endpoint '/version/openshift' doesn't exist
odo v2.2.2 (8b135744e)

Server: https://api.testocp47.psiodo.net:6443
Kubernetes: v1.20.0+bafe72f
I0701 16:31:18.317514  113297 odo.go:75] Could not get the latest release information in time. Never mind, exiting gracefully :)


```