### PR TITLE
Add odo installation docs

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,77 +6,70 @@ sidebar_position: 4
 odo can be used as a CLI tool and as an IDE plugin; it can be run on Linux, Windows and Mac systems.
 
 ## CLI Binary installation
+odo supports amd64 architecture for Linux, Mac and Windows.
+Additionally, it also supports amd64, arm64, s390x, and ppc64le architectures for Linux.
 
-### Installing odo on Linux
-```shell
-  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o /usr/local/bin/odo
-  $ chmod +x /usr/local/bin/odo
-```
+See the [release page](https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/) for more information.
 
-###  Installing odo on Linux on IBM Power
+### Installing odo on Linux/Mac
 ```shell
-  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le -o /usr/local/bin/odo
-  $ chmod +x /usr/local/bin/odo
-```
-
-### Installing odo on Linux on IBM Z
-```shell
-  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-s390x -o /usr/local/bin/odo
-  $ chmod +x /usr/local/bin/odo
-```
-
-### Installing odo on macOS
-```shell
-  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o /usr/local/bin/odo
-  $ chmod +x /usr/local/bin/odo
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-$OS-$ARCH -o odo
+sudo install odo /usr/local/bin/
 ```
 
 ### Installing odo on Windows
-1. Download the latest odo-windows-amd64.exe file.
+1. Download the [odo-windows-amd64.exe](https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe) file.
 2. Rename the downloaded file to odo.exe and move it to a folder of choice, for example C:\odo
-3. Add the location of odo.exe to %PATH%.
+3. Add the location of odo.exe to `%PATH%` variable (refer to the steps below).
 
 #### Setting the PATH variable in Windows 10
 1. Click **Search** and type `env` or `environment`.
 2. Select **Edit environment variables for your account**.
 3. Select **Path** from the **Variable** section and click **Edit**.
