### PR TITLE
Update DefaultDevfileRegistry link in IBM-Z and Power doc

### DIFF
--- a/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
+++ b/website/docs/tutorials/deploying-a-devfile-using-odo-on-IBM-Z-and-Power.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 [//]: # (Add prerequisite section)
 
 ### Deploying your first devfile on IBM Z & Power
-Since the [DefaultDevfileRegistry](https://github.com/odo-devfiles/registry) doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry, please check the doc [secure registry](../architecture/secure-registry.md).
+Since the [DefaultDevfileRegistry](https://registry.devfile.io/viewer) doesn't support IBM Z & Power now, you will need to create a secure private DevfileRegistry first. To create a new secure private DevfileRegistry, please check the doc [secure registry](../architecture/secure-registry.md).
 
 The images can be used for devfiles on IBM Z & Power
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind feature
> /kind cleanup
> /kind tests
/kind documentation
> Feel free to use other [labels](https://github.com/openshift/odo/labels) as needed. However one of the above labels must be present or the PR will not be reviewed. This instruction is for reviewers as well.

**What does this PR do / why we need it**:

In doc: https://odo.dev/docs/tutorials/deploying-a-devfile-using-odo-on-ibm-z-and-power/#deploying-your-first-devfile-on-ibm-z--power, DefaultDevfileRegistry use old link https://github.com/odo-devfiles/registry, need update it to https://registry.devfile.io/viewer 
**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [x] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
