### PR TITLE
Do not display "Waiting for component to start" twice

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- `odo push` now displays "Waiting for component to start" only once ([4919](https://github.com/openshift/odo/pull/4919))
+
 ### Tests
 
 ### Documentation


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

`WaitAndGetPodWithEvents` now waits for an event with a Phase different from the expected one before to start the Spinner. This way, the spinner is only displayed when the pod is not in the expected phase.

**Which issue(s) this PR fixes**:

Fixes #4362 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [x] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
