### PR TITLE
delete dangling dir created by unit-tests

### DIFF
--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -135,9 +135,9 @@ func CleanupEnv(confFiles []*os.File, t *testing.T) {
 		}
 		if err := confFile.Close(); err != nil {
 			t.Errorf("failed to cleanup the test env. Error: %v", err)
-			os.Remove(filepath.Dir(confFile.Name()))
 		}
 		os.Remove(confFile.Name())
+		os.Remove(filepath.Dir(confFile.Name()))
 	}
 }
 

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path/filepath"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -134,6 +135,7 @@ func CleanupEnv(confFiles []*os.File, t *testing.T) {
 		}
 		if err := confFile.Close(); err != nil {
 			t.Errorf("failed to cleanup the test env. Error: %v", err)
+			os.Remove(filepath.Dir(confFile.Name()))
 		}
 		os.Remove(confFile.Name())
 	}


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
This PR cleanup the dangling dirs created when we run unit tests

**Which issue(s) this PR fixes**:

Fixes https://github.com/openshift/odo/issues/4817

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
