### PR TITLE
Add Sonar Cloud config file: sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,28 @@
+sonar.projectKey=openshift_odo
+sonar.projectName=odo
+
+# Path to sources
+sonar.sources=cmd,pkg
+# Source File Exclusions: Patterns used to exclude some source files from analysis.
+# sonar.exclusions=
+# Source File Inclusions : Patterns used to include some source files and only these ones in analysis.
+# sonar.inclusions=
+
+# Path to tests
+sonar.tests=tests
+# Test File Inclusions: Patterns used to include some test files and only these ones in analysis.
+sonar.test.inclusions=**/*_test.go
+# Test File Exclusions: Patterns used to exclude some test files from analysis.
+sonar.test.exclusions=examples/**
+
+# List of file path patterns to be excluded from analysis of Go files.
+sonar.go.exclusions=**/vendor/**
+# List of suffixes for files to analyze.
+sonar.go.file.suffixes=.go
+
+# Ignore Issues on Multiple Criteria : Patterns to ignore issues on certain components and for certain coding rules.
+sonar.issue.ignore.multicriteria=g1
+
+# Ignore "Define a constant instead of duplicating this literal" rule on test files
+sonar.issue.ignore.multicriteria.g1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.g1.resourceKey=**/*_test.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,16 +4,14 @@ sonar.projectName=odo
 # Path to sources
 sonar.sources=cmd,pkg
 # Source File Exclusions: Patterns used to exclude some source files from analysis.
-# sonar.exclusions=
+sonar.exclusions=**/*_test.go
 # Source File Inclusions : Patterns used to include some source files and only these ones in analysis.
 # sonar.inclusions=
 
 # Path to tests
-sonar.tests=tests
+sonar.tests=tests,cmd,pkg
 # Test File Inclusions: Patterns used to include some test files and only these ones in analysis.
 sonar.test.inclusions=**/*_test.go
-# Test File Exclusions: Patterns used to exclude some test files from analysis.
-sonar.test.exclusions=examples/**
 
 # List of file path patterns to be excluded from analysis of Go files.
 sonar.go.exclusions=**/vendor/**


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
This PR adds config file for Sonar Cloud Code Analysis so that we can track any changes to its configuration instead of manually doing it from the website.

Current config - 
1. - [x] Analyze source code from cmd and pkg directory.
    1. - [x] Exclude any (unit)test file.
2. - [x] Analyze test code from tests directory.
3. - [x] Exclude analyzing any files under vendor directory.
4. - [x] Ignore the "Define a constant instead of duplicating this literal" rule for test files. See code smells in test files [here](https://sonarcloud.io/project/issues?id=openshift_odo&resolved=false).

**Which issue(s) this PR fixes**:

Fixes part of #4879 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Check the current config and let me know if you think something is amiss.