### PR TITLE
Add linked service information in odo describe

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - param based `odo service create` for operator backed services ([#4704](https://github.com/openshift/odo/pull/4704))
 - add `odo catalog describe service <operator> --example` ([#4821](https://github.com/openshift/odo/pull/4821))
 - `odo link` and `odo unlink` write to devfile without deploying to cluster. Deploying happens when running `odo push` ([#4819](https://github.com/openshift/odo/pull/4819))
+- `odo describe` shows linked services and components whether they are pushed or not. When deployed, it also shows environment variables or mounted files ([#4866](https://github.com/openshift/odo/pull/4866))
 
 ### Bug Fixes
 

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1602,7 +1602,7 @@ func setLinksServiceNames(client *occlient.Client, linkedSecrets []SecretMount) 
 		}
 		services := sbr.Spec.Services
 		if len(services) != 1 {
-			return errors.New("ServiceBinding should have only one service")
+			return errors.New("the ServiceBinding resource should define only one service")
 		}
 		service := services[0]
 		if service.Kind == "Service" {

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -36,12 +36,19 @@ type ComponentList struct {
 	Items           []Component `json:"items"`
 }
 
+// SecretMount describes a Secret mount (either as environment variables with envFrom or as a volume)
+type SecretMount struct {
+	ServiceName string
+	SecretName  string
+	MountVolume bool
+	MountPath   string
+}
+
 // ComponentStatus is Status of components
 type ComponentStatus struct {
-	Context          string              `json:"context,omitempty"`
-	State            State               `json:"state"`
-	LinkedComponents map[string][]string `json:"linkedComponents,omitempty"`
-	LinkedServices   []string            `json:"linkedServices,omitempty"`
+	Context        string        `json:"context,omitempty"`
+	State          State         `json:"state"`
+	LinkedServices []SecretMount `json:"linkedServices,omitempty"`
 }
 
 // CombinedComponentList is list of s2i and devfile components

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -351,6 +351,11 @@ func (c *Client) CreateDynamicResource(exampleCustomResource map[string]interfac
 // ListDynamicResource returns an unstructured list of instances of a Custom
 // Resource currently deployed in the active namespace of the cluster
 func (c *Client) ListDynamicResource(group, version, resource string) (*unstructured.UnstructuredList, error) {
+
+	if c.DynamicClient == nil {
+		return nil, nil
+	}
+
 	deploymentRes := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
 
 	list, err := c.DynamicClient.Resource(deploymentRes).Namespace(c.Namespace).List(context.TODO(), metav1.ListOptions{})

--- a/pkg/odo/cli/component/delete.go
+++ b/pkg/odo/cli/component/delete.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	applabels "github.com/openshift/odo/pkg/application/labels"
 	"github.com/openshift/odo/pkg/envinfo"
 
 	"github.com/openshift/odo/pkg/util"
@@ -151,43 +150,6 @@ func (do *DeleteOptions) s2iRun() (err error) {
 		}
 
 		if do.componentForceDeleteFlag || ui.Proceed(fmt.Sprintf("Are you sure you want to delete %v from %v?", do.componentName, do.Application)) {
-			// Before actually deleting the component, first unlink it from any component(s) in the cluster it might be linked to
-			// We do this in three steps:
-			// 1. Get list of active components in the cluster
-			// 2. Use this list to find the components to which our component is linked and generate secret names that are linked
-			// 3. Unlink these secrets from the components
-			var selector string
-			if do.Context.Application != "" {
-				selector = applabels.GetSelector(do.Context.Application)
-			}
-			compoList, err := component.List(do.Client, selector, do.LocalConfigInfo)
-			if err != nil {
-				return err
-			}
-
-			parentComponent, err := component.GetComponent(do.Client, do.componentName, do.Context.Application, do.Context.Project)
-			if err != nil {
-				return err
-			}
-
-			componentSecrets := component.UnlinkComponents(parentComponent, compoList)
-
-			for component, secret := range componentSecrets {
-				spinner := log.Spinner("Unlinking components")
-				for _, secretName := range secret {
-
-					defer spinner.End(false)
-
-					err = do.Client.UnlinkSecret(secretName, component, do.Context.Application)
-					if err != nil {
-						log.Errorf("Unlinking failed")
-						return err
-					}
-
-					spinner.End(true)
-					log.Successf(fmt.Sprintf("Unlinked component %q from component %q for secret %q", parentComponent.Name, component, secretName))
-				}
-			}
 			err = component.Delete(do.Client, do.componentDeleteWaitFlag, do.componentName, do.Application)
 			if err != nil {
 				return err

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -175,27 +175,6 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 
 	}
 
-	// Linked components
-	if len(componentDesc.Status.LinkedComponents) > 0 {
-
-		// Gather the output
-		var output string
-		for name, ports := range componentDesc.Status.LinkedComponents {
-			if len(ports) > 0 {
-				output += fmt.Sprintf(" · %v - Port(s): %v\n", name, strings.Join(ports, ","))
-			} else {
-				output += fmt.Sprintf(" · %v\n", name)
-			}
-		}
-
-		// Cut off the last newline and output
-		if len(output) > 0 {
-			output = output[:len(output)-1]
-			log.Describef("Linked Components:\n", output)
-		}
-
-	}
-
 	// Linked services
 	if len(componentDesc.Status.LinkedServices) > 0 {
 
@@ -204,7 +183,7 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 		for _, linkedService := range componentDesc.Status.LinkedServices {
 
 			// Let's also get the secrets / environment variables that are being passed in.. (if there are any)
-			secrets, err := client.GetKubeClient().GetSecret(linkedService, project)
+			secrets, err := client.GetKubeClient().GetSecret(linkedService.SecretName, project)
 			LogErrorAndExit(err, "")
 
 			if len(secrets.Data) > 0 {
@@ -217,11 +196,11 @@ func PrintComponentInfo(client *occlient.Client, currentComponentName string, co
 				if len(secretOutput) > 0 {
 					// Cut off the last newline
 					secretOutput = secretOutput[:len(secretOutput)-1]
-					output += fmt.Sprintf(" · %s\n   Environment Variables:\n%s\n", linkedService, secretOutput)
+					output += fmt.Sprintf(" · %s\n   Environment Variables:\n%s\n", linkedService.SecretName, secretOutput)
 				}
 
 			} else {
-				output += fmt.Sprintf(" · %s\n", linkedService)
+				output += fmt.Sprintf(" · %s\n", linkedService.SecretName)
 			}
 
 		}

--- a/pkg/odo/util/completion/completionhandlers.go
+++ b/pkg/odo/util/completion/completionhandlers.go
@@ -362,7 +362,7 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 	}
 
 	completions = make([]string, 0, len(components)+len(services.Items))
-	secretNames := comp.GetLinkedSecretNames()
+	secretMounts := comp.GetLinkedSecrets()
 	for _, component := range components {
 		// we found the name in the list which means
 		// that the name has been already selected by the user so no need to suggest more
@@ -372,8 +372,8 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 		// we don't want to show the selected component as a target for linking, so we remove it from the suggestions
 		if component != context.Component() {
 			// we also need to make sure that this component has been linked to the current component
-			for _, secret := range secretNames {
-				if strings.Contains(secret, component) {
+			for _, secret := range secretMounts {
+				if strings.Contains(secret.SecretName, component) {
 					completions = append(completions, component)
 				}
 			}
@@ -387,8 +387,8 @@ var UnlinkCompletionHandler = func(cmd *cobra.Command, args parsedArgs, context 
 			return nil
 		}
 		// we also need to make sure that this component has been linked to the current component
-		for _, secret := range secretNames {
-			if strings.Contains(secret, service.Name) {
+		for _, secret := range secretMounts {
+			if strings.Contains(secret.SecretName, service.Name) {
 				completions = append(completions, service.Name)
 			}
 		}


### PR DESCRIPTION
/kind feature

**What does this PR do / why we need it**:

- [x] Shows the linked components with variables / files when pushed
- [x] Shows the linked components names when not pushed
- [x] Shows the linked services with variables / files when pushed
- [x] Shows the linked services names when not pushed
- [x] Linked components are shown in the section "Linked services" along with the linked services

> Unused code relative to "linked components" has been removed, because it was detecting the linked components using the old way (based on labels and annotations instead of ServiceBindingRequests):
>
> ```
> componentName, containsComponentLabel := secret.Labels[componentlabels.ComponentLabel]
> 		if containsComponentLabel {
> 			if port, ok := secret.Annotations[kclient.ComponentPortAnnotationName]; ok {
> 				linkedComponents[componentName] = append(linkedComponents[componentName], port)
> 			}
> 		}
> ```
>
> Issue #4871  tracks the update of this behaviour with the new way to create links (with ServiceBindings).

**Which issue(s) this PR fixes**:

Fixes #3734 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
