### PR TITLE
Send Identify event with every Track event

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -98,7 +98,7 @@ func (c *Client) Upload(data TelemetryData) error {
 	}
 
 	// obtain the user ID
-	userId, uerr := getUserIdentity(c, c.TelemetryFilePath)
+	userId, uerr := getUserIdentity(c.TelemetryFilePath)
 	if uerr != nil {
 		return uerr
 	}
@@ -122,7 +122,7 @@ func (c *Client) Upload(data TelemetryData) error {
 
 	// send the Identify message data that helps identify the user on segment
 	err := c.SegmentClient.Enqueue(analytics.Identify{
-		UserId: strings.TrimSpace(string(userId)),
+		UserId: userId,
 		Traits: addConfigTraits(),
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ func addConfigTraits() analytics.Traits {
 }
 
 // getUserIdentity returns the anonymous ID if it exists, else creates a new one and sends the data to Segment
-func getUserIdentity(client *Client, telemetryFilePath string) (string, error) {
+func getUserIdentity(telemetryFilePath string) (string, error) {
 	var id []byte
 
 	// Get-or-Create the '$HOME/.redhat' directory


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This will make sure that we identify every user,
not just those for which we created anonymousId.
User can already have anonymousId assigned by other tools like crc or
vscode plugins.
Before this odo did not send identify event for those users. This created
a situation where we were missing some information about those users.


More info about this in https://github.com/openshift/odo/issues/4994#issuecomment-902606879


**Which issue(s) this PR fixes**:



**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
