### PR TITLE
Set odo to use staging registry in `CommonBeforeEach`

### DIFF
--- a/tests/e2escenarios/e2e_devfile_test.go
+++ b/tests/e2escenarios/e2e_devfile_test.go
@@ -33,7 +33,6 @@ var _ = Describe("odo devfile supported tests", func() {
 		projectDirPath = commonVar.Context + projectDir
 		helper.MakeDir(projectDirPath)
 		helper.Chdir(projectDirPath)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/helper/helper_generic.go
+++ b/tests/helper/helper_generic.go
@@ -302,6 +302,7 @@ func CommonBeforeEach() CommonVar {
 	cfg, _ := preference.New()
 	err := cfg.SetConfiguration(preference.ConsentTelemetrySetting, "false")
 	Expect(err).To(BeNil())
+	SetDefaultDevfileRegistryAsStaging()
 	return commonVar
 }
 

--- a/tests/integration/devfile/cmd_devfile_app_test.go
+++ b/tests/integration/devfile/cmd_devfile_app_test.go
@@ -18,7 +18,6 @@ var _ = Describe("odo devfile app command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		namespace = commonVar.Project
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_catalog_test.go
+++ b/tests/integration/devfile/cmd_devfile_catalog_test.go
@@ -22,7 +22,6 @@ var _ = Describe("odo devfile catalog command tests", func() {
 		// odo catalog list components.
 		// TODO: Investigate this more.
 		helper.Cmd("odo", "preference", "set", "registrycachetime", "0").ShouldPass()
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_config_test.go
+++ b/tests/integration/devfile/cmd_devfile_config_test.go
@@ -13,7 +13,6 @@ var _ = Describe("odo devfile config command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -27,7 +27,6 @@ var _ = Describe("odo devfile create command tests", func() {
 		cmpName = helper.RandString(6)
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_debug_test.go
+++ b/tests/integration/devfile/cmd_devfile_debug_test.go
@@ -24,7 +24,6 @@ var _ = Describe("odo devfile debug command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_delete_test.go
+++ b/tests/integration/devfile/cmd_devfile_delete_test.go
@@ -32,7 +32,6 @@ var _ = Describe("odo devfile delete command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_describe_test.go
+++ b/tests/integration/devfile/cmd_devfile_describe_test.go
@@ -23,7 +23,6 @@ var _ = Describe("odo devfile describe command tests", func() {
 		}
 
 		commonVar = helper.CommonBeforeEach()
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_env_test.go
+++ b/tests/integration/devfile/cmd_devfile_env_test.go
@@ -21,7 +21,6 @@ var _ = Describe("odo devfile env command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_exec_test.go
+++ b/tests/integration/devfile/cmd_devfile_exec_test.go
@@ -17,7 +17,6 @@ var _ = Describe("odo devfile exec command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_list_test.go
+++ b/tests/integration/devfile/cmd_devfile_list_test.go
@@ -22,7 +22,6 @@ var _ = Describe("odo list with devfile", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_log_test.go
+++ b/tests/integration/devfile/cmd_devfile_log_test.go
@@ -17,7 +17,6 @@ var _ = Describe("odo devfile log command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_push_test.go
+++ b/tests/integration/devfile/cmd_devfile_push_test.go
@@ -25,7 +25,6 @@ var _ = Describe("odo devfile push command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_registry_test.go
+++ b/tests/integration/devfile/cmd_devfile_registry_test.go
@@ -19,7 +19,6 @@ var _ = Describe("odo devfile registry command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_status_test.go
+++ b/tests/integration/devfile/cmd_devfile_status_test.go
@@ -30,7 +30,6 @@ var _ = Describe("odo devfile status command tests", func() {
 		namespace = commonVar.Project
 		context = commonVar.Context
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// Clean up after the test

--- a/tests/integration/devfile/cmd_devfile_storage_test.go
+++ b/tests/integration/devfile/cmd_devfile_storage_test.go
@@ -19,7 +19,6 @@ var _ = Describe("odo devfile storage command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_test_test.go
+++ b/tests/integration/devfile/cmd_devfile_test_test.go
@@ -17,7 +17,6 @@ var _ = Describe("odo devfile test command tests", func() {
 	var _ = BeforeEach(func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_url_test.go
+++ b/tests/integration/devfile/cmd_devfile_url_test.go
@@ -22,7 +22,6 @@ var _ = Describe("odo devfile url command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		componentName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/cmd_devfile_watch_test.go
+++ b/tests/integration/devfile/cmd_devfile_watch_test.go
@@ -24,7 +24,6 @@ var _ = Describe("odo devfile watch command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		cmpName = helper.RandString(6)
 		helper.Chdir(commonVar.Context)
-		helper.SetDefaultDevfileRegistryAsStaging()
 	})
 
 	// This is run after every Spec (It)

--- a/tests/integration/devfile/debug/debug_suite_test.go
+++ b/tests/integration/devfile/debug/debug_suite_test.go
@@ -3,15 +3,9 @@ package debug
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
 	"github.com/openshift/odo/tests/helper"
 )
 
 func TestDebug(t *testing.T) {
 	helper.RunTestSpecs(t, "Devfile Debug Suite")
 }
-
-// Use JustBeforeEach to use the preference file set into BeforeEach
-var _ = JustBeforeEach(func() {
-	helper.SetDefaultDevfileRegistryAsStaging()
-})


### PR DESCRIPTION
**What type of PR is this?**

/kind tests

**What does this PR do / why we need it**:
Sets up odo to use staging registry in the `CommonBeforeEach` so that we don't need to set it again each time.

**Which issue(s) this PR fixes**:

Fixes #5056 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
CI should pass.