### PR TITLE
Fix typo when there are no services

### DIFF
--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -48,7 +48,7 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 			return err
 		}
 	} else {
-		return fmt.Errorf("failed to list operator backed services, have you installed operators on the cluseter?")
+		return fmt.Errorf("failed to list operator backed services, have you installed operators on the cluster?")
 	}
 	return
 }

--- a/pkg/odo/cli/service/list.go
+++ b/pkg/odo/cli/service/list.go
@@ -48,7 +48,7 @@ func (o *ServiceListOptions) Complete(name string, cmd *cobra.Command, args []st
 			return err
 		}
 	} else {
-		return fmt.Errorf("failed to list operator backed services, have you installed operators on the cluster?")
+		return fmt.Errorf("failed to list Operator backed services, make sure you have installed the Operators on the cluster")
 	}
 	return
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Fixes typo in `odo service list` output

**Which issue(s) this PR fixes**:

Fixes N/A

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Run `odo service list` when no services are created in devfile.