### PR TITLE
Do not cancel the whole execution if one of the test suite fails

### DIFF
--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -27,14 +27,18 @@ oc login -u developer -p password@123
 oc whoami
 
 # Integration tests
-make test-integration
-make test-integration-devfile
-make test-cmd-login-logout
-make test-cmd-project
-make test-operator-hub
+make test-integration || error=true
+make test-integration-devfile || error=true
+make test-cmd-login-logout || error=true
+make test-cmd-project || error=true
+make test-operator-hub || error=true
 
 # E2e tests
-make test-e2e-all
+make test-e2e-all || error=true
+
+if [ $error ]; then
+    exit -1
+fi
 
 cp -r reports $ARTIFACT_DIR 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does this PR do / why we need it**:
This pr allows other suites to atleast run, even if one suite fails. If there is any failure build automatically failed because of that but atleast entire test suite runs on periodic job

**Which issue(s) this PR fixes**:

Fixes #?NA

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
All the test suite should run as part of periodic job