### PR TITLE
release v2.3.1

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,7 +16,7 @@ LABEL com.redhat.component=atomic-openshift-odo-cli-artifacts-container \
     summary="This image contains the Linux, Mac and Windows version of odo"
 
 # Change version as needed. Note no "-" is allowed
-LABEL version=2.3.0
+LABEL version=2.3.1
 
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/darwin-amd64/odo /usr/share/openshift/odo/mac/odo
 COPY --from=builder /go/src/github.com/openshift/odo/dist/bin/windows-amd64/odo.exe /usr/share/openshift/odo/windows/odo.exe

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ Changing these values will change the versioning information when releasing odo.
 
 var (
 	// VERSION  is version number that will be displayed when running ./odo version
-	VERSION = "v2.3.0"
+	VERSION = "v2.3.1"
 
 	// GITCOMMIT is hash of the commit that will be displayed when running ./odo version
 	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/openshift/odo/cmd.GITCOMMIT=$(GITCOMMIT)"

--- a/scripts/rpm-prepare.sh
+++ b/scripts/rpm-prepare.sh
@@ -5,7 +5,7 @@ set +ex
 echo "Reading ODO_VERSION, ODO_RELEASE and GIT_COMMIT env, if they are set"
 # Change version as needed. In most cases ODO_RELEASE would not be touched unless
 # we want to do a re-lease of same version as we are not backporting
-export ODO_VERSION=${ODO_VERSION:=2.3.0}
+export ODO_VERSION=${ODO_VERSION:=2.3.1}
 export ODO_RELEASE=${ODO_RELEASE:=1}
 
 export GIT_COMMIT=${GIT_COMMIT:=`git rev-parse --short HEAD 2>/dev/null`}


### PR DESCRIPTION
**What type of PR is this?**

version bump before release

**Changelog draft:**

# Release of v2.3.1

## [v2.3.1](https://github.com/openshift/odo/tree/v2.3.1) (2021-09-07)

[Full Changelog](https://github.com/openshift/odo/compare/v2.3.0...v2.3.1)

**Features/Enhancements:**

- Get parameters information of operator backed services from Kubernetes OpenAPI spec [\#5020](https://github.com/openshift/odo/pull/5020) ([feloy](https://github.com/feloy))
- Send telemetry data on user interrupt [\#4963](https://github.com/openshift/odo/pull/4963) ([valaparthvi](https://github.com/valaparthvi))
- Refactor machine output code [\#4948](https://github.com/openshift/odo/pull/4948) ([feloy](https://github.com/feloy))

**Bugs:**

- Send Identify event with every Track event [\#5040](https://github.com/openshift/odo/pull/5040) ([kadel](https://github.com/kadel))
- Fix clusterwide permission issues with odo link and run K8s tests with a developer user [\#5032](https://github.com/openshift/odo/pull/5032) ([valaparthvi](https://github.com/valaparthvi))
- Replace "nightly" tag with "next" in some integration tests devfiles [\#5028](https://github.com/openshift/odo/pull/5028) ([feloy](https://github.com/feloy))
- Display default project value while creating a component interactively [\#5026](https://github.com/openshift/odo/pull/5026) ([valaparthvi](https://github.com/valaparthvi))
- List all services in JSON output [\#5025](https://github.com/openshift/odo/pull/5025) ([feloy](https://github.com/feloy))
- Fix typo when there are no services [\#5018](https://github.com/openshift/odo/pull/5018) ([dharmit](https://github.com/dharmit))
- Adding filtering for service binding services [\#5015](https://github.com/openshift/odo/pull/5015) ([mohammedzee1000](https://github.com/mohammedzee1000))
- Fixes ephemeral storage mount issue [\#4979](https://github.com/openshift/odo/pull/4979) ([mik-dass](https://github.com/mik-dass))
- Updating config cmds and tests for logged out senario [\#4975](https://github.com/openshift/odo/pull/4975) ([mohammedzee1000](https://github.com/mohammedzee1000))
- Fixes the usage of service create command with parameters and dry-run flag [\#4974](https://github.com/openshift/odo/pull/4974) ([mik-dass](https://github.com/mik-dass))
- Uses the deployment while listing storage from the cluster [\#4970](https://github.com/openshift/odo/pull/4970) ([mik-dass](https://github.com/mik-dass))
- Set correct component name in the devfile metadata [\#4927](https://github.com/openshift/odo/pull/4927) ([valaparthvi](https://github.com/valaparthvi))

**Documentation:**

- Update readme to point to latest links [\#5024](https://github.com/openshift/odo/pull/5024) ([valaparthvi](https://github.com/valaparthvi))
- Add Cluster Setup documentation [\#4973](https://github.com/openshift/odo/pull/4973) ([valaparthvi](https://github.com/valaparthvi))
- Add Tutorials section to doc website [\#4934](https://github.com/openshift/odo/pull/4934) ([valaparthvi](https://github.com/valaparthvi))

**Testing/CI:**

- Increasing timeout from 1min to 5min for PodsShuouldBeRunning [\#5035](https://github.com/openshift/odo/pull/5035) ([anandrkskd](https://github.com/anandrkskd))
- Fix project list flake [\#4969](https://github.com/openshift/odo/pull/4969) ([prietyc123](https://github.com/prietyc123))
- devfile push test refactor [\#4924](https://github.com/openshift/odo/pull/4924) ([anandrkskd](https://github.com/anandrkskd))
- add PSI and IBM cloud to the script for test [\#4946](https://github.com/openshift/odo/pull/4946) ([anandrkskd](https://github.com/anandrkskd))


**Cleanup/Refactor:**

- Removes code related to s2i storage [\#5021](https://github.com/openshift/odo/pull/5021) ([mik-dass](https://github.com/mik-dass))
- Add sonar rule to ignore 'duplicated string literals' error on test files [\#5017](https://github.com/openshift/odo/pull/5017) ([valaparthvi](https://github.com/valaparthvi))
- Removed QE members from top-level reviewers [\#5009](https://github.com/openshift/odo/pull/5009) ([dharmit](https://github.com/dharmit))
- Cleanup namespaces [\#4985](https://github.com/openshift/odo/pull/4985) ([anandrkskd](https://github.com/anandrkskd))




\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*





