### PR TITLE
Replace "nightly" tag with "next" in some integration tests devfiles

### DIFF
--- a/tests/e2escenarios/e2e_devfile_test.go
+++ b/tests/e2escenarios/e2e_devfile_test.go
@@ -33,6 +33,7 @@ var _ = Describe("odo devfile supported tests", func() {
 		projectDirPath = commonVar.Context + projectDir
 		helper.MakeDir(projectDirPath)
 		helper.Chdir(projectDirPath)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/examples/source/devfiles/nodejs/devfile-with-invalid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-invalid-events.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       endpoints:
         - name: "3000-tcp"
@@ -17,7 +17,7 @@ components:
       mountSources: true
   - name: "tools"
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       mountSources: true
       memoryLimit: 1024Mi
 commands:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-invalid-volmount.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-invalid-volmount.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       endpoints:
         - name: "3000-tcp"
           targetPort: 3000
@@ -19,7 +19,7 @@ components:
           path: /data
   - name: runtime2
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       mountSources: false
       volumeMounts:
         - name: invalidvol2

--- a/tests/examples/source/devfiles/nodejs/devfile-with-preStart.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-preStart.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       endpoints:
         - name: "3000-tcp"
@@ -17,7 +17,7 @@ components:
       mountSources: true
   - name: "tools"
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       mountSources: true
       memoryLimit: 1024Mi
 commands:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-valid-events.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       endpoints:
         - name: "3000-tcp"
@@ -17,7 +17,7 @@ components:
       mountSources: true
   - name: "tools"
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       mountSources: true
       memoryLimit: 1024Mi
 commands:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volume-components.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       env:
         - name: FOO
@@ -24,7 +24,7 @@ components:
         - name: secondvol
   - name: runtime2
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       mountSources: false
       volumeMounts:

--- a/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-volumes.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       env:
         - name: FOO
@@ -23,7 +23,7 @@ components:
           path: /data
   - name: runtime2
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       mountSources: false
       volumeMounts:

--- a/tests/examples/source/devfiles/nodejs/devfile-without-devinit.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-without-devinit.yaml
@@ -9,7 +9,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       env:
         - name: FOO

--- a/tests/examples/source/devfiles/nodejs/devfileSourceMapping.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfileSourceMapping.yaml
@@ -10,7 +10,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: quay.io/eclipse/che-nodejs10-ubi:nightly
+      image: quay.io/eclipse/che-nodejs10-ubi:next
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /test

--- a/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-metadataname-foobar.yaml
@@ -10,7 +10,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
@@ -20,7 +20,7 @@ components:
       mountSources: true
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"

--- a/tests/examples/source/devfiles/springboot/devfile-with-subDir.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile-with-subDir.yaml
@@ -11,7 +11,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
@@ -21,7 +21,7 @@ components:
           path: /data/cache/.m2
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"

--- a/tests/examples/source/devfiles/springboot/devfile.yaml
+++ b/tests/examples/source/devfiles/springboot/devfile.yaml
@@ -10,7 +10,7 @@ starterProjects:
 components:
   - name: tools
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       command: ['tail']
       args: [ '-f', '/dev/null']
@@ -20,7 +20,7 @@ components:
           path: /data/cache/.m2
   - name: runtime
     container:
-      image: quay.io/eclipse/che-java11-maven:nightly
+      image: quay.io/eclipse/che-java11-maven:next
       memoryLimit: 768Mi
       endpoints:
         - name: "8080-tcp"

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -373,3 +373,9 @@ func VerifyResourcesToBeDeleted(runner CliRunner, resources []ResourceInfo) {
 		runner.VerifyResourceToBeDeleted(item)
 	}
 }
+
+func SetDefaultDevfileRegistryAsStaging() {
+	const registryName string = "DefaultDevfileRegistry"
+	const addRegistryURL string = "https://registry.stage.devfile.io"
+	Cmd("odo", "registry", "update", registryName, addRegistryURL, "-f").ShouldPass()
+}

--- a/tests/integration/devfile/cmd_devfile_app_test.go
+++ b/tests/integration/devfile/cmd_devfile_app_test.go
@@ -18,6 +18,7 @@ var _ = Describe("odo devfile app command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		namespace = commonVar.Project
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -22,6 +22,7 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		// odo catalog list components.
 		// TODO: Investigate this more.
 		helper.Cmd("odo", "preference", "set", "registrycachetime", "0").ShouldPass()
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_config_test.go
+++ b/tests/integration/devfile/cmd_devfile_config_test.go
@@ -13,6 +13,7 @@ var _ = Describe("odo devfile config command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -27,6 +27,7 @@ var _ = Describe("odo devfile create command tests", func() {
 		cmpName = helper.RandString(6)
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -24,6 +24,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -32,6 +32,7 @@ var _ = Describe("odo devfile delete command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -19,6 +19,7 @@ var _ = Describe("odo devfile describe command tests", func() {
 		}
 
 		commonVar = helper.CommonBeforeEach()
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -19,6 +19,7 @@ var _ = Describe("odo devfile env command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -17,6 +17,7 @@ var _ = Describe("odo devfile exec command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -19,6 +19,7 @@ var _ = Describe("odo list with devfile", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -17,6 +17,7 @@ var _ = Describe("odo devfile log command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -25,6 +25,7 @@ var _ = Describe("odo devfile push command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -19,6 +19,7 @@ var _ = Describe("odo devfile registry command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_status_test.go
+++ b/tests/integration/devfile/cmd_devfile_status_test.go
@@ -30,6 +30,7 @@ var _ = Describe("odo devfile status command tests", func() {
 		namespace = commonVar.Project
 		context = commonVar.Context
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// Clean up after the test

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -19,6 +19,7 @@ var _ = Describe("odo devfile storage command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -17,6 +17,7 @@ var _ = Describe("odo devfile test command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -22,6 +22,7 @@ var _ = Describe("odo devfile url command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -24,6 +24,7 @@ var _ = Describe("odo devfile watch command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -11,10 +11,7 @@ func TestDebug(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Debug Suite")
 }
 
-var _ = BeforeSuite(func() {
-	const registryName string = "DefaultDevfileRegistry"
-	const addRegistryURL string = "https://registry.stage.devfile.io"
-
-	// Use staging OCI-based registry for tests to avoid a potential overload
-	helper.Cmd("odo", "registry", "update", registryName, addRegistryURL).ShouldPass()
+// Use JustBeforeEach to use the preference file set into BeforeEach
+var _ = JustBeforeEach(func() {
+	helper.SetDefaultDevfileRegistryAsStaging()
 })

--- a/tests/integration/devfile/devfile_suite_test.go
+++ b/tests/integration/devfile/devfile_suite_test.go
@@ -3,18 +3,9 @@ package devfile
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
 	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDevfiles(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Suite")
 }
-
-var _ = BeforeSuite(func() {
-	const registryName string = "DefaultDevfileRegistry"
-	const addRegistryURL string = "https://registry.stage.devfile.io"
-
-	// Use staging OCI-based registry for tests to avoid a potential overload
-	helper.Cmd("odo", "registry", "update", registryName, addRegistryURL, "-f").ShouldPass()
-})


### PR DESCRIPTION
/kind bug

**What does this PR do / why we need it**:

Some integration tests were using devfiles defining images non existing anymore: `quay.io/eclipse/che-java11-maven:nightly` and `quay.io/eclipse/che-nodejs10-ubi:nightly`.

Also, use JustBeforeEach instead of BeforeSuite to set the Registry preference, as GLOBALODOCONFIG is set on a BeforeEach block, in the `debug` directory`.

It is not possible to use `JustBeforeEach` on the `devfile` directory, as it is not executed fotr the following tests:

```
Context("devfile is modified", func() {
		// Tests https://github.com/openshift/odo/issues/3838
		ensureFilesSyncedTest := func(namespace string, shouldForcePush bool) {
                            [...]
                }

		Context("odo push -f is executed", func() {
			ensureFilesSyncedTest(commonVar.Project, true)
		})
		Context("odo push (without -f) is executed", func() {
			ensureFilesSyncedTest(commonVar.Project, false)
		})
	})
```

**Which issue(s) this PR fixes**:

Fixes #5027 

See https://github.com/devfile/registry/pull/67

See also https://github.com/eclipse/che/issues/19905