### PR TITLE
Set correct component name in the devfile metadata

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -50,7 +50,7 @@ const ComponentSourceTypeAnnotation = "app.kubernetes.io/component-source-type"
 const componentRandomNamePartsMaxLen = 12
 const componentNameMaxRetries = 3
 const componentNameMaxLen = -1
-const NOTAVAILABLE = "Not available"
+const NotAvailable = "Not available"
 
 const apiVersion = "odo.dev/v1alpha1"
 
@@ -1021,7 +1021,7 @@ func GetComponentTypeFromDevfileMetadata(metadata devfile.DevfileMetadata) strin
 	} else if metadata.Language != "" {
 		componentType = metadata.Language
 	} else {
-		componentType = NOTAVAILABLE
+		componentType = NotAvailable
 	}
 	return componentType
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devfile/api/v2/pkg/devfile"
+
 	v1 "k8s.io/api/apps/v1"
 
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -48,6 +50,7 @@ const ComponentSourceTypeAnnotation = "app.kubernetes.io/component-source-type"
 const componentRandomNamePartsMaxLen = 12
 const componentNameMaxRetries = 3
 const componentNameMaxLen = -1
+const NOTAVAILABLE = "Not available"
 
 const apiVersion = "odo.dev/v1alpha1"
 
@@ -988,7 +991,7 @@ func GetComponentFromDevfile(info *envinfo.EnvSpecificInfo) (Component, parser.D
 		if err != nil {
 			return Component{}, parser.DevfileObj{}, err
 		}
-		component, err := getComponentFrom(info, devfile.Data.GetMetadata().Name)
+		component, err := getComponentFrom(info, GetComponentTypeFromDevfileMetadata(devfile.Data.GetMetadata()))
 		if err != nil {
 			return Component{}, parser.DevfileObj{}, err
 		}
@@ -1007,6 +1010,20 @@ func GetComponentFromDevfile(info *envinfo.EnvSpecificInfo) (Component, parser.D
 		return component, devfile, nil
 	}
 	return Component{}, parser.DevfileObj{}, nil
+}
+
+// GetComponentTypeFromDevfileMetadata returns component type from the devfile metadata;
+// it could either be projectType or language, if neither of them are set, return 'Not available'
+func GetComponentTypeFromDevfileMetadata(metadata devfile.DevfileMetadata) string {
+	var componentType string
+	if metadata.ProjectType != "" {
+		componentType = metadata.ProjectType
+	} else if metadata.Language != "" {
+		componentType = metadata.Language
+	} else {
+		componentType = NOTAVAILABLE
+	}
+	return componentType
 }
 
 func getComponentFrom(info localConfigProvider.LocalConfigProvider, componentType string) (Component, error) {
@@ -1519,12 +1536,19 @@ func getRemoteComponentMetadata(client *occlient.Client, componentName string, a
 		}
 	}
 
+	// Secrets
 	linkedSecrets := fromCluster.GetLinkedSecrets()
 	err = setLinksServiceNames(client, linkedSecrets, componentlabels.GetSelector(componentName, applicationName))
 	if err != nil {
 		return Component{}, fmt.Errorf("unable to get name of services: %w", err)
 	}
 	component.Status.LinkedServices = linkedSecrets
+
+	// Annotations
+	component.Annotations = fromCluster.GetAnnotations()
+
+	// Labels
+	component.Labels = fromCluster.GetLabels()
 
 	component.Namespace = client.Namespace
 	component.Spec.App = applicationName

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -998,19 +998,21 @@ func TestGetComponentTypeFromDevfileMetadata(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		var want string
-		got := GetComponentTypeFromDevfileMetadata(tt)
-		switch tt.Name {
-		case "ReturnProject":
-			want = tt.ProjectType
-		case "ReturnLanguage":
-			want = tt.Language
-		case "ReturnNA":
-			want = NOTAVAILABLE
-		}
-		if got != want {
-			t.Errorf("Incorrect component type returned; got: %q, want: %q", got, want)
-		}
+		t.Run(tt.Name, func(t *testing.T) {
+			var want string
+			got := GetComponentTypeFromDevfileMetadata(tt)
+			switch tt.Name {
+			case "ReturnProject":
+				want = tt.ProjectType
+			case "ReturnLanguage":
+				want = tt.Language
+			case "ReturnNA":
+				want = NotAvailable
+			}
+			if got != want {
+				t.Errorf("Incorrect component type returned; got: %q, want: %q", got, want)
+			}
+		})
 	}
 }
 

--- a/pkg/component/labels/labels.go
+++ b/pkg/component/labels/labels.go
@@ -14,6 +14,8 @@ const ComponentTypeLabel = "app.kubernetes.io/name"
 // ComponentTypeVersion is a Kubernetes label that identifies the component version
 const ComponentTypeVersion = "app.openshift.io/runtime-version"
 
+const ComponentTypeAnnotation = "odo.dev/project-type"
+
 // GetLabels return labels that should be applied to every object for given component in active application
 // additional labels are used only for creating object
 // if you are creating something use additional=true

