### PR TITLE
Modifies the error message to list the available starters

### DIFF
--- a/pkg/component/starter_project.go
+++ b/pkg/component/starter_project.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	parsercommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
@@ -53,17 +54,20 @@ func GetStarterProject(projects []devfilev1.StarterProject, projectPassed string
 		project = &projects[0]
 		log.Warning("There are multiple projects in this devfile but none have been specified in --starter. Downloading the first: " + project.Name)
 	} else { //If the user has specified a project
+		var availableNames []string
+
 		projectFound := false
 		for indexOfProject, projectInfo := range projects {
+			availableNames = append(availableNames, projectInfo.Name)
 			if projectInfo.Name == projectPassed { //Get the index
 				project = &projects[indexOfProject]
 				projectFound = true
-				break
 			}
 		}
 
 		if !projectFound {
-			return nil, errors.Errorf("the project: %s specified in --starter does not exist", projectPassed)
+			availableNamesString := strings.Join(availableNames, ",")
+			return nil, errors.Errorf("the project: %s specified in --starter does not exist, available projects: %s", projectPassed, availableNamesString)
 		}
 	}
 

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -285,7 +285,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 			output := helper.Cmd("odo", "create", "nodejs", "--starter=invalid-project-name").ShouldFail().Err()
 			expectedString := "the project: " + invalidProjectName + " specified in --starter does not exist"
-			helper.MatchAllInOutput(output, []string{expectedString})
+			helper.MatchAllInOutput(output, []string{expectedString, "available projects", "nodejs-starter"})
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

It modifies the error message to list the available starters.

**Which issue(s) this PR fixes**:

Fixes #4481 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Trigger `odo create --starter=<invalid-starter-name> nodejs`
- The error message should show the names of the available starters.