### PR TITLE
Send telemetry data on user interrupt

### DIFF
--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -89,6 +89,7 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt, os.Kill}
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, captureSignals...)
+	defer signal.Stop(c)
 	go commonutil.StartSignalWatcher(captureSignals, func() {
 		receivedSignal := <-c
 		scontext.SetSignal(cmd.Context(), receivedSignal)

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -11,11 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/AlecAivazis/survey.v1/terminal"
-
 	commonutil "github.com/openshift/odo/pkg/util"
-
 	"github.com/pkg/errors"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 
 	"github.com/openshift/odo/pkg/version"
 
@@ -41,7 +39,7 @@ type Runnable interface {
 
 func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	var err error
-	var startTime time.Time
+	startTime := time.Now()
 	cfg, _ := preference.New()
 	disableTelemetry, _ := strconv.ParseBool(os.Getenv(segment.DisableTelemetryEnv))
 
@@ -69,7 +67,12 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 	// set value for telemetry status in context so that we do not need to call IsTelemetryEnabled every time to check its status
 	scontext.SetTelemetryStatus(cmd.Context(), segment.IsTelemetryEnabled(cfg))
 
-	startTime = time.Now()
+	// Send data to telemetry in case of user interrupt
+	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}
+	go commonutil.StartSignalWatcher(captureSignals, func(receivedSignals os.Signal) {
+		scontext.SetSignal(cmd.Context(), receivedSignals)
+		startTelemetry(cmd, errors.Wrapf(terminal.InterruptErr, "user interrupted the command execution"), startTime)
+	})
 
 	// CheckMachineReadableOutput
 	// fixes / checks all related machine readable output functions
@@ -84,12 +87,6 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 		startTelemetry(cmd, err, startTime)
 	}
 	util.LogErrorAndExit(err, "")
-
-	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}
-	go commonutil.StartSignalWatcher(captureSignals, func(receivedSignals os.Signal) {
-		scontext.SetSignal(cmd.Context(), receivedSignals)
-		startTelemetry(cmd, errors.Wrapf(terminal.InterruptErr, "user interrupted the command execution"), startTime)
-	})
 
 	err = o.Validate()
 	if err != nil {

--- a/pkg/odo/genericclioptions/runnable.go
+++ b/pkg/odo/genericclioptions/runnable.go
@@ -69,8 +69,8 @@ func GenericRun(o Runnable, cmd *cobra.Command, args []string) {
 
 	// Send data to telemetry in case of user interrupt
 	captureSignals := []os.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}
-	go commonutil.StartSignalWatcher(captureSignals, func(receivedSignals os.Signal) {
-		scontext.SetSignal(cmd.Context(), receivedSignals)
+	go commonutil.StartSignalWatcher(captureSignals, func(receivedSignal os.Signal) {
+		scontext.SetSignal(cmd.Context(), receivedSignal)
 		startTelemetry(cmd, errors.Wrapf(terminal.InterruptErr, "user interrupted the command execution"), startTime)
 	})
 

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"os"
 	"sync"
 
 	"github.com/openshift/odo/pkg/util"
@@ -83,6 +84,10 @@ func SetClusterType(ctx context.Context, client *occlient.Client) {
 // SetTelemetryStatus sets telemetry status before a command is run
 func SetTelemetryStatus(ctx context.Context, isEnabled bool) {
 	setContextProperty(ctx, TelemetryStatus, isEnabled)
+}
+
+func SetSignal(ctx context.Context, signal os.Signal) {
+	setContextProperty(ctx, "Signal", signal)
 }
 
 // GetTelemetryStatus gets the telemetry status that is set before a command is run

--- a/pkg/segment/context/context.go
+++ b/pkg/segment/context/context.go
@@ -87,7 +87,7 @@ func SetTelemetryStatus(ctx context.Context, isEnabled bool) {
 }
 
 func SetSignal(ctx context.Context, signal os.Signal) {
-	setContextProperty(ctx, "Signal", signal)
+	setContextProperty(ctx, "receivedSignal", signal.String())
 }
 
 // GetTelemetryStatus gets the telemetry status that is set before a command is run

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -120,6 +120,7 @@ func (c *Client) Upload(data TelemetryData) error {
 		properties = properties.Set("error", data.Properties.Error).Set("error-type", data.Properties.ErrorType)
 	}
 
+	fmt.Println("Sending data to telemetry")
 	// queue the data that has telemetry information
 	return c.SegmentClient.Enqueue(analytics.Track{
 		UserId:     userId,

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -120,7 +120,6 @@ func (c *Client) Upload(data TelemetryData) error {
 		properties = properties.Set("error", data.Properties.Error).Set("error-type", data.Properties.ErrorType)
 	}
 
-	fmt.Println("Sending data to telemetry")
 	// queue the data that has telemetry information
 	return c.SegmentClient.Enqueue(analytics.Track{
 		UserId:     userId,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1461,7 +1461,7 @@ func GitSubDir(srcPath, destinationPath, subDir string) error {
 
 // gitSubDir handles subDir for git components
 func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem) error {
-	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT}, func() {
+	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}, func() {
 		err := cleanDir(destinationPath, map[string]bool{
 			"devfile.yaml": true,
 		}, fs)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1408,13 +1408,13 @@ func copyDirWithFS(src string, dst string, fs filesystem.Filesystem) error {
 }
 
 // StartSignalWatcher watches for signals and handles the situation before exiting the program
-func StartSignalWatcher(watchSignals []os.Signal, handle func()) {
+func StartSignalWatcher(watchSignals []os.Signal, handle func(receivedSignals os.Signal)) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, watchSignals...)
 	defer signal.Stop(signals)
 
-	<-signals
-	handle()
+	receivedSignals := <-signals
+	handle(receivedSignals)
 	// exit here to stop spinners from rotating
 	os.Exit(1)
 }
@@ -1461,7 +1461,7 @@ func GitSubDir(srcPath, destinationPath, subDir string) error {
 
 // gitSubDir handles subDir for git components
 func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem) error {
-	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}, func() {
+	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}, func(receivedSignals os.Signal) {
 		err := cleanDir(destinationPath, map[string]bool{
 			"devfile.yaml": true,
 		}, fs)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1408,13 +1408,13 @@ func copyDirWithFS(src string, dst string, fs filesystem.Filesystem) error {
 }
 
 // StartSignalWatcher watches for signals and handles the situation before exiting the program
-func StartSignalWatcher(watchSignals []os.Signal, handle func(receivedSignals os.Signal)) {
+func StartSignalWatcher(watchSignals []os.Signal, handle func(receivedSignal os.Signal)) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, watchSignals...)
 	defer signal.Stop(signals)
 
-	receivedSignals := <-signals
-	handle(receivedSignals)
+	receivedSignal := <-signals
+	handle(receivedSignal)
 	// exit here to stop spinners from rotating
 	os.Exit(1)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1407,14 +1407,10 @@ func copyDirWithFS(src string, dst string, fs filesystem.Filesystem) error {
 	return nil
 }
 
-// StartSignalWatcher watches for kill,interrupt etc signals and cleans up temp files and folders
-func StartSignalWatcher(handle func()) {
+// StartSignalWatcher watches for signals and handles the situation before exiting the program
+func StartSignalWatcher(watchSignals []os.Signal, handle func()) {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
+	signal.Notify(signals, watchSignals...)
 	defer signal.Stop(signals)
 
 	<-signals
@@ -1465,7 +1461,7 @@ func GitSubDir(srcPath, destinationPath, subDir string) error {
 
 // gitSubDir handles subDir for git components
 func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem) error {
-	go StartSignalWatcher(func() {
+	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT}, func() {
 		err := cleanDir(destinationPath, map[string]bool{
 			"devfile.yaml": true,
 		}, fs)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1461,7 +1461,7 @@ func GitSubDir(srcPath, destinationPath, subDir string) error {
 
 // gitSubDir handles subDir for git components
 func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem) error {
-	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}, func(receivedSignals os.Signal) {
+	go StartSignalWatcher([]os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt}, func(_ os.Signal) {
 		err := cleanDir(destinationPath, map[string]bool{
 			"devfile.yaml": true,
 		}, fs)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
This PR allows sending telemetry data for odo push on user interrupt.

**Which issue(s) this PR fixes**:

Fixes #4929 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
```sh
odo preference set consenttelemetry true -f
odo create java-openliberty myproject --starter
odo push     <- interrupt the program
Ctrl^C
```

See if telemetry data was sent to Segment.
Sample telemetry data - 
```
map[string]interface{}{
    "clusterType": "kubernetes",
    "componentType": "docker",
    "duration(ms)": 995,
    "error": "User quit.",
    "error-type": "*errors.fundamental",
    "success": false,
    "tty": true,
    "version": "odo v2.2.3 (2e661bf71)",
  }
```