--- a/pkg/component/pushed_component.go
+++ b/pkg/component/pushed_component.go
@@ -247,7 +247,7 @@ func getType(component provider) (string, error) {
 		return componentType, nil
 	} else if _, ok = component.GetLabels()[componentlabels.ComponentTypeLabel]; ok {
 		klog.V(1).Info("No annotation assigned; retuning 'Not available' since labels are assigned. Annotations will be assigned when user pushes again.")
-		return NOTAVAILABLE, nil
+		return NotAvailable, nil
 	}
 	return "", fmt.Errorf("%s component doesn't provide a type annotation; consider pushing the component again", component.GetName())
 }

--- a/pkg/component/pushed_component.go
+++ b/pkg/component/pushed_component.go
@@ -243,10 +243,13 @@ func getSource(component provider) (string, string, error) {
 }
 
 func getType(component provider) (string, error) {
-	if componentType, ok := component.GetLabels()[componentlabels.ComponentTypeLabel]; ok {
+	if componentType, ok := component.GetAnnotations()[componentlabels.ComponentTypeAnnotation]; ok {
 		return componentType, nil
+	} else if _, ok = component.GetLabels()[componentlabels.ComponentTypeLabel]; ok {
+		klog.V(1).Info("No annotation assigned; retuning 'Not available' since labels are assigned. Annotations will be assigned when user pushes again.")
+		return NOTAVAILABLE, nil
 	}
-	return "", fmt.Errorf("%s component doesn't provide a type label", component.GetName())
+	return "", fmt.Errorf("%s component doesn't provide a type annotation; consider pushing the component again", component.GetName())
 }
 
 // GetPushedComponents retrieves a map of PushedComponents from the cluster, keyed by their name

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -427,8 +427,14 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 	}
 
 	componentName := a.ComponentName
-
-	componentType := strings.TrimSuffix(a.AdapterContext.Devfile.Data.GetMetadata().Name, "-")
+	var componentType string
+	// We insert the component type in deployment annotations since its value might be in a namespaced/versioned format,
+	// since labels do not support such formats, we extract these formats before assigning its value to the corresponding label.
+	// This annotated value will later be used when listing the components; we do this to show and stay inline with the component type value set in the devfile.
+	annotatedComponentType := component.GetComponentTypeFromDevfileMetadata(a.AdapterContext.Devfile.Data.GetMetadata())
+	if annotatedComponentType != component.NOTAVAILABLE {
+		componentType = strings.TrimSuffix(util.ExtractComponentType(componentType), "-")
+	}
 
 	labels := componentlabels.GetLabels(componentName, a.AppName, true)
 	labels["component"] = componentName
@@ -515,10 +521,14 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 	}
 
 	deployment := generator.GetDeployment(deployParams)
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+
+	// Add annotation for component type; this will be later used while listing/describing a component
+	deployment.Annotations[componentlabels.ComponentTypeAnnotation] = annotatedComponentType
+
 	if vcsUri := util.GetGitOriginPath(a.Context); vcsUri != "" {
-		if deployment.Annotations == nil {
-			deployment.Annotations = make(map[string]string)
-		}
 		deployment.Annotations["app.openshift.io/vcs-uri"] = vcsUri
 	}
 

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -428,11 +428,11 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 
 	componentName := a.ComponentName
 	var componentType string
-	// We insert the component type in deployment annotations since its value might be in a namespaced/versioned format,
-	// since labels do not support such formats, we extract these formats before assigning its value to the corresponding label.
-	// This annotated value will later be used when listing the components; we do this to show and stay inline with the component type value set in the devfile.
+	// We insert the component type in deployment annotations because its value might be in a namespaced/versioned format,
+	// since labels do not support such formats, we extract the component type from these formats before assigning its value to the corresponding label.
+	// This annotated value will later be used when listing the components; we do this to list/describe and stay inline with the component type value set in the devfile.
 	annotatedComponentType := component.GetComponentTypeFromDevfileMetadata(a.AdapterContext.Devfile.Data.GetMetadata())
-	if annotatedComponentType != component.NOTAVAILABLE {
+	if annotatedComponentType != component.NotAvailable {
 		componentType = strings.TrimSuffix(util.ExtractComponentType(componentType), "-")
 	}
 
@@ -525,7 +525,7 @@ func (a *Adapter) createOrUpdateComponent(componentExists bool, ei envinfo.EnvSp
 		deployment.Annotations = make(map[string]string)
 	}
 
-	// Add annotation for component type; this will be later used while listing/describing a component
+	// Add annotation for component type; this will later be used while listing/describing a component
 	deployment.Annotations[componentlabels.ComponentTypeAnnotation] = annotatedComponentType
 
 	if vcsUri := util.GetGitOriginPath(a.Context); vcsUri != "" {

--- a/pkg/devfile/adapters/kubernetes/component/adapter_test.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter_test.go
@@ -47,6 +47,9 @@ func TestCreateOrUpdateComponent(t *testing.T) {
 				applabels.ApplicationLabel:     testAppName,
 				componentLabels.ComponentLabel: testComponentName,
 			},
+			Annotations: map[string]string{
+				componentLabels.ComponentTypeAnnotation: "",
+			},
 		},
 	}
 
