### PR TITLE
odo link: fix command description

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Feature/Enhancements
 
 - Added a column in odo list output to indicate components created by odo ([#4962](https://github.com/openshift/odo/pull/4962))
+- Fix description for "odo link" command ([#4930](https://github.com/openshift/odo/pull/4930))
 
 ### Bug Fixes
 

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -44,7 +44,7 @@ var (
 # and make the secrets accessible as files in the '/bindings/etcd/' directory
 %[1]s EtcdCluster/myetcd  --bind-as-files --name etcd`)
 
-	linkLongDesc = `Link component to a service (backed by an Operator or Service Catalog) or component (works only with s2i components)
+	linkLongDesc = `Link component to a service (backed by an Operator or Service Catalog) or component
 
 If the source component is not provided, the current active component is assumed.
 In both use cases, link adds the appropriate secret to the environment of the source component. 

--- a/pkg/odo/cli/component/link.go
+++ b/pkg/odo/cli/component/link.go
@@ -66,7 +66,7 @@ Here myetcdcluster is the name of the EtcdCluster service which can be found usi
 We've also created a backend application called 'backend' with port 8080 exposed:
 odo create nodejs backend --port 8080
 
-We can now link the two applications (works only with s2i components):
+We can now link the two applications:
 odo link backend --component frontend
 
 Now the frontend has 2 ENV variables it can use:

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -32,7 +32,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 	Context("when running help for link and unlink command", func() {
 		It("should display the help", func() {
 			appHelp := helper.Cmd("odo", "link", "-h").ShouldPass().Out()
-			helper.MatchAllInOutput(appHelp, []string{"Link component to a service ", "backed by an Operator or Service Catalog", "or component", "works only with s2i components"})
+			helper.MatchAllInOutput(appHelp, []string{"Link component to a service ", "backed by an Operator or Service Catalog", "or component"})
 			appHelp = helper.Cmd("odo", "unlink", "-h").ShouldPass().Out()
 			Expect(appHelp).To(ContainSubstring("Unlink component or service from a component"))
 		})


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup


**What does this PR do / why we need it**:
odo link had an outdated description
 commands supports linking two devfile components


