### PR TITLE
Refactor machine output code

### DIFF
--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -108,7 +108,7 @@ func TestGetComponentFrom(t *testing.T) {
 			if tt.isEnvInfo {
 				mockLocalConfigProvider.EXPECT().GetName().Return(tt.cmpSetting.componentName)
 
-				component := getMachineReadableFormat(tt.cmpSetting.componentName, tt.componentType)
+				component := newComponentWithType(tt.cmpSetting.componentName, tt.componentType)
 
 				mockLocalConfigProvider.EXPECT().GetNamespace().Return(tt.cmpSetting.project)
 
@@ -432,7 +432,7 @@ func TestList(t *testing.T) {
 			name:          "Case 2: no component and no config exists",
 			wantErr:       false,
 			projectExists: true,
-			output:        GetMachineReadableFormatForList([]Component{}),
+			output:        newComponentList([]Component{}),
 		},
 		{
 			name:                      "Case 3: Components are returned from the config plus and cluster",
@@ -459,7 +459,7 @@ func TestList(t *testing.T) {
 			wantErr:                 false,
 			projectExists:           false,
 			existingLocalConfigInfo: &existingSampleLocalConfig,
-			output:                  GetMachineReadableFormatForList([]Component{componentConfig2}),
+			output:                  newComponentList([]Component{componentConfig2}),
 		},
 		{
 			name:                      "Case 5: Components are returned from deployments on a kubernetes cluster",
@@ -755,7 +755,7 @@ func Test_getMachineReadableFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getMachineReadableFormat(tt.args.componentName, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
+			if got := newComponentWithType(tt.args.componentName, tt.args.componentType); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getMachineReadableFormat() = %v, want %v", got, tt.want)
 			}
 		})
@@ -842,7 +842,7 @@ func Test_getMachineReadableFormatForList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetMachineReadableFormatForList(tt.args.components); !reflect.DeepEqual(got, tt.want) {
+			if got := newComponentList(tt.args.components); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getMachineReadableFormatForList() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -1,11 +1,14 @@
 package component
 
 import (
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/storage"
 	"github.com/openshift/odo/pkg/url"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const ComponentKind = "Component"
 
 // Component
 type Component struct {
@@ -71,3 +74,63 @@ const (
 	// StateTypeUnknown means that odo cannot tell its state
 	StateTypeUnknown State = "Unknown"
 )
+
+func newComponentWithType(componentName, componentType string) Component {
+	cmp := NewComponent(componentName)
+	cmp.Spec.Type = componentType
+	return cmp
+}
+
+// NewComponent provides a constructor to component struct with some metadata prefilled
+func NewComponent(componentName string) Component {
+	return Component{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ComponentKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentName,
+		},
+		Status: ComponentStatus{},
+	}
+}
+
+// newComponentList returns list of devfile and s2i components in machine readable format
+func newComponentList(comps []Component) ComponentList {
+	if len(comps) == 0 {
+		comps = []Component{}
+	}
+
+	return ComponentList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       machineoutput.ListKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ListMeta: metav1.ListMeta{},
+		Items:    comps,
+	}
+}
+
+// NewCombinedComponentList returns list of devfile, s2i components and other components(not managed by odo) in machine readable format
+func NewCombinedComponentList(s2iComps []Component, devfileComps []Component, otherComps []Component) CombinedComponentList {
+	if len(s2iComps) == 0 {
+		s2iComps = []Component{}
+	}
+	if len(devfileComps) == 0 {
+		devfileComps = []Component{}
+	}
+	if len(otherComps) == 0 {
+		otherComps = []Component{}
+	}
+
+	return CombinedComponentList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       machineoutput.ListKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ListMeta:          metav1.ListMeta{},
+		S2IComponents:     s2iComps,
+		DevfileComponents: devfileComps,
+		OtherComponents:   otherComps,
+	}
+}

--- a/pkg/debug/info.go
+++ b/pkg/debug/info.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
+// Info contains the information about the current Debug session
 type Info struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -13,37 +13,10 @@ import (
 	"github.com/openshift/odo/pkg/testingutil/filesystem"
 
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
 	"github.com/openshift/odo/pkg/util"
 )
-
-type JSONEnvInfoRepr struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ComponentSettings `json:"spec" yaml:"spec"`
-}
-
-// ComponentSettings holds all component related information
-type ComponentSettings struct {
-	Name string `yaml:"Name,omitempty" json:"name,omitempty"`
-
-	Project string `yaml:"Project,omitempty" json:"project,omitempty"`
-
-	UserCreatedDevfile bool `yaml:"UserCreatedDevfile,omitempty" json:"UserCreatedDevfile,omitempty"`
-
-	URL *[]localConfigProvider.LocalURL `yaml:"Url,omitempty" json:"url,omitempty"`
-	// AppName is the application name. Application is a virtual concept present in odo used
-	// for grouping of components. A namespace can contain multiple applications
-	AppName string `yaml:"AppName,omitempty" json:"appName,omitempty"`
-
-	// DebugPort controls the port used by the pod to run the debugging agent on
-	DebugPort *int `yaml:"DebugPort,omitempty" json:"debugPort,omitempty"`
-
-	// RunMode indicates the mode of run used for a successful push
-	RunMode *RUNMode `yaml:"RunMode,omitempty" json:"runMode,omitempty"`
-}
 
 type RUNMode string
 
@@ -85,16 +58,6 @@ type EnvSpecificInfo struct {
 	fs                filesystem.Filesystem
 	EnvInfo           `yaml:",omitempty"`
 	envinfoFileExists bool
-}
-
-func WrapForJSONOutput(compSettings ComponentSettings) JSONEnvInfoRepr {
-	return JSONEnvInfoRepr{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "EnvInfo",
-			APIVersion: "odo.dev/v1alpha1",
-		},
-		Spec: compSettings,
-	}
 }
 
 func (esi EnvSpecificInfo) GetDevfilePath() string {

--- a/pkg/envinfo/types.go
+++ b/pkg/envinfo/types.go
@@ -1,0 +1,76 @@
+package envinfo
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"text/tabwriter"
+
+	"github.com/openshift/odo/pkg/localConfigProvider"
+	"github.com/openshift/odo/pkg/machineoutput"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Info struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              ComponentSettings `json:"spec"`
+}
+
+const InfoKind = "EnvInfo"
+
+// ComponentSettings holds all component related information
+type ComponentSettings struct {
+	Name string `yaml:"Name,omitempty" json:"name,omitempty"`
+
+	Project string `yaml:"Project,omitempty" json:"project,omitempty"`
+
+	UserCreatedDevfile bool `yaml:"UserCreatedDevfile,omitempty" json:"UserCreatedDevfile,omitempty"`
+
+	URL *[]localConfigProvider.LocalURL `yaml:"Url,omitempty" json:"url,omitempty"`
+	// AppName is the application name. Application is a virtual concept present in odo used
+	// for grouping of components. A namespace can contain multiple applications
+	AppName string `yaml:"AppName,omitempty" json:"appName,omitempty"`
+
+	// DebugPort controls the port used by the pod to run the debugging agent on
+	DebugPort *int `yaml:"DebugPort,omitempty" json:"debugPort,omitempty"`
+
+	// RunMode indicates the mode of run used for a successful push
+	RunMode *RUNMode `yaml:"RunMode,omitempty" json:"runMode,omitempty"`
+}
+
+func NewInfo(cs ComponentSettings) Info {
+	return Info{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       InfoKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		Spec: cs,
+	}
+}
+
+func (o Info) Output(w io.Writer) {
+	wr := tabwriter.NewWriter(w, 5, 2, 2, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(wr, "PARAMETER NAME", "\t", "PARAMETER VALUE")
+	fmt.Fprintln(wr, "Name", "\t", o.Spec.Name)
+	fmt.Fprintln(wr, "Project", "\t", o.Spec.Project)
+	fmt.Fprintln(wr, "Application", "\t", o.Spec.AppName)
+	fmt.Fprintln(wr, "DebugPort", "\t", showBlankIfNil(o.Spec.DebugPort))
+	wr.Flush()
+}
+
+func showBlankIfNil(intf interface{}) interface{} {
+	imm := reflect.ValueOf(intf)
+
+	// if the value is nil then we should return a blank string
+	if imm.IsNil() {
+		return ""
+	}
+
+	// if its a pointer then we should de-ref it because we cant de-ref an interface{}
+	if imm.Kind() == reflect.Ptr {
+		return imm.Elem().Interface()
+	}
+
+	return intf
+}

--- a/pkg/envinfo/types.go
+++ b/pkg/envinfo/types.go
@@ -67,7 +67,7 @@ func showBlankIfNil(intf interface{}) interface{} {
 		return ""
 	}
 
-	// if its a pointer then we should de-ref it because we cant de-ref an interface{}
+	// if it's a pointer then we should de-ref it because we cant de-ref an interface{}
 	if imm.Kind() == reflect.Ptr {
 		return imm.Elem().Interface()
 	}

--- a/pkg/envinfo/types.go
+++ b/pkg/envinfo/types.go
@@ -60,16 +60,16 @@ func (o Info) Output(w io.Writer) {
 }
 
 func showBlankIfNil(intf interface{}) interface{} {
-	imm := reflect.ValueOf(intf)
+	value := reflect.ValueOf(intf)
 
 	// if the value is nil then we should return a blank string
-	if imm.IsNil() {
+	if value.IsNil() {
 		return ""
 	}
 
 	// if it's a pointer then we should de-ref it because we cant de-ref an interface{}
-	if imm.Kind() == reflect.Ptr {
-		return imm.Elem().Interface()
+	if value.Kind() == reflect.Ptr {
+		return value.Elem().Interface()
 	}
 
 	return intf

--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -9,11 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// SuccessStatus outputs a metav1.Status with the Status field set to "Success"
 func SuccessStatus(kind string, name string, msg string) {
-	Status(kind, name, metav1.StatusSuccess, msg)
+	status(kind, name, metav1.StatusSuccess, msg)
 }
 
-func Status(kind string, name string, statusStr string, msg string) {
+// status outputs a metav1.Status resource
+func status(kind string, name string, statusStr string, msg string) {
 	status := metav1.Status{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Status",

--- a/pkg/machineoutput/types.go
+++ b/pkg/machineoutput/types.go
@@ -9,10 +9,33 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Kind is what kind we should use in the machine readable output
-const Kind = "Error"
+func SuccessStatus(kind string, name string, msg string) {
+	Status(kind, name, metav1.StatusSuccess, msg)
+}
 
-// APIVersion is the current API version we are using
+func Status(kind string, name string, statusStr string, msg string) {
+	status := metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
+		Status: statusStr,
+		Details: &metav1.StatusDetails{
+			Name: name,
+			Kind: kind,
+		},
+		Message: msg,
+	}
+	OutputSuccess(status)
+}
+
+// ListKind is the kind used for all lists in the machine readable output
+const ListKind = "List"
+
+// ErrorKind is the kind used for errors in the machine readable output
+const ErrorKind = "Error"
+
+// APIVersion is the current API version used in the machine readable output
 const APIVersion = "odo.dev/v1alpha1"
 
 // GenericError for machine readable output error messages

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -304,45 +304,43 @@ func NewCmdList(name, fullName string) *cobra.Command {
 
 func HumanReadableOutputInPath(wr io.Writer, o component.CombinedComponentList) {
 	w := tabwriter.NewWriter(wr, 5, 2, 3, ' ', tabwriter.TabIndent)
+	defer w.Flush()
 
-	var hasDevfileComponents bool
+	// if we dont have any components then
+	if len(o.DevfileComponents) == 0 && len(o.S2IComponents) == 0 {
+		fmt.Fprintln(w, "No components found")
+		return
+	}
+
 	if len(o.DevfileComponents) != 0 {
-		hasDevfileComponents = true
 		fmt.Fprintln(w, "Devfile Components: ")
 		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "STATE", "\t", "CONTEXT")
 		for _, comp := range o.DevfileComponents {
 			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Status.State, "\t", comp.Status.Context)
 		}
-	}
-	if hasDevfileComponents {
 		fmt.Fprintln(w)
 	}
 
-	var hasS2IComponents bool
 	if len(o.S2IComponents) != 0 {
-		hasS2IComponents = true
 		fmt.Fprintln(w, "S2I Components: ")
 		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE", "\t", "CONTEXT")
 		for _, comp := range o.S2IComponents {
 			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State, "\t", comp.Status.Context)
-
 		}
 	}
-
-	// if we dont have any then
-	if !hasDevfileComponents && !hasS2IComponents {
-		fmt.Fprintln(w, "No components found")
-	}
-
-	w.Flush()
 
 }
 
 func HumanReadableOutput(wr io.Writer, o component.CombinedComponentList) {
 	w := tabwriter.NewWriter(wr, 5, 2, 3, ' ', tabwriter.TabIndent)
-	var hasDevfileComponents bool
+	defer w.Flush()
+
+	if len(o.DevfileComponents) == 0 && len(o.S2IComponents) == 0 && len(o.OtherComponents) == 0 {
+		log.Info("There are no components deployed.")
+		return
+	}
+
 	if len(o.DevfileComponents) != 0 || len(o.OtherComponents) != 0 {
-		hasDevfileComponents = true
 		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "MANAGED BY ODO")
 		for _, comp := range o.DevfileComponents {
 			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State, "\t", "Yes")
@@ -350,27 +348,14 @@ func HumanReadableOutput(wr io.Writer, o component.CombinedComponentList) {
 		for _, comp := range o.OtherComponents {
 			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", component.StateTypePushed, "\t", "No")
 		}
-		w.Flush()
-
-	}
-	if hasDevfileComponents {
 		fmt.Fprintln(w)
 	}
 
-	var hasS2IComponents bool
 	if len(o.S2IComponents) != 0 {
-		hasS2IComponents = true
-		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
 		fmt.Fprintln(w, "S2I Components: ")
 		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
 		for _, comp := range o.S2IComponents {
 			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
 		}
-		w.Flush()
-	}
-
-	if !hasDevfileComponents && !hasS2IComponents && len(o.OtherComponents) == 0 {
-		log.Info("There are no components deployed.")
-		return
 	}
 }

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"text/tabwriter"
@@ -37,14 +38,12 @@ var listExample = ktemplates.Examples(`  # List all components in the applicatio
 
 // ListOptions is a dummy container to attach complete, validate and run pattern
 type ListOptions struct {
-	pathFlag             string
-	allAppsFlag          bool
-	componentContext     string
-	componentType        string
-	hasDCSupport         bool
-	hasDevfileComponents bool
-	hasS2IComponents     bool
-	devfilePath          string
+	pathFlag         string
+	allAppsFlag      bool
+	componentContext string
+	componentType    string
+	hasDCSupport     bool
+	devfilePath      string
 	*genericclioptions.Context
 }
 
@@ -147,42 +146,12 @@ func (lo *ListOptions) Run(cmd *cobra.Command) (err error) {
 			return err
 		}
 
-		combinedComponents := component.GetMachineReadableFormatForCombinedCompList(s2iComps, devfileComps, otherComps)
+		combinedComponents := component.NewCombinedComponentList(s2iComps, devfileComps, otherComps)
 
 		if log.IsJSON() {
 			machineoutput.OutputSuccess(combinedComponents)
 		} else {
-
-			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-
-			if len(devfileComps) != 0 {
-				lo.hasDevfileComponents = true
-				fmt.Fprintln(w, "Devfile Components: ")
-				fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "STATE", "\t", "CONTEXT")
-				for _, comp := range devfileComps {
-					fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Status.State, "\t", comp.Status.Context)
-				}
-			}
-			if lo.hasDevfileComponents {
-				fmt.Fprintln(w)
-			}
-
-			if len(s2iComps) != 0 {
-				lo.hasS2IComponents = true
-				fmt.Fprintln(w, "S2I Components: ")
-				fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE", "\t", "CONTEXT")
-				for _, comp := range s2iComps {
-					fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State, "\t", comp.Status.Context)
-
-				}
-			}
-
-			// if we dont have any then
-			if !lo.hasDevfileComponents && !lo.hasS2IComponents {
-				fmt.Fprintln(w, "No components found")
-			}
-
-			w.Flush()
+			HumanReadableOutputInPath(os.Stdout, combinedComponents)
 		}
 		return nil
 	}
@@ -293,44 +262,11 @@ func (lo *ListOptions) Run(cmd *cobra.Command) (err error) {
 	}
 	otherComps = otherComponents.Items
 
-	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-
-	if !log.IsJSON() {
-
-		if len(devfileComponents) != 0 || len(otherComps) != 0 {
-			lo.hasDevfileComponents = true
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "MANAGED BY ODO")
-			for _, comp := range devfileComponents {
-				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State, "\t", "Yes")
-			}
-			for _, comp := range otherComps {
-				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", component.StateTypePushed, "\t", "No")
-			}
-			w.Flush()
-
-		}
-		if lo.hasDevfileComponents {
-			fmt.Fprintln(w)
-		}
-
-		if len(s2iComponents) != 0 {
-			lo.hasS2IComponents = true
-			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "S2I Components: ")
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
-			for _, comp := range s2iComponents {
-				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
-			}
-			w.Flush()
-		}
-
-		if !lo.hasDevfileComponents && !lo.hasS2IComponents && len(otherComps) == 0 {
-			log.Info("There are no components deployed.")
-			return
-		}
-	} else {
-		combinedComponents := component.GetMachineReadableFormatForCombinedCompList(s2iComponents, devfileComponents, otherComps)
+	combinedComponents := component.NewCombinedComponentList(s2iComponents, devfileComponents, otherComps)
+	if log.IsJSON() {
 		machineoutput.OutputSuccess(combinedComponents)
+	} else {
+		HumanReadableOutput(os.Stdout, combinedComponents)
 	}
 
 	return
@@ -364,4 +300,77 @@ func NewCmdList(name, fullName string) *cobra.Command {
 	completion.RegisterCommandFlagHandler(componentListCmd, "path", completion.FileCompletionHandler)
 
 	return componentListCmd
+}
+
+func HumanReadableOutputInPath(wr io.Writer, o component.CombinedComponentList) {
+	w := tabwriter.NewWriter(wr, 5, 2, 3, ' ', tabwriter.TabIndent)
+
+	var hasDevfileComponents bool
+	if len(o.DevfileComponents) != 0 {
+		hasDevfileComponents = true
+		fmt.Fprintln(w, "Devfile Components: ")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "STATE", "\t", "CONTEXT")
+		for _, comp := range o.DevfileComponents {
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Status.State, "\t", comp.Status.Context)
+		}
+	}
+	if hasDevfileComponents {
+		fmt.Fprintln(w)
+	}
+
+	var hasS2IComponents bool
+	if len(o.S2IComponents) != 0 {
+		hasS2IComponents = true
+		fmt.Fprintln(w, "S2I Components: ")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE", "\t", "CONTEXT")
+		for _, comp := range o.S2IComponents {
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State, "\t", comp.Status.Context)
+
+		}
+	}
+
+	// if we dont have any then
+	if !hasDevfileComponents && !hasS2IComponents {
+		fmt.Fprintln(w, "No components found")
+	}
+
+	w.Flush()
+
+}
+
+func HumanReadableOutput(wr io.Writer, o component.CombinedComponentList) {
+	w := tabwriter.NewWriter(wr, 5, 2, 3, ' ', tabwriter.TabIndent)
+	var hasDevfileComponents bool
+	if len(o.DevfileComponents) != 0 || len(o.OtherComponents) != 0 {
+		hasDevfileComponents = true
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "MANAGED BY ODO")
+		for _, comp := range o.DevfileComponents {
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State, "\t", "Yes")
+		}
+		for _, comp := range o.OtherComponents {
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", component.StateTypePushed, "\t", "No")
+		}
+		w.Flush()
+
+	}
+	if hasDevfileComponents {
+		fmt.Fprintln(w)
+	}
+
+	var hasS2IComponents bool
+	if len(o.S2IComponents) != 0 {
+		hasS2IComponents = true
+		w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(w, "S2I Components: ")
+		fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
+		for _, comp := range o.S2IComponents {
+			fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
+		}
+		w.Flush()
+	}
+
+	if !hasDevfileComponents && !hasS2IComponents && len(o.OtherComponents) == 0 {
+		log.Info("There are no components deployed.")
+		return
+	}
 }

--- a/pkg/odo/cli/debug/info.go
+++ b/pkg/odo/cli/debug/info.go
@@ -83,11 +83,11 @@ func (o InfoOptions) Validate() error {
 
 // Run implements all the necessary functionality for port-forward cmd.
 func (o InfoOptions) Run(cmd *cobra.Command) error {
-	if debugFileInfo, debugging := debug.GetDebugInfo(o.PortForwarder); debugging {
+	if debugInfo, debugging := debug.GetInfo(o.PortForwarder); debugging {
 		if log.IsJSON() {
-			machineoutput.OutputSuccess(debugFileInfo)
+			machineoutput.OutputSuccess(debugInfo)
 		} else {
-			log.Infof("Debug is running for the component on the local port : %v", debugFileInfo.Spec.LocalPort)
+			log.Infof("Debug is running for the component on the local port : %v", debugInfo.Spec.LocalPort)
 		}
 	} else {
 		return fmt.Errorf("debug is not running for the component %v", o.componentName)

--- a/pkg/odo/cli/env/view.go
+++ b/pkg/odo/cli/env/view.go
@@ -3,8 +3,6 @@ package env
 import (
 	"fmt"
 	"os"
-	"reflect"
-	"text/tabwriter"
 
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/log"
@@ -60,37 +58,13 @@ func (o *ViewOptions) Validate() (err error) {
 
 // Run contains the logic for the command
 func (o *ViewOptions) Run(cmd *cobra.Command) (err error) {
-	cs := o.cfg.GetComponentSettings()
+	info := envinfo.NewInfo(o.cfg.GetComponentSettings())
 	if log.IsJSON() {
-		machineoutput.OutputSuccess(envinfo.WrapForJSONOutput(cs))
+		machineoutput.OutputSuccess(info)
 		return
 	}
-	w := tabwriter.NewWriter(os.Stdout, 5, 2, 2, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "PARAMETER NAME", "\t", "PARAMETER VALUE")
-	fmt.Fprintln(w, "Name", "\t", cs.Name)
-	fmt.Fprintln(w, "Project", "\t", cs.Project)
-	fmt.Fprintln(w, "Application", "\t", cs.AppName)
-	fmt.Fprintln(w, "DebugPort", "\t", showBlankIfNil(cs.DebugPort))
-
-	w.Flush()
-
+	info.Output(os.Stdout)
 	return nil
-}
-
-func showBlankIfNil(intf interface{}) interface{} {
-	imm := reflect.ValueOf(intf)
-
-	// if the value is nil then we should return a blank string
-	if imm.IsNil() {
-		return ""
-	}
-
-	// if its a pointer then we should de-ref it because we cant de-ref an interface{}
-	if imm.Kind() == reflect.Ptr {
-		return imm.Elem().Interface()
-	}
-
-	return intf
 }
 
 // NewCmdView implements the env view odo command

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -78,7 +78,7 @@ func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
 	}
 	s.End(true)
 
-	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)
+	successMessage := fmt.Sprintf(`Project %q is ready for use`, pco.projectName)
 	log.Successf(successMessage)
 
 	// Set the current project when created

--- a/pkg/odo/cli/project/create.go
+++ b/pkg/odo/cli/project/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/project"
 	scontext "github.com/openshift/odo/pkg/segment/context"
@@ -60,7 +61,6 @@ func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
 	if scontext.GetTelemetryStatus(cmd.Context()) {
 		scontext.SetClusterType(cmd.Context(), pco.Client)
 	}
-	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)
 
 	// Create the "spinner"
 	s := &log.Status{}
@@ -77,20 +77,24 @@ func (pco *ProjectCreateOptions) Run(cmd *cobra.Command) (err error) {
 		return err
 	}
 	s.End(true)
+
+	successMessage := fmt.Sprintf(`Project '%s' is ready for use`, pco.projectName)
 	log.Successf(successMessage)
 
-	// Set the current project when created. If it's json output, we output a json output error
+	// Set the current project when created
 	err = project.SetCurrent(pco.Context, pco.projectName)
 	if err != nil {
 		return err
 	}
 
+	log.Successf("New project created and now using project: %v", pco.projectName)
+
 	// If -o json has been passed, let's output the appropriate json output.
 	if log.IsJSON() {
-		project.MachineReadableSuccessOutput(pco.projectName, successMessage)
-	} else {
-		log.Successf("New project created and now using project: %v", pco.projectName)
+		prj := project.NewProject(pco.projectName, true)
+		machineoutput.OutputSuccess(prj)
 	}
+
 	return
 }
 

--- a/pkg/odo/cli/project/delete.go
+++ b/pkg/odo/cli/project/delete.go
@@ -102,7 +102,7 @@ func (pdo *ProjectDeleteOptions) Run(cmd *cobra.Command) (err error) {
 
 		successMessage := fmt.Sprintf("Deleted project : %v", pdo.projectName)
 		log.Success(successMessage)
-		log.Warning("Warning! Projects are deleted from the cluster asynchronously. Odo does its best to delete the project. Due to multi-tenant clusters, the project may still exist on a different node.")
+		log.Warning("Warning! Projects are asynchronously deleted from the cluster. odo does its best to delete the project. Due to multi-tenant clusters, the project may still exist on a different node.")
 
 		if log.IsJSON() {
 			machineoutput.SuccessStatus(project.ProjectKind, pdo.projectName, successMessage)

--- a/pkg/odo/cli/project/get.go
+++ b/pkg/odo/cli/project/get.go
@@ -51,16 +51,20 @@ func (pgo *ProjectGetOptions) Validate() (err error) {
 	return
 }
 
-// Run runs the project get command
+// Run the project get command
 func (pgo *ProjectGetOptions) Run(cmd *cobra.Command) (err error) {
 	currentProject := pgo.Context.Project
 
 	if pgo.projectShortFlag {
 		fmt.Print(currentProject)
-	} else if log.IsJSON() {
-		machineoutput.OutputSuccess(project.GetMachineReadableFormat(currentProject, true))
-	} else {
-		log.Infof("The current project is: %v", currentProject)
+		return
+	}
+
+	log.Infof("The current project is: %v", currentProject)
+
+	if log.IsJSON() {
+		prj := project.NewProject(currentProject, true)
+		machineoutput.OutputSuccess(prj)
 	}
 
 	return

--- a/pkg/odo/cli/storage/create.go
+++ b/pkg/odo/cli/storage/create.go
@@ -86,7 +86,7 @@ func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 	}
 
 	if log.IsJSON() {
-		storageResultMachineReadable := storage.GetMachineReadableFormat(o.storage.Name, o.storage.Size, o.storage.Path)
+		storageResultMachineReadable := storage.NewStorage(o.storage.Name, o.storage.Size, o.storage.Path)
 		machineoutput.OutputSuccess(storageResultMachineReadable)
 	} else {
 		log.Successf("Added storage %v to %v", o.storageName, o.Context.LocalConfigProvider.GetName())

--- a/pkg/odo/cli/storage/delete.go
+++ b/pkg/odo/cli/storage/delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	"github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/cli/ui"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
@@ -83,11 +84,11 @@ func (o *DeleteOptions) Run(cmd *cobra.Command) (err error) {
 
 		successMessage := fmt.Sprintf("Deleted storage %v from %v", o.storageName, o.Context.LocalConfigProvider.GetName())
 
+		log.Infof(successMessage)
+		log.Italic("\nPlease use `odo push` command to delete the storage from the cluster")
+
 		if log.IsJSON() {
-			storage.MachineReadableSuccessOutput(o.storageName, successMessage)
-		} else {
-			log.Infof(successMessage)
-			log.Italic("\nPlease use `odo push` command to delete the storage from the cluster")
+			machineoutput.SuccessStatus(storage.StorageKind, o.storageName, successMessage)
 		}
 	} else {
 		return fmt.Errorf("aborting deletion of storage: %v", o.storageName)

--- a/pkg/odo/cli/storage/list_test.go
+++ b/pkg/odo/cli/storage/list_test.go
@@ -28,8 +28,8 @@ func Test_isContainerDisplay(t *testing.T) {
 			args: args{
 				storageList: storage.StorageList{
 					Items: []storage.Storage{
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-1"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-1"),
 					},
 				},
 				obj: []localConfigProvider.LocalContainer{
@@ -48,8 +48,8 @@ func Test_isContainerDisplay(t *testing.T) {
 			args: args{
 				storageList: storage.StorageList{
 					Items: []storage.Storage{
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/path"), storage.StateTypePushed, "container-1"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/path"), storage.StateTypePushed, "container-1"),
 					},
 				},
 				obj: []localConfigProvider.LocalContainer{
@@ -68,8 +68,8 @@ func Test_isContainerDisplay(t *testing.T) {
 			args: args{
 				storageList: storage.StorageList{
 					Items: []storage.Storage{
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypeNotPushed, "container-1"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypeNotPushed, "container-1"),
 					},
 				},
 				obj: []localConfigProvider.LocalContainer{
@@ -88,7 +88,7 @@ func Test_isContainerDisplay(t *testing.T) {
 			args: args{
 				storageList: storage.StorageList{
 					Items: []storage.Storage{
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
 					},
 				},
 				obj: []localConfigProvider.LocalContainer{
@@ -107,8 +107,8 @@ func Test_isContainerDisplay(t *testing.T) {
 			args: args{
 				storageList: storage.StorageList{
 					Items: []storage.Storage{
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
-						generateStorage(storage.GetMachineReadableFormat("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-1"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-0"),
+						generateStorage(storage.NewStorage("pvc-1", "1Gi", "/data"), storage.StateTypePushed, "container-1"),
 					},
 				},
 				obj: []localConfigProvider.LocalContainer{

--- a/pkg/odo/cli/url/create.go
+++ b/pkg/odo/cli/url/create.go
@@ -7,9 +7,11 @@ import (
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/openshift/odo/pkg/localConfigProvider"
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/machineoutput"
 	clicomponent "github.com/openshift/odo/pkg/odo/cli/component"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/odo/util/completion"
+	"github.com/openshift/odo/pkg/url"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/odo/pkg/util"
@@ -191,6 +193,14 @@ func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 		log.Italic("\nTo apply the URL configuration changes, please use `odo push`")
 	}
 
+	if log.IsJSON() {
+		u := url.NewURLFromLocalURL(o.url)
+		u.Status.State = url.StateTypeNotPushed
+		if o.now {
+			u.Status.State = url.StateTypePushed
+		}
+		machineoutput.OutputSuccess(u)
+	}
 	return
 }
 
@@ -198,11 +208,12 @@ func (o *CreateOptions) Run(cmd *cobra.Command) (err error) {
 func NewCmdURLCreate(name, fullName string) *cobra.Command {
 	o := NewURLCreateOptions()
 	urlCreateCmd := &cobra.Command{
-		Use:     name + " [url name]",
-		Short:   urlCreateShortDesc,
-		Long:    urlCreateLongDesc,
-		Example: fmt.Sprintf(urlCreateExample, fullName),
-		Args:    cobra.MaximumNArgs(1),
+		Use:         name + " [url name]",
+		Short:       urlCreateShortDesc,
+		Long:        urlCreateLongDesc,
+		Example:     fmt.Sprintf(urlCreateExample, fullName),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"machineoutput": "json"},
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/util/cmdutils.go
+++ b/pkg/odo/util/cmdutils.go
@@ -36,7 +36,7 @@ func LogErrorAndExit(err error, context string, a ...interface{}) {
 			// Machine readble error output
 			machineOutput := machineoutput.GenericError{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       machineoutput.Kind,
+					Kind:       machineoutput.ErrorKind,
 					APIVersion: machineoutput.APIVersion,
 				},
 				Message: err.Error(),

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -418,31 +418,25 @@ func TestList(t *testing.T) {
 			name:             "Case 1: Multiple projects returned",
 			wantErr:          false,
 			returnedProjects: testingutil.FakeProjects(),
-			expectedProjects: getMachineReadableFormatForList(
-				[]Project{
-					GetMachineReadableFormat("testing", false),
-					GetMachineReadableFormat("prj1", false),
-					GetMachineReadableFormat("prj2", false),
-				},
-			),
+			expectedProjects: NewProjectList([]Project{
+				NewProject("testing", false),
+				NewProject("prj1", false),
+				NewProject("prj2", false),
+			}),
 		},
 		{
 			name:             "Case 2: Single project returned",
 			wantErr:          false,
 			returnedProjects: testingutil.FakeOnlyOneExistingProjects(),
-			expectedProjects: getMachineReadableFormatForList(
-				[]Project{
-					GetMachineReadableFormat("testing", false),
-				},
-			),
+			expectedProjects: NewProjectList([]Project{
+				NewProject("testing", false),
+			}),
 		},
 		{
 			name:             "Case 3: No project returned",
 			wantErr:          false,
 			returnedProjects: &projectv1.ProjectList{},
-			expectedProjects: getMachineReadableFormatForList(
-				nil,
-			),
+			expectedProjects: NewProjectList([]Project{}),
 		},
 	}
 

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -1,25 +1,51 @@
 package project
 
 import (
+	"github.com/openshift/odo/pkg/machineoutput"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const ProjectKind = "Project"
 
 type Project struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ProjectSpec   `json:"spec,omitempty"`
-	Status            ProjectStatus `json:"status,omitempty"`
+	Status            Status `json:"status,omitempty"`
 }
 
-type ProjectSpec struct{}
-
-type ProjectStatus struct {
+type Status struct {
 	Active bool `json:"active"`
 }
 
-// ProjectList holds a list of Project
+// NewProject creates and returns a new project instance
+func NewProject(projectName string, isActive bool) Project {
+	return Project{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ProjectKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: projectName,
+		},
+		Status: Status{
+			Active: isActive,
+		},
+	}
+}
+
 type ProjectList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Project `json:"items"`
+}
+
+// NewProjectList returns an instance of a list containing the `items` projects
+func NewProjectList(items []Project) ProjectList {
+	return ProjectList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       machineoutput.ListKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		Items: items,
+	}
 }

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -141,7 +141,7 @@ func (k kubernetesClient) ListFromCluster() (StorageList, error) {
 
 				found = true
 				size := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-				storage = append(storage, GetMachineFormatWithContainer(pvc.Labels[storagelabels.DevfileStorageLabel], size.String(), volumeMount.Spec.Path, volumeMount.Spec.ContainerName))
+				storage = append(storage, NewStorageWithContainer(pvc.Labels[storagelabels.DevfileStorageLabel], size.String(), volumeMount.Spec.Path, volumeMount.Spec.ContainerName))
 			}
 		}
 		if !found {
@@ -205,5 +205,5 @@ func (k kubernetesClient) List() (StorageList, error) {
 			storageList = append(storageList, clusterStore)
 		}
 	}
-	return GetMachineReadableFormatForList(storageList), nil
+	return NewStorageList(storageList), nil
 }

--- a/pkg/storage/kubernetes_test.go
+++ b/pkg/storage/kubernetes_test.go
@@ -103,8 +103,8 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-0"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-0"),
 				},
 			},
 			wantErr: false,
@@ -138,9 +138,9 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-1"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-1"),
 				},
 			},
 			wantErr: false,
@@ -195,7 +195,7 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
 				},
 			},
 			wantErr: false,
@@ -261,9 +261,9 @@ func Test_kubernetesClient_ListFromCluster(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-1"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-1"),
 				},
 			},
 			wantErr: false,
@@ -380,7 +380,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 			returnedPVCs: &corev1.PersistentVolumeClaimList{
 				Items: []corev1.PersistentVolumeClaim{},
 			},
-			want:    GetMachineReadableFormatForList(nil),
+			want:    NewStorageList(nil),
 			wantErr: false,
 		},
 		{
@@ -400,7 +400,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 			returnedPVCs: &corev1.PersistentVolumeClaimList{
 				Items: []corev1.PersistentVolumeClaim{},
 			},
-			want:    GetMachineReadableFormatForList(nil),
+			want:    NewStorageList(nil),
 			wantErr: false,
 		},
 		{
@@ -441,9 +441,9 @@ func Test_kubernetesClient_List(t *testing.T) {
 					*testingutil.FakePVC("volume-1", "10Gi", map[string]string{"component": "nodejs", storageLabels.DevfileStorageLabel: "volume-1"}),
 				},
 			},
-			want: GetMachineReadableFormatForList([]Storage{
-				generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), StateTypePushed, "container-0"),
+			want: NewStorageList([]Storage{
+				generateStorage(NewStorage("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
+				generateStorage(NewStorage("volume-1", "10Gi", "/path"), StateTypePushed, "container-0"),
 			}),
 			wantErr: false,
 		},
@@ -485,11 +485,11 @@ func Test_kubernetesClient_List(t *testing.T) {
 					*testingutil.FakePVC("volume-11", "10Gi", map[string]string{"component": "nodejs", storageLabels.DevfileStorageLabel: "volume-11"}),
 				},
 			},
-			want: GetMachineReadableFormatForList([]Storage{
-				generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), StateTypeNotPushed, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), StateTypeNotPushed, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-00", "5Gi", "/data"), StateTypeLocallyDeleted, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-11", "10Gi", "/path"), StateTypeLocallyDeleted, "container-0"),
+			want: NewStorageList([]Storage{
+				generateStorage(NewStorage("volume-0", "5Gi", "/data"), StateTypeNotPushed, "container-0"),
+				generateStorage(NewStorage("volume-1", "10Gi", "/path"), StateTypeNotPushed, "container-0"),
+				generateStorage(NewStorage("volume-00", "5Gi", "/data"), StateTypeLocallyDeleted, "container-0"),
+				generateStorage(NewStorage("volume-11", "10Gi", "/path"), StateTypeLocallyDeleted, "container-0"),
 			}),
 			wantErr: false,
 		},
@@ -529,9 +529,9 @@ func Test_kubernetesClient_List(t *testing.T) {
 					*testingutil.FakePVC("volume-0", "5Gi", map[string]string{"component": "nodejs", storageLabels.DevfileStorageLabel: "volume-0"}),
 				},
 			},
-			want: GetMachineReadableFormatForList([]Storage{
-				generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/data"), StateTypeNotPushed, "container-1"),
+			want: NewStorageList([]Storage{
+				generateStorage(NewStorage("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
+				generateStorage(NewStorage("volume-1", "10Gi", "/data"), StateTypeNotPushed, "container-1"),
 			}),
 			wantErr: false,
 		},
@@ -568,9 +568,9 @@ func Test_kubernetesClient_List(t *testing.T) {
 					*testingutil.FakePVC("volume-0", "5Gi", map[string]string{"component": "nodejs", storageLabels.DevfileStorageLabel: "volume-0"}),
 				},
 			},
-			want: GetMachineReadableFormatForList([]Storage{
-				generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
-				generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), StateTypeLocallyDeleted, "container-1"),
+			want: NewStorageList([]Storage{
+				generateStorage(NewStorage("volume-0", "5Gi", "/data"), StateTypePushed, "container-0"),
+				generateStorage(NewStorage("volume-0", "5Gi", "/data"), StateTypeLocallyDeleted, "container-1"),
 			}),
 			wantErr: false,
 		},
@@ -664,7 +664,7 @@ func Test_kubernetesClient_Create(t *testing.T) {
 				},
 			},
 			args: args{
-				storage: GetMachineFormatWithContainer("storage-0", "5Gi", "/data", "runtime"),
+				storage: NewStorageWithContainer("storage-0", "5Gi", "/data", "runtime"),
 			},
 		},
 		{
@@ -676,7 +676,7 @@ func Test_kubernetesClient_Create(t *testing.T) {
 				},
 			},
 			args: args{
-				storage: GetMachineFormatWithContainer("storage-0", "example", "/data", "runtime"),
+				storage: NewStorageWithContainer("storage-0", "example", "/data", "runtime"),
 			},
 			wantErr: true,
 		},
@@ -689,7 +689,7 @@ func Test_kubernetesClient_Create(t *testing.T) {
 				},
 			},
 			args: args{
-				storage: GetMachineFormatWithContainer("odo-projects-vol", "5Gi", "/data", "runtime"),
+				storage: NewStorageWithContainer("odo-projects-vol", "5Gi", "/data", "runtime"),
 			},
 		},
 	}

--- a/pkg/storage/s2i.go
+++ b/pkg/storage/s2i.go
@@ -101,14 +101,14 @@ func (s s2iClient) ListFromCluster() (StorageList, error) {
 			}
 			storageName := getStorageFromPVC(&pvc)
 			storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-			storageMachineReadable := GetMachineReadableFormat(getStorageFromPVC(&pvc),
+			storageMachineReadable := NewStorage(getStorageFromPVC(&pvc),
 				storageSize.String(),
 				mountedStorageMap[storageName],
 			)
 			storage = append(storage, storageMachineReadable)
 		}
 	}
-	storageList := GetMachineReadableFormatForList(storage)
+	storageList := NewStorageList(storage)
 	return storageList, nil
 }
 
@@ -146,5 +146,5 @@ func (s s2iClient) List() (StorageList, error) {
 		}
 	}
 
-	return GetMachineReadableFormatForList(storageList), nil
+	return NewStorageList(storageList), nil
 }

--- a/pkg/storage/s2i_test.go
+++ b/pkg/storage/s2i_test.go
@@ -23,13 +23,13 @@ func Test_s2iClient_List(t *testing.T) {
 
 	pvc3 := testingutil.FakePVC(generatePVCNameFromStorageName("storage-3-app"), "100Mi", getStorageLabels("storage-3", componentName, appName))
 
-	storage1 := GetMachineReadableFormat("storage-1", "100Mi", "/tmp1")
+	storage1 := NewStorage("storage-1", "100Mi", "/tmp1")
 	storage1.Status = StateTypePushed
 
-	storage2 := GetMachineReadableFormat("storage-2", "100Mi", "/tmp2")
+	storage2 := NewStorage("storage-2", "100Mi", "/tmp2")
 	storage2.Status = StateTypeNotPushed
 
-	storage3 := GetMachineReadableFormat("storage-3", "100Mi", "/tmp3")
+	storage3 := NewStorage("storage-3", "100Mi", "/tmp3")
 	storage3.Status = StateTypeLocallyDeleted
 
 	type fields struct {
@@ -62,7 +62,7 @@ func Test_s2iClient_List(t *testing.T) {
 			mountedMap: map[string]*corev1.PersistentVolumeClaim{
 				"/tmp1": pvc1,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{storage1}),
+			wantedStorageList: NewStorageList([]Storage{storage1}),
 			wantErr:           false,
 		},
 		{
@@ -80,7 +80,7 @@ func Test_s2iClient_List(t *testing.T) {
 				Items: []corev1.PersistentVolumeClaim{},
 			},
 			mountedMap:        map[string]*corev1.PersistentVolumeClaim{},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{storage2}),
+			wantedStorageList: NewStorageList([]Storage{storage2}),
 			wantErr:           false,
 		},
 
@@ -100,7 +100,7 @@ func Test_s2iClient_List(t *testing.T) {
 				Items: []corev1.PersistentVolumeClaim{*pvc1, *pvc3},
 			},
 			mountedMap:        map[string]*corev1.PersistentVolumeClaim{"/tmp1": pvc1, "/tmp3": pvc3},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{storage1, storage3}),
+			wantedStorageList: NewStorageList([]Storage{storage1, storage3}),
 			wantErr:           false,
 		},
 	}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -93,7 +93,7 @@ func TestGetMachineReadableFormat(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pvc-example",
 				},
-				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta: metav1.TypeMeta{Kind: StorageKind, APIVersion: "odo.dev/v1alpha1"},
 				Spec: StorageSpec{
 					Size: "100Mi",
 					Path: "data",
@@ -110,7 +110,7 @@ func TestGetMachineReadableFormat(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pvc-example",
 				},
-				TypeMeta: metav1.TypeMeta{Kind: "storage", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta: metav1.TypeMeta{Kind: StorageKind, APIVersion: "odo.dev/v1alpha1"},
 				Spec: StorageSpec{
 					Size: "500Mi",
 					Path: "",
@@ -120,7 +120,7 @@ func TestGetMachineReadableFormat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotStorage := GetMachineReadableFormat(tt.storageName, tt.storageSize, tt.mountedPath)
+			gotStorage := NewStorage(tt.storageName, tt.storageSize, tt.mountedPath)
 			if !reflect.DeepEqual(tt.want, gotStorage) {
 				t.Errorf("the returned storage is different, expected: %v, got: %v", tt.want, gotStorage)
 			}
@@ -244,7 +244,7 @@ func TestGetMachineReadableFormatForList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotStorage := GetMachineReadableFormatForList(tt.inputStorage)
+			gotStorage := NewStorageList(tt.inputStorage)
 			if !reflect.DeepEqual(tt.want, gotStorage) {
 				t.Errorf("the returned storage is different, expected: %v, got: %v", tt.want, gotStorage)
 			}
@@ -364,9 +364,9 @@ func TestList(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc2,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
 			}),
 			wantErr: false,
 		},
@@ -385,9 +385,9 @@ func TestList(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc2,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
 			}),
 			wantErr: false,
 		},
@@ -406,10 +406,10 @@ func TestList(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc2,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
-				GetMachineReadableFormat("storage-4", "100Mi", ""),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
+				NewStorage("storage-4", "100Mi", ""),
 			}),
 			wantErr: false,
 		},
@@ -428,9 +428,9 @@ func TestList(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc5,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
 			}),
 			wantErr: true,
 		},
@@ -509,9 +509,9 @@ func TestListMounted(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc2,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
 			}),
 			wantErr: false,
 		},
@@ -530,9 +530,9 @@ func TestListMounted(t *testing.T) {
 				"/data":   pvc1,
 				"/data-1": pvc2,
 			},
-			wantedStorageList: GetMachineReadableFormatForList([]Storage{
-				GetMachineReadableFormat("storage-1", "100Mi", "/data"),
-				GetMachineReadableFormat("storage-2", "500Mi", "/data-1"),
+			wantedStorageList: NewStorageList([]Storage{
+				NewStorage("storage-1", "100Mi", "/data"),
+				NewStorage("storage-2", "500Mi", "/data-1"),
 			}),
 			wantErr: false,
 		},
@@ -605,8 +605,8 @@ func TestS2iPush(t *testing.T) {
 			args: args{
 				storageList: StorageList{
 					Items: []Storage{
-						GetMachineReadableFormat("backend", "100Mi", "data"),
-						GetMachineReadableFormat("backend-1", "500Mi", "data-1"),
+						NewStorage("backend", "100Mi", "data"),
+						NewStorage("backend-1", "500Mi", "data-1"),
 					},
 				},
 				componentName:     "nodejs",
@@ -647,8 +647,8 @@ func TestS2iPush(t *testing.T) {
 			args: args{
 				storageList: StorageList{
 					Items: []Storage{
-						GetMachineReadableFormat("backend", "100Mi", "data"),
-						GetMachineReadableFormat("backend-1", "500Mi", "data-1"),
+						NewStorage("backend", "100Mi", "data"),
+						NewStorage("backend-1", "500Mi", "data-1"),
 					},
 				},
 				componentName:     "nodejs",
@@ -671,8 +671,8 @@ func TestS2iPush(t *testing.T) {
 			name: "case 4: component exists, three PVCs, one in config and cluster, one not in cluster and one not in config",
 			args: args{
 				storageList: StorageList{Items: []Storage{
-					GetMachineReadableFormat("backend", "100Mi", "data"),
-					GetMachineReadableFormat("backend-1", "500Mi", "data-1"),
+					NewStorage("backend", "100Mi", "data"),
+					NewStorage("backend-1", "500Mi", "data-1"),
 				}},
 				componentName:     "nodejs",
 				applicationName:   "app",
@@ -696,8 +696,8 @@ func TestS2iPush(t *testing.T) {
 			args: args{
 				storageList: StorageList{
 					Items: []Storage{
-						GetMachineReadableFormat("backend", "100Mi", "data"),
-						GetMachineReadableFormat("backend-1", "500Mi", "data-100"),
+						NewStorage("backend", "100Mi", "data"),
+						NewStorage("backend-1", "500Mi", "data-100"),
 					},
 				},
 				componentName:     "nodejs",
@@ -718,8 +718,8 @@ func TestS2iPush(t *testing.T) {
 			args: args{
 				storageList: StorageList{
 					Items: []Storage{
-						GetMachineReadableFormat("backend", "100Mi", "data"),
-						GetMachineReadableFormat("backend-1", "50Mi", "data-1"),
+						NewStorage("backend", "100Mi", "data"),
+						NewStorage("backend-1", "50Mi", "data-1"),
 					},
 				},
 				componentName:     "nodejs",
@@ -926,8 +926,8 @@ func TestDevfileListMounted(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-0"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-0"),
 				},
 			},
 			wantErr: false,
@@ -959,9 +959,9 @@ func TestDevfileListMounted(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-0"),
-					generateStorage(GetMachineReadableFormat("volume-1", "10Gi", "/path"), "", "container-1"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-0"),
+					generateStorage(NewStorage("volume-1", "10Gi", "/path"), "", "container-1"),
 				},
 			},
 			wantErr: false,
@@ -1012,7 +1012,7 @@ func TestDevfileListMounted(t *testing.T) {
 			},
 			want: StorageList{
 				Items: []Storage{
-					generateStorage(GetMachineReadableFormat("volume-0", "5Gi", "/data"), "", "container-0"),
+					generateStorage(NewStorage("volume-0", "5Gi", "/data"), "", "container-0"),
 				},
 			},
 			wantErr: false,
@@ -1058,8 +1058,8 @@ func TestPush(t *testing.T) {
 		Container: "runtime-1",
 	}
 
-	clusterStorage0 := GetMachineFormatWithContainer("storage-0", "1Gi", "/data", "runtime-0")
-	clusterStorage1 := GetMachineFormatWithContainer("storage-1", "5Gi", "/path", "runtime-1")
+	clusterStorage0 := NewStorageWithContainer("storage-0", "1Gi", "/data", "runtime-0")
+	clusterStorage1 := NewStorageWithContainer("storage-1", "5Gi", "/path", "runtime-1")
 
 	tests := []struct {
 		name                string
@@ -1203,8 +1203,8 @@ func TestPush(t *testing.T) {
 			returnedFromLocal: []localConfigProvider.LocalStorage{},
 			returnedFromCluster: StorageList{
 				Items: []Storage{
-					GetMachineFormatWithContainer("storage-0", "1Gi", "/data", "runtime-0"),
-					GetMachineFormatWithContainer("storage-0", "1Gi", "/data", "runtime-1"),
+					NewStorageWithContainer("storage-0", "1Gi", "/data", "runtime-0"),
+					NewStorageWithContainer("storage-0", "1Gi", "/data", "runtime-1"),
 				},
 			},
 			deletedItems: []string{"storage-0"},

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
+	"github.com/openshift/odo/pkg/machineoutput"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const StorageKind = "Storage"
 
 // Storage holds the information about storage attached to the component
 type Storage struct {
@@ -38,4 +41,40 @@ type StorageList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Storage `json:"items"`
+}
+
+// NewStorageList returns an instance of a list containning the `items` storages
+func NewStorageList(items []Storage) StorageList {
+	return StorageList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       machineoutput.ListKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ListMeta: metav1.ListMeta{},
+		Items:    items,
+	}
+}
+
+// NewStorage returns an instance of Storage
+// storagePath indicates the path to which the storage is mounted to, "" if not mounted
+func NewStorage(storageName, storageSize, storagePath string) Storage {
+	return Storage{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       StorageKind,
+			APIVersion: machineoutput.APIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: storageName},
+		Spec: StorageSpec{
+			Size: storageSize,
+			Path: storagePath,
+		},
+	}
+}
+
+// NewStorageWithContainer returns an instance of Storage with container specified
+// storagePath indicates the path to which the storage is mounted to, "" if not mounted
+func NewStorageWithContainer(storageName, storageSize, storagePath string, container string) Storage {
+	storage := NewStorage(storageName, storageSize, storagePath)
+	storage.Spec.ContainerName = container
+	return storage
 }

--- a/pkg/url/kubernetes.go
+++ b/pkg/url/kubernetes.go
@@ -2,8 +2,9 @@ package url
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/unions"
 	"sort"
+
+	"github.com/openshift/odo/pkg/unions"
 
 	"github.com/devfile/library/pkg/devfile/generator"
 	routev1 "github.com/openshift/api/route/v1"
@@ -53,11 +54,11 @@ func (k kubernetesClient) ListFromCluster() (URLList, error) {
 		if r.OwnerReferences != nil && r.OwnerReferences[0].Kind == "Ingress" {
 			continue
 		}
-		clusterURL := getMachineReadableFormat(r)
+		clusterURL := NewURL(r)
 		clusterURLs = append(clusterURLs, clusterURL)
 	}
 
-	return getMachineReadableFormatForList(clusterURLs), nil
+	return NewURLList(clusterURLs), nil
 }
 
 // List lists both route/ingress based URLs and local URLs with respective states
@@ -88,7 +89,7 @@ func (k kubernetesClient) List() (URLList, error) {
 			if !k.isRouteSupported && url.Kind == localConfigProvider.ROUTE {
 				continue
 			}
-			localURL := ConvertEnvinfoURL(url, k.componentName)
+			localURL := NewURLFromEnvinfoURL(url, k.componentName)
 			if localURL.Spec.Protocol == "" {
 				if localURL.Spec.Secure {
 					localURL.Spec.Protocol = "https"
@@ -130,7 +131,7 @@ func (k kubernetesClient) List() (URLList, error) {
 
 	// sort urls by name to get consistent output
 	sort.Sort(urls)
-	urlList := getMachineReadableFormatForList(urls)
+	urlList := NewURLList(urls)
 	return urlList, nil
 }
 

--- a/pkg/url/kubernetes_test.go
+++ b/pkg/url/kubernetes_test.go
@@ -2,10 +2,11 @@ package url
 
 import (
 	"fmt"
-	"github.com/openshift/odo/pkg/unions"
-	networkingv1 "k8s.io/api/networking/v1"
 	"reflect"
 	"testing"
+
+	"github.com/openshift/odo/pkg/unions"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	"github.com/devfile/library/pkg/devfile/generator"
 	"github.com/golang/mock/gomock"
@@ -33,7 +34,7 @@ import (
 func getFakeURL(name string, host string, port int, path string, protocol string, kind localConfigProvider.URLKind, urlState StateType) URL {
 	return URL{
 		TypeMeta: v1.TypeMeta{
-			Kind:       "url",
+			Kind:       "URL",
 			APIVersion: "odo.dev/v1alpha1",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -94,7 +95,7 @@ func Test_kubernetesClient_ListCluster(t *testing.T) {
 					ingress1,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				NewURLFromKubernetesIngress(ingress0, false),
 				NewURLFromKubernetesIngress(ingress1, false),
 			}),
@@ -114,9 +115,9 @@ func Test_kubernetesClient_ListCluster(t *testing.T) {
 					route1,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
-				getMachineReadableFormat(route0),
-				getMachineReadableFormat(route1)},
+			want: NewURLList([]URL{
+				NewURL(route0),
+				NewURL(route1)},
 			),
 		},
 		{
@@ -140,11 +141,11 @@ func Test_kubernetesClient_ListCluster(t *testing.T) {
 					ingress1,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				NewURLFromKubernetesIngress(ingress0, false),
 				NewURLFromKubernetesIngress(ingress1, false),
-				getMachineReadableFormat(route0),
-				getMachineReadableFormat(route1),
+				NewURL(route0),
+				NewURL(route1),
 			}),
 		},
 		{
@@ -156,7 +157,7 @@ func Test_kubernetesClient_ListCluster(t *testing.T) {
 				},
 				isRouteSupported: true,
 			},
-			want: getMachineReadableFormatForList(nil),
+			want: NewURLList(nil),
 		},
 		{
 			name: "case 5: ignore the routes with ingress kind owners",
@@ -173,8 +174,8 @@ func Test_kubernetesClient_ListCluster(t *testing.T) {
 					routeOwnedByIngress,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
-				getMachineReadableFormat(route0)},
+			want: NewURLList([]URL{
+				NewURL(route0)},
 			),
 		},
 	}
@@ -261,7 +262,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 					Kind:   localConfigProvider.INGRESS,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				getFakeURL("example-1", "example-1.com", 8080, "", "http", localConfigProvider.INGRESS, StateTypeNotPushed),
 				getFakeURL("example-2", "example-2.com", 8080, "", "http", localConfigProvider.INGRESS, StateTypeNotPushed)}),
 		},
@@ -282,7 +283,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 			},
 			returnedLocalURLs: []localConfigProvider.LocalURL{},
 
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				getFakeURL("testRoute0", "example.com", 8080, "/", "http", localConfigProvider.ROUTE, StateTypeLocallyDeleted),
 				getFakeURL("testRoute1", "example.com", 8080, "/", "http", localConfigProvider.ROUTE, StateTypeLocallyDeleted)}),
 		},
@@ -322,7 +323,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 					Kind:   localConfigProvider.INGRESS,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				getFakeURL("testIngress0", "testIngress0.com", 8080, "/", "http", localConfigProvider.INGRESS, StateTypePushed),
 				getFakeURL("testRoute0", "example.com", 8080, "/", "http", localConfigProvider.ROUTE, StateTypePushed),
 			}),
@@ -363,7 +364,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 				},
 			},
 
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				getFakeURL("testIngress0", "testIngress0.com", 8080, "/", "http", localConfigProvider.INGRESS, StateTypePushed),
 				getFakeURL("testRoute0", "", 8080, "/", "http", localConfigProvider.ROUTE, StateTypeNotPushed),
 				getFakeURL("testRoute1", "example.com", 8080, "/", "http", localConfigProvider.ROUTE, StateTypeLocallyDeleted),
@@ -395,7 +396,7 @@ func Test_kubernetesClient_List(t *testing.T) {
 					Kind:   localConfigProvider.INGRESS,
 				},
 			},
-			want: getMachineReadableFormatForList([]URL{
+			want: NewURLList([]URL{
 				getFakeURL("testIngress0", "testIngress0.com", 8080, "/", "http", localConfigProvider.INGRESS, StateTypeNotPushed),
 			}),
 		},

--- a/pkg/url/s2i.go
+++ b/pkg/url/s2i.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"fmt"
+
 	applabels "github.com/openshift/odo/pkg/application/labels"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/localConfigProvider"
@@ -37,11 +38,11 @@ func (s s2iClient) ListFromCluster() (URLList, error) {
 
 	var urls []URL
 	for _, r := range routes {
-		a := getMachineReadableFormat(r)
+		a := NewURL(r)
 		urls = append(urls, a)
 	}
 
-	urlList := getMachineReadableFormatForList(urls)
+	urlList := NewURLList(urls)
 	return urlList, nil
 }
 
@@ -62,7 +63,7 @@ func (s s2iClient) List() (URLList, error) {
 	for _, clusterURL := range clusterUrls.Items {
 		var found = false
 		for _, configURL := range localConfigURLs {
-			localURL := ConvertConfigURL(configURL)
+			localURL := NewURLFromConfigURL(configURL)
 			if localURL.Name == clusterURL.Name {
 				// URL is in both local config and cluster
 				clusterURL.Status.State = StateTypePushed
@@ -79,7 +80,7 @@ func (s s2iClient) List() (URLList, error) {
 	}
 
 	for _, configURL := range localConfigURLs {
-		localURL := ConvertConfigURL(configURL)
+		localURL := NewURLFromConfigURL(configURL)
 		var found = false
 		for _, clusterURL := range clusterUrls.Items {
 			if localURL.Name == clusterURL.Name {
@@ -93,7 +94,7 @@ func (s s2iClient) List() (URLList, error) {
 		}
 	}
 
-	urlList := getMachineReadableFormatForList(urls)
+	urlList := NewURLList(urls)
 	return urlList, nil
 }
 

--- a/pkg/url/url_test.go
+++ b/pkg/url/url_test.go
@@ -227,13 +227,13 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Port:   8080,
 					Secure: false,
 					Kind:   localConfigProvider.ROUTE,
 				}),
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example-1",
 					Port:   9090,
 					Secure: false,
@@ -246,9 +246,9 @@ func TestPush(t *testing.T) {
 			componentName:   "wildfly",
 			applicationName: "app",
 			args:            args{isRouteSupported: true, networkingV1IngressSupported: false, extensionV1IngressSupported: true},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
-				getMachineReadableFormat(testingutil.GetSingleRoute("example", 8080, "wildfly", "app")),
-				getMachineReadableFormat(testingutil.GetSingleRoute("example-1", 9100, "wildfly", "app")),
+			existingClusterURLs: NewURLList([]URL{
+				NewURL(testingutil.GetSingleRoute("example", 8080, "wildfly", "app")),
+				NewURL(testingutil.GetSingleRoute("example-1", 9100, "wildfly", "app")),
 			}),
 			deletedItems: []deleteParameters{
 				{"example", localConfigProvider.ROUTE},
@@ -274,22 +274,22 @@ func TestPush(t *testing.T) {
 					Kind:   localConfigProvider.ROUTE,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
-				getMachineReadableFormat(testingutil.GetSingleRoute("example", 8080, "wildfly", "app")),
-				getMachineReadableFormat(testingutil.GetSingleRoute("example-1", 9100, "wildfly", "app")),
+			existingClusterURLs: NewURLList([]URL{
+				NewURL(testingutil.GetSingleRoute("example", 8080, "wildfly", "app")),
+				NewURL(testingutil.GetSingleRoute("example-1", 9100, "wildfly", "app")),
 			}),
 			deletedItems: []deleteParameters{
 				{"example", localConfigProvider.ROUTE},
 				{"example-1", localConfigProvider.ROUTE},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example-local-0",
 					Port:   8080,
 					Secure: false,
 					Kind:   localConfigProvider.ROUTE,
 				}),
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example-local-1",
 					Port:   9090,
 					Secure: false,
@@ -343,12 +343,12 @@ func TestPush(t *testing.T) {
 					Kind:   localConfigProvider.ROUTE,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example", "nodejs", "app", true, false), false),
 				NewURLFromKubernetesIngress(fake.GetSingleSecureKubernetesIngress("example-default-secret", "nodejs", "app", "", true, false), false),
 				NewURLFromKubernetesIngress(fake.GetSingleSecureKubernetesIngress("example-user-secret", "nodejs", "app", "secret-name", true, false), false),
-				getMachineReadableFormat(testingutil.GetSingleRoute("example-1", 9100, "nodejs", "app")),
-				getMachineReadableFormat(testingutil.GetSingleSecureRoute("example-11", 9100, "nodejs", "app")),
+				NewURL(testingutil.GetSingleRoute("example-1", 9100, "nodejs", "app")),
+				NewURL(testingutil.GetSingleSecureRoute("example-11", 9100, "nodejs", "app")),
 			}),
 			createdURLs: []URL{},
 		},
@@ -379,13 +379,13 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example",
 					Host: "com",
 					Port: 8080,
 					Kind: localConfigProvider.INGRESS,
 				}),
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-1",
 					Host: "com",
 					Port: 9090,
@@ -399,7 +399,7 @@ func TestPush(t *testing.T) {
 			applicationName:   "app",
 			args:              args{isRouteSupported: true, networkingV1IngressSupported: true, extensionV1IngressSupported: false},
 			existingLocalURLs: []localConfigProvider.LocalURL{},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-0", "nodejs", "app", true, false), false),
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-1", "nodejs", "app", true, false), false),
 			}),
@@ -427,18 +427,18 @@ func TestPush(t *testing.T) {
 					Kind: localConfigProvider.INGRESS,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-0", "nodejs", "app", true, false), false),
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-1", "nodejs", "app", true, false), false),
 			}),
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-local-0",
 					Host: "com",
 					Port: 8080,
 					Kind: localConfigProvider.INGRESS,
 				}),
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-local-1",
 					Host: "com",
 					Port: 9090,
@@ -475,7 +475,7 @@ func TestPush(t *testing.T) {
 					Path:     "/",
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetKubernetesIngressListWithMultiple("wildfly", "app", true, false).Items[0], false),
 				NewURLFromKubernetesIngress(fake.GetKubernetesIngressListWithMultiple("wildfly", "app", true, false).Items[1], false),
 			}),
@@ -500,17 +500,17 @@ func TestPush(t *testing.T) {
 					Kind: localConfigProvider.INGRESS,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-0", "nodejs", "app", true, false), false),
-				getMachineReadableFormat(testingutil.GetSingleRoute("example-1", 9090, "nodejs", "app")),
+				NewURL(testingutil.GetSingleRoute("example-1", 9090, "nodejs", "app")),
 			}),
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-local-0",
 					Port: 8080,
 					Kind: localConfigProvider.ROUTE,
 				}),
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-local-1",
 					Host: "com",
 					Port: 9090,
@@ -538,7 +538,7 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:      "example",
 					Host:      "com",
 					TLSSecret: "secret",
@@ -564,11 +564,11 @@ func TestPush(t *testing.T) {
 					Kind: localConfigProvider.ROUTE,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
+			existingClusterURLs: NewURLList([]URL{
 				NewURLFromKubernetesIngress(fake.GetSingleKubernetesIngress("example-local-0", "nodejs", "app", true, false), false),
 			}),
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example-local-0",
 					Port: 8080,
 					Kind: localConfigProvider.ROUTE,
@@ -592,11 +592,11 @@ func TestPush(t *testing.T) {
 					Kind:   localConfigProvider.ROUTE,
 				},
 			},
-			existingClusterURLs: getMachineReadableFormatForList([]URL{
-				getMachineReadableFormat(testingutil.GetSingleRoute("example-local-0-app", 9090, "nodejs", "app")),
+			existingClusterURLs: NewURLList([]URL{
+				NewURL(testingutil.GetSingleRoute("example-local-0-app", 9090, "nodejs", "app")),
 			}),
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example-local-0",
 					Port:   8080,
 					Secure: false,
@@ -622,7 +622,7 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Port:   8080,
 					Secure: true,
@@ -645,7 +645,7 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Host:   "com",
 					Secure: true,
@@ -670,7 +670,7 @@ func TestPush(t *testing.T) {
 				},
 			},
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:      "example",
 					Host:      "com",
 					TLSSecret: "secret",
@@ -709,7 +709,7 @@ func TestPush(t *testing.T) {
 			},
 			wantErr: false,
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Port:   8080,
 					Kind:   localConfigProvider.ROUTE,
@@ -732,7 +732,7 @@ func TestPush(t *testing.T) {
 			},
 			wantErr: false,
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name: "example",
 					Host: "com",
 					Port: 8080,
@@ -756,7 +756,7 @@ func TestPush(t *testing.T) {
 			},
 			wantErr: false,
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Port:   8080,
 					Secure: false,
@@ -782,7 +782,7 @@ func TestPush(t *testing.T) {
 			},
 			wantErr: false,
 			createdURLs: []URL{
-				ConvertLocalURL(localConfigProvider.LocalURL{
+				NewURLFromLocalURL(localConfigProvider.LocalURL{
 					Name:   "example",
 					Host:   "com",
 					Port:   8080,
@@ -859,7 +859,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 				Kind:   localConfigProvider.INGRESS,
 			},
 			wantURL: URL{
-				TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta:   metav1.TypeMeta{Kind: "URL", APIVersion: "odo.dev/v1alpha1"},
 				ObjectMeta: metav1.ObjectMeta{Name: urlName},
 				Spec:       URLSpec{Host: fmt.Sprintf("%s.%s", urlName, host), Port: 8080, Secure: false, Kind: localConfigProvider.INGRESS},
 			},
@@ -874,7 +874,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 				Kind:   localConfigProvider.INGRESS,
 			},
 			wantURL: URL{
-				TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta:   metav1.TypeMeta{Kind: "URL", APIVersion: "odo.dev/v1alpha1"},
 				ObjectMeta: metav1.ObjectMeta{Name: urlName},
 				Spec:       URLSpec{Host: fmt.Sprintf("%s.%s", urlName, host), Port: 8080, Secure: true, TLSSecret: fmt.Sprintf("%s-tlssecret", serviceName), Kind: localConfigProvider.INGRESS},
 			},
@@ -890,7 +890,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 				Kind:      localConfigProvider.INGRESS,
 			},
 			wantURL: URL{
-				TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta:   metav1.TypeMeta{Kind: "URL", APIVersion: "odo.dev/v1alpha1"},
 				ObjectMeta: metav1.ObjectMeta{Name: urlName},
 				Spec:       URLSpec{Host: fmt.Sprintf("%s.%s", urlName, host), Port: 8080, Secure: true, TLSSecret: secretName, Kind: localConfigProvider.INGRESS},
 			},
@@ -903,7 +903,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 				Kind: localConfigProvider.ROUTE,
 			},
 			wantURL: URL{
-				TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta:   metav1.TypeMeta{Kind: "URL", APIVersion: "odo.dev/v1alpha1"},
 				ObjectMeta: metav1.ObjectMeta{Name: urlName},
 				Spec:       URLSpec{Port: 8080, Secure: false, Kind: localConfigProvider.ROUTE},
 			},
@@ -917,7 +917,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 				Kind:   localConfigProvider.ROUTE,
 			},
 			wantURL: URL{
-				TypeMeta:   metav1.TypeMeta{Kind: "url", APIVersion: "odo.dev/v1alpha1"},
+				TypeMeta:   metav1.TypeMeta{Kind: "URL", APIVersion: "odo.dev/v1alpha1"},
 				ObjectMeta: metav1.ObjectMeta{Name: urlName},
 				Spec:       URLSpec{Port: 8080, Secure: true, Kind: localConfigProvider.ROUTE},
 			},
@@ -925,7 +925,7 @@ func TestConvertEnvinfoURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := ConvertEnvinfoURL(tt.envInfoURL, serviceName)
+			url := NewURLFromEnvinfoURL(tt.envInfoURL, serviceName)
 			if !reflect.DeepEqual(url, tt.wantURL) {
 				t.Errorf("Expected %v, got %v", tt.wantURL, url)
 			}

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -336,6 +336,21 @@ func GjsonMatcher(values []gjson.Result, expected []string) bool {
 	return matched == numVars
 }
 
+// GjsonExactMatcher validates if []results from gjson.GetMany match the expected values for each json path requested
+// Values is an array of results returned by the gjson.GetMany function
+// Expected is an array of strings, defines the expected values for each of the paths requested in the gjson.GetMany function
+// For documentation about gjson see https://github.com/tidwall/gjson#get-multiple-values-at-once
+func GjsonExactMatcher(values []gjson.Result, expected []string) bool {
+	matched := 0
+	for i, v := range values {
+		if v.String() == expected[i] {
+			matched++
+		}
+	}
+	numVars := len(expected)
+	return matched == numVars
+}
+
 //SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters
 func SetProjectName() string {
 	//Get current test filename and remove file path, file extension and replace undescores with hyphens

--- a/tests/integration/cmd_storage_test.go
+++ b/tests/integration/cmd_storage_test.go
@@ -50,7 +50,7 @@ var _ = Describe("odo storage command tests", func() {
 
 			It("should create", func() {
 				valuesStoreC := gjson.GetMany(actualJSONStorage, "kind", "metadata.name", "spec.size", "spec.path")
-				expectedStoreC := []string{"storage", "mystorage", "1Gi", "/opt/app-root/src/storage/"}
+				expectedStoreC := []string{"Storage", "mystorage", "1Gi", "/opt/app-root/src/storage/"}
 				Expect(helper.GjsonMatcher(valuesStoreC, expectedStoreC)).To(Equal(true))
 
 			})
@@ -65,7 +65,7 @@ var _ = Describe("odo storage command tests", func() {
 
 				It("should list output in json format", func() {
 					valuesStoreL := gjson.GetMany(actualStorageList, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.size")
-					expectedStoreL := []string{"List", "storage", "mystorage", "1Gi"}
+					expectedStoreL := []string{"List", "Storage", "mystorage", "1Gi"}
 					Expect(helper.GjsonMatcher(valuesStoreL, expectedStoreL)).To(Equal(true))
 
 				})

--- a/tests/integration/cmd_url_test.go
+++ b/tests/integration/cmd_url_test.go
@@ -92,7 +92,7 @@ var _ = Describe("odo url command tests", func() {
 			// odo url list -o json
 			actualURLListJSON := helper.Cmd("odo", "url", "list", "-o", "json").ShouldPass().Out()
 			valuesURLL := gjson.GetMany(actualURLListJSON, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.kind", "items.0.status.state")
-			expectedURLL := []string{"List", "url", "myurl", "route", "Pushed"}
+			expectedURLL := []string{"List", "URL", "myurl", "route", "Pushed"}
 			Expect(helper.GjsonMatcher(valuesURLL, expectedURLL)).To(Equal(true))
 
 		})
@@ -102,7 +102,7 @@ var _ = Describe("odo url command tests", func() {
 			helper.Cmd("odo", "url", "create", "myurl", "--secure").ShouldPass()
 			actualURLListJSON := helper.Cmd("odo", "url", "list", "-o", "json").ShouldPass().Out()
 			valuesURLLJ := gjson.GetMany(actualURLListJSON, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.port", "items.0.status.state")
-			expectedURLLJ := []string{"List", "url", "myurl", "8080", "Not Pushed"}
+			expectedURLLJ := []string{"List", "URL", "myurl", "8080", "Not Pushed"}
 			Expect(helper.GjsonMatcher(valuesURLLJ, expectedURLLJ)).To(Equal(true))
 
 			helper.Cmd("odo", "push").ShouldPass()
@@ -110,7 +110,7 @@ var _ = Describe("odo url command tests", func() {
 			// odo url list -o json
 			actualURLListJSON = helper.Cmd("odo", "url", "list", "-o", "json").ShouldPass().Out()
 			valuesURLLJP := gjson.GetMany(actualURLListJSON, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.port", "items.0.spec.secure", "items.0.status.state")
-			expectedURLLJP := []string{"List", "url", "myurl", "8080", "true", "Pushed"}
+			expectedURLLJP := []string{"List", "URL", "myurl", "8080", "true", "Pushed"}
 			Expect(helper.GjsonMatcher(valuesURLLJP, expectedURLLJP)).To(Equal(true))
 
 		})

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/openshift/odo/pkg/util"
+	"github.com/tidwall/gjson"
 
 	"github.com/openshift/odo/tests/helper"
 
@@ -51,11 +51,9 @@ var _ = Describe("odo devfile debug command tests", func() {
 			// Make sure that the debug information output, outputs correctly.
 			// We do *not* check the json output since the debugProcessID will be different each time.
 			helper.WaitForCmdOut("odo", []string{"debug", "info", "-o", "json", "--context", commonVar.Context}, 1, false, func(output string) bool {
-				if strings.Contains(output, `"kind": "OdoDebugInfo"`) &&
-					strings.Contains(output, `"localPort": `+freePort) {
-					return true
-				}
-				return false
+				values := gjson.GetMany(output, "kind", "spec.localPort")
+				expected := []string{"OdoDebugInfo", freePort}
+				return helper.GjsonMatcher(values, expected)
 			})
 
 			stopChannel <- true

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -61,59 +61,59 @@ var _ = Describe("odo devfile env command tests", func() {
 			expected := []string{"EnvInfo", "acomponentname", commonVar.Project, "app"}
 			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 		})
-	})
 
-	When("executing env set", func() {
-		BeforeEach(func() {
-			helper.Cmd("odo", "create", "nodejs").ShouldPass()
-			helper.Cmd("odo", "env", "set", "Name", testName, "-f").ShouldPass()
-			helper.Cmd("odo", "env", "set", "Project", testProject, "-f").ShouldPass()
-			helper.Cmd("odo", "env", "set", "DebugPort", testDebugPort, "-f").ShouldPass()
-		})
-
-		It("should successfully view the parameters", func() {
-			output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
-			wantOutput := []string{
-				"PARAMETER NAME",
-				"PARAMETER VALUE",
-				"NAME",
-				testName,
-				"Project",
-				testProject,
-				"DebugPort",
-				testDebugPort,
-			}
-			helper.MatchAllInOutput(output, wantOutput)
-		})
-
-		It("should successfully view the parameters with JSON output", func() {
-			output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
-			values := gjson.GetMany(output, "kind", "spec.name", "spec.project", "spec.debugPort")
-			expected := []string{"EnvInfo", testName, testProject, testDebugPort}
-			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
-		})
-
-		When("unsetting a parameter", func() {
+		When("executing env set", func() {
 			BeforeEach(func() {
-				helper.Cmd("odo", "env", "unset", "DebugPort", "-f").ShouldPass()
+				helper.Cmd("odo", "env", "set", "Name", testName, "-f").ShouldPass()
+				helper.Cmd("odo", "env", "set", "Project", testProject, "-f").ShouldPass()
+				helper.Cmd("odo", "env", "set", "DebugPort", testDebugPort, "-f").ShouldPass()
 			})
 
-			It("should not show the parameter", func() {
+			It("should successfully view the parameters", func() {
 				output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
-				dontWantOutput := []string{
+				wantOutput := []string{
+					"PARAMETER NAME",
+					"PARAMETER VALUE",
+					"NAME",
+					testName,
+					"Project",
+					testProject,
+					"DebugPort",
 					testDebugPort,
+					"Application",
+					"app",
 				}
-				helper.DontMatchAllInOutput(output, dontWantOutput)
-				helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
+				helper.MatchAllInOutput(output, wantOutput)
 			})
 
-			It("should not show the parameter in JSON output", func() {
+			It("should successfully view the parameters with JSON output", func() {
 				output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
-				values := gjson.GetMany(output, "kind", "spec.debugPort")
-				expected := []string{"EnvInfo", ""}
+				values := gjson.GetMany(output, "kind", "spec.name", "spec.project", "spec.debugPort")
+				expected := []string{"EnvInfo", testName, testProject, testDebugPort}
 				Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 			})
+
+			When("unsetting a parameter", func() {
+				BeforeEach(func() {
+					helper.Cmd("odo", "env", "unset", "DebugPort", "-f").ShouldPass()
+				})
+
+				It("should not show the parameter", func() {
+					output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
+					dontWantOutput := []string{
+						testDebugPort,
+					}
+					helper.DontMatchAllInOutput(output, dontWantOutput)
+					helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
+				})
+
+				It("should not show the parameter in JSON output", func() {
+					output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
+					values := gjson.GetMany(output, "kind", "spec.debugPort")
+					expected := []string{"EnvInfo", ""}
+					Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
+				})
+			})
 		})
 	})
-
 })

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -2,7 +2,9 @@ package devfile
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/openshift/odo/tests/helper"
+	"github.com/tidwall/gjson"
 )
 
 var _ = Describe("odo devfile env command tests", func() {
@@ -27,15 +29,23 @@ var _ = Describe("odo devfile env command tests", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	Context("When executing env view", func() {
-		It("Should view all default parameters", func() {
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project).ShouldPass()
+	When("creating a component", func() {
+		BeforeEach(func() {
+			helper.Cmd("odo", "create", "nodejs", "acomponentname", "--project", commonVar.Project).ShouldPass()
+		})
+
+		It("Should fail to set and unset an invalid parameter", func() {
+			helper.Cmd("odo", "env", "set", fakeParameter, fakeParameter, "-f").ShouldFail()
+			helper.Cmd("odo", "env", "unset", fakeParameter, "-f").ShouldFail()
+		})
+
+		It("should show all default parameters with odo view info", func() {
 			output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
 			wantOutput := []string{
 				"PARAMETER NAME",
 				"PARAMETER VALUE",
 				"NAME",
-				"nodejs",
+				"acomponentname",
 				"Project",
 				commonVar.Project,
 				"DebugPort",
@@ -44,14 +54,24 @@ var _ = Describe("odo devfile env command tests", func() {
 			}
 			helper.MatchAllInOutput(output, wantOutput)
 		})
+
+		It("should show all default parameters with odo view info and JSON output ", func() {
+			output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
+			values := gjson.GetMany(output, "kind", "spec.name", "spec.project", "spec.appName")
+			expected := []string{"EnvInfo", "acomponentname", commonVar.Project, "app"}
+			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
+		})
 	})
 
-	Context("When executing env set and unset", func() {
-		It("Should successfully set and unset the parameters", func() {
+	When("executing env set", func() {
+		BeforeEach(func() {
 			helper.Cmd("odo", "create", "nodejs").ShouldPass()
 			helper.Cmd("odo", "env", "set", "Name", testName, "-f").ShouldPass()
 			helper.Cmd("odo", "env", "set", "Project", testProject, "-f").ShouldPass()
 			helper.Cmd("odo", "env", "set", "DebugPort", testDebugPort, "-f").ShouldPass()
+		})
+
+		It("should successfully view the parameters", func() {
 			output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
 			wantOutput := []string{
 				"PARAMETER NAME",
@@ -64,20 +84,35 @@ var _ = Describe("odo devfile env command tests", func() {
 				testDebugPort,
 			}
 			helper.MatchAllInOutput(output, wantOutput)
-
-			helper.Cmd("odo", "env", "unset", "DebugPort", "-f").ShouldPass()
-			output = helper.Cmd("odo", "env", "view").ShouldPass().Out()
-			dontWantOutput := []string{
-				testDebugPort,
-			}
-			helper.DontMatchAllInOutput(output, dontWantOutput)
-			helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
 		})
 
-		It("Should fail to set and unset an invalid parameter", func() {
-			helper.Cmd("odo", "create", "nodejs").ShouldPass()
-			helper.Cmd("odo", "env", "set", fakeParameter, fakeParameter, "-f").ShouldFail()
-			helper.Cmd("odo", "env", "unset", fakeParameter, "-f").ShouldFail()
+		It("should successfully view the parameters with JSON output", func() {
+			output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
+			values := gjson.GetMany(output, "kind", "spec.name", "spec.project", "spec.debugPort")
+			expected := []string{"EnvInfo", testName, testProject, testDebugPort}
+			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
+		})
+
+		When("unsetting a parameter", func() {
+			BeforeEach(func() {
+				helper.Cmd("odo", "env", "unset", "DebugPort", "-f").ShouldPass()
+			})
+
+			It("should not show the parameter", func() {
+				output := helper.Cmd("odo", "env", "view").ShouldPass().Out()
+				dontWantOutput := []string{
+					testDebugPort,
+				}
+				helper.DontMatchAllInOutput(output, dontWantOutput)
+				helper.Cmd("odo", "push", "--project", commonVar.Project).ShouldPass()
+			})
+
+			It("should not show the parameter in JSON output", func() {
+				output := helper.Cmd("odo", "env", "view", "-o", "json").ShouldPass().Out()
+				values := gjson.GetMany(output, "kind", "spec.debugPort")
+				expected := []string{"EnvInfo", ""}
+				Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
+			})
 		})
 	})
 

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/odo/tests/helper"
+	"github.com/tidwall/gjson"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,53 +28,89 @@ var _ = Describe("odo list with devfile", func() {
 		helper.CommonAfterEach(commonVar)
 	})
 
-	When("two components in different applications", func() {
-		It("should correctly output component information", func() {
+	When("a component created in 'app' application", func() {
 
-			// component created in "app" application
+		BeforeEach(func() {
 			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, cmpName).ShouldPass()
 			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), commonVar.Context)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(commonVar.Context, "devfile.yaml"))
 
-			By("checking that component correctly shows as 'NotPushed'")
-			output := helper.Cmd("odo", "list").ShouldPass().Out()
-			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
-
-			output = helper.Cmd("odo", "push").ShouldPass().Out()
-			Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
-
-			// component created in different application
-			context2 := helper.CreateNewContext()
-			cmpName2 := helper.RandString(6)
-			appName := helper.RandString(6)
-
-			helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2).ShouldPass()
-			helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
-			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
-
-			By("checking that second component correctly shows as 'NotPushed'")
-			output = helper.Cmd("odo", "list", "--context", context2).ShouldPass().Out()
-			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", appName, cmpName2, commonVar.Project, "nodejs"))))
-
-			output2 := helper.Cmd("odo", "push", "--context", context2).ShouldPass().Out()
-			Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
-
-			By("checking listing components in the current application in 'Pushed' state")
-			output = helper.Cmd("odo", "list", "--project", commonVar.Project).ShouldPass().Out()
-			// this test makes sure that a devfile component doesn't show up as an s2i component as well
-			Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
-			APP        NAME       PROJECT        TYPE       STATE        MANAGED BY ODO
-			app        %[1]s     %[2]s           nodejs     Pushed		 Yes
-			`, cmpName, commonVar.Project))))
-
-			By("checking that it shows components in all applications")
-			output = helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
-			Expect(output).To(ContainSubstring(cmpName))
-			Expect(output).To(ContainSubstring(cmpName2))
-
-			helper.DeleteDir(context2)
 		})
 
