### PR TITLE
Add telemetry contextual properties if it is enabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,10 @@
 - param based `odo service create` for operator backed services ([#4704](https://github.com/openshift/odo/pull/4704))
 - add `odo catalog describe service <operator> --example` ([#4821](https://github.com/openshift/odo/pull/4821))
 - `odo link` and `odo unlink` write to devfile without deploying to cluster. Deploying happens when running `odo push` ([#4819](https://github.com/openshift/odo/pull/4819))
+- collect component type and cluster type data for telemetry ([#4763](https://github.com/openshift/odo/pull/4763))
 
 ### Bug Fixes
+- Update telemetry contextual properties only when it is enabled([#4870](https://github.com/openshift/odo/pull/4870))
 
 - Completely move to using networking v1 and extensions v1 ingresses based on cluster support as extensions v1 ingress is deprecated ([#4853](https://github.com/openshift/odo/pull/4853))
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/odo/pkg/segment"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -845,7 +843,7 @@ func (co *CreateOptions) devfileRun(cmd *cobra.Command) (err error) {
 		return errors.Wrap(err, "unable to parse devfile")
 	}
 	// Add component type in case it is not already added or is empty
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		if value, ok := scontext.GetContextProperties(cmd.Context())[scontext.ComponentType]; !ok || value == "" {
 			scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(devObj.Data.GetMetadata()))
 		}
@@ -923,7 +921,7 @@ func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
 
 	// By default we run Devfile
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
-		if segment.IsTelemetryEnabled(nil) {
+		if scontext.GetTelemetryStatus(cmd.Context()) {
 			scontext.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
 		}
 		err := co.devfileRun(cmd)
@@ -937,7 +935,7 @@ func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	// Add component type for s2i components
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetComponentType(cmd.Context(), *co.componentSettings.Type)
 	}
 	// we only do conversion if the --s2i is provided and the component is not of --git type

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -843,8 +845,10 @@ func (co *CreateOptions) devfileRun(cmd *cobra.Command) (err error) {
 		return errors.Wrap(err, "unable to parse devfile")
 	}
 	// Add component type in case it is not already added or is empty
-	if value, ok := scontext.GetContextProperties(cmd.Context())[scontext.ComponentType]; !ok || value == "" {
-		scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(devObj.Data.GetMetadata()))
+	if segment.IsTelemetryEnabled(nil) {
+		if value, ok := scontext.GetContextProperties(cmd.Context())[scontext.ComponentType]; !ok || value == "" {
+			scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(devObj.Data.GetMetadata()))
+		}
 	}
 	err = validate.ValidateDevfileData(devObj.Data)
 	if err != nil {
@@ -919,7 +923,9 @@ func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
 
 	// By default we run Devfile
 	if !co.forceS2i && co.devfileMetadata.devfileSupport {
-		scontext.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
+		if segment.IsTelemetryEnabled(nil) {
+			scontext.SetComponentType(cmd.Context(), co.devfileMetadata.componentType)
+		}
 		err := co.devfileRun(cmd)
 		if err != nil {
 			return err
@@ -931,7 +937,9 @@ func (co *CreateOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	// Add component type for s2i components
-	scontext.SetComponentType(cmd.Context(), *co.componentSettings.Type)
+	if segment.IsTelemetryEnabled(nil) {
+		scontext.SetComponentType(cmd.Context(), *co.componentSettings.Type)
+	}
 	// we only do conversion if the --s2i is provided and the component is not of --git type
 	if co.forceS2i && len(co.componentGit) == 0 && len(co.componentBinary) == 0 {
 		log.Info("Conversion")

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
 	scontext "github.com/openshift/odo/pkg/segment/context"
@@ -258,16 +260,22 @@ func (po *PushOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run(cmd *cobra.Command) (err error) {
-	scontext.SetClusterType(cmd.Context(), po.Client)
+	if segment.IsTelemetryEnabled(nil) {
+		scontext.SetClusterType(cmd.Context(), po.Client)
+	}
 	// If experimental mode is enabled, use devfile push
 	if util.CheckPathExists(po.DevfilePath) {
-		scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(po.Devfile.Data.GetMetadata()))
+		if segment.IsTelemetryEnabled(nil) {
+			scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(po.Devfile.Data.GetMetadata()))
+		}
 		// Return Devfile push
 		return po.DevfilePush()
 	}
 
 	// Legacy odo push
-	scontext.SetComponentType(cmd.Context(), po.LocalConfigInfo.GetType())
+	if segment.IsTelemetryEnabled(nil) {
+		scontext.SetComponentType(cmd.Context(), po.LocalConfigInfo.GetType())
+	}
 	return po.Push()
 }
 

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/openshift/odo/pkg/segment"
-
 	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/pkg/log"
 	scontext "github.com/openshift/odo/pkg/segment/context"
@@ -260,12 +258,12 @@ func (po *PushOptions) Validate() (err error) {
 
 // Run has the logic to perform the required actions as part of command
 func (po *PushOptions) Run(cmd *cobra.Command) (err error) {
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetClusterType(cmd.Context(), po.Client)
 	}
 	// If experimental mode is enabled, use devfile push
 	if util.CheckPathExists(po.DevfilePath) {
-		if segment.IsTelemetryEnabled(nil) {
+		if scontext.GetTelemetryStatus(cmd.Context()) {
 			scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(po.Devfile.Data.GetMetadata()))
 		}
 		// Return Devfile push
@@ -273,7 +271,7 @@ func (po *PushOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	// Legacy odo push
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetComponentType(cmd.Context(), po.LocalConfigInfo.GetType())
 	}
 	return po.Push()

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -3,8 +3,6 @@ package project
 import (
 	"fmt"
 
-	"github.com/openshift/odo/pkg/segment"
-
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
@@ -59,7 +57,7 @@ func (pco *ProjectCreateOptions) Validate() (err error) {
 
 // Run runs the project create command
 func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetClusterType(cmd.Context(), pco.Client)
 	}
 	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -3,6 +3,8 @@ package project
 import (
 	"fmt"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
@@ -57,7 +59,9 @@ func (pco *ProjectCreateOptions) Validate() (err error) {
 
 // Run runs the project create command
 func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
-	scontext.SetClusterType(cmd.Context(), pco.Client)
+	if segment.IsTelemetryEnabled(nil) {
+		scontext.SetClusterType(cmd.Context(), pco.Client)
+	}
 	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)
 
 	// Create the "spinner"

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -3,6 +3,8 @@ package project
 import (
 	"fmt"
 
+	"github.com/openshift/odo/pkg/segment"
+
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
@@ -68,7 +70,9 @@ func (pso *ProjectSetOptions) Validate() (err error) {
 
 // Run runs the project set command
 func (pso *ProjectSetOptions) Run(cmd *cobra.Command) (err error) {
-	scontext.SetClusterType(cmd.Context(), pso.Client)
+	if segment.IsTelemetryEnabled(nil) {
+		scontext.SetClusterType(cmd.Context(), pso.Client)
+	}
 	current := pso.Project
 	err = project.SetCurrent(pso.Context, pso.projectName)
 	if err != nil {

--- a/pkg/odo/cli/project/set.go
+++ b/pkg/odo/cli/project/set.go
@@ -3,8 +3,6 @@ package project
 import (
 	"fmt"
 
-	"github.com/openshift/odo/pkg/segment"
-
 	"github.com/openshift/odo/pkg/log"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
@@ -70,7 +68,7 @@ func (pso *ProjectSetOptions) Validate() (err error) {
 
 // Run runs the project set command
 func (pso *ProjectSetOptions) Run(cmd *cobra.Command) (err error) {
-	if segment.IsTelemetryEnabled(nil) {
+	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetClusterType(cmd.Context(), pso.Client)
 	}
 	current := pso.Project

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -13,8 +13,8 @@ import (
 )
 
 const ComponentType = "componentType"
-
 const ClusterType = "clusterType"
+const TelemetryStatus = "isTelemetryEnabled"
 
 const NOTFOUND = "not-found"
 
@@ -78,6 +78,20 @@ func SetClusterType(ctx context.Context, client *occlient.Client) {
 		}
 	}
 	setContextProperty(ctx, ClusterType, value)
+}
+
+// SetTelemetryStatus sets telemetry status before a command is run
+func SetTelemetryStatus(ctx context.Context, isEnabled bool) {
+	setContextProperty(ctx, TelemetryStatus, isEnabled)
+}
+
+// GetTelemetryStatus gets the telemetry status that is set before a command is run
+func GetTelemetryStatus(ctx context.Context) bool {
+	isEnabled, ok := GetContextProperties(ctx)[TelemetryStatus]
+	if ok {
+		return isEnabled.(bool)
+	}
+	return false
 }
 
 // set safely sets value for a key in storage

--- a/pkg/segment/context/context_test.go
+++ b/pkg/segment/context/context_test.go
@@ -76,6 +76,26 @@ func TestSetClusterType(t *testing.T) {
 	}
 }
 
+func TestGetTelemetryStatus(t *testing.T) {
+	want := true
+	ctx := NewContext(context.Background())
+	setContextProperty(ctx, TelemetryStatus, want)
+	got := GetTelemetryStatus(ctx)
+	if got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestSetTelemetryStatus(t *testing.T) {
+	want := false
+	ctx := NewContext(context.Background())
+	SetTelemetryStatus(ctx, want)
+	got := GetContextProperties(ctx)[TelemetryStatus]
+	if got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
 var apiResourceList = map[string]*metav1.APIResourceList{
 	"operators.coreos.com/v1alpha1": {
 		GroupVersion: "operators.coreos.com/v1alpha1",

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	scontext "github.com/openshift/odo/pkg/segment/context"
+
 	"github.com/openshift/odo/pkg/preference"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
@@ -104,7 +106,9 @@ func (c *Client) Upload(data TelemetryData) error {
 	// add information to the data
 	properties := analytics.NewProperties()
 	for k, v := range data.Properties.CmdProperties {
-		properties = properties.Set(k, v)
+		if k != scontext.TelemetryStatus {
+			properties = properties.Set(k, v)
+		}
 	}
 
 	properties = properties.Set("version", data.Properties.Version).

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -207,6 +207,7 @@ func RunningInTerminal() bool {
 
 // IsTelemetryEnabled returns true if user has consented to telemetry
 func IsTelemetryEnabled(cfg *preference.PreferenceInfo) bool {
+	klog.V(4).Info("Checking telemetry enable status")
 	var err error
 	if cfg == nil {
 		cfg, err = preference.New()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
The changes introduced with this PR will add properties to telemetry context only if telemetry is enabled.

**Which issue(s) this PR fixes**:

Fixes part of #4462 

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
There isn't much to test here, except you can disable telemetry and check if the data is added to contextual property with debugger.