### PR TITLE
Fixes the usage of service create command with parameters and dry-run flag

### DIFF
--- a/pkg/odo/cli/service/operator_backend.go
+++ b/pkg/odo/cli/service/operator_backend.go
@@ -158,9 +158,10 @@ func (b *OperatorBackend) ValidateServiceCreate(o *CreateOptions) (err error) {
 			if exists {
 				return fmt.Errorf("service %q already exists; please provide a different name or delete the existing service first", svcFullName)
 			}
-
-			d.SetServiceName(o.ServiceName)
 		}
+
+		d.SetServiceName(o.ServiceName)
+
 		err = d.ValidateMetadataInCRD()
 		if err != nil {
 			return err

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -81,6 +81,14 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 					helper.Cmd("odo", "delete", "--all", "-f", "--context", commonVar.Context).ShouldPass().Out()
 				})
 
+				It("should try to create a service in dry run mode with some provided params", func() {
+					serviceName := helper.RandString(10)
+					output := helper.Cmd("odo", "service", "create", postgresDatabase, serviceName, "-p",
+						"databaseName=odo", "-p", "size=1", "-p", "databaseUser=odo", "-p",
+						"databaseStorageRequest=1Gi", "-p", "databasePassword=odopasswd", "--dry-run", "--context", commonVar.Context).ShouldPass().Out()
+					helper.MatchAllInOutput(output, []string{fmt.Sprintf("name: %s", serviceName), "odo", "odopasswd", "1Gi"})
+				})
+
 				When("creating a postgres operand with params", func() {
 					var operandName string
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

It fixes the usage of service create command with parameters and dry-run flag.

**Which issue(s) this PR fixes**:

Fixes #4813 and #4913 

**PR acceptance criteria**:

- [ ] Unit test 

- [X] Integration test 

- [ ] Documentation 

- [ ] Update changelog

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

- Running service create with the `--dry-run` flag and user provided parameters e.g `odo service create postgresql-operator.v0.1.1/Database -p databaseName=mydb -p databaseUser=user -p databasePassword=pass --dry-run` should display
```
      apiVersion: postgresql.dev4devs.com/v1alpha1
      kind: Database
      metadata:
        name: database
      spec:
        databaseName: mydb
        databasePassword: pass
        databaseUser: user
```