### PR TITLE
Add documentation for global configuration

### DIFF
--- a/pkg/preference/preference.go
+++ b/pkg/preference/preference.go
@@ -53,7 +53,7 @@ const (
 	// PushTimeoutSetting is the name of the setting controlling PushTimeout
 	PushTimeoutSetting = "PushTimeout"
 
-	// ExperimentalSetting is the name of the setting confrolling exposure of features in development/experimental mode
+	// ExperimentalSetting is the name of the setting controlling exposure of features in development/experimental mode
 	ExperimentalSetting = "Experimental"
 
 	// ExperimentalDescription is human-readable description for the experimental setting

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -31,8 +31,10 @@ $ odo preference set updatenotification false
 Global preference was successfully updated
 ```
 
+Note that the preference key is case-insensitive.
+
 ### Unset a configuration
-To unset a value of a preference key, run `odo preference unset <key>`.
+To unset a value of a preference key, run `odo preference unset <key>`; use `-f` flag to skip the confirmation.
 ```shell
 $ odo preference unset updatednotification
 ? Do you want to unset updatenotification in the preference (y/N) y
@@ -43,13 +45,13 @@ Unsetting a preference key sets it back to its default value.
 
 ### Preference Key Table
 
-| Preference | Description | Default |
-| ----------- | ----------- | ----------- |
-| UpdateNotification | Control if an update notification is shown or not | True |
-| NamePrefix | Set a default name prefix | Current directory name |
-| Timeout | Timeout for server connection check | 1 second |
-| BuildTimeout | Timeout for waiting for a build of the git component to complete | 300 seconds |
-| PushTimeout | Timeout for waiting for a Pod to come up |  240 seconds |
-| Experimental | Expose features in development/experimental mode | False |
-| Ephemeral | Control whether odo should create a emptyDir volume to store source code | False |
-| ConsentTelemetry | Control whether odo can collect telemetry for the user's odo usage | False |
+| Preference            | Description                                                               | Default                   |
+| --------------------- | ------------------------------------------------------------------------- | ------------------------- |
+| UpdateNotification    | Control if an update notification is shown or not                         | True                      |
+| NamePrefix            | Set a default name prefix                                                 | Current directory name    |
+| Timeout               | Timeout for server connection check                                       | 1 second                  |
+| BuildTimeout          | Timeout for waiting for a build of the git component to complete          | 300 seconds               |
+| PushTimeout           | Timeout for waiting for a Pod to come up                                  |  240 seconds              |
+| Experimental          | Expose features in development/experimental mode                          | False                     |
+| Ephemeral             | Control whether odo should create a emptyDir volume to store source code  | False                     |
+| ConsentTelemetry      | Control whether odo can collect telemetry for the user's odo usage        | False                     |

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -69,7 +69,7 @@ $ odo preference unset updatednotification
 Global preference was successfully updated
 ```
 
-Unsetting a preference key sets it back to its default value.
+Unsetting a preference key sets it to an empty value in the preference file. odo will use the [default value](./configure#preference-key-table) for such configuration.
 
 ### Preference Key Table
 

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 The global settings for odo can be found in `preference.yaml` file; which is located by default in the `.odo` directory of the user's HOME directory.
 
-Example -
+Example:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -18,9 +18,9 @@ values={[
 {label: 'Windows', value: 'windows'},
 {label: 'Mac', value: 'mac'},
 ]}>
-<TabItem value="linux">/home/user/foo/myProject/.odo/preference.yaml</TabItem>
-<TabItem value="windows">C:\\myProject\.odo\preference.yaml</TabItem>
-<TabItem value="mac">/home/user/foo/myProject/.odo/preference.yaml</TabItem>
+<TabItem value="linux">/home/foo/.odo/preference.yaml</TabItem>
+<TabItem value="windows">C:\\Users\foo\.odo\preference.yaml</TabItem>
+<TabItem value="mac">/Users/foo/.odo/preference.yaml</TabItem>
 </Tabs>
 
 ---
@@ -32,7 +32,7 @@ To view the current configuration, run `odo preference view`.
 ```shell
 odo preference view
 ```
-Example -
+Example:
 ```shell
 $ odo preference view
 PARAMETER             CURRENT_VALUE
@@ -50,7 +50,7 @@ To set a value for a preference key, run `odo preference set <key> <value>`.
 ```shell
 odo preference set updatenotification false
 ```
-Example -
+Example:
 ```shell
 $ odo preference set updatenotification false
 Global preference was successfully updated
@@ -62,7 +62,7 @@ To unset a value of a preference key, run `odo preference unset <key>`; use `-f`
 ```shell
 odo preference unset updatednotification
 ```
-Example -
+Example:
 ```shell
 $ odo preference unset updatednotification
 ? Do you want to unset updatenotification in the preference (y/N) y

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -12,7 +12,10 @@ A  different location can be set for the `preference.yaml` by exporting `GLOBALO
 To view the current configuration, run `odo preference view`.
 
 ```shell
-$ odo preference view
+odo preference view
+```
+_Expected Output:_
+```shell
 PARAMETER             CURRENT_VALUE
 UpdateNotification
 NamePrefix
@@ -23,20 +26,24 @@ Experimental
 Ephemeral
 ConsentTelemetry
 ```
-
 ### Set a configuration
 To set a value for a preference key, run `odo preference set <key> <value>`.
 ```shell
-$ odo preference set updatenotification false
+odo preference set updatenotification false
+```
+_Expected Output:_
+```shell
 Global preference was successfully updated
 ```
-
 Note that the preference key is case-insensitive.
 
 ### Unset a configuration
 To unset a value of a preference key, run `odo preference unset <key>`; use `-f` flag to skip the confirmation.
 ```shell
-$ odo preference unset updatednotification
+odo preference unset updatednotification
+```
+_Expected Output:_
+```shell
 ? Do you want to unset updatenotification in the preference (y/N) y
 Global preference was successfully updated
 ```
@@ -47,11 +54,11 @@ Unsetting a preference key sets it back to its default value.
 
 | Preference            | Description                                                               | Default                   |
 | --------------------- | ------------------------------------------------------------------------- | ------------------------- |
-| UpdateNotification    | Control if an update notification is shown or not                         | True                      |
-| NamePrefix            | Set a default name prefix                                                 | Current directory name    |
-| Timeout               | Timeout for server connection check                                       | 1 second                  |
+| UpdateNotification    | Control whether a notification to update odo is shown                     | True                      |
+| NamePrefix            | Set a default name prefix for an odo resource (component, storage, etc)   | Current directory name    |
+| Timeout               | Timeout for OpenShift server connection check                             | 1 second                  |
 | BuildTimeout          | Timeout for waiting for a build of the git component to complete          | 300 seconds               |
-| PushTimeout           | Timeout for waiting for a Pod to come up                                  |  240 seconds              |
+| PushTimeout           | Timeout for waiting for a component to start                              | 240 seconds               |
 | Experimental          | Expose features in development/experimental mode                          | False                     |
-| Ephemeral             | Control whether odo should create a emptyDir volume to store source code  | False                     |
+| Ephemeral             | Control whether odo should create a emptyDir volume to store source code  | True                      |
 | ConsentTelemetry      | Control whether odo can collect telemetry for the user's odo usage        | False                     |

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -4,4 +4,52 @@ sidebar_position: 6
 ---
 # Configuring odo global settings
 
-This doc explains everything in `~/.odo/preference.yaml` file.
+The global settings for odo can be found in `preference.yaml` file; which is located by default in the `.odo` directory of the user's HOME directory.
+
+A  different location can be set for the `preference.yaml` by exporting `GLOBALODOCONFIG` in the user environment.
+
+### View the configuration
+To view the current configuration, run `odo preference view`.
+
+```shell
+$ odo preference view
+PARAMETER             CURRENT_VALUE
+UpdateNotification
+NamePrefix
+Timeout
+BuildTimeout
+PushTimeout
+Experimental
+Ephemeral
+ConsentTelemetry
+```
+
+### Set a configuration
+To set a value for a preference key, run `odo preference set <key> <value>`.
+```shell
+$ odo preference set updatenotification false
+Global preference was successfully updated
+```
+
+### Unset a configuration
+To unset a value of a preference key, run `odo preference unset <key>`.
+```shell
+$ odo preference unset updatednotification
+? Do you want to unset updatenotification in the preference (y/N) y
+Global preference was successfully updated
+```
+
+Unsetting a preference key sets it back to its default value.
+
+### Preference Key Table
+
+| Preference | Description | Default |
+| ----------- | ----------- | ----------- |
+| UpdateNotification | Control if an update notification is shown or not | True |
+| NamePrefix | Set a default name prefix | Current directory name |
+| Timeout | Timeout for server connection check | 1 second |
+| BuildTimeout | Timeout for waiting for a build of the git component to complete | 300 seconds |
+| PushTimeout | Timeout for waiting for a Pod to come up |  240 seconds |
+| Experimental | Expose features in development/experimental mode | False |
+| Ephemeral | Control whether odo should create a emptyDir volume to store source code | False |
+| ConsentTelemetry | Control whether odo can collect telemetry for the user's odo usage | False |

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -18,9 +18,9 @@ values={[
 {label: 'Windows', value: 'windows'},
 {label: 'Mac', value: 'mac'},
 ]}>
-<TabItem value="linux">/home/foo/.odo/preference.yaml</TabItem>
-<TabItem value="windows">C:\\Users\foo\.odo\preference.yaml</TabItem>
-<TabItem value="mac">/Users/foo/.odo/preference.yaml</TabItem>
+<TabItem value="linux">/home/userName/.odo/preference.yaml</TabItem>
+<TabItem value="windows">C:\\Users\userName\.odo\preference.yaml</TabItem>
+<TabItem value="mac">/Users/userName/.odo/preference.yaml</TabItem>
 </Tabs>
 
 ---

--- a/website/docs/getting-started/configure.md
+++ b/website/docs/getting-started/configure.md
@@ -6,6 +6,24 @@ sidebar_position: 6
 
 The global settings for odo can be found in `preference.yaml` file; which is located by default in the `.odo` directory of the user's HOME directory.
 
+Example -
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+defaultValue="Linux"
+values={[
+{label: 'Linux', value: 'linux'},
+{label: 'Windows', value: 'windows'},
+{label: 'Mac', value: 'mac'},
+]}>
+<TabItem value="linux">/home/user/foo/myProject/.odo/preference.yaml</TabItem>
+<TabItem value="windows">C:\\myProject\.odo\preference.yaml</TabItem>
+<TabItem value="mac">/home/user/foo/myProject/.odo/preference.yaml</TabItem>
+</Tabs>
+
+---
 A  different location can be set for the `preference.yaml` by exporting `GLOBALODOCONFIG` in the user environment.
 
 ### View the configuration
@@ -14,8 +32,9 @@ To view the current configuration, run `odo preference view`.
 ```shell
 odo preference view
 ```
-_Expected Output:_
+Example -
 ```shell
+$ odo preference view
 PARAMETER             CURRENT_VALUE
 UpdateNotification
 NamePrefix
@@ -31,8 +50,9 @@ To set a value for a preference key, run `odo preference set <key> <value>`.
 ```shell
 odo preference set updatenotification false
 ```
-_Expected Output:_
+Example -
 ```shell
+$ odo preference set updatenotification false
 Global preference was successfully updated
 ```
 Note that the preference key is case-insensitive.
@@ -42,8 +62,9 @@ To unset a value of a preference key, run `odo preference unset <key>`; use `-f`
 ```shell
 odo preference unset updatednotification
 ```
-_Expected Output:_
+Example -
 ```shell
+$ odo preference unset updatednotification
 ? Do you want to unset updatenotification in the preference (y/N) y
 Global preference was successfully updated
 ```


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
This PR adds documentation for global odo configuration.
**Which issue(s) this PR fixes**:

Fixes part of #4894

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
$ cd website/docs
# if you are doing it for the first time
$ npm install # this command installs dependencies required to create the website
$ npm run start
```