### PR TITLE
Add language and projectType metadata in devfile for s2i components

### DIFF
--- a/pkg/devfile/convert/convert.go
+++ b/pkg/devfile/convert/convert.go
@@ -84,10 +84,12 @@ func GenerateDevfileYaml(client *occlient.Client, co *config.LocalConfigInfo, co
 
 	// set metadata
 	s2iDevfile.SetMetadata(devfilepkg.DevfileMetadata{
-		Name:    co.GetName(),
-		Version: "1.0.0",
+		Name:        co.GetName(),
+		Version:     "1.0.0",
+		Language:    componentType,
+		ProjectType: componentType,
 	})
-	// set commponents
+	// set components
 	err = setDevfileComponentsForS2I(s2iDevfile, imageforDevfile, co, s2iEnv)
 	if err != nil {
 		return err

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/openshift/odo/pkg/devfile"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
@@ -266,7 +268,14 @@ func componentTests(args ...string) {
 				Expect(info.GetApplication(), appName)
 				Expect(info.GetName(), cmpName)
 			})
-
+			It("should set the correct component name, language and projectType in devfile metadata", func() {
+				devObj, err := devfile.ParseFromFile(filepath.Join(commonVar.Context, "devfile.yaml"))
+				Expect(err).ToNot(HaveOccurred())
+				metadata := devObj.Data.GetMetadata()
+				Expect(metadata.Name).To(BeEquivalentTo(cmpName))
+				Expect(metadata.Language).To(ContainSubstring("nodejs"))
+				Expect(metadata.ProjectType).To(ContainSubstring("nodejs"))
+			})
 			It("should list the component when it is not pushed", func() {
 				cmpList := helper.Cmd("odo", append(args, "list", "--context", commonVar.Context)...).ShouldPass().Out()
 				helper.MatchAllInOutput(cmpList, []string{cmpName, "Not Pushed"})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What does this PR do / why we need it**:
This PR adds user-provided component name to devfile metadata for normal component creation and language to devfile metadata for s2i creation.

**Which issue(s) this PR fixes**:

Fixes #4816

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. Create a s2i component and check if `.metadata.language` and  `.metadata.projectType` is set properly in the devfile.yaml. `odo create --s2i nodejs mynodecomp`.