### PR TITLE
Fixing now implementation for config set and unset in devfile

### DIFF
--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -64,12 +64,10 @@ func (po *PushOptions) DevfilePush() error {
 }
 
 func (po *PushOptions) devfilePushInner() (err error) {
-
 	devObj, err := devfile.ParseFromFile(po.DevfilePath)
 	if err != nil {
 		return err
 	}
-
 	componentName := po.EnvSpecificInfo.GetName()
 
 	// Set the source path to either the context or current working directory (if context not set)

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -109,7 +109,7 @@ func (o *SetOptions) Complete(name string, cmd *cobra.Command, args []string) (e
 // Validate validates the SetOptions based on completed values
 func (o *SetOptions) Validate() (err error) {
 	if !o.Context.LocalConfigProvider.Exists() {
-		return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
+		return fmt.Errorf("the directory doesn't contain a component. Use 'odo create' to create a component")
 	}
 	if !o.IsDevfile && o.now {
 		err = o.ValidateComponentCreate()
@@ -183,7 +183,7 @@ func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 		if o.now {
 			err = o.Push()
 			if err != nil {
-				return errors.Wrap(err, "failed to push changes")
+				return fmt.Errorf("failed to push changes %w", err)
 			}
 		} else {
 			log.Italic("\nRun `odo push --config` command to apply changes to the cluster")
@@ -219,7 +219,7 @@ func (o *SetOptions) Run(cmd *cobra.Command) (err error) {
 	if o.now {
 		err = o.Push()
 		if err != nil {
-			return errors.Wrap(err, "failed to push changes")
+			return fmt.Errorf("failed to push changes %w", err)
 		}
 	} else {
 		log.Italic("\nRun `odo push --config` command to apply changes to the cluster")

--- a/pkg/odo/cli/config/set.go
+++ b/pkg/odo/cli/config/set.go
@@ -127,7 +127,7 @@ func (o *SetOptions) DevfileRun() (err error) {
 		if err != nil {
 			return err
 		}
-		err = o.Context.EnvSpecificInfo.GetDevfileObj().AddEnvVars(newEnvVarList.ToDevfileEnv())
+		err = o.EnvSpecificInfo.GetDevfileObj().AddEnvVars(newEnvVarList.ToDevfileEnv())
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func (o *SetOptions) DevfileRun() (err error) {
 	}
 	if !o.configForceFlag {
 
-		if config.IsSetInDevfile(o.Context.EnvSpecificInfo.GetDevfileObj(), o.paramName) {
+		if config.IsSetInDevfile(o.EnvSpecificInfo.GetDevfileObj(), o.paramName) {
 			if !ui.Proceed(fmt.Sprintf("%v is already set. Do you want to override it in the devfile", o.paramName)) {
 				fmt.Println("Aborted by the user.")
 				return nil
@@ -148,7 +148,7 @@ func (o *SetOptions) DevfileRun() (err error) {
 		}
 	}
 
-	err = config.SetDevfileConfiguration(o.Context.EnvSpecificInfo.GetDevfileObj(), strings.ToLower(o.paramName), o.paramValue)
+	err = config.SetDevfileConfiguration(o.EnvSpecificInfo.GetDevfileObj(), strings.ToLower(o.paramName), o.paramValue)
 	if err != nil {
 		return err
 	}

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -9,7 +9,6 @@ import (
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
@@ -104,7 +103,7 @@ func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) 
 // Validate validates the UnsetOptions based on completed values
 func (o *UnsetOptions) Validate() (err error) {
 	if !o.Context.LocalConfigProvider.Exists() {
-		return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
+		return fmt.Errorf("the directory doesn't contain a component. Use 'odo create' to create a component")
 	}
 	if !o.IsDevfile && o.now {
 		err = o.ValidateComponentCreate()
@@ -141,7 +140,7 @@ func (o *UnsetOptions) DevfileRun() (err error) {
 		}
 		return err
 	}
-	return errors.New("config already unset, cannot unset a configuration which is not set")
+	return fmt.Errorf("config already unset, cannot unset a configuration which is not set")
 }
 
 // Run contains the logic for the command
@@ -168,7 +167,7 @@ func (o *UnsetOptions) Run(cmd *cobra.Command) (err error) {
 		if o.now {
 			err = o.Push()
 			if err != nil {
-				return errors.Wrap(err, "failed to push changes")
+				return fmt.Errorf("failed to push changes %w", err)
 			}
 		} else {
 			log.Italic("\nRun `odo push --config` command to apply changes to the cluster")
@@ -190,14 +189,14 @@ func (o *UnsetOptions) Run(cmd *cobra.Command) (err error) {
 		if o.now {
 			err = o.Push()
 			if err != nil {
-				return errors.Wrap(err, "failed to push changes")
+				return fmt.Errorf("failed to push changes %w", err)
 			}
 		} else {
 			log.Italic("\nRun `odo push --config` command to apply changes to the cluster")
 		}
 		return nil
 	}
-	return errors.New("config already unset, cannot unset a configuration which is not set")
+	return fmt.Errorf("config already unset, cannot unset a configuration which is not set")
 
 }
 

--- a/pkg/odo/cli/config/unset.go
+++ b/pkg/odo/cli/config/unset.go
@@ -2,17 +2,13 @@ package config
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
-
-	"github.com/devfile/library/pkg/devfile/parser"
-	"github.com/openshift/odo/pkg/odo/genericclioptions"
-	"github.com/openshift/odo/pkg/util"
 
 	"github.com/openshift/odo/pkg/config"
 	"github.com/openshift/odo/pkg/log"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
+	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -55,71 +51,65 @@ var (
 
 // UnsetOptions encapsulates the options for the command
 type UnsetOptions struct {
-	*clicomponent.CommonPushOptions
+	*clicomponent.PushOptions
 	paramName       string
 	configForceFlag bool
 	envArray        []string
 	now             bool
-	devfilePath     string
-	devfileObj      parser.DevfileObj
 	IsDevfile       bool
 }
 
 // NewUnsetOptions creates a new UnsetOptions instance
 func NewUnsetOptions() *UnsetOptions {
-	return &UnsetOptions{CommonPushOptions: clicomponent.NewCommonPushOptions()}
+	return &UnsetOptions{PushOptions: clicomponent.NewPushOptions()}
 }
 
 // Complete completes UnsetOptions after they've been created
 func (o *UnsetOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	context := genericclioptions.GetContextFlagValue(cmd)
-	devfilePath := filepath.Join(context, "devfile.yaml")
-	if util.CheckPathExists(devfilePath) {
-		o.devfilePath = devfilePath
+	checkRouteAvailability := false
+	if o.now {
+		checkRouteAvailability = true
+	}
+	o.Context, err = genericclioptions.New(genericclioptions.CreateParameters{
+		Cmd:                    cmd,
+		DevfilePath:            "",
+		ComponentContext:       o.GetComponentContext(),
+		IsNow:                  o.now,
+		CheckRouteAvailability: checkRouteAvailability,
+	})
+	if o.Context.EnvSpecificInfo != nil {
 		o.IsDevfile = true
-		o.devfileObj, err = parser.Parse(o.devfilePath)
-		if err != nil {
-			return err
-		}
+		o.DevfilePath = o.Context.EnvSpecificInfo.GetDevfilePath()
+		o.EnvSpecificInfo = o.Context.EnvSpecificInfo
+	} else {
+		o.IsDevfile = false
 	}
 
 	if o.envArray == nil {
 		o.paramName = args[0]
 	}
 
-	if !o.IsDevfile {
-		if o.now {
-			o.Context, err = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
-			if err != nil {
-				return err
-			}
-			prjName := o.LocalConfigInfo.GetProject()
-			o.ResolveSrcAndConfigFlags()
-			err = o.ResolveProject(prjName)
-			if err != nil {
-				return err
-			}
-		} else {
-			o.Context = genericclioptions.NewConfigContext(cmd)
+	if o.now {
+		prjName := o.Context.LocalConfigProvider.GetNamespace()
+		o.ResolveSrcAndConfigFlags()
+		err = o.ResolveProject(prjName)
+		if err != nil {
+			return err
 		}
 	}
+
 	return
 }
 
 // Validate validates the UnsetOptions based on completed values
 func (o *UnsetOptions) Validate() (err error) {
-	if !o.IsDevfile {
-		if !o.LocalConfigInfo.Exists() {
-			return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
-		}
+	if !o.Context.LocalConfigProvider.Exists() {
+		return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
 	}
-
-	if !o.IsDevfile {
-		if o.now {
-			err = o.ValidateComponentCreate()
-			if err != nil {
-				return err
-			}
+	if !o.IsDevfile && o.now {
+		err = o.ValidateComponentCreate()
+		if err != nil {
+			return err
 		}
 	}
 	return
@@ -129,20 +119,26 @@ func (o *UnsetOptions) Validate() (err error) {
 func (o *UnsetOptions) DevfileRun() (err error) {
 	if o.envArray != nil {
 
-		if err := o.devfileObj.RemoveEnvVars(o.envArray); err != nil {
+		if err := o.EnvSpecificInfo.GetDevfileObj().RemoveEnvVars(o.envArray); err != nil {
 			return err
 		}
 		log.Success("Environment variables were successfully updated")
+		if o.now {
+			return o.DevfilePush()
+		}
 		log.Italic("\nRun `odo push` command to apply changes to the cluster")
 		return err
 	}
-	if isSet := config.IsSetInDevfile(o.devfileObj, o.paramName); isSet {
+	if isSet := config.IsSetInDevfile(o.EnvSpecificInfo.GetDevfileObj(), o.paramName); isSet {
 		if !o.configForceFlag && !ui.Proceed(fmt.Sprintf("Do you want to unset %s in the devfile", o.paramName)) {
 			fmt.Println("Aborted by the user.")
 			return nil
 		}
-		err = config.DeleteDevfileConfiguration(o.devfileObj, strings.ToLower(o.paramName))
+		err = config.DeleteDevfileConfiguration(o.EnvSpecificInfo.GetDevfileObj(), strings.ToLower(o.paramName))
 		log.Success("Devfile was successfully updated.")
+		if o.now {
+			return o.DevfilePush()
+		}
 		return err
 	}
 	return errors.New("config already unset, cannot unset a configuration which is not set")

--- a/pkg/odo/genericclioptions/context.go
+++ b/pkg/odo/genericclioptions/context.go
@@ -62,7 +62,6 @@ type CreateParameters struct {
 // New creates a context based on the given parameters
 func New(parameters CreateParameters, toggles ...bool) (context *Context, err error) {
 	parameters.DevfilePath = completeDevfilePath(parameters.ComponentContext, parameters.DevfilePath)
-
 	isDevfile := odoutil.CheckPathExists(parameters.DevfilePath)
 	if isDevfile {
 		context, err = NewDevfileContext(parameters.Cmd)

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -256,7 +256,6 @@ var _ = Describe("odo preference and config command tests", func() {
 		})
 	})
 
-	// TODO: issue https://github.com/openshift/odo/issues/4594
 	Context("when using --now with config command", func() {
 		var oc helper.OcRunner
 		BeforeEach(func() {

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -276,12 +276,12 @@ var _ = Describe("odo preference and config command tests", func() {
 			Expect(ok).To(BeTrue())
 			Expect(val).To(ContainSubstring("world"))
 			// unset a valid env var
-			//helper.Cmd("odo", "config", "unset", "--now", "--env", "hello", "--context", commonVar.Context).ShouldPass()
-			//configValue2 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
-			//helper.DontMatchAllInOutput(configValue2, []string{"hello", "world"})
-			//envs = oc.GetEnvsDevFileDeployment("nodejs", "app",commonVar.Project)
-			//_, ok = envs["hello"]
-			//Expect(ok).To(BeFalse())
+			helper.Cmd("odo", "config", "unset", "--now", "--env", "hello", "--context", commonVar.Context).ShouldPass()
+			configValue2 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
+			helper.DontMatchAllInOutput(configValue2, []string{"hello", "world"})
+			envs = oc.GetEnvsDevFileDeployment("nodejs", "app",commonVar.Project)
+			_, ok = envs["hello"]
+			Expect(ok).To(BeFalse())
 		})
 	})
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -257,29 +257,33 @@ var _ = Describe("odo preference and config command tests", func() {
 	})
 
 	// TODO: issue https://github.com/openshift/odo/issues/4594
-	// Context("when using --now with config command", func() {
-	// 	It("should successfully set and unset variables", func() {
-	// 		//set env var
-	// 		helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
-	// 		helper.Cmd("odo", "create", "--s2i", "nodejs", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context).ShouldPass()
-	// 		helper.Cmd("odo", "config", "set", "--now", "--env", "hello=world", "--context", commonVar.Context).ShouldPass()
-	// 		//*Check config
-	// 		configValue1 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
-	// 		helper.MatchAllInOutput(configValue1, []string{"hello", "world"})
-	// 		//*Check dc
-	// 		envs := oc.GetEnvsDevFileDeployment("nodejs", commonVar.Project)
-	// 		val, ok := envs["hello"]
-	// 		Expect(ok).To(BeTrue())
-	// 		Expect(val).To(ContainSubstring("world"))
-	// 		// unset a valid env var
-	// 		helper.Cmd("odo", "config", "unset", "--now", "--env", "hello", "--context", commonVar.Context).ShouldPass()
-	// 		configValue2 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
-	// 		helper.DontMatchAllInOutput(configValue2, []string{"hello", "world"})
-	// 		envs = oc.GetEnvsDevFileDeployment("nodejs", commonVar.Project)
-	// 		_, ok = envs["hello"]
-	// 		Expect(ok).To(BeFalse())
-	// 	})
-	// })
+	Context("when using --now with config command", func() {
+		var oc helper.OcRunner
+		BeforeEach(func() {
+			oc = helper.NewOcRunner("oc")
+		})
+		It("should successfully set and unset variables", func() {
+			//set env var
+			helper.CopyExample(filepath.Join("source", "nodejs"), commonVar.Context)
+			helper.Cmd("odo", "create", "--s2i", "nodejs", "nodejs", "--project", commonVar.Project, "--context", commonVar.Context).ShouldPass()
+			helper.Cmd("odo", "config", "set", "--now", "--env", "hello=world", "--context", commonVar.Context).ShouldPass()
+			//*Check config
+			configValue1 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
+			helper.MatchAllInOutput(configValue1, []string{"hello", "world"})
+			//*Check dc
+			envs := oc.GetEnvsDevFileDeployment("nodejs", "app", commonVar.Project)
+			val, ok := envs["hello"]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(ContainSubstring("world"))
+			// unset a valid env var
+			//helper.Cmd("odo", "config", "unset", "--now", "--env", "hello", "--context", commonVar.Context).ShouldPass()
+			//configValue2 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
+			//helper.DontMatchAllInOutput(configValue2, []string{"hello", "world"})
+			//envs = oc.GetEnvsDevFileDeployment("nodejs", "app",commonVar.Project)
+			//_, ok = envs["hello"]
+			//Expect(ok).To(BeFalse())
+		})
+	})
 
 	Context("When no ConsentTelemetry preference value is set", func() {
 		var _ = JustBeforeEach(func() {

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -279,7 +279,7 @@ var _ = Describe("odo preference and config command tests", func() {
 			helper.Cmd("odo", "config", "unset", "--now", "--env", "hello", "--context", commonVar.Context).ShouldPass()
 			configValue2 := helper.Cmd("odo", "config", "view", "--context", commonVar.Context).ShouldPass().Out()
 			helper.DontMatchAllInOutput(configValue2, []string{"hello", "world"})
-			envs = oc.GetEnvsDevFileDeployment("nodejs", "app",commonVar.Project)
+			envs = oc.GetEnvsDevFileDeployment("nodejs", "app", commonVar.Project)
 			_, ok = envs["hello"]
 			Expect(ok).To(BeFalse())
 		})


### PR DESCRIPTION
Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
[see title]

**Which issue(s) this PR fixes**:

Fixes #4594

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
With now flag
```bash
> odo create nodejs
...
> odo push

Validation
 ✓  Validating the devfile [164372ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [7s]
 ✓  Waiting for component to start [427ms]

Applying URL changes
 ✓  URL http-3000: http://http-3000-nodejs-nodejs-ex-odtu-uv.apps.testocp47.psiodo.net/ created

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking files for pushing [4ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [371ms]
 ✓  Executing install command "npm install" [11s]
 ✓  Executing run command "npm start" [4s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> oc get deployments
NAME                        READY     UP-TO-DATE   AVAILABLE   AGE
nodejs-nodejs-ex-odtu-app   1/1       1            1           69s
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1024Mi
> oc describe deployment/nodejs-nodejs-ex-odtu-app
Name:               nodejs-nodejs-ex-odtu-app
Namespace:          uv
CreationTimestamp:  Tue, 06 Jul 2021 19:31:55 +0530
Labels:             app=app
                    app.kubernetes.io/instance=nodejs-nodejs-ex-odtu
                    app.kubernetes.io/managed-by=odo
                    app.kubernetes.io/managed-by-version=v2.2.2
                    app.kubernetes.io/name=nodejs
                    app.kubernetes.io/part-of=app
                    component=nodejs-nodejs-ex-odtu
Annotations:        app.openshift.io/vcs-uri=https://github.com/openshift/nodejs-ex
                    deployment.kubernetes.io/revision=1
Selector:           component=nodejs-nodejs-ex-odtu
Replicas:           1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:       Recreate
MinReadySeconds:    0
Pod Template:
  Labels:  app=app
           app.kubernetes.io/instance=nodejs-nodejs-ex-odtu
           app.kubernetes.io/managed-by=odo
           app.kubernetes.io/managed-by-version=v2.2.2
           app.kubernetes.io/name=nodejs
           app.kubernetes.io/part-of=app
           component=nodejs-nodejs-ex-odtu
  Init Containers:
   copy-supervisord:
    Image:      registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.10
    Port:       <none>
    Host Port:  <none>
    Command:
      /usr/bin/cp
    Args:
      -r
      /opt/odo-init/.
      /opt/odo/
    Environment:  <none>
    Mounts:
      /opt/odo/ from odo-supervisord-shared-data (rw)
  Containers:
   runtime:
    Image:      registry.access.redhat.com/ubi8/nodejs-14:latest
    Port:       3000/TCP
    Host Port:  0/TCP
    Command:
      /opt/odo/bin/supervisord
    Args:
      -c
      /opt/odo/conf/devfile-supervisor.conf
    Limits:
      memory:  1Gi
    Environment:
      PROJECTS_ROOT:                  /project
      PROJECT_SOURCE:                 /project
      ODO_COMMAND_RUN:                npm start
      ODO_COMMAND_RUN_WORKING_DIR:    /project
      ODO_COMMAND_DEBUG:              npm run debug
      ODO_COMMAND_DEBUG_WORKING_DIR:  /project
      DEBUG_PORT:                     5858
    Mounts:
      /opt/odo/ from odo-supervisord-shared-data (rw)
      /project from odo-projects (rw)
  Volumes:
   odo-projects:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:  
   odo-supervisord-shared-data:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:  
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  nodejs-nodejs-ex-odtu-app-56887ccfc6 (1/1 replicas created)
NewReplicaSet:   <none>
Events:
  Type    Reason             Age   From                   Message
  ----    ------             ----  ----                   -------
  Normal  ScalingReplicaSet  2m    deployment-controller  Scaled up replica set nodejs-nodejs-ex-odtu-app-56887ccfc6 to 1
> odo config set --env KAFKA_HOST=kafka --env KAFKA_PORT=6639 --now
 ✓  Environment variables were successfully updated
 ✓  Waiting for component to start [367ms]

Validation
 ✓  Validating the devfile [126361ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [9s]
 ✓  Waiting for component to start [416ms]

Applying URL changes
 ✓  URLs are synced with the cluster, no changes are required.

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking file changes for pushing [2ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [362ms]
 ✓  Executing install command "npm install" [10s]
 ✓  Executing run command "npm start" [3s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  EnvironmentVariables:
  - Name: KAFKA_HOST
    Value: kafka
  - Name: KAFKA_PORT
    Value: "6639"
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1024Mi
> oc describe deployment/nodejs-nodejs-ex-odtu-app
...
    Environment:
      PROJECTS_ROOT:                  /project
      PROJECT_SOURCE:                 /project
      ODO_COMMAND_RUN:                npm start
      ODO_COMMAND_RUN_WORKING_DIR:    /project
      ODO_COMMAND_DEBUG:              npm run debug
      ODO_COMMAND_DEBUG_WORKING_DIR:  /project
      DEBUG_PORT:                     5858
      KAFKA_HOST:                     kafka
      KAFKA_PORT:                     6639
> odo config set Memory 1536Mi --force --now
 ✓  Devfile successfully updated
 ✓  Waiting for component to start [379ms]

Validation
 ✓  Validating the devfile [110625ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [18s]
 ✓  Waiting for component to start [426ms]

Applying URL changes
 ✓  URLs are synced with the cluster, no changes are required.

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking file changes for pushing [4ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [379ms]
 ✓  Executing install command "npm install" [10s]
 ✓  Executing run command "npm start" [3s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  EnvironmentVariables:
  - Name: KAFKA_HOST
    Value: kafka
  - Name: KAFKA_PORT
    Value: "6639"
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1536Mi
> oc describe deployment/nodejs-nodejs-ex-odtu-app
...
    Limits:
      memory:  1536Mi

...
> odo config unset --env KAFKA_HOST --env KAFKA_PORT --now
 ✓  Environment variables were successfully updated
 ✓  Waiting for component to start [405ms]

Validation
 ✓  Validating the devfile [159908ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [15s]
 ✓  Waiting for component to start [374ms]

Applying URL changes
 ✓  URLs are synced with the cluster, no changes are required.

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking file changes for pushing [2ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [362ms]
 ✓  Executing install command "npm install" [11s]
 ✓  Executing run command "npm start" [4s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1536Mi
> oc describe deployment/nodejs-nodejs-ex-odtu-app
...
    Environment:
      PROJECTS_ROOT:                  /project
      PROJECT_SOURCE:                 /project
      ODO_COMMAND_RUN:                npm start
      ODO_COMMAND_RUN_WORKING_DIR:    /project
      ODO_COMMAND_DEBUG:              npm run debug
      ODO_COMMAND_DEBUG_WORKING_DIR:  /project
      DEBUG_PORT:                     5858
    Mounts:

```

Control (to ensure nothin is broken without now flag)

```bash
> odo delete
? Are you sure you want to delete the devfile component: nodejs-nodejs-ex-odtu? Yes

Gathering information for component nodejs-nodejs-ex-odtu
 ✓  Checking status for component [371ms]

Deleting component nodejs-nodejs-ex-odtu
 ✓  Deleting Kubernetes resources for component [360ms]
 ✓  Successfully deleted component
> odo push

Validation
 ✓  Validating the devfile [43446ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [5s]
 ✓  Waiting for component to start [408ms]

Applying URL changes
 ✓  URL http-3000: http://http-3000-nodejs-nodejs-ex-odtu-uv.apps.testocp47.psiodo.net/ created

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking files for pushing [4ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [401ms]
 ✓  Executing install command "npm install" [10s]
 ✓  Executing run command "npm start" [3s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> odo config set Memory 1024Mi --force
 ✓  Devfile successfully updated

Run `odo push` command to apply changes to the cluster
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1536Mi
> odo config set Memory 1024Mi --force
 ✓  Devfile successfully updated

Run `odo push` command to apply changes to the cluster
> odo config set --env KAFKA_HOST=kafka --env KAFKA_PORT=6639
 ✓  Environment variables were successfully updated

Run `odo push` command to apply changes to the cluster
> odo config view
ComponentName: nodejs
Configs:
- ContainerName: runtime
  EnvironmentVariables:
  - Name: KAFKA_HOST
    Value: kafka
  - Name: KAFKA_PORT
    Value: "6639"
  Ports:
  - ExposedPort: 3000
    Name: http-3000
    Protocol: http
Memory: 1024Mi
> odo push
 ✓  Waiting for component to start [379ms]

Validation
 ✓  Validating the devfile [118638ns]

Updating services
 ✓  Services and Links are in sync with the cluster, no changes are required

Creating Kubernetes resources for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [14s]
 ✓  Waiting for component to start [403ms]

Applying URL changes
 ✓  URLs are synced with the cluster, no changes are required.

Syncing to component nodejs-nodejs-ex-odtu
 ✓  Checking file changes for pushing [2ms]
 ✓  Syncing files to the component [9s]

Executing devfile commands for component nodejs-nodejs-ex-odtu
 ✓  Waiting for component to start [388ms]
 ✓  Executing install command "npm install" [11s]
 ✓  Executing run command "npm start" [3s]

Pushing devfile component "nodejs-nodejs-ex-odtu"
 ✓  Changes successfully pushed to component
> oc describe deployment/nodejs-nodejs-ex-odtu-app
...
    Limits:
      memory:  1Gi
    Environment:
      PROJECTS_ROOT:                  /project
      PROJECT_SOURCE:                 /project
      ODO_COMMAND_RUN:                npm start
      ODO_COMMAND_RUN_WORKING_DIR:    /project
      ODO_COMMAND_DEBUG:              npm run debug
      ODO_COMMAND_DEBUG_WORKING_DIR:  /project
      DEBUG_PORT:                     5858
      KAFKA_HOST:                     kafka
      KAFKA_PORT:                     6639

...
```