-4. Click **New** and type `<location_of_odo_binary>` into the field or click **Browse** and select the directory, and click **OK**.
+4. Click **New**, add the location where you copied the odo binary (e.g. `C:\odo` in [Step 2 of Installation](#installing-odo-on-windows) into the field or click **Browse** and select the directory, and click **OK**.
 
 #### Setting the PATH variable in Windows 7/8
 1. Click **Start** and in the Search box types `Advance System Settings`.
 2. Select **Advanced systems settings** and click the **Environment Variables** button at the bottom.
 3. Select the **Path** variable from the **System variable** section and click **Edit**.
-4. Scroll to the end of the **Variable Value** and add `;<location_of_odo_binary>` and click **OK**.
+4. Scroll to the end of the **Variable Value** and add `;` followed by the location where you copied the odo binary (e.g. `C:\odo` in [Step 2 of Installation](#installing-odo-on-windows) and click **OK**.
 5. Click **OK** to close the **Environment Variable** dialog.
 6. Click **OK** to close the **Systems Properties** dialog.
 
 ## Installing odo in Visual Studio Code (VSCode)
-The OpenShift VSCode extension uses both odo and the oc binary to interact with Kubernetes or OpenShift cluster.
+The [OpenShift VSCode extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector) uses both odo and oc binary to interact with Kubernetes or OpenShift cluster.
 1. Open VS Code.
 2. Launch VS Code Quick Open (Ctrl+P)
 3. Paste the following command:
     ```shell
-     $ ext install redhat.vscode-openshift-connector
+     ext install redhat.vscode-openshift-connector
     ```
 
-## Installation from source
-1. Clone the repository and cd.
-```shell
-$ git clone https://github.com/openshift/odo.git; cd odo
-```
+## Installing from source
+1. Clone the repository and cd into it.
+   ```shell
+   git clone https://github.com/openshift/odo.git
+   cd odo
+   ```
 2. Install tools used by the build and test system.
-```shell
-make goget-tools
-```
-3. Build the executable in `cmd/odo`.
-```shell
-make bin
-```
-4. Install the executable in the system's GOPATH.
-```shell
-make install
-```
-5. Run the command to verify that it was installed properly.
-```shell
-odo
-```
+   ```shell
+   make goget-tools
+   ```
+3. Build the executable from the sources in `cmd/odo`.
+   ```shell
+   make bin
+   ```
+4. Check the build version to verify that it was built properly.
+   ```shell
+   ./odo version
+   ```
+5. Install the executable in the system's GOPATH.
+   ```shell
+   make install
+   ```
+6. Check the binary version to verify that it was installed properly; verify that it is same as the build version.
+   ```shell
+   odo version
+   ```

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ sudo install odo /usr/local/bin/
 
 ### Installing odo on Windows
 1. Download the [odo-windows-amd64.exe](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe) file.
-2. Rename the downloaded file to odo.exe and move it to a folder of choice, for example C:\odo
+2. Rename the downloaded file to odo.exe and move it to a folder of choice, for example `C:\odo`.
 3. Add the location of odo.exe to `%PATH%` variable (refer to the steps below).
 
 #### Setting the PATH variable in Windows 10
@@ -31,12 +31,12 @@ sudo install odo /usr/local/bin/
 4. Click **New**, add the location where you copied the odo binary (e.g. `C:\odo` in [Step 2 of Installation](#installing-odo-on-windows) into the field or click **Browse** and select the directory, and click **OK**.
 
 #### Setting the PATH variable in Windows 7/8
-1. Click **Start** and in the Search box types `Advance System Settings`.
+1. Click **Start** and in the Search box types `Advanced System Settings`.
 2. Select **Advanced systems settings** and click the **Environment Variables** button at the bottom.
-3. Select the **Path** variable from the **System variable** section and click **Edit**.
-4. Scroll to the end of the **Variable Value** and add `;` followed by the location where you copied the odo binary (e.g. `C:\odo` in [Step 2 of Installation](#installing-odo-on-windows) and click **OK**.
-5. Click **OK** to close the **Environment Variable** dialog.
-6. Click **OK** to close the **Systems Properties** dialog.
+3. Select the **Path** variable from the **System variables** section and click **Edit**.
+4. Scroll to the end of the **Variable value** and add `;` followed by the location where you copied the odo binary (e.g. `C:\odo` in [Step 2 of Installation](#installing-odo-on-windows) and click **OK**.
+5. Click **OK** to close the **Environment Variables** dialog.
+6. Click **OK** to close the **System Properties** dialog.
 
 ## Installing odo in Visual Studio Code (VSCode)
 The [OpenShift VSCode extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector) uses both odo and oc binary to interact with Kubernetes or OpenShift cluster.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -9,18 +9,18 @@ odo can be used as a CLI tool and as an IDE plugin; it can be run on Linux, Wind
 odo supports amd64 architecture for Linux, Mac and Windows.
 Additionally, it also supports amd64, arm64, s390x, and ppc64le architectures for Linux.
 
-See the [release page](https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/) for more information.
+See the [release page](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/) for more information.
 
 ### Installing odo on Linux/Mac
 ```shell
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
-curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-$OS-$ARCH -o odo
+curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-$OS-$ARCH -o odo
 sudo install odo /usr/local/bin/
 ```
 
 ### Installing odo on Windows
-1. Download the [odo-windows-amd64.exe](https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe) file.
+1. Download the [odo-windows-amd64.exe](https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe) file.
 2. Rename the downloaded file to odo.exe and move it to a folder of choice, for example C:\odo
 3. Add the location of odo.exe to `%PATH%` variable (refer to the steps below).
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -2,3 +2,81 @@
 title: Installation
 sidebar_position: 4
 ---
+
+odo can be used as a CLI tool and as an IDE plugin; it can be run on Linux, Windows and Mac systems.
+
+## CLI Binary installation
+
+### Installing odo on Linux
+```shell
+  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o /usr/local/bin/odo
+  $ chmod +x /usr/local/bin/odo
+```
+
+###  Installing odo on Linux on IBM Power
+```shell
+  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le -o /usr/local/bin/odo
+  $ chmod +x /usr/local/bin/odo
+```
+
+### Installing odo on Linux on IBM Z
+```shell
+  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-s390x -o /usr/local/bin/odo
+  $ chmod +x /usr/local/bin/odo
+```
+
+### Installing odo on macOS
+```shell
+  $ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o /usr/local/bin/odo
+  $ chmod +x /usr/local/bin/odo
+```
+
+### Installing odo on Windows
+1. Download the latest odo-windows-amd64.exe file.
+2. Rename the downloaded file to odo.exe and move it to a folder of choice, for example C:\odo
+3. Add the location of odo.exe to %PATH%.
+
+#### Setting the PATH variable in Windows 10
+1. Click **Search** and type `env` or `environment`.
+2. Select **Edit environment variables for your account**.
+3. Select **Path** from the **Variable** section and click **Edit**.
+4. Click **New** and type `<location_of_odo_binary>` into the field or click **Browse** and select the directory, and click **OK**.
+
+#### Setting the PATH variable in Windows 7/8
+1. Click **Start** and in the Search box types `Advance System Settings`.
+2. Select **Advanced systems settings** and click the **Environment Variables** button at the bottom.
+3. Select the **Path** variable from the **System variable** section and click **Edit**.
+4. Scroll to the end of the **Variable Value** and add `;<location_of_odo_binary>` and click **OK**.
+5. Click **OK** to close the **Environment Variable** dialog.
+6. Click **OK** to close the **Systems Properties** dialog.
+
+## Installing odo in Visual Studio Code (VSCode)
+The OpenShift VSCode extension uses both odo and the oc binary to interact with Kubernetes or OpenShift cluster.
+1. Open VS Code.
+2. Launch VS Code Quick Open (Ctrl+P)
+3. Paste the following command:
+    ```shell
+     $ ext install redhat.vscode-openshift-connector
+    ```
+
+## Installation from source
+1. Clone the repository and cd.
+```shell
+$ git clone https://github.com/openshift/odo.git; cd odo
+```
+2. Install tools used by the build and test system.
+```shell
+make goget-tools
+```
+3. Build the executable in `cmd/odo`.
+```shell
+make bin
+```
+4. Install the executable in the system's GOPATH.
+```shell
+make install
+```
+5. Run the command to verify that it was installed properly.
+```shell
+odo
+```


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
This PR adds odo installation docs.
**Which issue(s) this PR fixes**:

Fixes part of #4894

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
$ cd website/docs
# if you are doing it for the first time
$ npm install # this command installs dependencies required to create the website
$ npm run start

Go to Getting Started > Installations
```