### PR TITLE
disable rpm-build test from unit test

### DIFF
--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -20,4 +20,4 @@ make cross
 cp -r dist $ARTIFACT_DIR
 
 # RPM Tests
-scripts/rpm-x86_64-test.sh
+#scripts/rpm-x86_64-test.sh


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
This PR disable tests for rpm builds on unit tests

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
