### PR TITLE
Removed QE members from top-level reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,7 +12,5 @@ reviewers:
 - mik-dass
 - mohammedzee1000
 - dharmit
-- prietyc123
 - valaparthvi
-- rnapoles-rh
-- anandrkskd
+- feloy

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -5,3 +5,13 @@ approvers:
 - prietyc123
 - anandrkskd
 - rnapoles-rh
+
+reviewers:
+- prietyc123
+- rnapoles-rh
+- anandrkskd
+- mohammedzee1000
+- valaparthvi
+- feloy
+- mik-dass
+- dharmit


### PR DESCRIPTION


/kind cleanup

**What does this PR do / why we need it**:
To ensure right folks get selected by the bot for reviews

**Which issue(s) this PR fixes**:

Fixes - NA