### PR TITLE
Add Tutorials section to doc website

### DIFF
--- a/website/docs/architecture/_category_.json
+++ b/website/docs/architecture/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Architecture",
-  "position": 5
+  "position": 6
 }

--- a/website/docs/architecture/secure-registry.md
+++ b/website/docs/architecture/secure-registry.md
@@ -1,0 +1,4 @@
+---
+title: Secure Registry
+sidebar_position: 5
+---

--- a/website/docs/architecture/secure-registry.md
+++ b/website/docs/architecture/secure-registry.md
@@ -2,3 +2,60 @@
 title: Secure Registry
 sidebar_position: 5
 ---
+
+**What is a secure devfile registry?**
+
+A secure devfile registry is a devfile registry that a user can only access using credentials.
+
+**Where to host secure devfile registry?**
+
+A user can host a secure devfile registry on a private GitHub repository or an enterprise GitHub repository.
+
+## Adding a secure devfile registry on a GitHub repository
+
+1. [Create new private or enterprise GitHub repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-new-repository) to host the secure devfile registry and push the devfile registry to the created repository. The sample GitHub-hosted devfile registry can be found [here](https://github.com/odo-devfiles/registry/).
+
+2. [Create a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to access the secure devfile registry with `repo` as token scope.
+
+3. Keyring setup: There is no specific keyring setup for secure devfile registry, you only need to ensure the keyring is working properly on your system.
+
+  If you hit issues with keyring please follow the below instructions to troubleshoot with respect to the corresponding platforms.
+    * [Mac keychain](https://support.apple.com/en-ca/guide/keychain-access/welcome/mac)
+    * [GNOME keyring setup on RedHat Enterprise Linux](https://nurdletech.com/linux-notes/agents/keyring.html)
+    * [GNOME keyring setup on Ubuntu Linux](https://howtoinstall.co/en/ubuntu/xenial/gnome-keyring)
+    * [Linux GNOME keyring](https://help.gnome.org/users/seahorse/stable/index.html.en)
+    * [Windows credential manager](https://support.microsoft.com/en-ca/help/4026814/windows-accessing-credential-manager)
+
+4. Add a secure devfile registry to odo.
+   ```shell
+   odo registry add <registry name> <registry URL> --token <token>
+   ```
+     * registry name: user-defined devfile registry name.
+     * registry URL: the URL of GitHub repository that you create on step 1.
+     * token: the personal access token that you created on step 2.
+
+## Steps for setting up a secure starter project on a GitHub repository
+
+1. [Create a new private or enterprise GitHub repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-new-repository) and push the starter project to the created repository. The sample GitHub-hosted starter project can be found [here](https://github.com/odo-devfiles/nodejs-ex).
+
+  Ensure the `starterProjects` section in the corresponding devfile of your secure devfile registry links to the secure starter project, for example:
+
+  ```shell
+  starterProjects:
+    - name: nodejs-starter
+      git:
+        remotes:
+          origin: "<secure starter project link>"
+  ```
+
+2. [Create a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to access the secure devfile registry with `repo` as token scope.
+
+3. Create a devfile component from the secure devfile registry and download the secure starter project.
+
+  ```shell
+  odo create nodejs --registry <registry name> --starter --starter-token <starter project token>
+  ```
+    * registry name: user-defined devfile registry name.
+    * starter project token: the personal access token that you create on step 2.
+
+**Note:** GitHub only supports user-scoped personal access tokens. If the repository that hosts the secure registry and the repository that hosts the secure starter project are created under the same GitHub user, then the token can be used for both downloading the devfile and starter project. For that case you don't need to explicitly pass in the flag `--starter-token <starter project token>`, odo can automatically use one token to download both devfile and starter project.

--- a/website/docs/contributing/_category_.json
+++ b/website/docs/contributing/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Contribute to odo",
-  "position": 6
+  "position": 7
 }

--- a/website/docs/tutorials/_category_.json
+++ b/website/docs/tutorials/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Tutorials",
+  "position": 6
+}

--- a/website/docs/tutorials/_category_.json
+++ b/website/docs/tutorials/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Tutorials",
-  "position": 6
+  "position": 5
 }

--- a/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
+++ b/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
@@ -3,7 +3,7 @@ title: Using odo on IBM-Z and Power
 sidebar_position: 2
 ---
 ### Pre-requisites
-1. Read [Architecture > Devfile](../architecture/devfile.md).
+1. [Devfile](../architecture/devfile.md).
 
 ### Deploying your first devfile on IBM Z & Power
 Since the [DefaultDevfileRegistry](https://github.com/odo-devfiles/registry) doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry, please check the doc [secure registry](../architecture/secure-registry.md).

--- a/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
+++ b/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
@@ -2,8 +2,7 @@
 title: Using odo on IBM-Z and Power
 sidebar_position: 2
 ---
-### Pre-requisites
-1. [Devfile](../architecture/devfile.md).
+[//]: # (Add prerequisite section)
 
 ### Deploying your first devfile on IBM Z & Power
 Since the [DefaultDevfileRegistry](https://github.com/odo-devfiles/registry) doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry, please check the doc [secure registry](../architecture/secure-registry.md).
@@ -23,4 +22,4 @@ The images can be used for devfiles on IBM Z & Power
 
 **Note**: Access to the Red Hat registry is required to use these images on IBM Power Systems & IBM Z.
 
-Steps to use devfiles can be found in [Deploying your first devfile](deploying-your-first-devfile.md).
+[//]: # (Steps to use devfiles can be found in Deploying your first devfile)

--- a/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
+++ b/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
@@ -1,0 +1,26 @@
+---
+title: Using odo on IBM-Z and Power
+sidebar_position: 2
+---
+### Pre-requisites
+1. Read [Architecture > Devfile](../architecture/devfile.md).
+
+### Deploying your first devfile on IBM Z & Power
+Since the [DefaultDevfileRegistry](https://github.com/odo-devfiles/registry) doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry, please check the doc [secure registry](../architecture/secure-registry.md).
+
+The images can be used for devfiles on IBM Z & Power
+
+|Language   | Devfile Name  | Description   | Image Source  | Supported Platform    |
+| ----------- | ----------- | ----------- | ----------- | ----------- |
+| Java      | java-maven    | Upstream Maven and OpenJDK 11 | registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8 | s390x, ppc64le |
+| Java      | java-openliberty | Open Liberty microservice in Java | registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8 | s390x, ppc64le |
+| Java | java-quarkus | Upstream Quarkus with Java+GraalVM | registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8 | s390x, ppc64le|
+| Java | java-springboot | Spring Boot® using Java| registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8 | s390x, ppc64le|
+| Vert.x Java| java-vertx | Upstream Vert.x using Java | registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8 | s390x, ppc64le|
+| Node.JS | nodejs | Stack with NodeJS 12 | registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8 | s390x, ppc64le|
+| Python| python | Python Stack with Python 3.7 | registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8 | s390x, ppc64le|
+| Django| python-django| Python3.7 with Django| registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8| s390x, ppc64le|
+
+**Note**: Access to the Red Hat registry is required to use these images on IBM Power Systems & IBM Z.
+
+Steps to use devfiles can be found in [Deploying your first devfile](deploying-your-first-devfile.md).

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -13,7 +13,7 @@ In this example there are two roles:
 ## Cluster admin
 ---
 
-This section assumes that you have installed minikube and configured it. See [Getting Started > Cluster Setup > Kubernetes](../getting-started/cluster-setup/kubernetes.md).
+This section assumes that you have installed minikube and configured it. See the section on setting up[Kubernetes](../getting-started/cluster-setup/kubernetes.md) if you have not already configured it.
 
 The cluster admin must install two Operators into the cluster:
 
@@ -24,7 +24,7 @@ An _Operator Backed Service_ is an operator that helps in deploying instances of
 
 Furthermore, these operators are "bind-able" as they expose information necessary for an application to connect to their instances.
 
-We will use Dev4Devs PostgreSQL Operator found in the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
+We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
 
 Service Binding Operator is an operator that helps in easily binding an application to other Operator Backed Services. It accomplishes this through automatically collecting binding information and sharing with an application to bind it with operator managed backing services
 
@@ -42,12 +42,12 @@ Service Binding Operator is an operator that helps in easily binding an applicat
     ```shell
     kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
     ```
-  Refer to [Getting Started > Cluster Setup > Operators](../getting-started/cluster-setup/operators.md) for more information on installing operators.
+  Refer to the [Operators guide](../getting-started/cluster-setup/operators.md) for more information on installing operators.
 
 ## Application Developer
 ---
 
-This section assumes that you have installed `odo`. See [Getting Started > Installation](../getting-started/installation.md).
+This section assumes that you have installed `odo`. See the [Installation guide](../getting-started/installation.md) if you have not already installed odo.
 
 Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
 

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -3,58 +3,58 @@ title: Deploying a Java OpenLiberty application with PostgreSQL
 sidebar_position: 1
 ---
 
-This scenario illustrates binding an `odo` managed Java MicroServices JPA application to an in-cluster Operator managed PostgreSQL Database in the minikube environment.
-
-### Pre-requisites
-
-1. `odo` is installed. See [Getting Started > Installation](../getting-started/installation.md).
-2. minikube is installed and configured. See [Getting Started > Cluster Setup > Kubernetes](../getting-started/cluster-setup/kubernetes.md).
-
-## Actions to be performed by a cluster admin and application developer
+This scenario illustrates deploying a Java application with odo and linking it to an in-cluster PostgreSQL service in the minikube environment.
 
 In this example there are two roles:
 
-1. Cluster Admin - Installs the Operators to the cluster
-2. Application Developer - Imports a Java MicroServices JPA application, creates a DB instance, creates a request to bind the application and DB (to connect the DB and the application).
- 
+1. Cluster Admin - Prepare the cluster by installing the required operators into the cluster
+2. Application Developer - Imports a Java application, creates a Database instance, and connect the application to the Database instance.
 
-### Cluster admin
+## Cluster admin
 ---
+
+This section assumes that you have installed minikube and configured it. See [Getting Started > Cluster Setup > Kubernetes](../getting-started/cluster-setup/kubernetes.md).
 
 The cluster admin must install two Operators into the cluster:
 
-1. Service Binding Operator
-2. A Backing Service Operator
+1. Operator Backed Service
+2. Service Binding Operator
 
-A Backing Service Operator that is "bind-able," in other
-words a Backing Service Operator that exposes binding information in secrets, config maps, status, and/or spec attributes. The Backing Service Operator may represent a database or other services required by applications. We will use Dev4Devs PostgreSQL Operator found in the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
+An _Operator Backed Service_ is an operator that helps in deploying instances of a given service, for example PostgreSQL, MySQL, Redis.
 
-#### Installing the Service Binding Operator
+Furthermore, these operators are "bind-able" as they expose information necessary for an application to connect to their instances.
 
-* Run the following `kubectl` command to make the Service Binding Operator available in all namespaces on your minikube:
-    ```shell
-    $ kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
-    ```
-    Refer to [Getting Started > Cluster Setup > Operators](../getting-started/cluster-setup/operators.md) for more information on installing operators.
+We will use Dev4Devs PostgreSQL Operator found in the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
 
-#### Installing the database operator
+Service Binding Operator is an operator that helps in easily binding an application to other Operator Backed Services. It accomplishes this through automatically collecting binding information and sharing with an application to bind it with operator managed backing services
+
+### Installing the Operator Backed Service
 
 * Run the following `kubectl` command to make the PostgreSQL Operator available in `my-postgresql-operator-dev4devs-com` namespace of your minikube cluster:
 ```shell
   $ kubectl create -f https://operatorhub.io/install/postgresql-operator-dev4devs-com.yaml
   ```
 
-**NOTE**: The `my-postgresql-operator-dev4devs-com` Operator will be installed in the `my-postgresql-operator-dev4devs-com` namespace and will be usable from this namespace only.
+**Note**: The `my-postgresql-operator-dev4devs-com` Operator will be installed in the `my-postgresql-operator-dev4devs-com` namespace and will be usable from this namespace only.
 
-### Application Developer
+### Installing the Service Binding Operator
+* Run the following `kubectl` command to make the Service Binding Operator available in all namespaces on your minikube:
+    ```shell
+    $ kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
+    ```
+  Refer to [Getting Started > Cluster Setup > Operators](../getting-started/cluster-setup/operators.md) for more information on installing operators.
+
+## Application Developer
 ---
+
+This section assumes that you have installed `odo`. See [Getting Started > Installation](../getting-started/installation.md).
 
 Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
 
 ```shell
 $ odo project set my-postgresql-operator-dev4devs-com
 ```
-### Importing the demo Java MicroService JPA application
+## Importing the demo Java MicroService JPA application
 
 In this example we will use odo to manage a sample [Java MicroServices JPA application](https://github.com/OpenLiberty/application-stack-samples.git).
 
@@ -146,7 +146,7 @@ URL/CreatePerson.xhtml' and enter a user's name and age data using the form.
 
 Note that the entry of any data does not result in the data being displayed when you click on the "View Persons Record List" link.
 
-#### Creating a database to be used by the sample application
+### Creating a database to be used by the sample application
 
 You can use the default configurations of the PostgreSQL Operator to start a Postgres database from it. But since our app uses few specific configuration values, lets make sure they are properly populated in the database service we start.
 
@@ -181,7 +181,7 @@ You can use the default configurations of the PostgreSQL Operator to start a Pos
 
     This action will create a database instance pod in the `my-postgresql-operator-dev4devs-com` namespace. The application will be configured to use this database.
 
-#### Binding the database and the application
+## Binding the database and the application
 
 Now, the only thing that remains is to connect the DB and the application. We will use odo to create a link to the Dev4Devs PostgreSQL Database Operator in order to access the database connection information.
 

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -3,35 +3,35 @@ title: Deploying a Java OpenLiberty application with PostgreSQL
 sidebar_position: 1
 ---
 
-This scenario illustrates deploying a Java application with odo and linking it to an in-cluster PostgreSQL service in the minikube environment.
+This tutorial illustrates deploying a [Java OpenLiberty](https://openliberty.io/) application with odo and linking it to an in-cluster PostgreSQL service in the minikube environment.
 
 There are two roles in this example:
 
-1. Cluster Admin - Prepare the cluster by installing the required operators into the cluster.
+1. Cluster Admin - Prepare the cluster by installing the required operators on the cluster.
 2. Application Developer - Imports a Java application, creates a Database instance, and connect the application to the Database instance.
 
 ## Cluster admin
 ---
 
-This section assumes that you have installed minikube and configured it. See the section on setting up a [Kubernetes](../getting-started/cluster-setup/kubernetes.md) cluster using minikube if you have not already configured it.
+This section assumes that you have installed [minikube and configured it](../getting-started/cluster-setup/kubernetes.md).
+
+We will be using Operators in this guide. An Operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
+
+Furthermore, these Operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances,
+
+See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an Operator in the Kubernetes cluster, if you have not already done so.
 
 The cluster admin must install two Operators into the cluster:
 
 1. PostgreSQL Operator
 2. Service Binding Operator
 
-An operator helps in deploying instances of a given service, for example PostgreSQL, MySQL, Redis.
-
-Furthermore, these operators are "bind-able" as they expose information necessary for an application to connect to their instances.
-
-See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an operator in the Kubernetes cluster, if you have not already done so.
-
 We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
-
+   
 ## Application Developer
 ---
 
-This section assumes that you have installed `odo`. See the [Installation guide](../getting-started/installation.md) if you have not already installed it.
+This section assumes that you have [installed `odo`](../getting-started/installation.md).
 
 Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
 
@@ -52,7 +52,7 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     cd ./application-stack-samples/jpa
     ```
 
-3. Initialize the project:
+3. Initialize the application:
     ```shell
     odo create java-openliberty mysboproj
     ```
@@ -60,7 +60,7 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
 
 4. Push the application to the cluster:
     ```shell
-    odo push --show-logs
+    odo push --show-log
     ```
 
 5. The application is now deployed to the cluster - you can view the status of the cluster, and the application test results by streaming the cluster logs into the terminal.
@@ -100,14 +100,14 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     ```
    Note: This error will be fixed at a later stage in the tutorial when we connect a database instance to this application.
 
-6. You can also create an ingress URL with `odo` to access the application:
+6. You can also create a URL with `odo` to access the application:
     ```shell
     odo url create --host $(minikube ip).nip.io
     ```
 
 7. Push the URL to activate it:
     ```shell
-    odo push --show-logs
+    odo push --show-log
     ```
 
 8. Display the created URL:
@@ -123,9 +123,8 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     mysboproj-9080     Pushed     http://mysboproj-9080.192.168.49.2.nip.io     9080     false      ingress
     ```
 
-10. Use the URL to navigate to the `CreatePerson.xhtml` data entry page and enter requested data:
-URL/CreatePerson.xhtml and enter a user's name and age data using the form.
-
+10. Use the URL to navigate to the `CreatePerson.xhtml` data entry page to use the application:
+    In case of this tutorial, we will access `http://mysboproj-9080.192.168.49.2.nip.io/CreatePerson.xhtml`. Note that the URL could be different for you. Now, enter a name and age data using the form.
 11. Click on the **Save** button when complete
 
 
@@ -163,7 +162,7 @@ You can use the default configuration of the PostgreSQL Operator to start a Post
     odo service create --from-file db.yaml
    ```
    ```shell
-    odo push --show-logs
+    odo push --show-log
     ```
 
     This action will create a database instance pod in the `my-postgresql-operator-dev4devs-com` namespace. The application will be configured to use this database.
@@ -202,7 +201,7 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
 4. Push this link to the cluster:
     ```shell
-    odo push --show-logs
+    odo push --show-log
     ```
 
     After the link has been created and pushed, a secret will have been created containing the database connection data that the application requires.

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -74,7 +74,29 @@ In this example we will use odo to manage a sample [Java JPA MicroService applic
     ```shell
     odo push --show-log
     ```
+   **Troubleshooting**:
+   The Open Liberty image used by this application is relatively large(~850 MB), and depending on your internet connection, it might fail to download within the BuildTimeout set by odo; default timeout is 300 seconds.
+   ```shell
+   $ odo push   
+   Validation
+   ✓  Validating the devfile [45508ns]
+   
+   Updating services
+   ✓  Services and Links are in sync with the cluster, no changes are required
+   
+   Creating Kubernetes resources for component mysboproj
+   ✗  Waiting for component to start [5m]
+   ✗  Failed to start component with name "mysboproj". Error: Failed to create the component: error while waiting for deployment rollout: timeout while waiting for mysboproj-app deployment roll out
+   ```
 
+   In case this step fails due to a timeout, consider increasing the Build Timeout:
+   ```shell
+   odo preference set BuildTimeout 600
+   ```
+   Deploy the application to the cluster again:
+   ```shell
+   odo push --show-log -f
+   ```
 5. The application is now deployed to the cluster - you can view the status of the cluster, and the application test results by streaming the cluster logs of the component that we pushed to the cluster in the previous step.
     ```shell
     odo log --follow

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -32,7 +32,7 @@ Service Binding Operator is an operator that helps in easily binding an applicat
 
 * Run the following `kubectl` command to make the PostgreSQL Operator available in `my-postgresql-operator-dev4devs-com` namespace of your minikube cluster:
 ```shell
-  $ kubectl create -f https://operatorhub.io/install/postgresql-operator-dev4devs-com.yaml
+  kubectl create -f https://operatorhub.io/install/postgresql-operator-dev4devs-com.yaml
   ```
 
 **Note**: The `my-postgresql-operator-dev4devs-com` Operator will be installed in the `my-postgresql-operator-dev4devs-com` namespace and will be usable from this namespace only.
@@ -40,7 +40,7 @@ Service Binding Operator is an operator that helps in easily binding an applicat
 ### Installing the Service Binding Operator
 * Run the following `kubectl` command to make the Service Binding Operator available in all namespaces on your minikube:
     ```shell
-    $ kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
+    kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
     ```
   Refer to [Getting Started > Cluster Setup > Operators](../getting-started/cluster-setup/operators.md) for more information on installing operators.
 
@@ -52,7 +52,7 @@ This section assumes that you have installed `odo`. See [Getting Started > Insta
 Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
 
 ```shell
-$ odo project set my-postgresql-operator-dev4devs-com
+odo project set my-postgresql-operator-dev4devs-com
 ```
 ## Importing the demo Java MicroService JPA application
 
@@ -60,27 +60,27 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
 
 1. Clone the sample application to your system:
     ```shell
-    $ git clone https://github.com/OpenLiberty/application-stack-samples.git
+    git clone https://github.com/OpenLiberty/application-stack-samples.git
     ```
 
 2. Go to the sample JPA app directory:
     ```shell
-    $ cd ./application-stack-samples/jpa
+    cd ./application-stack-samples/jpa
     ```
 
 3. Initialize the project:
     ```shell
-    $ odo create java-openliberty mysboproj
+    odo create java-openliberty mysboproj
     ```
 
 4. Push the application to the cluster:
     ```shell
-    $ odo push
+    odo push
     ```
 
 5. The application is now deployed to the cluster - you can view the status of the cluster and the application test results by streaming the OpenShift logs to the terminal.
     ```shell
-    $ odo log
+    odo log
     ```
 
     Notice the failing tests due to an UnknownDatabaseHostException:
@@ -116,17 +116,17 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
 
 6. You can also create an ingress URL with `odo` to access the application:
     ```shell
-    $ odo url create --host $(minikube ip).nip.io
+    odo url create --host $(minikube ip).nip.io
     ```
 
 7. Push the URL to activate it:
     ```shell
-    $ odo push
+    odo push
     ```
 
 8. Display the created URL:
     ```shell
-    $ odo url list
+    odo url list
     ```
 
     You will see a fully formed URL that can be used in a web browser:
@@ -152,7 +152,7 @@ You can use the default configurations of the PostgreSQL Operator to start a Pos
 
 1. Store the YAML of the service in a file:
     ```shell
-    $ odo service create postgresql-operator.v0.1.1/Database --dry-run > db.yaml
+    odo service create postgresql-operator.v0.1.1/Database --dry-run > db.yaml
     ```
 
 2. Modify and add following values under `metadata:` section in the `db.yaml` file:
@@ -175,8 +175,10 @@ You can use the default configurations of the PostgreSQL Operator to start a Pos
 
 4. Create the database from the YAML file:
     ```shell
-    $ odo service create --from-file db.yaml
-    $ odo push
+    odo service create --from-file db.yaml
+   ```
+   ```shell
+    odo push
     ```
 
     This action will create a database instance pod in the `my-postgresql-operator-dev4devs-com` namespace. The application will be configured to use this database.
@@ -187,7 +189,7 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
 1. Display the services available to odo: - You will see an entry for the PostgreSQL Database Operator displayed:
     ```shell
-    $ odo catalog list services
+    odo catalog list services
     Operators available in the cluster
     NAME                                             CRDs
     postgresql-operator.v0.1.1                       Backup, Database
@@ -195,19 +197,19 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
 2. List the service associated with the database created via the PostgreSQL Operator:
     ```shell
-    $ odo service list
+    odo service list
     NAME                       MANAGED BY ODO     STATE     AGE
     Database/sampledatabase   Yes (mysboproj)    Pushed    6m35s
     ```
 
 3. Create a Service Binding Request between the application and the database using the Service Binding Operator service created in the previous step `odo link` command:
     ```shell
-    $ odo link Database/sampledatabase
+    odo link Database/sampledatabase
     ```
 
 4. Push this link to the cluster:
     ```shell
-    $ odo push
+    odo push
     ```
 
     After the link has been created and pushed a secret will have been created containing the database connection data that the application requires.
@@ -218,10 +220,10 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
 5. Once the new pod has initialized you can see the secret database connection data as it is injected into the pod environment by executing the following:
     ```shell
-    $ odo exec -- bash -c 'export | grep DATABASE'
-    declare -x DATABASE_CLUSTERIP="10.106.182.173"
-    declare -x DATABASE_DB_NAME="sampledb"
-    declare -x DATABASE_DB_PASSWORD="samplepwd"
+    odo exec -- bash -c 'export | grep DATABASE' \
+    declare -x DATABASE_CLUSTERIP="10.106.182.173" \
+    declare -x DATABASE_DB_NAME="sampledb" \
+    declare -x DATABASE_DB_PASSWORD="samplepwd" \
     declare -x DATABASE_DB_USER="sampleuser"
     ```
     Once the new version is up (there will be a slight delay until application is available), navigate to the CreatePerson.xhtml using the URL created in a previous step. Enter requested data and click the **Save** button.

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 This tutorial illustrates deploying a [Java Open Liberty](https://openliberty.io/) application with odo and linking it to an in-cluster PostgreSQL service in a minikube environment.
 
 There are two roles in this example:
-1. Cluster Admin - Prepare the cluster by installing the required operators on the cluster.
+1. Cluster Admin - Prepare the cluster by installing the required Operators on the cluster.
 2. Application Developer - Imports a Java application, creates a Database instance, and connect the application to the Database instance.
 
 ## Cluster admin
@@ -18,19 +18,19 @@ There are two roles in this example:
 ----
 [//]: # (Move this section to Architecture > Service Binding or create a new Operators doc)
 
-We will be using operators in this guide. An operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
+We will be using Operators in this guide. An Operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
 
-Furthermore, these operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances.
+Furthermore, these Operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances.
 
 [//]: # (Move until here)
 
-See the [operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an operator on a minikube cluster.
+See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an Operator on a minikube cluster.
 
-The cluster admin must install two operators into the cluster:
+The cluster admin must install two Operators into the cluster:
 1. PostgreSQL Operator
 2. Service Binding Operator
 
-We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case. This operator will be installed in `my-postgresql-operator-dev4devs-com` namespace by default, if you want to use another namespace, make sure that you add your namespace to `.spec.targetNamespaces` list in the definition file before installing it. 
+We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case. This Operator will be installed in `my-postgresql-operator-dev4devs-com` namespace by default, if you want to use another namespace, make sure that you add your namespace to `.spec.targetNamespaces` list in the definition file before installing it. 
 
 **Note**: We will use the `my-postgresql-operator-dev4devs-com` namespace for this guide.
 
@@ -45,7 +45,7 @@ Since the PostgreSQL Operator installed in above step is available only in `my-p
 ```shell
 odo project set my-postgresql-operator-dev4devs-com
 ```
-If you installed the operator in a different namespace, ensure that odo uses it to perform any tasks:
+If you installed the Operator in a different namespace, ensure that odo uses it to perform any tasks:
 ```shell
 odo project set <your-namespace>
 ```

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -1,0 +1,259 @@
+---
+title: Deploying a Java OpenLiberty application with PostgreSQL
+sidebar_position: 1
+---
+
+This scenario illustrates binding an `odo` managed Java MicroServices JPA application to an in-cluster Operator managed PostgreSQL Database in the minikube environment.
+
+### Pre-requisites
+
+1. `odo` is installed. See [Getting Started > Installation](../getting-started/installation.md).
+2. minikube is installed and configured. See [Getting Started > Cluster Setup > Kubernetes](../getting-started/cluster-setup/kubernetes.md).
+
+## Actions to be performed by a cluster admin and application developer
+
+In this example there are two roles:
+
+1. Cluster Admin - Installs the Operators to the cluster
+2. Application Developer - Imports a Java MicroServices JPA application, creates a DB instance, creates a request to bind the application and DB (to connect the DB and the application).
+ 
+
+### Cluster admin
+---
+
+The cluster admin must install two Operators into the cluster:
+
+1. Service Binding Operator
+2. A Backing Service Operator
+
+A Backing Service Operator that is "bind-able," in other
+words a Backing Service Operator that exposes binding information in secrets, config maps, status, and/or spec attributes. The Backing Service Operator may represent a database or other services required by applications. We will use Dev4Devs PostgreSQL Operator found in the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
+
+#### Installing the Service Binding Operator
+
+* Run the following `kubectl` command to make the Service Binding Operator available in all namespaces on your minikube:
+    ```shell
+    $ kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
+    ```
+    Refer to [Getting Started > Cluster Setup > Operators](../getting-started/cluster-setup/operators.md) for more information on installing operators.
+
+#### Installing the database operator
+
+* Run the following `kubectl` command to make the PostgreSQL Operator available in `my-postgresql-operator-dev4devs-com` namespace of your minikube cluster:
+```shell
+  $ kubectl create -f https://operatorhub.io/install/postgresql-operator-dev4devs-com.yaml
+  ```
+
+**NOTE**: The `my-postgresql-operator-dev4devs-com` Operator will be installed in the `my-postgresql-operator-dev4devs-com` namespace and will be usable from this namespace only.
+
+### Application Developer
+---
+
+Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
+
+```shell
+$ odo project set my-postgresql-operator-dev4devs-com
+```
+### Importing the demo Java MicroService JPA application
+
+In this example we will use odo to manage a sample [Java MicroServices JPA application](https://github.com/OpenLiberty/application-stack-samples.git).
+
+1. Clone the sample application to your system:
+    ```shell
+    $ git clone https://github.com/OpenLiberty/application-stack-samples.git
+    ```
+
+2. Go to the sample JPA app directory:
+    ```shell
+    $ cd ./application-stack-samples/jpa
+    ```
+
+3. Initialize the project:
+    ```shell
+    $ odo create java-openliberty mysboproj
+    ```
+
+4. Push the application to the cluster:
+    ```shell
+    $ odo push
+    ```
+
+5. The application is now deployed to the cluster - you can view the status of the cluster and the application test results by streaming the OpenShift logs to the terminal.
+    ```shell
+    $ odo log
+    ```
+
+    Notice the failing tests due to an UnknownDatabaseHostException:
+    ```shell
+    [INFO] [err] java.net.UnknownHostException: ${DATABASE_CLUSTERIP}
+    [INFO] [err]    at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:220)
+    [INFO] [err]    at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:403)
+    [INFO] [err]    at java.base/java.net.Socket.connect(Socket.java:609)
+    [INFO] [err]    at org.postgresql.core.PGStream.<init>(PGStream.java:68)
+    [INFO] [err]    at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:144)
+    [INFO] [err]    ... 86 more
+    [ERROR] Tests run: 2, Failures: 1, Errors: 1, Skipped: 0, Time elapsed: 0.706 s <<< FAILURE! - in org.example.app.it.DatabaseIT
+    [ERROR] testGetAllPeople  Time elapsed: 0.33 s  <<< FAILURE!
+    org.opentest4j.AssertionFailedError: Expected at least 2 people to be registered, but there were only: [] ==> expected: <true> but was: <false>
+    at org.example.app.it.DatabaseIT.testGetAllPeople(DatabaseIT.java:57)
+    
+    [ERROR] testGetPerson  Time elapsed: 0.047 s  <<< ERROR!
+    java.lang.NullPointerException
+    at org.example.app.it.DatabaseIT.testGetPerson(DatabaseIT.java:41)
+    
+    [INFO]
+    [INFO] Results:
+    [INFO]
+    [ERROR] Failures:
+    [ERROR]   DatabaseIT.testGetAllPeople:57 Expected at least 2 people to be registered, but there were only: [] ==> expected: <true> but was: <false>
+    [ERROR] Errors:
+    [ERROR]   DatabaseIT.testGetPerson:41 NullPointer
+    [INFO]
+    [ERROR] Tests run: 2, Failures: 1, Errors: 1, Skipped: 0
+    [INFO]
+    [ERROR] Integration tests failed: There are test failures.
+    ```
+
+6. You can also create an ingress URL with `odo` to access the application:
+    ```shell
+    $ odo url create --host $(minikube ip).nip.io
+    ```
+
+7. Push the URL to activate it:
+    ```shell
+    $ odo push
+    ```
+
+8. Display the created URL:
+    ```shell
+    $ odo url list
+    ```
+
+    You will see a fully formed URL that can be used in a web browser:
+    ```shell
+    [root@pappuses1 jpa]# odo url list
+    Found the following URLs for component mysboproj
+    NAME               STATE      URL                                           PORT     SECURE     KIND
+    mysboproj-9080     Pushed     http://mysboproj-9080.192.168.49.2.nip.io     9080     false      ingress
+    [root@pappuses1 jpa]#
+    ```
+
+10. Use the URL to navigate to the `CreatePerson.xhtml` data entry page and enter requested data:
+URL/CreatePerson.xhtml' and enter a user's name and age data using the form.
+
+11. Click on the **Save** button when complete
+
+
+Note that the entry of any data does not result in the data being displayed when you click on the "View Persons Record List" link.
+
+#### Creating a database to be used by the sample application
+
+You can use the default configurations of the PostgreSQL Operator to start a Postgres database from it. But since our app uses few specific configuration values, lets make sure they are properly populated in the database service we start.
+
+1. Store the YAML of the service in a file:
+    ```shell
+    $ odo service create postgresql-operator.v0.1.1/Database --dry-run > db.yaml
+    ```
+
+2. Modify and add following values under `metadata:` section in the `db.yaml` file:
+    ```yaml
+    name: sampledatabase
+    annotations:
+      service.binding/db_name: 'path={.spec.databaseName}'
+      service.binding/db_password: 'path={.spec.databasePassword}'
+      service.binding/db_user: 'path={.spec.databaseUser}'
+    ```
+
+    This configuration ensures that when a database service is started using this file, appropriate annotations are added to it. Annotations help the Service Binding Operator in injecting those values into the application. Hence, the above configuration will help Service Binding Operator inject the values for `databaseName`, `databasePassword` and `databaseUser` into the application.
+
+3. Change the following values under `spec:` section of the YAML file:
+    ```yaml
+    databaseName: "sampledb"
+    databasePassword: "samplepwd"
+    databaseUser: "sampleuser"
+    ```
+
+4. Create the database from the YAML file:
+    ```shell
+    $ odo service create --from-file db.yaml
+    $ odo push
+    ```
+
+    This action will create a database instance pod in the `my-postgresql-operator-dev4devs-com` namespace. The application will be configured to use this database.
+
+#### Binding the database and the application
+
+Now, the only thing that remains is to connect the DB and the application. We will use odo to create a link to the Dev4Devs PostgreSQL Database Operator in order to access the database connection information.
+
+1. Display the services available to odo: - You will see an entry for the PostgreSQL Database Operator displayed:
+    ```shell
+    $ odo catalog list services
+    Operators available in the cluster
+    NAME                                             CRDs
+    postgresql-operator.v0.1.1                       Backup, Database
+    ```
+
+2. List the service associated with the database created via the PostgreSQL Operator:
+    ```shell
+    $ odo service list
+    NAME                       MANAGED BY ODO     STATE     AGE
+    Database/sampledatabase   Yes (mysboproj)    Pushed    6m35s
+    ```
+
+3. Create a Service Binding Request between the application and the database using the Service Binding Operator service created in the previous step `odo link` command:
+    ```shell
+    $ odo link Database/sampledatabase
+    ```
+
+4. Push this link to the cluster:
+    ```shell
+    $ odo push
+    ```
+
+    After the link has been created and pushed a secret will have been created containing the database connection data that the application requires.
+    
+    You can inspect the new intermediate secret via the dashboard console in the 'my-postgresql-operator-dev4devs-com' namespace by navigating to Secrets and clicking on the secret named `mysboproj-database-sampledatabase`: notice it contains 4 pieces of data all related to the connection information for your PostgreSQL database instance.
+    
+    Pushing the newly created link will also terminate the existing application pod and start a new application pod that mounts this secret.
+
+5. Once the new pod has initialized you can see the secret database connection data as it is injected into the pod environment by executing the following:
+    ```shell
+    $ odo exec -- bash -c 'export | grep DATABASE'
+    declare -x DATABASE_CLUSTERIP="10.106.182.173"
+    declare -x DATABASE_DB_NAME="sampledb"
+    declare -x DATABASE_DB_PASSWORD="samplepwd"
+    declare -x DATABASE_DB_USER="sampleuser"
+    ```
+    Once the new version is up (there will be a slight delay until application is available), navigate to the CreatePerson.xhtml using the URL created in a previous step. Enter requested data and click the **Save** button.
+    
+    Notice you are re-directed to the `PersonList.xhtml` page, where your data is displayed having been input to the postgreSQL database and retrieved for display purposes.
+    
+    You may inspect the database instance itself and query the table to see the data in place by using the postgreSQL command line tool, psql.
+
+6. Navigate to the pod containing your db from the Kubernetes Dashboard
+
+7. Click on the terminal tab.
+
+8. At the terminal prompt access psql for your database
+    ```shell
+    sh-4.2$ psql sampledb
+    psql (12.3)
+    Type "help" for help.
+    
+    sampledb=#
+    ```
+
+9. Issue the following SQL statement:
+    ```shell
+    sampledb=# SELECT * FROM person;
+    ```
+
+9. You can see the data that appeared in the results of the test run:
+    ```shell
+    personid | age |  name   
+    ----------+-----+---------
+    5 |  52 | person1
+    (1 row)
+    
+    sampledb=#
+    ```

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -1,50 +1,58 @@
 ---
-title: Deploying a Java OpenLiberty application with PostgreSQL
+title: Deploying a Java Open Liberty application with PostgreSQL
 sidebar_position: 1
 ---
 
-This tutorial illustrates deploying a [Java OpenLiberty](https://openliberty.io/) application with odo and linking it to an in-cluster PostgreSQL service in the minikube environment.
+This tutorial illustrates deploying a [Java Open Liberty](https://openliberty.io/) application with odo and linking it to an in-cluster PostgreSQL service in a minikube environment.
 
 There are two roles in this example:
-
 1. Cluster Admin - Prepare the cluster by installing the required operators on the cluster.
 2. Application Developer - Imports a Java application, creates a Database instance, and connect the application to the Database instance.
 
 ## Cluster admin
 ---
 
-This section assumes that you have installed [minikube and configured it](../getting-started/cluster-setup/kubernetes.md).
+### Prerequisites
+* This section assumes that you have installed [minikube and configured it](../getting-started/cluster-setup/kubernetes.md).
 
+----
 [//]: # (Move this section to Architecture > Service Binding or create a new Operators doc)
 
-We will be using Operators in this guide. An Operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
+We will be using operators in this guide. An operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
 
-Furthermore, these Operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances.
+Furthermore, these operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances.
 
 [//]: # (Move until here)
 
-See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an Operator in the Kubernetes cluster.
+See the [operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an operator on a minikube cluster.
 
-The cluster admin must install two Operators into the cluster:
-
+The cluster admin must install two operators into the cluster:
 1. PostgreSQL Operator
 2. Service Binding Operator
 
-We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
-   
+We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case. This operator will be installed in `my-postgresql-operator-dev4devs-com` namespace by default, if you want to use another namespace, make sure that you add your namespace to `.spec.targetNamespaces` list in the definition file before installing it. 
+
+**Note**: We will use the `my-postgresql-operator-dev4devs-com` namespace for this guide.
+
 ## Application Developer
 ---
 
+### Prerequisites
 This section assumes that you have [installed `odo`](../getting-started/installation.md).
 
-Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that `odo` uses this namespace to perform any tasks:
-
+---
+Since the PostgreSQL Operator installed in above step is available only in `my-postgresql-operator-dev4devs-com` namespace, ensure that odo uses this namespace to perform any tasks:
 ```shell
 odo project set my-postgresql-operator-dev4devs-com
 ```
-### Importing the demo Java MicroService JPA application
+If you installed the operator in a different namespace, ensure that odo uses it to perform any tasks:
+```shell
+odo project set <your-namespace>
+```
 
-In this example we will use odo to manage a sample [Java MicroServices JPA application](https://github.com/OpenLiberty/application-stack-samples.git).
+### Importing the JPA MicroService
+
+In this example we will use odo to manage a sample [Java JPA MicroService application](https://github.com/OpenLiberty/application-stack-samples.git).
 
 1. Clone the sample application to your system:
     ```shell
@@ -60,7 +68,7 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     ```shell
     odo create java-openliberty mysboproj
     ```
-   `java-openliberty` is the type of your application and `mysboproject` is the name of your application.
+   `java-openliberty` is the type of your application and `mysboproj` is the name of your application.
 
 4. Deploy the application to the cluster:
     ```shell
@@ -172,7 +180,7 @@ You can use the default configuration of the PostgreSQL Operator to start a Post
 
 ### Binding the database and the application
 
-Now, the only thing that remains is to connect the DB and the application. We will use odo to create a link to the Dev4Devs PostgreSQL Database Operator in order to access the database connection information.
+Now, the only thing that remains is to connect the DB and the application. We will use odo to create a link to the PostgreSQL Database Operator in order to access the database connection information.
 
 1. List the service associated with the database created via the PostgreSQL Operator:
     ```shell

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -15,11 +15,15 @@ There are two roles in this example:
 
 This section assumes that you have installed [minikube and configured it](../getting-started/cluster-setup/kubernetes.md).
 
+[//]: # (Move this section to Architecture > Service Binding or create a new Operators doc)
+
 We will be using Operators in this guide. An Operator helps in deploying the instances of a given service, for example PostgreSQL, MySQL, Redis.
 
-Furthermore, these Operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances,
+Furthermore, these Operators are "bind-able". Meaning, if they expose information necessary to connect to them, odo can help connect your component to their instances.
 
-See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an Operator in the Kubernetes cluster, if you have not already done so.
+[//]: # (Move until here)
+
+See the [Operator installation guide](../getting-started/cluster-setup/kubernetes.md) to install and configure an Operator in the Kubernetes cluster.
 
 The cluster admin must install two Operators into the cluster:
 
@@ -58,14 +62,14 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     ```
    `java-openliberty` is the type of your application and `mysboproject` is the name of your application.
 
-4. Push the application to the cluster:
+4. Deploy the application to the cluster:
     ```shell
     odo push --show-log
     ```
 
-5. The application is now deployed to the cluster - you can view the status of the cluster, and the application test results by streaming the cluster logs into the terminal.
+5. The application is now deployed to the cluster - you can view the status of the cluster, and the application test results by streaming the cluster logs of the component that we pushed to the cluster in the previous step.
     ```shell
-    odo log
+    odo log --follow
     ```
 
     Notice the failing tests due to an `UnknownDatabaseHostException`:
@@ -125,14 +129,14 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
 
 10. Use the URL to navigate to the `CreatePerson.xhtml` data entry page to use the application:
     In case of this tutorial, we will access `http://mysboproj-9080.192.168.49.2.nip.io/CreatePerson.xhtml`. Note that the URL could be different for you. Now, enter a name and age data using the form.
+
 11. Click on the **Save** button when complete
 
-
-Note that the entry of any data does not result in the data being displayed when you click on the "View Persons Record List" link.
+Note that the entry of any data does not result in the data being displayed when you click on the "View Persons Record List" link, until we connect the application to a database.
 
 ### Creating a database to be used by the sample application
 
-You can use the default configuration of the PostgreSQL Operator to start a Postgre database from it. But, since our app uses few specific configuration values, lets make sure they are properly populated in the database service we start.
+You can use the default configuration of the PostgreSQL Operator to start a Postgre database from it. But since our app uses few specific configuration values, lets make sure they are properly populated in the database service we start.
 
 1. Store the YAML of the service in a file:
     ```shell
@@ -147,8 +151,7 @@ You can use the default configuration of the PostgreSQL Operator to start a Post
       service.binding/db_password: 'path={.spec.databasePassword}'
       service.binding/db_user: 'path={.spec.databaseUser}'
     ```
-
-    This configuration ensures that when a database service is started using this file, appropriate annotations are added to it. Annotations help the Service Binding Operator in injecting those values into the application. Hence, the above configuration will help Service Binding Operator inject the values for `databaseName`, `databasePassword` and `databaseUser` into the application.
+   This configuration ensures that when a database service is started using this file, appropriate annotations are added to it. Annotations help the Service Binding Operator in injecting those values into the application. Hence, the above configuration will help Service Binding Operator inject the values for `databaseName`, `databasePassword` and `databaseUser` into the application.
 
 3. Change the following values under `spec:` section of the YAML file:
     ```yaml
@@ -171,19 +174,7 @@ You can use the default configuration of the PostgreSQL Operator to start a Post
 
 Now, the only thing that remains is to connect the DB and the application. We will use odo to create a link to the Dev4Devs PostgreSQL Database Operator in order to access the database connection information.
 
-1. Display the services available to odo: - You will see an entry for the PostgreSQL Database Operator displayed:
-    ```shell
-   odo catalog list services
-   ```
-   Your output should look similar to the following:
-   ```shell
-   $ odo catalog list services
-   Operators available in the cluster
-   NAME                                             CRDs
-   postgresql-operator.v0.1.1                       Backup, Database
-    ```
-
-2. List the service associated with the database created via the PostgreSQL Operator:
+1. List the service associated with the database created via the PostgreSQL Operator:
     ```shell
     odo service list
    ```
@@ -194,12 +185,12 @@ Now, the only thing that remains is to connect the DB and the application. We wi
     Database/sampledatabase   Yes (mysboproj)    Pushed    6m35s
     ```
 
-3. Create a Service Binding Request between the application, and the database using the Service Binding Operator service created in the previous step:
+2. Create a Service Binding Request between the application, and the database using the Service Binding Operator service created in the previous step:
     ```shell
     odo link Database/sampledatabase
     ```
 
-4. Push this link to the cluster:
+3. Push this link to the cluster:
     ```shell
     odo push --show-log
     ```
@@ -212,7 +203,7 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
     Note: Pushing the newly created link will terminate the existing application pod and start a new application pod that mounts this secret.
 
-5. Once the new pod has initialized, you can see the secret database connection data as it is injected into the pod environment by executing the following:
+4. Once the new pod has initialized, you can see the secret database connection data as it is injected into the pod environment by executing the following:
     ```shell
     odo exec -- bash -c 'export | grep DATABASE' \
     declare -x DATABASE_CLUSTERIP="10.106.182.173" \
@@ -226,11 +217,11 @@ Now, the only thing that remains is to connect the DB and the application. We wi
     
     You may inspect the database instance itself and query the table to see the data in place by using the postgreSQL command line tool, `psql`.
 
-6. Navigate to the pod containing your db from the dashboard console. Use `minikube dashboard` to start the console.
+5. Navigate to the pod containing your db from the dashboard console. Use `minikube dashboard` to start the console.
 
-7. Click on the terminal tab.
+6. Click on the terminal tab.
 
-8. At the terminal prompt access `psql` for your database `sampledb`.
+7. At the terminal prompt access `psql` for your database `sampledb`.
     ```shell
    psql sampledb
    ```
@@ -243,12 +234,12 @@ Now, the only thing that remains is to connect the DB and the application. We wi
    sampledb=#
     ```
 
-9. Issue the following SQL statement from your :
+8. Issue the following SQL statement from your :
     ```postgresql
     SELECT * FROM person;
     ```
 
-10. You can see the data that appeared in the results of the test run:
+9. You can see the data that appeared in the results of the test run:
     ```shell
     sampledb=# SELECT * FROM person;
 

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -135,7 +135,6 @@ In this example we will use odo to manage a sample [Java MicroServices JPA appli
     Found the following URLs for component mysboproj
     NAME               STATE      URL                                           PORT     SECURE     KIND
     mysboproj-9080     Pushed     http://mysboproj-9080.192.168.49.2.nip.io     9080     false      ingress
-    [root@pappuses1 jpa]#
     ```
 
 10. Use the URL to navigate to the `CreatePerson.xhtml` data entry page and enter requested data:
@@ -252,10 +251,10 @@ Now, the only thing that remains is to connect the DB and the application. We wi
 
 9. You can see the data that appeared in the results of the test run:
     ```shell
+    sampledb=# SELECT * FROM person;
+
     personid | age |  name   
     ----------+-----+---------
     5 |  52 | person1
     (1 row)
-    
-    sampledb=#
     ```

--- a/website/docs/tutorials/deploying-java-app-with-database.md
+++ b/website/docs/tutorials/deploying-java-app-with-database.md
@@ -13,20 +13,18 @@ In this example there are two roles:
 ## Cluster admin
 ---
 
-This section assumes that you have installed minikube and configured it. See the section on setting up[Kubernetes](../getting-started/cluster-setup/kubernetes.md) if you have not already configured it.
+This section assumes that you have installed minikube and configured it. See the section on setting up [Kubernetes](../getting-started/cluster-setup/kubernetes.md) if you have not already configured it.
 
 The cluster admin must install two Operators into the cluster:
 
-1. Operator Backed Service
+1. PostgreSQL Operator
 2. Service Binding Operator
 
-An _Operator Backed Service_ is an operator that helps in deploying instances of a given service, for example PostgreSQL, MySQL, Redis.
+An operator helps in deploying instances of a given service, for example PostgreSQL, MySQL, Redis. Furthermore, these operators are "bind-able" as they expose information necessary for an application to connect to their instances.
 
-Furthermore, these operators are "bind-able" as they expose information necessary for an application to connect to their instances.
+See the [Operator installation guide](../getting-started/cluster-setup/operators.md) to install and configure an operator in the cluster, if you have not done already.
 
 We will use [Dev4Devs PostgreSQL Operator](https://operatorhub.io/operator/postgresql-operator-dev4devs-com) found on the [OperatorHub](https://operatorhub.io) to demonstrate a sample use case.
-
-Service Binding Operator is an operator that helps in easily binding an application to other Operator Backed Services. It accomplishes this through automatically collecting binding information and sharing with an application to bind it with operator managed backing services
 
 ### Installing the Operator Backed Service
 

--- a/website/docs/tutorials/deploying-your-first-devfile.md
+++ b/website/docs/tutorials/deploying-your-first-devfile.md
@@ -1,0 +1,4 @@
+---
+title: Deploying your first devfile
+sidebar_position: 4
+---

--- a/website/docs/tutorials/deploying-your-first-devfile.md
+++ b/website/docs/tutorials/deploying-your-first-devfile.md
@@ -2,3 +2,4 @@
 title: Deploying your first devfile
 sidebar_position: 4
 ---
+This document is a work in progress.

--- a/website/docs/tutorials/deploying-your-first-devfile.md
+++ b/website/docs/tutorials/deploying-your-first-devfile.md
@@ -1,5 +1,0 @@
----
-title: Deploying your first devfile
-sidebar_position: 4
----
-This document is a work in progress.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
1. Adds a tutorials section to the doc website
2. Adds docs which are copy-pasted from the old website.
    1. https://odo.dev/docs/deploying-java-app-with-database/ - Refer to the unpublished changes from https://github.com/openshift/odo/pull/4923 for review.
    2.  https://odo.dev/docs/deploying-a-devfile-using-odo-on-IBM-Z-and-Power - Content about introduction to devfile and relation between odo and devfile were duplicated, so that has been removed.
3. Adds placeholder for
    1. website/docs/architecture/secure-registry.md
    2. website/docs/tutorials/deploying-your-first-devfile.md

**Which issue(s) this PR fixes**:

Fixes part of #4894 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```
cd website/docs
npm install # if running for the first time
npm run start
```