### PR TITLE
Add deprecation warnings for s2i components

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 - Added a column in odo list output to indicate components created by odo ([#4962](https://github.com/openshift/odo/pull/4962))
 - Fix description for "odo link" command ([#4930](https://github.com/openshift/odo/pull/4930))
+- Add deprecation warnings for s2i components([#4967](https://github.com/openshift/odo/issues/4967))
 
 ### Bug Fixes
 

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -116,9 +116,11 @@ odo catalog list components
 %[1]s nodejs frontend --context ./frontend
 
 # Create new Java component with binary named sample.jar in './target' directory; this flag is specific to S2I
+# DEPRECATED: Use the devfile to create a component
 %[1]s java:8 --s2i --binary target/sample.jar
 
 # Create new Node.js component with source from remote git repository; this flag is specific to S2I
+# DEPRECATED: Use the devfile to create a component
 %[1]s nodejs --s2i --git https://github.com/openshift/nodejs-ex.git
 
 # Create new Node.js component with custom ports and environment variables
@@ -352,6 +354,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 	err = co.checkConflictingFlags()
 	if err != nil {
 		return
+	}
+
+	if co.forceS2i {
+		// Note: Remove this deprecation warning once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+		log.Deprecate("S2I components", "consider creating a devfile component instead")
 	}
 
 	var catalogList catalog.ComponentTypeList
@@ -1052,6 +1059,12 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	completion.RegisterCommandHandler(componentCreateCmd, completion.CreateCompletionHandler)
 	completion.RegisterCommandFlagHandler(componentCreateCmd, "context", completion.FileCompletionHandler)
 	completion.RegisterCommandFlagHandler(componentCreateCmd, "binary", completion.FileCompletionHandler)
+
+	// Note: Remove these deprecation warnings once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+	for _, flagName := range []string{"s2i", "git", "ref", "binary"} {
+		flag := componentCreateCmd.Flag(flagName)
+		flag.Deprecated = "support for the S2I components has been deprecated, consider creating a devfile component instead."
+	}
 
 	return componentCreateCmd
 }

--- a/pkg/odo/cli/component/push.go
+++ b/pkg/odo/cli/component/push.go
@@ -88,8 +88,17 @@ func (po *PushOptions) GetComponentContext() string {
 // Complete completes push args
 func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	po.CompleteDevfilePath()
+	devfileExists := util.CheckPathExists(po.DevfilePath)
 
-	if util.CheckPathExists(po.DevfilePath) {
+	if !devfileExists {
+		// Note: Remove this deprecation warning once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+		log.Deprecate(
+			"S2I components",
+			"Convert your existing S2I component to a Devfile component with `odo utils convert-to-devfile`, or consider re-creating with a Devfile component.",
+		)
+	}
+
+	if devfileExists {
 
 		po.Devfile, err = devfile.ParseFromFile(po.DevfilePath)
 		if err != nil {

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -115,24 +115,27 @@ func componentTests(args ...string) {
 
 	It("should print deprecation warning when creating a S2I component", func() {
 		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
-		stdOut := helper.Cmd("odo", "create", "nodejs", "--s2i", "--context", commonVar.Context).ShouldPass().Out()
+		// We are using .Err() since warnings are considered as a part of Error
+		stdOut := helper.Cmd("odo", "create", "nodejs", "--s2i", "--context", commonVar.Context).ShouldPass().Err()
 		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
 	})
 
 	It("should print deprecation warning when creating and pushing a S2I git component", func() {
 		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
-		stdOut := helper.Cmd("odo", "create", "nodejs", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", commonVar.Context).ShouldPass().Out()
+		// We are using .Err() since warnings are considered as a part of Error
+		stdOut := helper.Cmd("odo", "create", "nodejs", "--s2i", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", commonVar.Context).ShouldPass().Err()
 		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
-		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Out()
+		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Err()
 		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
 	})
 
 	It("should print deprecation warning when creating and pushing a S2I binary component", func() {
 		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
 		helper.CopyExample(filepath.Join("binary", "java", "openjdk"), commonVar.Context)
-		stdOut := helper.Cmd("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(commonVar.Context, "sb.jar"), "--context", commonVar.Context).ShouldPass().Out()
+		// We are using .Err() since warnings are considered as a part of Error
+		stdOut := helper.Cmd("odo", "create", "java:8", "sb-jar-test", "--s2i", "--binary", filepath.Join(commonVar.Context, "sb.jar"), "--context", commonVar.Context).ShouldPass().Err()
 		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
-		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Out()
+		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Err()
 		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
 	})
 

--- a/tests/integration/component.go
+++ b/tests/integration/component.go
@@ -113,6 +113,29 @@ func componentTests(args ...string) {
 		Expect(val).To(Equal("BAR"))
 	})
 
+	It("should print deprecation warning when creating a S2I component", func() {
+		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+		stdOut := helper.Cmd("odo", "create", "nodejs", "--s2i", "--context", commonVar.Context).ShouldPass().Out()
+		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
+	})
+
+	It("should print deprecation warning when creating and pushing a S2I git component", func() {
+		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+		stdOut := helper.Cmd("odo", "create", "nodejs", "--git", "https://github.com/openshift/nodejs-ex.git", "--context", commonVar.Context).ShouldPass().Out()
+		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
+		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Out()
+		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
+	})
+
+	It("should print deprecation warning when creating and pushing a S2I binary component", func() {
+		// Note: Remove these tests once the S2I cleanup is done, see https://github.com/openshift/odo/issues/4932.
+		helper.CopyExample(filepath.Join("binary", "java", "openjdk"), commonVar.Context)
+		stdOut := helper.Cmd("odo", "create", "java:8", "sb-jar-test", "--binary", filepath.Join(commonVar.Context, "sb.jar"), "--context", commonVar.Context).ShouldPass().Out()
+		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
+		stdOut = helper.Cmd("odo", "push", "--context", commonVar.Context).ShouldRun().Out()
+		Expect(stdOut).To(ContainSubstring("S2I components Deprecated"))
+	})
+
 	When("in context directory", func() {
 
 		BeforeEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What does this PR do / why we need it**:
This PR adds deprecation warning for S2I components on create and push.

**Which issue(s) this PR fixes**:

Fixes #4951

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] Update changelog

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
1. `odo create --help`: Run the help command and see deprecation notes for s2i, ref, git, and binary flags.
2. `odo create --s2i python mypy`
3. `odo create nodejs --s2i --git https://github.com/openshift/nodejs-ex.git` ; `odo push`
4. `touch sample.jar; odo create --s2i --binary sample.jar` ; `odo push`

**Note**: The deprecation warning message is not in its best state, I would appreciate if reviewers can suggest a better guidance  to the users regarding the next step.