### PR TITLE
add logic to run github_changelog_generator in container

### DIFF
--- a/scripts/changelog-script.sh
+++ b/scripts/changelog-script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script uses github_changelog_generator to generate a changelog
+# This script uses github_changelog_generator (https://github.com/github-changelog-generator/github-changelog-generator/) to generate a changelog
 # by using the kind labels that we use..
 #
 # Then outputs it to STDOUT. This helps generate a changelog when doing a release.
@@ -25,7 +25,28 @@ echo -e "# Installation of $2
 To install odo, follow our installation guide at [docs.openshift.com]($INSTALLATION_GUIDE)
 After each release, binaries are synced to [mirror.openshift.com]($MIRROR)" > /tmp/base
 
-github_changelog_generator \
+
+
+RUN_GITHUB_CHANGELOG_GENERATOR="github_changelog_generator"
+
+CONTAINER_ARGS="run -it --rm -v $(pwd):/usr/local/src/your-app docker.io/githubchangeloggenerator/github-changelog-generator"
+
+if [ -x "$(command -v podman)" ]; then
+  echo "Podman detected."
+  RUN_GITHUB_CHANGELOG_GENERATOR="podman $CONTAINER_ARGS"
+elif [ -x "$(command -v docker)" ]; then
+  echo "Docker detected."
+  RUN_GITHUB_CHANGELOG_GENERATOR="docker $CONTAINER_ARGS"
+else
+  echo "No container runtime detected."
+fi
+
+
+echo "Executing github_changelog_generator using '$RUN_GITHUB_CHANGELOG_GENERATOR'"
+echo ""
+
+
+$RUN_GITHUB_CHANGELOG_GENERATOR \
 --max-issues 500 \
 --user openshift \
 --project odo \
@@ -34,15 +55,19 @@ github_changelog_generator \
 --since-tag $1 \
 --future-release $2 \
 --base /tmp/base \
---output /tmp/changelog \
+--output release-changelog.md \
 --exclude-labels "lifecycle/rotten,duplicate,question,invalid,wontfix" \
 --header-label "# Release of $2" \
 --enhancement-label "**Features/Enhancements:**" \
 --enhancement-labels "kind/feature" \
 --bugs-label "**Bugs:**" \
 --bug-labels "kind/bug" \
---add-sections '{"documentation":{"prefix":"**Documentation:**","labels":["kind/documentation"]}, "tests": {"prefix": "**Testing/CI:**", "labels": ["kind/tests"]}, "cleanup": {"prefix": "**Cleanup/Refactor:", "labels": ["kind/cleanup"]}}'
+--add-sections '{"documentation":{"prefix":"**Documentation:**","labels":["kind/documentation"]}, "tests": {"prefix": "**Testing/CI:**", "labels": ["kind/tests", "kind/failing-test"]}, "cleanup": {"prefix": "**Cleanup/Refactor:**", "labels": ["kind/cleanup"]}}'
+
+echo "---------------------------------------"
+cat release-changelog.md
+echo "---------------------------------------"
 
 echo ""
-echo "The changelog is located at: /tmp/changelog"
+echo "The changelog is located at: ./release-changelog.md"
 echo ""


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Now it is not required to install `github_changelog_generator` on your system to generate changelog. 

