### PR TITLE
Add timezone information to Telemetry data

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -75,6 +75,9 @@ func newCustomClient(preference *preference.PreferenceInfo, telemetryFilePath st
 		DefaultContext: &analytics.Context{
 			IP:       net.IPv4(0, 0, 0, 0),
 			Timezone: getTimeZoneRelativeToUTC(),
+			OS: analytics.OSInfo{
+				Name: runtime.GOOS,
+			},
 		},
 	})
 	if err != nil {
@@ -153,6 +156,7 @@ func (c *Client) Upload(data TelemetryData) error {
 // addConfigTraits adds information about the system
 func addConfigTraits() analytics.Traits {
 	traits := analytics.NewTraits().Set("os", runtime.GOOS)
+	traits.Set("Timezone", getTimeZoneRelativeToUTC())
 	return traits
 }
 

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -156,7 +156,7 @@ func (c *Client) Upload(data TelemetryData) error {
 // addConfigTraits adds information about the system
 func addConfigTraits() analytics.Traits {
 	traits := analytics.NewTraits().Set("os", runtime.GOOS)
-	traits.Set("Timezone", getTimeZoneRelativeToUTC())
+	traits.Set("timezone", getTimeZoneRelativeToUTC())
 	return traits
 }
 

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	scontext "github.com/openshift/odo/pkg/segment/context"
 
@@ -72,7 +73,8 @@ func newCustomClient(preference *preference.PreferenceInfo, telemetryFilePath st
 		Endpoint: segmentEndpoint,
 		Verbose:  true,
 		DefaultContext: &analytics.Context{
-			IP: net.IPv4(0, 0, 0, 0),
+			IP:       net.IPv4(0, 0, 0, 0),
+			Timezone: getTimeZoneRelativeToUTC(),
 		},
 	})
 	if err != nil {
@@ -83,6 +85,14 @@ func newCustomClient(preference *preference.PreferenceInfo, telemetryFilePath st
 		Preference:        preference,
 		TelemetryFilePath: telemetryFilePath,
 	}, nil
+}
+
+// getTimeZoneRelativeToUTC returns time zone relative to UTC (UTC +0530, UTC 0000, etc.)
+func getTimeZoneRelativeToUTC() string {
+	// t is a string array of RHC8222Z representation of current time
+	// example - [13 Sep 21 16:37 +0530]
+	var t = strings.Split(time.Now().Format(time.RFC822Z), " ")
+	return fmt.Sprintf("UTC %s", t[len(t)-1])
 }
 
 // Close client connection and send the data


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:
$subject

**Which issue(s) this PR fixes**:

Fixes part of #4994

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Segment data should contain the timezone information in the format "UTC +0530", "UTC 0000", etc.