### PR TITLE
Display default project value while creating a component interactively

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -447,6 +447,10 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 
 		// Configure the default namespace
 		var defaultComponentNamespace string
+		client, err := genericclioptions.Client()
+		if err == nil {
+			defaultComponentNamespace = client.GetCurrentProjectName()
+		}
 
 		var componentType string
 		var componentName string

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -445,13 +445,6 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 			co.interactive = true
 		}
 
-		// Configure the default namespace
-		var defaultComponentNamespace string
-		client, err := genericclioptions.Client()
-		if err == nil {
-			defaultComponentNamespace = client.GetCurrentProjectName()
-		}
-
 		var componentType string
 		var componentName string
 		var componentNamespace string
@@ -484,7 +477,11 @@ func (co *CreateOptions) Complete(name string, cmd *cobra.Command, args []string
 						return err
 					}
 				} else {
-					componentNamespace = ui.EnterDevfileComponentProject(defaultComponentNamespace)
+					client, err := genericclioptions.Client()
+					// if the user is logged in or if we have cluster information, display the default project
+					if err == nil {
+						componentNamespace = ui.EnterDevfileComponentProject(client.GetCurrentProjectName())
+					}
 				}
 			}
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
This PR fixes the missing default project value while creating a component interactively,
**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
_**Deleted KUBECONFIG**_:
1. `mv $HOME/.kube/config $HOME/.kube/movedConfig`
2. `odo create` - After entering component type and name, check if the current project shows up in while entering the project value, in this case it should be an empty string.
    ```sh
    $ odo create
    ? Which devfile component type do you wish to create  [Use arrows to move, ent? Which devfile component type do you wish to create java-maven
    ? What do you wish to name the new devfile component java-maven
    ? What project do you want the devfile component to be created in 
    ```
_**Logged out of the cluster**_
1. `odo logout`.
2. Run `odo create` interactively like above and check if the current project shows up in the default project value.
    ```sh
    $ odo create
    ? Which devfile component type do you wish to create  [Use arrows to move, ent? Which devfile component type do you wish to create java-maven
    ? What do you wish to name the new devfile component java-maven
    ? What project do you want the devfile component to be created in (default)
    ```
_**Logged into the cluster**_
1. `odo login -uuser -ppwd <cluster_url>`
2. Run `odo create` interactively like above and check if the current project shows up in the default project value.
    ```sh
    $ odo create
    ? Which devfile component type do you wish to create  [Use arrows to move, ent? Which devfile component type do you wish to create java-maven
    ? What do you wish to name the new devfile component java-maven
    ? What project do you want the devfile component to be created in (default)
    ```