### PR TITLE
Debug test file cleanup left over

### DIFF
--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -328,7 +328,7 @@ func CommonAfterEach(commonVar CommonVar) {
 func GjsonMatcher(values []gjson.Result, expected []string) bool {
 	matched := 0
 	for i, v := range values {
-		if strings.Contains(v.String(), expected[i]) {
+		if CaseInsensitiveStringContains(v.String(), expected[i]) {
 			matched++
 		}
 	}
@@ -349,6 +349,12 @@ func GjsonExactMatcher(values []gjson.Result, expected []string) bool {
 	}
 	numVars := len(expected)
 	return matched == numVars
+}
+
+// CaseInsensitiveStringContains reports whether substr is within s, ignoring the case
+func CaseInsensitiveStringContains(s, substr string) bool {
+	s, substr = strings.ToLower(s), strings.ToLower(substr)
+	return strings.Contains(s, substr)
 }
 
 //SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -328,7 +328,7 @@ func CommonAfterEach(commonVar CommonVar) {
 func GjsonMatcher(values []gjson.Result, expected []string) bool {
 	matched := 0
 	for i, v := range values {
-		if CaseInsensitiveStringContains(v.String(), expected[i]) {
+		if strings.Contains(v.String(), expected[i]) {
 			matched++
 		}
 	}
@@ -349,12 +349,6 @@ func GjsonExactMatcher(values []gjson.Result, expected []string) bool {
 	}
 	numVars := len(expected)
 	return matched == numVars
-}
-
-// CaseInsensitiveStringContains reports whether substr is within s, ignoring the case
-func CaseInsensitiveStringContains(s, substr string) bool {
-	s, substr = strings.ToLower(s), strings.ToLower(substr)
-	return strings.Contains(s, substr)
 }
 
 //SetProjectName sets projectNames based on the neame of the test file name (withouth path and replacing _ with -), line number of current ginkgo execution, and a random string of 3 letters

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -151,7 +151,6 @@ var _ = Describe("odo devfile debug command tests", func() {
 			// but the solution is unacceptable https://github.com/golang/go/issues/6720#issuecomment-66087749
 			if runtime.GOOS != "windows" {
 				Expect(helper.ListFilesInDir(os.TempDir())).To(Not(ContainElement(commonVar.Project + "-app" + "-nodejs-cmp-" + commonVar.Project + "-odo-debug.json")))
-				helper.DeleteFile(filepath.Join(os.TempDir(), commonVar.Project+"-app"+"-nodejs-cmp-"+commonVar.Project+"-odo-debug.json"))
 			}
 
 		})

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -24,7 +24,6 @@ var _ = Describe("odo devfile debug command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)
@@ -111,6 +110,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			runningString := helper.Cmd("odo", "debug", "info", "--context", commonVar.Context).ShouldPass().Out()
 			Expect(runningString).To(ContainSubstring(freePort))
 			Expect(helper.ListFilesInDir(os.TempDir())).To(ContainElement(commonVar.Project + "-nodejs-cmp-odo-debug.json"))
+			helper.DeleteFile(filepath.Join(os.TempDir(), commonVar.Project+"-nodejs-cmp-odo-debug.json"))
 			stopChannel <- true
 		})
 
@@ -150,6 +150,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 			// but the solution is unacceptable https://github.com/golang/go/issues/6720#issuecomment-66087749
 			if runtime.GOOS != "windows" {
 				Expect(helper.ListFilesInDir(os.TempDir())).To(Not(ContainElement(commonVar.Project + "-app" + "-nodejs-cmp-" + commonVar.Project + "-odo-debug.json")))
+				helper.DeleteFile(filepath.Join(os.TempDir(), commonVar.Project+"-app"+"-nodejs-cmp-"+commonVar.Project+"-odo-debug.json"))
 			}
 
 		})

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -24,6 +24,7 @@ var _ = Describe("odo devfile debug command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
+		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)


### PR DESCRIPTION
**What type of PR is this?**

/kind tests

**What does this PR do / why we need it**:
This pr will remove the `tmp` directory debug test data leftover and also a workaround for https://github.com/openshift/odo/issues/5037 in tests

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
`make test-cmd-devfile-storage` should not throw error in https://github.com/openshift/odo/issues/5037