### PR TITLE
Limits memory requests to deploy more components

### DIFF
--- a/tests/examples/source/devfiles/nodejs/devfile-with-link.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-link.yaml
@@ -37,7 +37,7 @@ components:
     - name: http-3000
       targetPort: 3000
     image: registry.access.redhat.com/ubi8/nodejs-14:latest
-    memoryLimit: 1024Mi
+    memoryLimit: 300Mi
     mountSources: true
     sourceMapping: /project
   name: runtime

--- a/tests/integration/operatorhub/cmd_link_test.go
+++ b/tests/integration/operatorhub/cmd_link_test.go
@@ -54,6 +54,7 @@ var _ = Describe("odo link command tests for OperatorHub", func() {
 				helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 				componentName = "cmp-" + helper.RandString(6)
 				helper.Cmd("odo", "create", "nodejs", componentName).ShouldPass()
+				helper.Cmd("odo", "config", "set", "Memory", "300M", "-f").ShouldPass()
 
 				serviceName := "service-" + helper.RandString(6)
 				svcFullName = strings.Join([]string{"Redis", serviceName}, "/")

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -66,9 +66,11 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			When("a nodejs component is created", func() {
 
 				BeforeEach(func() {
+					helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 					// change the app name to avoid conflicts
 					appName := helper.RandString(5)
 					helper.Cmd("odo", "create", "nodejs", "--app", appName).ShouldPass().Out()
+					helper.Cmd("odo", "config", "set", "Memory", "300M", "-f").ShouldPass()
 				})
 
 				AfterEach(func() {
@@ -167,7 +169,9 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			When("a nodejs component is created", func() {
 
 				BeforeEach(func() {
+					helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
 					helper.Cmd("odo", "create", "nodejs").ShouldPass()
+					helper.Cmd("odo", "config", "set", "Memory", "300M", "-f").ShouldPass()
 				})
 
 				It("should fail for interactive mode", func() {
@@ -557,6 +561,7 @@ spec:`
 				cmp0 = helper.RandString(5)
 
 				helper.Cmd("odo", "create", "nodejs", cmp0, "--context", context0).ShouldPass()
+				helper.Cmd("odo", "config", "set", "Memory", "300M", "-f", "--context", context0).ShouldPass()
 
 				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context0)
 				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context0, "devfile.yaml"))
@@ -589,6 +594,7 @@ spec:`
 					cmp1 = helper.RandString(5)
 
 					helper.Cmd("odo", "create", "nodejs", cmp1, "--context", context1).ShouldPass()
+					helper.Cmd("odo", "config", "set", "Memory", "300M", "-f", "--context", context1).ShouldPass()
 
 					helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context1)
 					helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfileNestedCompCommands.yaml"), filepath.Join(context1, "devfile.yaml"))


### PR DESCRIPTION
**What type of PR is this?**

/kind flake


During the execution of the tests, you can check that all pod started by the tests have set a **Memory Request**, and that the system memory allocated is not exhausted by examining the output of `kubectl describe node`:

```
$ kubectl describe node <worker-node>
[...]
  Namespace                                   Name                                                             CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE
  ---------                                   ----                                                             ------------  ----------  ---------------  -------------  ---
  cmd-link-test99ggn                          cmp-hwbaqb-app-fdc5f8b95-vfc8t                                   0 (0%)        0 (0%)      300M (1%)        300M (1%)      3s
  cmd-link-test99ggn                          service-xrusig-0                                                 201m (3%)     201m (3%)   256Mi (1%)       256Mi (1%)     3s
  cmd-service-test192vok                      nodejs-x072280828-goxk-app-6758469dd5-std6r                      0 (0%)        0 (0%)      300M (1%)        300M (1%)      4s
  cmd-service-test324vxr                      nodejs-x251149076-zthe-app-68bb4575f6-89p7v                      0 (0%)        0 (0%)      300M (1%)        300M (1%)      4s
  cmd-service-test324vxr                      redis-0                                                          201m (3%)     201m (3%)   256Mi (1%)       256Mi (1%)     4s
  cmd-service-test443cdb                      lvbphg-0                                                         201m (3%)     201m (3%)   256Mi (1%)       256Mi (1%)     3s
  cmd-service-test443cdb                      nodejs-x468076898-bsok-app-db46c7dbd-xrnsq                       0 (0%)        0 (0%)      300M (1%)        300M (1%)      4s
  cmd-service-test577rtp                      xmyqh-app-cd6fdf694-5944b                                        0 (0%)        0 (0%)      1Gi (6%)         1Gi (6%)       4s
  odo-operator-test                           gcrmypbkoh-85f9fc5b4-4nspw                                       30m (0%)      60m (1%)    128Mi (0%)       512Mi (3%)     3s
  odo-operator-test                           nodejs-x144568958-xfqz-axjsr-65f797bf5d-qdfrj                    0 (0%)        0 (0%)      300M (1%)        300M (1%)      3s
  odo-operator-test                           nodejs-x272880799-puid-cryeu-5f585f4bcf-bb6t9                    0 (0%)        0 (0%)      300M (1%)        300M (1%)      5s
  odo-operator-test                           postgresql-operator-7df4c49c98-m7cvk                             30m (0%)      60m (1%)    64Mi (0%)        128Mi (0%)     46h
  odo-operator-test                           yiglippsoo-7fbb65dbf6-sztcm                                      30m (0%)      60m (1%)    128Mi (0%)       512Mi (3%)     5s
[...]
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests           Limits
  --------           --------           ------
  cpu                2768m (46%)        883m (14%)
  memory             11219358208 (67%)  6065607168 (36%)
  ephemeral-storage  0 (0%)             0 (0%)
  hugepages-1Gi      0 (0%)             0 (0%)
  hugepages-2Mi      0 (0%)             0 (0%)
```

In this case, 67% of the node memory has been reserved.