### PR TITLE
Mount persistent volumes for S2I images

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -14,6 +14,9 @@ const (
 	// OdoSourceVolume is the constant containing the name of the emptyDir volume containing the project source
 	OdoSourceVolume = "odo-projects"
 
+	// OdoSupervisordVolume is the constant containing the name of the emptyDir volume containing Supervisord shared data
+	OdoSupervisordVolume = "odo-supervisord-shared-data"
+
 	// OdoSourceVolumeSize specifies size for odo source volume.
 	OdoSourceVolumeSize = "2Gi"
 )

--- a/pkg/testingutil/deployments.go
+++ b/pkg/testingutil/deployments.go
@@ -32,8 +32,9 @@ func CreateFakeDeployment(podName string) *appsv1.Deployment {
 }
 
 // CreateFakeDeploymentsWithContainers creates a fake pod with the given pod name, container name and containers
-func CreateFakeDeploymentsWithContainers(podName string, containers []corev1.Container) *appsv1.Deployment {
+func CreateFakeDeploymentsWithContainers(podName string, containers []corev1.Container, initContainers []corev1.Container) *appsv1.Deployment {
 	fakeDeployment := CreateFakeDeployment(podName)
 	fakeDeployment.Spec.Template.Spec.Containers = containers
+	fakeDeployment.Spec.Template.Spec.InitContainers = initContainers
 	return fakeDeployment
 }

--- a/tests/integration/cmd_create_s2i_test.go
+++ b/tests/integration/cmd_create_s2i_test.go
@@ -1,0 +1,38 @@
+package integration
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/openshift/odo/tests/helper"
+	//. "github.com/onsi/gomega"
+)
+
+var _ = Describe("odo create --s2i command tests", func() {
+	//var oc helper.OcRunner
+	var commonVar helper.CommonVar
+
+	// This is run before every Spec (It)
+	var _ = BeforeEach(func() {
+		//	oc = helper.NewOcRunner("oc")
+		commonVar = helper.CommonBeforeEach()
+		helper.Chdir(commonVar.Context)
+	})
+
+	// Clean up after the test
+	// This is run after every Spec (It)
+	var _ = AfterEach(func() {
+		helper.CommonAfterEach(commonVar)
+	})
+
+	When("creating a component from s2i wildfly", func() {
+
+		BeforeEach(func() {
+			helper.Cmd("odo", "component", "create", "--s2i", "wildfly", "--project", commonVar.Project).ShouldPass()
+			// Workaround for https://github.com/openshift/odo/issues/5060
+			helper.ReplaceString("devfile.yaml", "/usr/local/s2i", "/usr/libexec/s2i")
+		})
+
+		It("should run odo push successfully", func() {
+			helper.Cmd("odo", "push").ShouldPass()
+		})
+	})
+})

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -64,7 +64,7 @@ var _ = Describe("odo storage command tests", func() {
 				})
 
 				It("should list output in json format", func() {
-					valuesStoreL := gjson.GetMany(actualStorageList, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.size")
+					valuesStoreL := gjson.GetMany(actualStorageList, "kind", "items.2.kind", "items.2.metadata.name", "items.2.spec.size")
 					expectedStoreL := []string{"List", "Storage", "mystorage", "1Gi"}
 					Expect(helper.GjsonMatcher(valuesStoreL, expectedStoreL)).To(Equal(true))
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This PR:
- mounts persistent volumes in /opt/app-root and the deployments directory 
- adds a preStart event to the devfile, to create an initContainer that copies original files in /opt/app-root into the persistent volume

**Which issue(s) this PR fixes**:

Fixes #4623 

**PR acceptance criteria**:

- [x] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

```
# install the wildfly image stream:

$ oc apply -n openshift -f https://raw.githubusercontent.com/openshift/library/master/arch/x86_64/community/wildfly/imagestreams/wildfly-centos7.json

# get wildfly sources from `tests/examples/source/wildfly/`

$ odo create --s2i wildfly

# check that the devfile contains `events/prestart` section

$ odo push

# check that component is running correctly
```

or

```
# get nodejs sources from tests/examples/source/nodejs/

$ odo create --s2i nodejs

# check that the devfile contains `events/prestart` section

$ odo push

# check that component is running correctly
```
