### PR TITLE
Add sonar rule to ignore 'duplicated string literals' error on test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,8 +19,12 @@ sonar.go.exclusions=**/vendor/**
 sonar.go.file.suffixes=.go
 
 # Ignore Issues on Multiple Criteria : Patterns to ignore issues on certain components and for certain coding rules.
-sonar.issue.ignore.multicriteria=g1
+sonar.issue.ignore.multicriteria=g1,g2
 
 # Ignore "Define a constant instead of duplicating this literal" rule on test files
 sonar.issue.ignore.multicriteria.g1.ruleKey=go:S1192
 sonar.issue.ignore.multicriteria.g1.resourceKey=**/*_test.go
+
+# Ignore "Define a constant instead of duplicating this literal" rule on all the files under tests/integration
+sonar.issue.ignore.multicriteria.g2.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.g2.resourceKey=tests/integration/*.go


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
This PR adds a new sonar rule to exclude all the files under tests/integration from the "duplicated string literals" error.
[See example](https://sonarcloud.io/project/issues?id=openshift_odo&open=AXsVq_A1ATb_4uWKYpVu&pullRequest=4927&resolved=false&types=CODE_SMELL).
**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
I am not sure if we can test it at the moment, we'll only know if this works once it is merged in.