### PR TITLE
Adds a column in odo list output to indicate components created by odo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 ### Feature/Enhancements
 
+- Added a column in odo list output to indicate components created by odo ([#4962](https://github.com/openshift/odo/pull/4962))
+
 ### Bug Fixes
 
 ### Tests

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,10 @@ test-plugin-handler: ## Run odo plugin handler tests
 test-cmd-devfile-catalog: ## Run odo catalog devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile catalog command tests" tests/integration/devfile/
 
+.PHONY: test-cmd-devfile-list
+test-cmd-devfile-list: ## Run odo list devfile command tests
+	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo list with devfile" tests/integration/devfile/
+
 .PHONY: test-cmd-devfile-create
 test-cmd-devfile-create: ## Run odo create devfile command tests
 	$(RUN_GINKGO) $(GINKGO_FLAGS) -focus="odo devfile create command tests" tests/integration/devfile/

--- a/pkg/odo/cli/component/list.go
+++ b/pkg/odo/cli/component/list.go
@@ -297,12 +297,14 @@ func (lo *ListOptions) Run(cmd *cobra.Command) (err error) {
 
 	if !log.IsJSON() {
 
-		if len(devfileComponents) != 0 {
+		if len(devfileComponents) != 0 || len(otherComps) != 0 {
 			lo.hasDevfileComponents = true
-			fmt.Fprintln(w, "Devfile Components: ")
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE")
+			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "STATE", "\t", "MANAGED BY ODO")
 			for _, comp := range devfileComponents {
-				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State)
+				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Status.State, "\t", "Yes")
+			}
+			for _, comp := range otherComps {
+				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", component.StateTypePushed, "\t", "No")
 			}
 			w.Flush()
 
@@ -318,15 +320,6 @@ func (lo *ListOptions) Run(cmd *cobra.Command) (err error) {
 			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE", "\t", "SOURCETYPE", "\t", "STATE")
 			for _, comp := range s2iComponents {
 				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type, "\t", comp.Spec.SourceType, "\t", comp.Status.State)
-			}
-			w.Flush()
-		}
-		if len(otherComps) != 0 {
-			w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
-			fmt.Fprintln(w, "Other Components running on the cluster(read-only): ")
-			fmt.Fprintln(w, "APP", "\t", "NAME", "\t", "PROJECT", "\t", "TYPE")
-			for _, comp := range otherComps {
-				fmt.Fprintln(w, comp.Spec.App, "\t", comp.Name, "\t", comp.Namespace, "\t", comp.Spec.Type)
 			}
 			w.Flush()
 		}

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -645,7 +645,7 @@ func componentTests(args ...string) {
 
 			// check the status of devfile component
 			stdout := helper.Cmd("odo", "list", "--context", commonVar.Context).ShouldPass().Out()
-			helper.MatchAllInOutput(stdout, []string{cmpName, "Devfile Components", "Pushed"})
+			helper.MatchAllInOutput(stdout, []string{cmpName, "Pushed"})
 
 			// verify the url
 			stdout = helper.Cmd("odo", "url", "list", "--context", commonVar.Context).ShouldPass().Out()
@@ -688,7 +688,7 @@ func componentTests(args ...string) {
 
 		// verifyListOutput verifies if the components not managed by odo are listed
 		var verifyListOutput = func(output string, componentList []compStruct) {
-			Expect(output).To(ContainSubstring("Other Components running on the cluster(read-only)"))
+			helper.MatchAllInOutput(output, []string{"MANAGED BY ODO", "No"})
 			for _, comp := range componentList {
 				Expect(output).To(ContainSubstring(comp.Name))
 				Expect(output).To(ContainSubstring(comp.App))

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -61,9 +61,8 @@ var _ = Describe("odo list with devfile", func() {
 			output = helper.Cmd("odo", "list", "--project", commonVar.Project).ShouldPass().Out()
 			// this test makes sure that a devfile component doesn't show up as an s2i component as well
 			Expect(helper.Suffocate(output)).To(Equal(helper.Suffocate(fmt.Sprintf(`
-			Devfile Components:
-			APP        NAME       PROJECT        TYPE       STATE
-			app        %[1]s     %[2]s           nodejs     Pushed
+			APP        NAME       PROJECT        TYPE       STATE        MANAGED BY ODO
+			app        %[1]s     %[2]s           nodejs     Pushed		 Yes
 			`, cmpName, commonVar.Project))))
 
 			By("checking that it shows components in all applications")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What does this PR do / why we need it**:

It adds a column in odo list output to indicate which components are created by odo.

**Which issue(s) this PR fixes**:

Fixes #4808

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Deploy some components in the same and different apps.
- `odo list`, `odo list --app <app-name>` && `odo list --all-apps` should display a column indicating which components are managed by odo.

Example output:
```
$ odo list --all-apps 
APP         NAME                         PROJECT     TYPE       STATE      MANAGED BY ODO
new-app     nodejs-nodejs-basic-ummk     blah        nodejs     Pushed     No
```