### PR TITLE
Renames the service name to include the app name

### DIFF
--- a/pkg/component/pushed_component.go
+++ b/pkg/component/pushed_component.go
@@ -103,7 +103,7 @@ func (d defaultPushedComponent) GetStorage() ([]storage.Storage, error) {
 			storageItems = append(storageItems, storageList.Items...)
 		}
 		if _, ok := d.provider.(*devfileComponent); ok {
-			storageList, err := storage.DevfileListMounted(d.client.GetKubeClient(), d.GetName())
+			storageList, err := storage.DevfileListMounted(d.client.GetKubeClient(), d.GetName(), d.GetApplication())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/debug/portforward.go
+++ b/pkg/debug/portforward.go
@@ -52,7 +52,7 @@ func (f *DefaultPortForwarder) ForwardPorts(portPair string, stopChan, readyChan
 			return err
 		}
 
-		pod, err = f.kClient.GetPodUsingComponentName(f.componentName)
+		pod, err = f.kClient.GetOnePod(f.componentName, f.appName)
 		if err != nil {
 			return err
 		}

--- a/pkg/kclient/errors.go
+++ b/pkg/kclient/errors.go
@@ -19,3 +19,12 @@ type DeploymentNotFoundError struct {
 func (e *DeploymentNotFoundError) Error() string {
 	return fmt.Sprintf("deployment not found for the selector: %s", e.Selector)
 }
+
+// ServiceNotFoundError returns an error if no service is found with the selector
+type ServiceNotFoundError struct {
+	Selector string
+}
+
+func (e *ServiceNotFoundError) Error() string {
+	return fmt.Sprintf("service not found for the selector: %s", e.Selector)
+}

--- a/pkg/kclient/errors.go
+++ b/pkg/kclient/errors.go
@@ -26,5 +26,5 @@ type ServiceNotFoundError struct {
 }
 
 func (e *ServiceNotFoundError) Error() string {
-	return fmt.Sprintf("service not found for the selector: %s", e.Selector)
+	return fmt.Sprintf("service not found for the selector %q", e.Selector)
 }

--- a/pkg/kclient/fake/ingress.go
+++ b/pkg/kclient/fake/ingress.go
@@ -83,7 +83,7 @@ func GetSingleExtensionV1Ingress(urlName, componentName, appName string) *extens
 func GetSingleSecureIngress(urlName, componentName, appName, secretName string) *extensionsv1.Ingress {
 
 	if secretName == "" {
-		secretName = componentName + "-tlssecret"
+		secretName = componentName + "-" + appName + "-tlssecret"
 	}
 	return generator.GetIngress(generator.IngressParams{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kclient/pods.go
+++ b/pkg/kclient/pods.go
@@ -17,6 +17,7 @@ import (
 
 	// api resource types
 
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -185,6 +186,11 @@ func (c *Client) ExtractProjectToComponent(containerName, podName string, target
 		return err
 	}
 	return nil
+}
+
+// GetOnePod gets a pod using the component and app name
+func (c *Client) GetOnePod(componentName, appName string) (*corev1.Pod, error) {
+	return c.GetOnePodFromSelector(componentlabels.GetSelector(componentName, appName))
 }
 
 // GetPodUsingComponentName gets a pod using the component name

--- a/pkg/kclient/services.go
+++ b/pkg/kclient/services.go
@@ -60,6 +60,7 @@ func (c *Client) DeleteService(serviceName string) error {
 }
 
 // GetOneService retrieves the service with the given component and app name
+// An error is thrown when exactly one service is not found for the selector.
 func (c *Client) GetOneService(componentName, appName string) (*corev1.Service, error) {
 	return c.GetOneServiceFromSelector(componentlabels.GetSelector(componentName, appName))
 }
@@ -69,7 +70,7 @@ func (c *Client) GetOneService(componentName, appName string) (*corev1.Service, 
 func (c *Client) GetOneServiceFromSelector(selector string) (*corev1.Service, error) {
 	services, err := c.ListServices(selector)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get Deployments for the selector: %v", selector)
+		return nil, fmt.Errorf("unable to get services for the selector %q : %w", selector, err)
 	}
 
 	num := len(services)

--- a/pkg/kclient/services.go
+++ b/pkg/kclient/services.go
@@ -2,7 +2,9 @@ package kclient
 
 import (
 	"context"
+	"fmt"
 
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,4 +48,36 @@ func (c *Client) ListServices(selector string) ([]corev1.Service, error) {
 		return nil, errors.Wrap(err, "unable to list Services")
 	}
 	return serviceList.Items, nil
+}
+
+// DeleteService deletes the service with the given service name
+func (c *Client) DeleteService(serviceName string) error {
+	err := c.KubeClient.CoreV1().Services(c.Namespace).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetOneService retrieves the service with the given component and app name
+func (c *Client) GetOneService(componentName, appName string) (*corev1.Service, error) {
+	return c.GetOneServiceFromSelector(componentlabels.GetSelector(componentName, appName))
+}
+
+// GetOneServiceFromSelector returns the service object associated with the given selector.
+// An error is thrown when exactly one service is not found for the selector.
+func (c *Client) GetOneServiceFromSelector(selector string) (*corev1.Service, error) {
+	services, err := c.ListServices(selector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get Deployments for the selector: %v", selector)
+	}
+
+	num := len(services)
+	if num == 0 {
+		return nil, &ServiceNotFoundError{Selector: selector}
+	} else if num > 1 {
+		return nil, fmt.Errorf("multiple services exist for the selector: %v. Only one must be present", selector)
+	}
+
+	return &services[0], nil
 }

--- a/pkg/odo/cli/component/common_link.go
+++ b/pkg/odo/cli/component/common_link.go
@@ -364,13 +364,16 @@ func (o *commonLinkOptions) validateForOperator() (err error) {
 			}
 		}
 
-		_, err := o.Context.Client.GetKubeClient().GetService(o.suppliedName)
+		// TODO find the service using an app name to link components in other apps
+		// requires modification of the app flag or finding some other way
+		service, err := o.Context.Client.GetKubeClient().GetOneService(o.suppliedName, o.EnvSpecificInfo.GetApplication())
 		if kerrors.IsNotFound(err) {
 			return fmt.Errorf("couldn't find component named %q. Refer %q to see list of running components", o.suppliedName, "odo list")
 		}
 		if err != nil {
 			return err
 		}
+		o.serviceName = service.Name
 	}
 
 	if o.operationName == unlink {

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/odo/pkg/util"
 	"github.com/pkg/errors"
 
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/devfile/adapters"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes"
@@ -193,9 +194,7 @@ func (do *DeleteOptions) DevfileComponentDelete() error {
 		Namespace: do.namespace,
 	}
 
-	labels := map[string]string{
-		"component": componentName,
-	}
+	labels := componentlabels.GetLabels(componentName, do.EnvSpecificInfo.GetApplication(), false)
 	devfileHandler, err := adapters.NewComponentAdapter(componentName, do.componentContext, do.Application, devObj, kc)
 	if err != nil {
 		return err

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -80,7 +80,7 @@ func (k kubernetesClient) Delete(name string) error {
 
 // ListFromCluster lists pvc based Storage from the cluster
 func (k kubernetesClient) ListFromCluster() (StorageList, error) {
-	pod, err := k.client.GetKubeClient().GetPodUsingComponentName(k.localConfig.GetName())
+	pod, err := k.client.GetKubeClient().GetOnePod(k.localConfig.GetName(), k.localConfig.GetApplication())
 	if err != nil {
 		if _, ok := err.(*kclient.PodNotFoundError); ok {
 			return StorageList{}, nil

--- a/pkg/storage/kubernetes_test.go
+++ b/pkg/storage/kubernetes_test.go
@@ -81,6 +81,7 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 			fields: fields{
 				generic: generic{
 					componentName: "nodejs",
+					appName:       "app",
 				},
 			},
 			returnedPods: &corev1.PodList{
@@ -329,6 +330,7 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 
 			mockLocalConfig := localConfigProvider.NewMockLocalConfigProvider(ctrl)
 			mockLocalConfig.EXPECT().GetName().Return(tt.fields.generic.componentName).AnyTimes()
+			mockLocalConfig.EXPECT().GetApplication().Return(tt.fields.generic.appName).AnyTimes()
 
 			tt.fields.generic.localConfig = mockLocalConfig
 
@@ -617,6 +619,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 
 			mockLocalConfig := localConfigProvider.NewMockLocalConfigProvider(ctrl)
 			mockLocalConfig.EXPECT().GetName().Return(tt.fields.generic.componentName).AnyTimes()
+			mockLocalConfig.EXPECT().GetApplication().Return(tt.fields.generic.appName).AnyTimes()
 			mockLocalConfig.EXPECT().ListStorage().Return(tt.returnedLocalStorage, nil)
 
 			tt.fields.generic.localConfig = mockLocalConfig

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -562,8 +562,8 @@ func MachineReadableSuccessOutput(storageName string, message string) {
 }
 
 // DevfileListMounted lists the storage which are mounted on a container
-func DevfileListMounted(kClient *kclient.Client, componentName string) (StorageList, error) {
-	pod, err := kClient.GetPodUsingComponentName(componentName)
+func DevfileListMounted(kClient *kclient.Client, componentName, appName string) (StorageList, error) {
+	pod, err := kClient.GetOnePod(componentName, appName)
 	if err != nil {
 		if _, ok := err.(*kclient.PodNotFoundError); ok {
 			return StorageList{}, nil

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -852,6 +852,7 @@ func generateStorage(storage Storage, status StorageStatus, containerName string
 func TestDevfileListMounted(t *testing.T) {
 	type args struct {
 		componentName string
+		appName       string
 	}
 	tests := []struct {
 		name         string
@@ -865,6 +866,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 1: should error out for multiple pods returned",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -878,6 +880,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 2: pod not found",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{},
@@ -889,6 +892,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 3: no volume mounts on pod",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -902,6 +906,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 4: two volumes mounted on a single container",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -931,6 +936,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 5: one volume is mounted on a single container and another on both",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -964,6 +970,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 6: pvc for volumeMount not found",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -987,6 +994,7 @@ func TestDevfileListMounted(t *testing.T) {
 			name: "case 7: the storage label should be used as the name of the storage",
 			args: args{
 				componentName: "nodejs",
+				appName:       "app",
 			},
 			returnedPods: &corev1.PodList{
 				Items: []corev1.Pod{
@@ -1022,7 +1030,7 @@ func TestDevfileListMounted(t *testing.T) {
 				return true, tt.returnedPods, nil
 			})
 
-			got, err := DevfileListMounted(fakeClient, tt.args.componentName)
+			got, err := DevfileListMounted(fakeClient, tt.args.componentName, tt.args.appName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("devfileListMounted() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/testingutil/pods.go
+++ b/pkg/testingutil/pods.go
@@ -1,6 +1,7 @@
 package testingutil
 
 import (
+	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -9,10 +10,8 @@ import (
 func CreateFakePod(componentName, podName string) *corev1.Pod {
 	fakePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-			Labels: map[string]string{
-				"component": componentName,
-			},
+			Name:   podName,
+			Labels: componentlabels.GetLabels(componentName, "app", false),
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,

--- a/pkg/testingutil/services.go
+++ b/pkg/testingutil/services.go
@@ -162,10 +162,8 @@ func FakeServiceClassInstance(serviceInstanceName string, serviceClassName strin
 func FakeKubeService(componentName, serviceName string) corev1.Service {
 	return corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceName,
-			Labels: map[string]string{
-				"component-name": componentName,
-			},
+			Name:   serviceName,
+			Labels: componentlabels.GetLabels(componentName, "app", false),
 		},
 	}
 }

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -277,7 +277,7 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 	// we avoid using the getResourceName() and use the previous method from s2i
 	// as the host name, which is automatically created on openshift,
 	// can become more than 63 chars, which is invalid
-	routeName, err := util.NamespaceOpenShiftObject(url.Name, k.componentName)
+	routeName, err := util.NamespaceOpenShiftObject(url.Name, k.appName)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to create namespaced name")
 	}

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -31,7 +31,7 @@ type kubernetesClient struct {
 
 // ListFromCluster lists both route and ingress based URLs from the cluster
 func (k kubernetesClient) ListFromCluster() (URLList, error) {
-	labelSelector := fmt.Sprintf("%v=%v", componentlabels.ComponentLabel, k.componentName)
+	labelSelector := componentlabels.GetSelector(k.componentName, k.appName)
 	klog.V(4).Infof("Listing ingresses with label selector: %v", labelSelector)
 	ingresses, err := k.client.GetKubeClient().ListIngresses(labelSelector)
 	if err != nil {
@@ -185,7 +185,12 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 	if url.Spec.Host == "" {
 		return "", errors.Errorf("the host cannot be empty")
 	}
-	serviceName := k.componentName
+
+	service, err := k.client.GetKubeClient().GetOneService(k.componentName, k.appName)
+	if err != nil {
+		return "", err
+	}
+
 	ingressDomain := fmt.Sprintf("%v.%v", url.Name, url.Spec.Host)
 
 	// generate the owner reference
@@ -204,7 +209,7 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 			}
 		} else {
 			// get the default secret
-			defaultTLSSecretName := getDefaultTLSSecretName(k.componentName)
+			defaultTLSSecretName := getDefaultTLSSecretName(k.componentName, k.appName)
 			_, err := k.client.GetKubeClient().GetSecret(defaultTLSSecretName, k.client.Namespace)
 
 			// create tls secret if it does not exist
@@ -250,7 +255,7 @@ func (k kubernetesClient) createIngress(url URL, labels map[string]string) (stri
 	ingressParam := generator.IngressParams{
 		ObjectMeta: objectMeta,
 		IngressSpecParams: generator.IngressSpecParams{
-			ServiceName:   serviceName,
+			ServiceName:   service.Name,
 			IngressDomain: ingressDomain,
 			PortNumber:    intstr.FromInt(url.Spec.Port),
 			TLSSecretName: url.Spec.TLSSecret,
@@ -276,7 +281,6 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to create namespaced name")
 	}
-	serviceName := k.componentName
 
 	deployment, err := k.client.GetKubeClient().GetOneDeployment(k.componentName, k.appName)
 	if err != nil {
@@ -284,8 +288,13 @@ func (k kubernetesClient) createRoute(url URL, labels map[string]string) (string
 	}
 	ownerReference := generator.GetOwnerReference(deployment)
 
+	service, err := k.client.GetKubeClient().GetOneService(k.componentName, k.appName)
+	if err != nil {
+		return "", err
+	}
+
 	// Pass in the namespace name, link to the service (componentName) and labels to create a route
-	route, err := k.client.CreateRoute(routeName, serviceName, intstr.FromInt(url.Spec.Port), labels, url.Spec.Secure, url.Spec.Path, ownerReference)
+	route, err := k.client.CreateRoute(routeName, service.Name, intstr.FromInt(url.Spec.Port), labels, url.Spec.Secure, url.Spec.Path, ownerReference)
 	if err != nil {
 		if kerrors.IsAlreadyExists(err) {
 			return "", fmt.Errorf("url named %q already exists in the same app named %q", url.Name, k.appName)

--- a/pkg/url/kubernetes_test.go
+++ b/pkg/url/kubernetes_test.go
@@ -706,7 +706,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "example-nodejs",
+					Name: "example-app",
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":  "app",
 						"app.kubernetes.io/instance": "nodejs",
@@ -737,7 +737,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "example-url-nodejs",
+					Name: "example-url-app",
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":  "app",
 						"app.kubernetes.io/instance": "nodejs",
@@ -772,7 +772,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 			},
 			returnedRoute: &routev1.Route{
 				ObjectMeta: v1.ObjectMeta{
-					Name: "example-url-nodejs",
+					Name: "example-url-app",
 					Labels: map[string]string{
 						"app.kubernetes.io/part-of":  "app",
 						"app.kubernetes.io/instance": "nodejs",

--- a/pkg/url/kubernetes_test.go
+++ b/pkg/url/kubernetes_test.go
@@ -563,10 +563,18 @@ func Test_kubernetesClient_createIngress(t *testing.T) {
 				client:           *client,
 			}
 
+			fakeKClientSet.Kubernetes.PrependReactor("list", "services", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &corev1.ServiceList{
+					Items: []corev1.Service{
+						testingutil.FakeKubeService("nodejs", "nodejs-app"),
+					},
+				}, nil
+			})
+
 			fakeKClientSet.Kubernetes.PrependReactor("get", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
 				var secretName string
 				if tt.args.url.Spec.TLSSecret == "" {
-					secretName = tt.fields.generic.componentName + "-tlssecret"
+					secretName = getDefaultTLSSecretName(tt.fields.generic.componentName, tt.fields.generic.appName)
 					if action.(ktesting.GetAction).GetName() != secretName {
 						return true, nil, fmt.Errorf("get for secrets called with invalid name, want: %s,got: %s", secretName, action.(ktesting.GetAction).GetName())
 					}
@@ -606,14 +614,14 @@ func Test_kubernetesClient_createIngress(t *testing.T) {
 
 			wantKubernetesActionLength := 0
 			if !tt.args.url.Spec.Secure {
-				wantKubernetesActionLength = 2
+				wantKubernetesActionLength = 3
 			} else {
 				if tt.args.url.Spec.TLSSecret != "" && tt.userGivenTLSExists {
-					wantKubernetesActionLength = 3
-				} else if !tt.defaultTLSExists {
 					wantKubernetesActionLength = 4
+				} else if !tt.defaultTLSExists {
+					wantKubernetesActionLength = 5
 				} else {
-					wantKubernetesActionLength = 3
+					wantKubernetesActionLength = 4
 				}
 			}
 			if len(fakeKClientSet.Kubernetes.Actions()) != wantKubernetesActionLength {
@@ -627,18 +635,18 @@ func Test_kubernetesClient_createIngress(t *testing.T) {
 			var createdIngress *extensionsv1.Ingress
 			createIngressActionNo := 0
 			if !tt.args.url.Spec.Secure {
-				createIngressActionNo = 1
+				createIngressActionNo = 2
 			} else {
 				if tt.args.url.Spec.TLSSecret != "" {
-					createIngressActionNo = 2
+					createIngressActionNo = 3
 				} else if !tt.defaultTLSExists {
-					createdDefaultTLS := fakeKClientSet.Kubernetes.Actions()[2].(ktesting.CreateAction).GetObject().(*corev1.Secret)
-					if createdDefaultTLS.Name != tt.fields.generic.componentName+"-tlssecret" {
+					createdDefaultTLS := fakeKClientSet.Kubernetes.Actions()[3].(ktesting.CreateAction).GetObject().(*corev1.Secret)
+					if createdDefaultTLS.Name != getDefaultTLSSecretName(tt.fields.generic.componentName, tt.fields.generic.appName) {
 						t.Errorf("default tls created with different name, want: %s,got: %s", tt.fields.generic.componentName+"-tlssecret", createdDefaultTLS.Name)
 					}
-					createIngressActionNo = 3
+					createIngressActionNo = 4
 				} else {
-					createIngressActionNo = 2
+					createIngressActionNo = 3
 				}
 			}
 			createdIngress = fakeKClientSet.Kubernetes.Actions()[createIngressActionNo].(ktesting.CreateAction).GetObject().(*extensionsv1.Ingress)
@@ -659,7 +667,7 @@ func Test_kubernetesClient_createIngress(t *testing.T) {
 
 			if tt.args.url.Spec.Secure {
 				if wantedIngressSpecParams.TLSSecretName == "" {
-					wantedIngressSpecParams.TLSSecretName = tt.fields.generic.componentName + "-tlssecret"
+					wantedIngressSpecParams.TLSSecretName = getDefaultTLSSecretName(tt.fields.generic.componentName, tt.fields.generic.appName)
 				}
 				if !reflect.DeepEqual(createdIngress.Spec.TLS[0].SecretName, wantedIngressSpecParams.TLSSecretName) {
 					t.Errorf("ingress tls name not matching, expected: %s, got %s", wantedIngressSpecParams.TLSSecretName, createdIngress.Spec.TLS)
@@ -711,7 +719,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					To: routev1.RouteTargetReference{
 						Kind: "Service",
-						Name: "nodejs",
+						Name: "nodejs-app",
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromInt(8080),
@@ -742,7 +750,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					To: routev1.RouteTargetReference{
 						Kind: "Service",
-						Name: "nodejs",
+						Name: "nodejs-app",
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromInt(9100),
@@ -781,7 +789,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 					},
 					To: routev1.RouteTargetReference{
 						Kind: "Service",
-						Name: "nodejs",
+						Name: "nodejs-app",
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromInt(9100),
@@ -804,6 +812,14 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 				return true, route, nil
 			})
 
+			fakeKClientSet.Kubernetes.PrependReactor("list", "services", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &corev1.ServiceList{
+					Items: []corev1.Service{
+						testingutil.FakeKubeService("nodejs", "nodejs-app"),
+					},
+				}, nil
+			})
+
 			fakeKClientSet.Kubernetes.PrependReactor("list", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, &appsv1.DeploymentList{Items: []appsv1.Deployment{*testingutil.CreateFakeDeployment("nodejs")}}, nil
 			})
@@ -823,7 +839,7 @@ func Test_kubernetesClient_createRoute(t *testing.T) {
 			}
 
 			if len(fakeClientSet.RouteClientset.Actions()) != 1 {
-				t.Errorf("expected 1 RouteClientset.Actions() in CreateService, got: %v", fakeClientSet.RouteClientset.Actions())
+				t.Errorf("expected 1 RouteClientset.Actions() in CreateService, got: %v", len(fakeClientSet.RouteClientset.Actions()))
 			}
 
 			createdRoute := fakeClientSet.RouteClientset.Actions()[0].(ktesting.CreateAction).GetObject().(*routev1.Route)
@@ -926,6 +942,14 @@ func Test_kubernetesClient_Create(t *testing.T) {
 				return true, &appsv1.DeploymentList{Items: []appsv1.Deployment{*testingutil.CreateFakeDeployment("nodejs")}}, nil
 			})
 
+			fakeKClientSet.Kubernetes.PrependReactor("list", "services", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &corev1.ServiceList{
+					Items: []corev1.Service{
+						testingutil.FakeKubeService("nodejs", "nodejs-app"),
+					},
+				}, nil
+			})
+
 			fakeClientSet.RouteClientset.PrependReactor("create", "routes", func(action ktesting.Action) (bool, runtime.Object, error) {
 				route := action.(ktesting.CreateAction).GetObject().(*routev1.Route)
 				route.Spec.Host = "host"
@@ -954,7 +978,7 @@ func Test_kubernetesClient_Create(t *testing.T) {
 			if tt.args.url.Spec.Kind == localConfigProvider.INGRESS {
 				requiredIngress := fake.GetSingleExtensionV1Ingress(tt.args.url.Name, tt.fields.generic.componentName, tt.fields.generic.appName)
 
-				createdIngress := fakeKClientSet.Kubernetes.Actions()[1].(ktesting.CreateAction).GetObject().(*extensionsv1.Ingress)
+				createdIngress := fakeKClientSet.Kubernetes.Actions()[2].(ktesting.CreateAction).GetObject().(*extensionsv1.Ingress)
 				requiredIngress.Labels["odo.openshift.io/url-name"] = tt.args.url.Name
 				if !reflect.DeepEqual(createdIngress.Labels, requiredIngress.Labels) {
 					t.Errorf("ingress name not matching, expected: %s, got %s", requiredIngress.Labels, createdIngress.Labels)

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -271,8 +271,8 @@ func getMachineReadableFormatExtensionV1Ingress(i iextensionsv1.Ingress) URL {
 }
 
 // getDefaultTLSSecretName returns the name of the default tls secret name
-func getDefaultTLSSecretName(componentName string) string {
-	return componentName + "-tlssecret"
+func getDefaultTLSSecretName(componentName, appName string) string {
+	return componentName + "-" + appName + "-tlssecret"
 }
 
 // ConvertExtensionV1IngressURLToIngress converts IngressURL to Ingress
@@ -377,7 +377,7 @@ func Push(parameters PushParameters) error {
 				// the default secret name is used during creation
 				// thus setting it to the local URLs to avoid config mismatch
 				if val.Spec.Secure && val.Spec.TLSSecret == "" {
-					val.Spec.TLSSecret = getDefaultTLSSecretName(parameters.LocalConfig.GetName())
+					val.Spec.TLSSecret = getDefaultTLSSecretName(parameters.LocalConfig.GetName(), parameters.LocalConfig.GetApplication())
 				}
 				val.Spec.Host = fmt.Sprintf("%v.%v", urlName, val.Spec.Host)
 			} else if val.Spec.Kind == localConfigProvider.ROUTE {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -182,6 +182,31 @@ func NamespaceKubernetesObject(componentName string, applicationName string) (st
 	return fmt.Sprintf("%s-%s", strings.Replace(componentName, "/", "-", -1), applicationName), nil
 }
 
+// NamespaceKubernetesObjectWithTrim hyphenates applicationName and componentName
+// if the resultant name is greater than 63 characters
+// it trims each to 31 characters
+// <31-characters>+"-"+<31-characters> = 63 characters
+func NamespaceKubernetesObjectWithTrim(componentName, applicationName string) (string, error) {
+	value, err := NamespaceKubernetesObject(componentName, applicationName)
+	if err != nil {
+		return "", err
+	}
+
+	// doesn't require trim
+	if len(value) <= 63 {
+		return value, nil
+	}
+
+	// trim to 31 characters
+	componentName = componentName[:31]
+	applicationName = applicationName[:31]
+	value, err = NamespaceKubernetesObject(componentName, applicationName)
+	if err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
 // ExtractComponentType returns only component type part from passed component type(default unqualified, fully qualified, versioned, etc...and their combinations) for use as component name
 // Possible types of parameters:
 // 1. "myproject/python:3.5" -- Return python

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2729,3 +2729,60 @@ func TestConvertLabelsToSelector(t *testing.T) {
 		}
 	}
 }
+
+func TestNamespaceKubernetesObjectWithTrim(t *testing.T) {
+	type args struct {
+		componentName   string
+		applicationName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "case 1: hyphenated name is less than 63 characters",
+			args: args{
+				componentName:   "nodejs",
+				applicationName: "app",
+			},
+			want:    "nodejs-app",
+			wantErr: false,
+		},
+		{
+			name: "case 2: hyphenated name is more than 63 characters",
+			args: args{
+				componentName:   "veryveryveryveryveryLongComponentName",
+				applicationName: "veryveryveryveryveryveryLongAppName",
+			},
+			want:    "veryveryveryveryveryLongCompone-veryveryveryveryveryveryLongApp",
+			wantErr: false,
+		},
+		{
+			name: "case 3: hyphenated name is equal to 63 characters",
+			args: args{
+				componentName:   "veryveryveryveryLongComponentGo",
+				applicationName: "veryveryveryveryLongAppNameInGo",
+			},
+			want:    "veryveryveryveryLongComponentGo-veryveryveryveryLongAppNameInGo",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NamespaceKubernetesObjectWithTrim(tt.args.componentName, tt.args.applicationName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NamespaceKubernetesObjectWithTrim() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NamespaceKubernetesObjectWithTrim() got = %v, want %v", got, tt.want)
+			}
+
+			if len(got) > 63 {
+				t.Errorf("got = %s should be less than or equal to 63 characters", got)
+			}
+		})
+	}
+}

--- a/tests/integration/devfile/cmd_devfile_app_test.go
+++ b/tests/integration/devfile/cmd_devfile_app_test.go
@@ -41,12 +41,12 @@ var _ = Describe("odo devfile app command tests", func() {
 			// create first component in the first app
 			context0 = helper.CreateNewContext()
 			component0 = helper.RandString(4)
-			createComponent(component0, app0, namespace, context0, "")
+			createComponent(component0, app0, namespace, context0)
 
 			// create second component in the second app
 			context1 = helper.CreateNewContext()
 			component1 = helper.RandString(4)
-			createComponent(component1, app1, namespace, context1, "")
+			createComponent(component1, app1, namespace, context1)
 		})
 
 		AfterEach(func() {
@@ -111,7 +111,7 @@ var _ = Describe("odo devfile app command tests", func() {
 
 				helper.Cmd("odo", "create", "nodejs", "--project", namespace, component00, "--context", context00, "--app", app0).ShouldPass()
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context00)
-				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context00, "devfile.yaml"))
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(context00, "devfile.yaml"))
 				helper.Cmd("odo", "storage", "create", storage00, "--path", "/data", "--size", "1Gi", "--context", context00).ShouldPass()
 				helper.Cmd("odo", "url", "create", url00, "--port", "3000", "--context", context00, "--host", "com", "--ingress").ShouldPass()
 				helper.Cmd("odo", "push", "--context", context00).ShouldPass()
@@ -154,11 +154,11 @@ var _ = Describe("odo devfile app command tests", func() {
 
 			// create first component in the first app
 			context0 = helper.CreateNewContext()
-			createComponent(component, app0, namespace, context0, "")
+			createComponent(component, app0, namespace, context0)
 
 			// create second component in the second app
 			context1 = helper.CreateNewContext()
-			createComponent(component, app1, namespace, context1, "devfileNestedCompCommands.yaml")
+			createComponent(component, app1, namespace, context1)
 		})
 
 		AfterEach(func() {
@@ -179,15 +179,10 @@ var _ = Describe("odo devfile app command tests", func() {
 })
 
 // createComponent creates with the given parameters and pushes it
-// devfileExampleName is the example devfile used during the creation
-// if empty a default devfile example is used
-func createComponent(componentName, appName, project, context, devfileExampleName string) {
-	if devfileExampleName == "" {
-		devfileExampleName = "devfile.yaml"
-	}
+func createComponent(componentName, appName, project, context string) {
 	helper.Cmd("odo", "create", "nodejs", "--project", project, componentName, "--context", context, "--app", appName).ShouldPass()
 	helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context)
-	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfileExampleName), filepath.Join(context, "devfile.yaml"))
+	helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context, "devfile.yaml"))
 	helper.Cmd("odo", "push", "--context", context).ShouldPass()
 }
 

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -69,7 +69,9 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			When("a nodejs component is created", func() {
 
 				BeforeEach(func() {
-					helper.Cmd("odo", "create", "nodejs").ShouldPass().Out()
+					// change the app name to avoid conflicts
+					appName := helper.RandString(5)
+					helper.Cmd("odo", "create", "nodejs", "--app", appName).ShouldPass().Out()
 				})
 
 				AfterEach(func() {

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -567,6 +567,10 @@ spec:
 				cmp0 = helper.RandString(5)
 
 				helper.Cmd("odo", "create", "nodejs", cmp0, "--context", context0).ShouldPass()
+
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context0)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context0, "devfile.yaml"))
+
 				helper.Cmd("odo", "push", "--context", context0).ShouldPass()
 			})
 
@@ -598,6 +602,10 @@ spec:
 					cmp1 = helper.RandString(5)
 
 					helper.Cmd("odo", "create", "nodejs", cmp1, "--context", context1).ShouldPass()
+
+					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context1)
+					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(context1, "devfile.yaml"))
+
 					helper.Cmd("odo", "push", "--context", context1).ShouldPass()
 				})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind design

**What does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4550 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

Create two components with the same name in different apps
- `odo create nodejs <component-name> --app app --context <directory of the first component>`
- `odo create springboot <component-name> --app app1 --context <directory of the second component>`
- Trigger `odo push` for the both the components
- `oc get service` should list both the services
- `oc get deployments` should list both the deployments
- Check the list output for `odo list --app app` and `odo list --app app1`.