### PR TITLE
Fix reports directory for operatorhub nightly tests

### DIFF
--- a/scripts/openshiftci-Nightly-SBO-tests.sh
+++ b/scripts/openshiftci-Nightly-SBO-tests.sh
@@ -30,6 +30,6 @@ oc whoami
 # Operatorhub integration tests
 make test-operator-hub
 
-cp -r reports $ARTIFACT_DIR 
+cp -r tests/reports $ARTIFACT_DIR 
 
 oc logout

--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -40,7 +40,6 @@ if [ $error ]; then
     exit -1
 fi
 
-cp -r reports $ARTIFACT_DIR 
-cp -r tests/reports/ $ARTIFACT_DIR/reports/
+cp -r reports tests/reports $ARTIFACT_DIR 
 
 oc logout

--- a/scripts/openshiftci-periodic-tests.sh
+++ b/scripts/openshiftci-periodic-tests.sh
@@ -41,5 +41,6 @@ if [ $error ]; then
 fi
 
 cp -r reports $ARTIFACT_DIR 
+cp -r tests/reports/ $ARTIFACT_DIR/reports/
 
 oc logout

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -69,5 +69,6 @@ else
 fi
 
 cp -r reports $ARTIFACT_DIR
+cp -r tests/reports/ $ARTIFACT_DIR/reports/
 
 oc logout

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -68,7 +68,6 @@ else
     fi
 fi
 
-cp -r reports $ARTIFACT_DIR
-cp -r tests/reports/ $ARTIFACT_DIR/reports/
+cp -r reports tests/reports $ARTIFACT_DIR
 
 oc logout


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
This PR will fix nightly test build failure for reports path https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-odo-main-v4.8-operatorhub-integration-nightly/1423433739802775552#1:build-log.txt%3A535

As we only run operator hub tests on nightly. It generates reports under `tests` directory and we are searching into current `odo` directory currently. Hence it error out with `no such file or directory`

**Which issue(s) this PR fixes**:

Fixes #? 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Nightly test should not fail.