@@ -90,6 +93,7 @@ func TestCreateOrUpdateComponent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var comp devfilev1.Component
 			if tt.componentType != "" {
+				deployment.Annotations[componentLabels.ComponentTypeAnnotation] = string(tt.componentType)
 				comp = testingutil.GetFakeContainerComponent("component")
 			}
 			devObj := devfileParser.DevfileObj{
@@ -98,6 +102,8 @@ func TestCreateOrUpdateComponent(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
+					metadata := devfileData.GetMetadata()
+					metadata.ProjectType = string(tt.componentType)
 					err = devfileData.AddComponents([]devfilev1.Component{comp})
 					if err != nil {
 						t.Error(err)

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -503,7 +503,7 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 					// If there is an existing devfile, and no component name is passed, parse it from the devfile,
 					// and assign the value if the metadata name is set
 					devfileObj, err := devfile.ParseFromFile(DevfilePath)
-					if (err == nil) && (devfileObj.GetMetadataName() != "") {
+					if err == nil && devfileObj.GetMetadataName() != "" {
 						componentName = devfileObj.GetMetadataName()
 					} else {
 						// If the metadata name is not available, then assign the current directory name to component

--- a/pkg/odo/cli/component/create_helpers.go
+++ b/pkg/odo/cli/component/create_helpers.go
@@ -2,7 +2,6 @@ package component
 
 import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/devfile/api/v2/pkg/devfile"
 	"github.com/devfile/library/pkg/devfile/parser"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"github.com/openshift/odo/pkg/component"
@@ -11,8 +10,6 @@ import (
 	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 )
-
-const NOTAVAILABLE = "Not available"
 
 func (co *CreateOptions) SetComponentSettings(args []string) error {
 	err := co.setComponentSourceAttributes()
@@ -93,17 +90,4 @@ func (co *CreateOptions) DevfileJSON() error {
 	}
 	machineoutput.OutputSuccess(cfd.GetComponent())
 	return nil
-}
-
-// GetComponentTypeFromDevfile returns component type from the devfile metadata
-func GetComponentTypeFromDevfile(metadata devfile.DevfileMetadata) string {
-	var componentType string
-	if metadata.ProjectType != "" {
-		componentType = metadata.ProjectType
-	} else if metadata.Language != "" {
-		componentType = metadata.Language
-	} else {
-		componentType = NOTAVAILABLE
-	}
-	return componentType
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -71,7 +71,7 @@ func (lo *ListOptions) Complete(name string, cmd *cobra.Command, args []string) 
 		if err != nil {
 			return err
 		}
-		lo.componentType = devObj.Data.GetMetadata().Name
+		lo.componentType = component.GetComponentTypeFromDevfileMetadata(devObj.Data.GetMetadata())
 
 	} else {
 		// here we use the config.yaml derived context if its present, else we use information from user's kubeconfig

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -273,7 +273,7 @@ func (po *PushOptions) Run(cmd *cobra.Command) (err error) {
 	// If experimental mode is enabled, use devfile push
 	if util.CheckPathExists(po.DevfilePath) {
 		if scontext.GetTelemetryStatus(cmd.Context()) {
-			scontext.SetComponentType(cmd.Context(), GetComponentTypeFromDevfile(po.Devfile.Data.GetMetadata()))
+			scontext.SetComponentType(cmd.Context(), component.GetComponentTypeFromDevfileMetadata(po.Devfile.Data.GetMetadata()))
 		}
 		// Return Devfile push
 		return po.DevfilePush()

--- a/pkg/testingutil/deployments.go
+++ b/pkg/testingutil/deployments.go
@@ -23,6 +23,9 @@ func CreateFakeDeployment(podName string) *appsv1.Deployment {
 				componentlabels.ComponentLabel: podName,
 				applabels.ManagedBy:            "odo",
 			},
+			Annotations: map[string]string{
+				componentlabels.ComponentTypeAnnotation: podName,
+			},
 		},
 	}
 	return &deployment

--- a/tests/examples/source/devfiles/nodejs/devfile.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile.yaml
@@ -1,6 +1,8 @@
 schemaVersion: 2.0.0
 metadata:
   name: nodejs
+  projectType: nodejs
+  language: nodejs
 starterProjects:
   - name: nodejs-starter
     git:

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
@@ -10,7 +10,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
@@ -20,7 +20,7 @@ components:
       mountSources: true
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-and-language-metadata.yaml
@@ -1,9 +1,7 @@
 ---
 schemaVersion: 2.0.0
 metadata:
-  name: java-spring-boot
-  language: java
-  projectType: spring
+  name: myspringbootproject
 starterProjects:
   - name: springbootproject
     git:
@@ -12,17 +10,17 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: quay.io/eclipse/che-java11-maven:nightly
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
-      mountSources: true
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
+      mountSources: true
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: quay.io/eclipse/che-java11-maven:nightly
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"
@@ -30,10 +28,9 @@ components:
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
-      mountSources: true
+      mountSources: false
   - name: springbootpvc
-    volume:
-      size: 3Gi
+    volume: {}
 commands:
   - id: defaultbuild
     exec:
@@ -42,6 +39,7 @@ commands:
       workingDir: /projects
       group:
         kind: build
+        isDefault: true
   - id: defaultrun
     exec:
       component: runtime
@@ -50,4 +48,3 @@ commands:
       group:
         kind: run
         isDefault: true
-

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
@@ -11,7 +11,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
@@ -21,7 +21,7 @@ components:
       mountSources: true
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"

--- a/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-missing-projectType-metadata.yaml
@@ -1,9 +1,8 @@
 ---
 schemaVersion: 2.0.0
 metadata:
-  name: java-spring-boot
+  name: myspringbootproject
   language: java
-  projectType: spring
 starterProjects:
   - name: springbootproject
     git:
@@ -12,17 +11,17 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: quay.io/eclipse/che-java11-maven:nightly
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
-      mountSources: true
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
+      mountSources: true
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:next
+      image: quay.io/eclipse/che-java11-maven:nightly
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"
@@ -30,10 +29,9 @@ components:
       volumeMounts:
         - name: springbootpvc
           path: /data/cache/.m2
-      mountSources: true
+      mountSources: false
   - name: springbootpvc
-    volume:
-      size: 3Gi
+    volume: {}
 commands:
   - id: defaultbuild
     exec:
@@ -42,6 +40,7 @@ commands:
       workingDir: /projects
       group:
         kind: build
+        isDefault: true
   - id: defaultrun
     exec:
       component: runtime
@@ -50,4 +49,3 @@ commands:
       group:
         kind: run
         isDefault: true
-

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -394,3 +394,10 @@ func SetDefaultDevfileRegistryAsStaging() {
 	const addRegistryURL string = "https://registry.stage.devfile.io"
 	Cmd("odo", "registry", "update", registryName, addRegistryURL, "-f").ShouldPass()
 }
+
+// CopyAndCreate copies required source code and devfile to the given context directory, and creates a component
+func CopyAndCreate(sourcePath, devfilePath, contextDir string) {
+	CopyExample(sourcePath, contextDir)
+	CopyExampleDevFile(devfilePath, filepath.Join(contextDir, "devfile.yaml"))
+	Cmd("odo", "create", "--context", contextDir).ShouldPass()
+}

--- a/tests/helper/odo_utils.go
+++ b/tests/helper/odo_utils.go
@@ -5,6 +5,9 @@ import (
 	"regexp"
 	"strings"
 
+	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
+	"github.com/openshift/odo/pkg/devfile"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -120,4 +123,11 @@ func DeleteProject(projectName string) {
 	fmt.Fprintf(GinkgoWriter, "Deleting project: %s\n", projectName)
 	session := Cmd("odo", "project", "delete", projectName, "-f").ShouldPass().Out()
 	Expect(session).To(ContainSubstring("Deleted project : " + projectName))
+}
+
+// GetMetadataFromDevfile retrieves the metadata from devfile
+func GetMetadataFromDevfile(devfilePath string) devfilepkg.DevfileMetadata {
+	devObj, err := devfile.ParseFromFile(devfilePath)
+	Expect(err).ToNot(HaveOccurred())
+	return devObj.Data.GetMetadata()
 }

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -356,17 +356,6 @@ func componentTests(args ...string) {
 				BeforeEach(func() {
 					helper.Cmd("odo", append(args, "push", "--context", commonVar.Context)...).ShouldPass()
 				})
-				When("odo describe is executed", func() {
-					var stdOut string
-					BeforeEach(func() {
-						stdOut = helper.Cmd("odo", "describe").ShouldPass().Out()
-					})
-					It("should have the correct component Name and Type in the describe output", func() {
-						metadata := helper.GetMetadataFromDevfile("devfile.yaml")
-						Expect(stdOut).To(ContainSubstring(metadata.ProjectType))
-						Expect(stdOut).To(ContainSubstring(cmpName))
-					})
-				})
 
 				It("should not list component even in new project with --project and --context at the same time", func() {
 					projectList := helper.Cmd("odo", "project", "list").ShouldPass().Out()

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -358,7 +358,7 @@ func componentTests(args ...string) {
 				})
 				When("odo describe is executed", func() {
 					var stdOut string
-					JustBeforeEach(func() {
+					BeforeEach(func() {
 						stdOut = helper.Cmd("odo", "describe").ShouldPass().Out()
 					})
 					It("should have the correct component Name and Type in the describe output", func() {

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -50,6 +50,13 @@ var _ = Describe("odo devfile create command tests", func() {
 		It("should successfully create the devfile component with valid component name", func() {
 			helper.Cmd("odo", "create", "java-openliberty", cmpName).ShouldPass()
 		})
+		It("should set the correct devfile metadata component name and language on component creation", func() {
+			// Reference: https://github.com/openshift/odo/issues/4815; we do not check projectType since it is subject to change.
+			helper.Cmd("odo", "create", "java-openliberty", cmpName).ShouldPass()
+			metadata := helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			Expect(metadata.Name).To(BeEquivalentTo(cmpName))
+			Expect(metadata.Language).To(ContainSubstring("java"))
+		})
 
 		It("should fail to create the devfile component with invalid component type", func() {
 			fakeComponentName := "fake-component"

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -51,7 +51,6 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.Cmd("odo", "create", "java-openliberty", cmpName).ShouldPass()
 		})
 		It("should set the correct devfile metadata component name and language on component creation", func() {
-			// Reference: https://github.com/openshift/odo/issues/4815; we do not check projectType since it is subject to change.
 			helper.Cmd("odo", "create", "java-openliberty", cmpName).ShouldPass()
 			metadata := helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			Expect(metadata.Name).To(BeEquivalentTo(cmpName))

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -2,9 +2,13 @@ package devfile
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
+	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/tests/helper"
 	"github.com/tidwall/gjson"
 )
@@ -37,14 +41,17 @@ var _ = Describe("odo devfile describe command tests", func() {
 		})
 
 		It("should describe the component when it is not pushed", func() {
-			helper.Cmd("odo", "create", "nodejs", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing").ShouldPass()
+			// Using Django example here because it helps to distinguish between language and projectType.
+			// With nodejs, both projectType and language is nodejs, but with python-django, django in the projectType and python is the language
+			// Reference: https://github.com/openshift/odo/issues/4815
+			helper.Cmd("odo", "create", "python-django", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing").ShouldPass()
 			helper.Cmd("odo", "url", "create", "url-1", "--port", "3000", "--host", "example.com", "--context", commonVar.Context).ShouldPass()
 			helper.Cmd("odo", "url", "create", "url-2", "--port", "4000", "--host", "example.com", "--context", commonVar.Context).ShouldPass()
 			helper.Cmd("odo", "storage", "create", "storage-1", "--size", "1Gi", "--path", "/data1", "--context", commonVar.Context).ShouldPass()
 			cmpDescribe := helper.Cmd("odo", "describe", "--context", commonVar.Context).ShouldPass().Out()
 			helper.MatchAllInOutput(cmpDescribe, []string{
 				"cmp-git",
-				"nodejs",
+				"django",
 				"url-1",
 				"url-2",
 				"storage-1",
@@ -53,7 +60,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 			cmpDescribeJSON, err := helper.Unindented(helper.Cmd("odo", "describe", "-o", "json", "--context", commonVar.Context).ShouldPass().Out())
 			Expect(err).Should(BeNil())
 			valuesDes := gjson.GetMany(cmpDescribeJSON, "kind", "spec.urls.items.0.metadata.name", "spec.urls.items.0.spec.host", "spec.urls.items.1.metadata.name", "spec.urls.items.1.spec.host", "spec.storages.items.0.metadata.name", "spec.storages.items.0.spec.containerName")
-			expectedDes := []string{"Component", "url-1", "url-1.example.com", "url-2", "url-2.example.com", "storage-1", "runtime"}
+			expectedDes := []string{"Component", "url-1", "url-1.example.com", "url-2", "url-2.example.com", "storage-1", "py-web"}
 			Expect(helper.GjsonMatcher(valuesDes, expectedDes)).To(Equal(true))
 
 			// odo should describe not pushed component if component name is given.
@@ -89,6 +96,19 @@ var _ = Describe("odo devfile describe command tests", func() {
 	})
 
 	Context("when running odo describe for machine readable output", func() {
+		When("a component is created with a custom name", func() {
+			const compName = "myComp"
+			JustBeforeEach(func() {
+				helper.Cmd("odo", "create", "nodejs", compName, "--context", commonVar.Context).ShouldPass()
+			})
+			It("json output should show the custom component name", func() {
+				// Reference: https://github.com/openshift/odo/issues/4815
+				output := helper.Cmd("odo", "describe", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
+				expected := gjson.Get(output, "metadata.name").String()
+				Expect(strings.ToLower(expected)).To(Equal(strings.ToLower(compName)))
+			})
+		})
+
 		It("should show json output for working cluster", func() {
 			helper.Cmd("odo", "create", "nodejs", "--context", commonVar.Context).ShouldPass()
 			output := helper.Cmd("odo", "describe", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
@@ -108,4 +128,66 @@ var _ = Describe("odo devfile describe command tests", func() {
 		})
 	})
 
+	Context("devfile has missing metadata", func() {
+		// Reference: https://github.com/openshift/odo/issues/4815
+		var metadata devfilepkg.DevfileMetadata
+
+		// copyAndCreate copies required devfile and creates a component
+		var copyAndCreate = func(path string) {
+			// Using SpringBoot example here because it helps to distinguish between language and projectType.
+			// In terms of SpringBoot, spring in the projectType and java is the language
+			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", path), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.Cmd("odo", "create", "--context", commonVar.Context).ShouldPass()
+		}
+
+		// checkDescribe checks the describe output (both normal and json) to see if it contains the expected componentType
+		var checkDescribe = func(componentType string) {
+			By("checking the normal output", func() {
+				stdOut := helper.Cmd("odo", "describe", "--context", commonVar.Context).ShouldPass().Out()
+				Expect(stdOut).To(ContainSubstring(componentType))
+			})
+			By("checking the json output", func() {
+				stdOut := helper.Cmd("odo", "describe", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
+				Expect(gjson.Get(stdOut, "spec.type").String()).To(Equal(componentType))
+			})
+		}
+
+		When("projectType is missing", func() {
+			JustBeforeEach(func() {
+				copyAndCreate("devfile-with-missing-projectType-metadata.yaml")
+				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			})
+
+			It("should show the language for 'Type' in odo describe", func() {
+				checkDescribe(metadata.Language)
+			})
+			When("the component is pushed", func() {
+				JustBeforeEach(func() {
+					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
+				})
+				It("should show the language for 'Type' in odo describe", func() {
+					checkDescribe(metadata.Language)
+				})
+			})
+
+		})
+		When("projectType and language is missing", func() {
+			JustBeforeEach(func() {
+				copyAndCreate("devfile-with-missing-projectType-and-language-metadata.yaml")
+				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			})
+			It("should show 'Not available' for 'Type' in odo describe", func() {
+				checkDescribe(component.NOTAVAILABLE)
+			})
+			When("the component is pushed", func() {
+				JustBeforeEach(func() {
+					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
+				})
+				It("should show 'Not available' for 'Type' in odo describe", func() {
+					checkDescribe(component.NOTAVAILABLE)
+				})
+			})
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -98,7 +98,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 	Context("when running odo describe for machine readable output", func() {
 		When("a component is created with a custom name", func() {
 			const compName = "myComp"
-			JustBeforeEach(func() {
+			BeforeEach(func() {
 				helper.Cmd("odo", "create", "nodejs", compName, "--context", commonVar.Context).ShouldPass()
 			})
 			It("json output should show the custom component name", func() {
@@ -130,16 +130,10 @@ var _ = Describe("odo devfile describe command tests", func() {
 
 	Context("devfile has missing metadata", func() {
 		// Reference: https://github.com/openshift/odo/issues/4815
-		var metadata devfilepkg.DevfileMetadata
+		// Note: We will be using SpringBoot example here because it helps to distinguish between language and projectType.
+		// In terms of SpringBoot, spring is the projectType and java is the language
 
-		// copyAndCreate copies required source code and devfile, and creates a component
-		var copyAndCreate = func(path string) {
-			// Using SpringBoot example here because it helps to distinguish between language and projectType.
-			// In terms of SpringBoot, spring in the projectType and java is the language
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", path), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "create", "--context", commonVar.Context).ShouldPass()
-		}
+		var metadata devfilepkg.DevfileMetadata
 
 		// checkDescribe checks the describe output (both normal and json) to see if it contains the expected componentType
 		var checkDescribe = func(componentType string) {
@@ -154,8 +148,8 @@ var _ = Describe("odo devfile describe command tests", func() {
 		}
 
 		When("projectType is missing", func() {
-			JustBeforeEach(func() {
-				copyAndCreate("devfile-with-missing-projectType-metadata.yaml")
+			BeforeEach(func() {
+				helper.CopyAndCreate(filepath.Join("source", "devfiles", "springboot", "project"), filepath.Join("source", "devfiles", "springboot", "devfile-with-missing-projectType-metadata.yaml"), commonVar.Context)
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 
@@ -163,7 +157,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 				checkDescribe(metadata.Language)
 			})
 			When("the component is pushed", func() {
-				JustBeforeEach(func() {
+				BeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show the language for 'Type' in odo describe", func() {
@@ -173,15 +167,15 @@ var _ = Describe("odo devfile describe command tests", func() {
 
 		})
 		When("projectType and language is missing", func() {
-			JustBeforeEach(func() {
-				copyAndCreate("devfile-with-missing-projectType-and-language-metadata.yaml")
+			BeforeEach(func() {
+				helper.CopyAndCreate(filepath.Join("source", "devfiles", "springboot", "project"), filepath.Join("source", "devfiles", "springboot", "devfile-with-missing-projectType-and-language-metadata.yaml"), commonVar.Context)
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 			It("should show 'Not available' for 'Type' in odo describe", func() {
 				checkDescribe(component.NotAvailable)
 			})
 			When("the component is pushed", func() {
-				JustBeforeEach(func() {
+				BeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show 'Not available' for 'Type' in odo describe", func() {

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -43,7 +43,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 		It("should describe the component when it is not pushed", func() {
 			// Using Django example here because it helps to distinguish between language and projectType.
 			// With nodejs, both projectType and language is nodejs, but with python-django, django is the projectType and python is the language
-			// Reference: https://github.com/openshift/odo/issues/4815
 			helper.Cmd("odo", "create", "python-django", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing").ShouldPass()
 			helper.Cmd("odo", "url", "create", "url-1", "--port", "3000", "--host", "example.com", "--context", commonVar.Context).ShouldPass()
 			helper.Cmd("odo", "url", "create", "url-2", "--port", "4000", "--host", "example.com", "--context", commonVar.Context).ShouldPass()
@@ -102,7 +101,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 				helper.Cmd("odo", "create", "nodejs", compName, "--context", commonVar.Context).ShouldPass()
 			})
 			It("json output should show the custom component name", func() {
-				// Reference: https://github.com/openshift/odo/issues/4815
 				output := helper.Cmd("odo", "describe", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
 				expected := gjson.Get(output, "metadata.name").String()
 				Expect(strings.ToLower(expected)).To(Equal(strings.ToLower(compName)))
@@ -129,9 +127,8 @@ var _ = Describe("odo devfile describe command tests", func() {
 	})
 
 	Context("devfile has missing metadata", func() {
-		// Reference: https://github.com/openshift/odo/issues/4815
 		// Note: We will be using SpringBoot example here because it helps to distinguish between language and projectType.
-		// In terms of SpringBoot, spring is the projectType and java is the language
+		// In terms of SpringBoot, spring is the projectType and java is the language; see https://github.com/openshift/odo/issues/4815
 
 		var metadata devfilepkg.DevfileMetadata
 

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -42,7 +42,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 
 		It("should describe the component when it is not pushed", func() {
 			// Using Django example here because it helps to distinguish between language and projectType.
-			// With nodejs, both projectType and language is nodejs, but with python-django, django in the projectType and python is the language
+			// With nodejs, both projectType and language is nodejs, but with python-django, django is the projectType and python is the language
 			// Reference: https://github.com/openshift/odo/issues/4815
 			helper.Cmd("odo", "create", "python-django", "cmp-git", "--project", commonVar.Project, "--context", commonVar.Context, "--app", "testing").ShouldPass()
 			helper.Cmd("odo", "url", "create", "url-1", "--port", "3000", "--host", "example.com", "--context", commonVar.Context).ShouldPass()
@@ -132,7 +132,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 		// Reference: https://github.com/openshift/odo/issues/4815
 		var metadata devfilepkg.DevfileMetadata
 
-		// copyAndCreate copies required devfile and creates a component
+		// copyAndCreate copies required source code and devfile, and creates a component
 		var copyAndCreate = func(path string) {
 			// Using SpringBoot example here because it helps to distinguish between language and projectType.
 			// In terms of SpringBoot, spring in the projectType and java is the language
@@ -178,14 +178,14 @@ var _ = Describe("odo devfile describe command tests", func() {
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 			It("should show 'Not available' for 'Type' in odo describe", func() {
-				checkDescribe(component.NOTAVAILABLE)
+				checkDescribe(component.NotAvailable)
 			})
 			When("the component is pushed", func() {
 				JustBeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show 'Not available' for 'Type' in odo describe", func() {
-					checkDescribe(component.NOTAVAILABLE)
+					checkDescribe(component.NotAvailable)
 				})
 			})
 		})

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -116,9 +116,8 @@ var _ = Describe("odo list with devfile", func() {
 		})
 	})
 	Context("devfile has missing metadata", func() {
-		// Reference: https://github.com/openshift/odo/issues/4815
 		// Note: We will be using SpringBoot example here because it helps to distinguish between language and projectType.
-		// In terms of SpringBoot, spring is the projectType and java is the language
+		// In terms of SpringBoot, spring is the projectType and java is the language; see https://github.com/openshift/odo/issues/4815
 
 		var metadata devfilepkg.DevfileMetadata
 

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -119,10 +119,10 @@ var _ = Describe("odo list with devfile", func() {
 		// Reference: https://github.com/openshift/odo/issues/4815
 		var metadata devfilepkg.DevfileMetadata
 
-		// copyAndCreate copies required devfile and creates a component
+		// copyAndCreate copies required source code and devfile, and creates a component
 		var copyAndCreate = func(path string) {
 			// Using SpringBoot example here because it helps to distinguish between language and projectType.
-			// In terms of SpringBoot, spring in the projectType and java is the language
+			// In terms of SpringBoot, spring is the projectType and java is the language
 			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", path), filepath.Join(commonVar.Context, "devfile.yaml"))
 			helper.Cmd("odo", "create", "--context", commonVar.Context).ShouldPass()
@@ -164,14 +164,14 @@ var _ = Describe("odo list with devfile", func() {
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 			It("should show 'Not available' for 'Type' in odo list", func() {
-				checkList(component.NOTAVAILABLE)
+				checkList(component.NotAvailable)
 			})
 			When("the component is pushed", func() {
 				JustBeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show 'Not available' for 'Type' in odo list", func() {
-					checkList(component.NOTAVAILABLE)
+					checkList(component.NotAvailable)
 				})
 			})
 		})

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
+	"github.com/openshift/odo/pkg/component"
 	"github.com/openshift/odo/tests/helper"
 	"github.com/tidwall/gjson"
 
@@ -109,6 +111,67 @@ var _ = Describe("odo list with devfile", func() {
 					output := helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
 					Expect(output).To(ContainSubstring(cmpName))
 					Expect(output).To(ContainSubstring(cmpName2))
+				})
+			})
+		})
+	})
+	Context("devfile has missing metadata", func() {
+		// Reference: https://github.com/openshift/odo/issues/4815
+		var metadata devfilepkg.DevfileMetadata
+
+		// copyAndCreate copies required devfile and creates a component
+		var copyAndCreate = func(path string) {
+			// Using SpringBoot example here because it helps to distinguish between language and projectType.
+			// In terms of SpringBoot, spring in the projectType and java is the language
+			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
+			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", path), filepath.Join(commonVar.Context, "devfile.yaml"))
+			helper.Cmd("odo", "create", "--context", commonVar.Context).ShouldPass()
+		}
+		// checkList checks the list output (both normal and json) to see if it contains the expected componentType
+		var checkList = func(componentType string) {
+			By("checking the normal output", func() {
+				stdOut := helper.Cmd("odo", "list", "--context", commonVar.Context).ShouldPass().Out()
+				Expect(stdOut).To(ContainSubstring(componentType))
+			})
+			By("checking the json output", func() {
+				stdOut := helper.Cmd("odo", "list", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
+				Expect(gjson.Get(stdOut, "devfileComponents.0.spec.type").String()).To(Equal(componentType))
+			})
+		}
+
+		When("projectType is missing", func() {
+			JustBeforeEach(func() {
+				copyAndCreate("devfile-with-missing-projectType-metadata.yaml")
+				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			})
+
+			It("should show the language for 'Type' in odo list", func() {
+				checkList(metadata.Language)
+			})
+			When("the component is pushed", func() {
+				JustBeforeEach(func() {
+					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
+				})
+				It("should show the language for 'Type' in odo list", func() {
+					checkList(metadata.Language)
+				})
+			})
+		})
+
+		When("projectType and language is missing", func() {
+			JustBeforeEach(func() {
+				copyAndCreate("devfile-with-missing-projectType-and-language-metadata.yaml")
+				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
+			})
+			It("should show 'Not available' for 'Type' in odo list", func() {
+				checkList(component.NOTAVAILABLE)
+			})
+			When("the component is pushed", func() {
+				JustBeforeEach(func() {
+					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
+				})
+				It("should show 'Not available' for 'Type' in odo list", func() {
+					checkList(component.NOTAVAILABLE)
 				})
 			})
 		})

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -117,16 +117,11 @@ var _ = Describe("odo list with devfile", func() {
 	})
 	Context("devfile has missing metadata", func() {
 		// Reference: https://github.com/openshift/odo/issues/4815
+		// Note: We will be using SpringBoot example here because it helps to distinguish between language and projectType.
+		// In terms of SpringBoot, spring is the projectType and java is the language
+
 		var metadata devfilepkg.DevfileMetadata
 
-		// copyAndCreate copies required source code and devfile, and creates a component
-		var copyAndCreate = func(path string) {
-			// Using SpringBoot example here because it helps to distinguish between language and projectType.
-			// In terms of SpringBoot, spring is the projectType and java is the language
-			helper.CopyExample(filepath.Join("source", "devfiles", "springboot", "project"), commonVar.Context)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "springboot", path), filepath.Join(commonVar.Context, "devfile.yaml"))
-			helper.Cmd("odo", "create", "--context", commonVar.Context).ShouldPass()
-		}
 		// checkList checks the list output (both normal and json) to see if it contains the expected componentType
 		var checkList = func(componentType string) {
 			By("checking the normal output", func() {
@@ -140,8 +135,8 @@ var _ = Describe("odo list with devfile", func() {
 		}
 
 		When("projectType is missing", func() {
-			JustBeforeEach(func() {
-				copyAndCreate("devfile-with-missing-projectType-metadata.yaml")
+			BeforeEach(func() {
+				helper.CopyAndCreate(filepath.Join("source", "devfiles", "springboot", "project"), filepath.Join("source", "devfiles", "springboot", "devfile-with-missing-projectType-metadata.yaml"), commonVar.Context)
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 
@@ -149,7 +144,7 @@ var _ = Describe("odo list with devfile", func() {
 				checkList(metadata.Language)
 			})
 			When("the component is pushed", func() {
-				JustBeforeEach(func() {
+				BeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show the language for 'Type' in odo list", func() {
@@ -159,15 +154,15 @@ var _ = Describe("odo list with devfile", func() {
 		})
 
 		When("projectType and language is missing", func() {
-			JustBeforeEach(func() {
-				copyAndCreate("devfile-with-missing-projectType-and-language-metadata.yaml")
+			BeforeEach(func() {
+				helper.CopyAndCreate(filepath.Join("source", "devfiles", "springboot", "project"), filepath.Join("source", "devfiles", "springboot", "devfile-with-missing-projectType-and-language-metadata.yaml"), commonVar.Context)
 				metadata = helper.GetMetadataFromDevfile(filepath.Join(commonVar.Context, "devfile.yaml"))
 			})
 			It("should show 'Not available' for 'Type' in odo list", func() {
 				checkList(component.NotAvailable)
 			})
 			When("the component is pushed", func() {
-				JustBeforeEach(func() {
+				BeforeEach(func() {
 					helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldPass().Out()
 				})
 				It("should show 'Not available' for 'Type' in odo list", func() {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug
/kind code-refactoring

**What does this PR do / why we need it**:
1. Set the correct component name in the devfile metadata.
2. In case a devfile is already present and user runs `odo create`, name the component to what is present in the devfile and not the dir name. If the `.metadata.name` is not present or if the devfile is not accessible, only then name the component to context dir name.
2. List and Describe to show the `.metadata.projectType` or `.metadata.Language` as the component type, if neither of them are available, it sets the type to `Not available`.
2. Add tests, and modify existing tests.
4. Move `GetComponentTypeFromMetadata` from `create_helpers.go` to `component.go`  so that the function can be used in both the files without any cyclic dependencies.
5. Add annotation for component-type to the component being pushed, and make `getType` to retrieve this annotation to check type, instead of label. For an existing pushed component, if an annotation is not present, but a label is, simply return Not available, and running with verbose suggests pushing the component again.
6. `getRemoteComponentMetadata` now returns annotations and labels.

**Which issue(s) this PR fixes**:

Fixes #4815

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. `odo create java-maven mycomp`
2. Check if `mycomp` is set in devfile.yaml.
3. Run `odo describe`; also check for `odo describe -o json`.
4. Check if `mycomp` is displayed in `Name` and `Maven` in `Type`.
5. Run `odo list`, also check for `odo list -o json`.
6. Check if `mycomp` is displayed in `Name` and `Maven` in `Type`.
Experiment the above by removing projectType or, both projectType and Language.

Additionally,
1. Copy a devfile to the context dir.
2. `odo create`
3. Run `odo list` or `odo describe` and check its name, make sure it corresponds to that of `.metadata.name`, and in case the field is absent, it should name it to the context dir.
Experiment the above by removing the metadata.name along with `odo create custom_name`.