-	})
+		It("should show the component as 'Not Pushed'", func() {
+			output := helper.Cmd("odo", "list").ShouldPass().Out()
+			Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", "app", cmpName, commonVar.Project, "nodejs"))))
+		})
 
+		It("should show the component as 'Not Pushed' in JSON output", func() {
+			output := helper.Cmd("odo", "list", "-o", "json").ShouldPass().Out()
+			values := gjson.GetMany(output, "kind", "devfileComponents.0.kind", "devfileComponents.0.metadata.name", "devfileComponents.0.status.state")
+			expected := []string{"List", "Component", cmpName, "Not Pushed"}
+			Expect(helper.GjsonExactMatcher(values, expected)).To(Equal(true))
+		})
+
+		When("the first component is pushed and a second component is created in different application", func() {
+			var context2 string
+			var cmpName2 string
+			var appName string
+
+			BeforeEach(func() {
+				output := helper.Cmd("odo", "push").ShouldPass().Out()
+				Expect(output).To(ContainSubstring("Changes successfully pushed to component"))
+
+				context2 = helper.CreateNewContext()
+				cmpName2 = helper.RandString(6)
+				appName = helper.RandString(6)
+
+				helper.Cmd("odo", "create", "nodejs", "--project", commonVar.Project, "--app", appName, "--context", context2, cmpName2).ShouldPass()
+				helper.CopyExample(filepath.Join("source", "devfiles", "nodejs", "project"), context2)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile.yaml"), filepath.Join(context2, "devfile.yaml"))
+			})
+
+			AfterEach(func() {
+				helper.DeleteDir(context2)
+			})
+
+			It("should show the second component as 'NotPushed'", func() {
+				output := helper.Cmd("odo", "list", "--context", context2).ShouldPass().Out()
+				Expect(helper.Suffocate(output)).To(ContainSubstring(helper.Suffocate(fmt.Sprintf("%s%s%s%sNotPushed", appName, cmpName2, commonVar.Project, "nodejs"))))
+			})
+
+			It("should show the second component as 'Not Pushed' in JSON output", func() {
+				output := helper.Cmd("odo", "list", "-o", "json", "--context", context2).ShouldPass().Out()
+				values := gjson.GetMany(output, "kind", "devfileComponents.0.kind", "devfileComponents.0.metadata.name", "devfileComponents.0.status.state")
+				expected := []string{"List", "Component", cmpName2, "Not Pushed"}
+				Expect(helper.GjsonExactMatcher(values, expected)).To(Equal(true))
+			})
+
+			When("second component is pushed", func() {
+				BeforeEach(func() {
+					output2 := helper.Cmd("odo", "push", "--context", context2).ShouldPass().Out()
+					Expect(output2).To(ContainSubstring("Changes successfully pushed to component"))
+				})
+
+				It("should show components in the current application in 'Pushed' state", func() {
+					output := helper.Cmd("odo", "list", "--project", commonVar.Project).ShouldPass().Out()
+					// this test makes sure that a devfile component doesn't show up as an s2i component as well
+					Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
+					APP        NAME       PROJECT        TYPE       STATE        MANAGED BY ODO
+					app        %[1]s     %[2]s           nodejs     Pushed                Yes
+					`, cmpName, commonVar.Project))))
+				})
+
+				It("should show components in the current application in 'Pushed' state in JSON output", func() {
+					output := helper.Cmd("odo", "list", "-o", "json", "--project", commonVar.Project).ShouldPass().Out()
+					values := gjson.GetMany(output, "kind", "devfileComponents.0.kind", "devfileComponents.0.metadata.name", "devfileComponents.0.status.state")
+					expected := []string{"List", "Component", cmpName, "Pushed"}
+					Expect(helper.GjsonExactMatcher(values, expected)).To(Equal(true))
+				})
+
+				It("should show components in all applications", func() {
+					output := helper.Cmd("odo", "list", "--all-apps", "--project", commonVar.Project).ShouldPass().Out()
+					Expect(output).To(ContainSubstring(cmpName))
+					Expect(output).To(ContainSubstring(cmpName2))
+				})
+			})
+		})
+	})
 })

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -162,7 +162,7 @@ var _ = Describe("odo devfile storage command tests", func() {
 			Expect(len(PVCs)).To(Equal(1))
 		})
 
-		It("should create and output in json format", func() {
+		It("should create, delete and output in json format", func() {
 			args := []string{"create", "nodejs", cmpName, "--context", commonVar.Context, "--project", commonVar.Project}
 			helper.Cmd("odo", args...).ShouldPass()
 
@@ -171,9 +171,13 @@ var _ = Describe("odo devfile storage command tests", func() {
 
 			actualJSONStorage := helper.Cmd("odo", "storage", "create", "mystorage", "--path=/opt/app-root/src/storage/", "--size=1Gi", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
 			values := gjson.GetMany(actualJSONStorage, "kind", "metadata.name", "spec.size", "spec.path")
-			expected := []string{"storage", "mystorage", "1Gi", "/opt/app-root/src/storage/"}
+			expected := []string{"Storage", "mystorage", "1Gi", "/opt/app-root/src/storage/"}
 			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 
+			deleteJSONStorage := helper.Cmd("odo", "storage", "delete", "mystorage", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
+			deleteValues := gjson.GetMany(deleteJSONStorage, "kind", "status", "message", "details.name", "details.kind")
+			deleteExpected := []string{"Status", "Success", "Deleted storage", "mystorage", "Storage"}
+			Expect(helper.GjsonMatcher(deleteValues, deleteExpected)).To(Equal(true))
 		})
 	})
 
@@ -257,10 +261,9 @@ var _ = Describe("odo devfile storage command tests", func() {
 			helper.Cmd("odo", "storage", "create", "mystorage", "--path=/opt/app-root/src/storage/", "--size=1Gi", "--context", commonVar.Context).ShouldPass()
 
 			actualStorageList := helper.Cmd("odo", "storage", "list", "--context", commonVar.Context, "-o", "json").ShouldPass().Out()
-			valuesSL := gjson.GetMany(actualStorageList, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.size", "items.0.spec.containerName", "items.0.status")
-			expectedSL := []string{"List", "storage", "mystorage", "1Gi", "runtime", "Not Pushed"}
+			valuesSL := gjson.GetMany(actualStorageList, "kind", "items.0.kind", "items.0.metadata.name", "items.0.spec.size", "items.0.spec.path", "items.0.spec.containerName", "items.0.status")
+			expectedSL := []string{"List", "Storage", "mystorage", "1Gi", "/opt/app-root/src/storage/", "runtime", "Not Pushed"}
 			Expect(helper.GjsonMatcher(valuesSL, expectedSL)).To(Equal(true))
-
 		})
 	})
 

--- a/tests/integration/generic_test.go
+++ b/tests/integration/generic_test.go
@@ -86,8 +86,8 @@ var _ = Describe("odo generic", func() {
 		// odo project create foobar -o json
 		It("should be able to create project and show output in json format", func() {
 			actual := helper.Cmd("odo", "project", "create", projectName, "-o", "json").ShouldPass().Out()
-			values := gjson.GetMany(actual, "kind", "message")
-			expected := []string{"Project", "is ready for use"}
+			values := gjson.GetMany(actual, "kind", "metadata.name", "status.active")
+			expected := []string{"Project", projectName, "true"}
 			Expect(helper.GjsonMatcher(values, expected)).To(Equal(true))
 		})
 	})
@@ -123,7 +123,7 @@ var _ = Describe("odo generic", func() {
 
 			actual := helper.Cmd("odo", "project", "delete", projectName, "-o", "json").ShouldPass().Out()
 			valuesDel := gjson.GetMany(actual, "kind", "message")
-			expectedDel := []string{"Project", "Deleted project"}
+			expectedDel := []string{"Status", "Deleted project"}
 			Expect(helper.GjsonMatcher(valuesDel, expectedDel)).To(Equal(true))
 
 		})

--- a/website/docs/command-reference/json-output.md
+++ b/website/docs/command-reference/json-output.md
@@ -1,12 +1,12 @@
 ---
 title: JSON Output
-sidebar_position: 2
+sidebar_position: 1
 ---
 # JSON Output
 
 The `odo` commands that output some content generally accept a `-o json` flag to output this content in a JSON format, suitable for other programs to parse this output more easily.
 
-The output structure is similar to Kubernetes resources, with `Kind`, `apiVersion`, `metadata` ,`spec` and `status` fields.
+The output structure is similar to Kubernetes resources, with `kind`, `apiVersion`, `metadata` ,`spec` and `status` fields.
 
 List commands return a `List` resource, containing an `items` (or similar) field listing the items of the list, each item being also similar to Kubernetes resources.
 

--- a/website/docs/using-odo/json-output.md
+++ b/website/docs/using-odo/json-output.md
@@ -1,0 +1,43 @@
+---
+title: JSON Output
+sidebar_position: 2
+---
+# JSON Output
+
+The `odo` commands that output some content generally accept a `-o json` flag to output this content in a JSON format, suitable for other programs to parse this output more easily.
+
+The output structure is similar to Kubernetes resources, with `Kind`, `apiVersion`, `metadata` ,`spec` and `status` fields.
+
+List commands return a `List` resource, containing an `items` (or similar) field listing the items of the list, each item being also similar to Kubernetes resources.
+
+Delete commands return a `Status` resource; see the [Status Kubernetes resource](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/status/).
+
+Other commands return a resource associated with the command (`Application`, `Storage`', `URL`, etc).
+
+The exhaustive list of commands accepting the `-o json` flag is currently:
+
+| commands                       | Kind (version)                          | Kind (version) of list items                                 | Complete content?         | 
+|--------------------------------|-----------------------------------------|--------------------------------------------------------------|---------------------------|
+| odo application describe       | Application (odo.dev/v1alpha1)          | *n/a*                                                        |no                         |
+| odo application list           | List (odo.dev/v1alpha1)                 | Application (odo.dev/v1alpha1)                               | ?                         |
+| odo catalog list components    | List (odo.dev/v1alpha1)                 | ComponentType (odo.dev/v1alpha1) (s2i) / *missing* (devfile) | yes (s2i) / yes (devfile) |
+| odo catalog list services      | List (odo.dev/v1alpha1)                 | ClusterServiceVersion (operators.coreos.com/v1alpha1)        | ?                         |
+| odo catalog describe component | *missing*                               | *n/a*                                                        | yes                       |
+| odo catalog describe service   | CRDDescription (odo.dev/v1alpha1)       | *n/a*                                                        | yes                       |
+| odo component create           | Component (odo.dev/v1alpha1)            | *n/a*                                                        | yes                       |
+| odo component describe         | Component (odo.dev/v1alpha1)            | *n/a*                                                        | yes                       |
+| odo component list             | List (odo.dev/v1alpha1)                 | Component (odo.dev/v1alpha1)                                 | yes                       |
+| odo config view                | DevfileConfiguration (odo.dev/v1alpha1) | *n/a*                                                        | yes                       |
+| odo debug info                 | OdoDebugInfo (odo.dev/v1alpha1)         | *n/a*                                                        | yes                       |
+| odo env view                   | EnvInfo (odo.dev/v1alpha1)              | *n/a*                                                        | yes                       |
+| odo preference view            | PreferenceList (odo.dev/v1alpha1)       | *n/a*                                                        | yes                       |
+| odo project create             | Project (odo.dev/v1alpha1)              | *n/a*                                                        | yes                       |
+| odo project delete             | Status (v1)                             | *n/a*                                                        | yes                       |
+| odo project get                | Project (odo.dev/v1alpha1)              | *n/a*                                                        | yes                       |
+| odo project list               | List (odo.dev/v1alpha1)                 | Project (odo.dev/v1alpha1)                                   | yes                       |
+| odo registry list              | List (odo.dev/v1alpha1)                 | *missing*                                                    | yes                       |
+| odo service list               | *missing*                               | *depending on services types*                                | ?                         |
+| odo storage create             | Storage (odo.dev/v1alpha1)              | *n/a*                                                        | yes                       |
+| odo storage delete             | Status (v1)                             | *n/a*                                                        | yes                       |
+| odo storage list               | List (odo.dev/v1alpha1)                 | Storage (odo.dev/v1alpha1)                                   | yes                       |
+| odo url list                   | List (odo.dev/v1alpha1)                 | URL (odo.dev/v1alpha1)                                       | yes                       |

--- a/website/docs/using-odo/json-output.md
+++ b/website/docs/using-odo/json-output.md
@@ -20,7 +20,7 @@ The exhaustive list of commands accepting the `-o json` flag is currently:
 |--------------------------------|-----------------------------------------|--------------------------------------------------------------|---------------------------|
 | odo application describe       | Application (odo.dev/v1alpha1)          | *n/a*                                                        |no                         |
 | odo application list           | List (odo.dev/v1alpha1)                 | Application (odo.dev/v1alpha1)                               | ?                         |
-| odo catalog list components    | List (odo.dev/v1alpha1)                 | ComponentType (odo.dev/v1alpha1) (s2i) / *missing* (devfile) | yes (s2i) / yes (devfile) |
+| odo catalog list components    | List (odo.dev/v1alpha1)                 | *missing* | yes |
 | odo catalog list services      | List (odo.dev/v1alpha1)                 | ClusterServiceVersion (operators.coreos.com/v1alpha1)        | ?                         |
 | odo catalog describe component | *missing*                               | *n/a*                                                        | yes                       |
 | odo catalog describe service   | CRDDescription (odo.dev/v1alpha1)       | *n/a*                                                        | yes                       |


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What does this PR do / why we need it:

#### Refactored the code for the JSON output of the following commands:

- `odo debug info`
- `odo env view`
- `odo project create`
- `odo project delete`
- `odo project get`
- `odo project list`
- `odo storage create`
- `odo storage delete`
- `odo url create`
- `odo url list`
- `odo component list`

Main changes:
- `project.GetMachineReadableFormat` function renamed to `project.NewProject` (and similar for other kinds)
- `project.getMachineReadableFormatForList` renamed to `project.NewProjectList` (and similar for other kinds)
- `(o Project) HumanReadableOutput` created (and similar for other kinds)

#### Kinds are capitalized:
- url -> URL
- storage -> Storage

#### Messages are not included in the returned value:

There are no `message` fields in the odo objects (Project, Storage, etc). 

$ odo project create test1 -o json
{
	"kind": "Project",
	"apiVersion": "odo.dev/v1alpha1",
	"metadata": {
		"name": "test1",
		"namespace": "test1",
		"creationTimestamp": null
	},
~~"message": "Project 'test1' is ready for use"~~
}

#### Delete commands return a `Status` object:

APIs generally does not return the deleted object. If we want to try to be compatible with other Kubernetes CLIs/APIs, we could use the `Status` kind returned by calls to the Kubernetes API  DELETE endpoints (example: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#delete-delete-a-deployment).

```
$ odo project delete prj2 -o json
{
	"kind": "Status",
	"apiVersion": "v1",
	"metadata": {},
	"status": "Success",
	"message": "Deleted project : prj2",
	"details": {
		"name": "prj2",
		"kind": "Project"
	}
}
```

**Which issue(s) this PR fixes**:

Related to #2784 

**PR acceptance criteria**:

- [x] Unit test 

- [x] Integration test 
  - [x] odo debug info
  - [x] odo env view
  - [x] odo project create
  - [x] odo project delete
  - [x] odo project get
  - [x] odo project list
  - [x] odo storage list
  - [x] odo storage create
  - [x] odo storage delete
  - [x] odo url create
  - [x] odo url list
  - [x] odo component list
- [x] Documentation 

- [ ] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
