### PR TITLE
Do not use Service Binding Operator

### DIFF
--- a/pkg/kclient/operators.go
+++ b/pkg/kclient/operators.go
@@ -25,7 +25,9 @@ const (
 
 // IsServiceBindingSupported checks if resource of type service binding request present on the cluster
 func (c *Client) IsServiceBindingSupported() (bool, error) {
-	return c.IsResourceSupported("binding.operators.coreos.com", "v1alpha1", "servicebindings")
+	// Detection of SBO has been removed from issue https://github.com/openshift/odo/issues/5084
+	return false, nil
+	//	return c.IsResourceSupported("binding.operators.coreos.com", "v1alpha1", "servicebindings")
 }
 
 // IsCSVSupported checks if resource of type service binding request present on the cluster

--- a/scripts/configure-cluster/common/setup-operators.sh
+++ b/scripts/configure-cluster/common/setup-operators.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -x
 
-export SBO_CATALOG_SOURCE="redhat-operators"
-export SBO_SUBSCRIPTION_NAME="rh-service-binding-operator"
-
 install_redis_operator(){
   $1 create -f - <<EOF
   apiVersion: operators.coreos.com/v1alpha1
@@ -19,55 +16,10 @@ install_redis_operator(){
 EOF
 }
 
-install_service_binding_operator(){
-  $1 create -f - <<EOF
-  apiVersion: operators.coreos.com/v1alpha1
-  kind: Subscription
-  metadata:
-    name: my-service-binding-operator
-    namespace: $2
-  spec:
-    channel: beta
-    name: $3
-    source: $4
-    sourceNamespace: $5
-EOF
-}
-
-deploy_service_binding_operator_master(){
-  oc create -f - <<EOF
-  apiVersion: operators.coreos.com/v1alpha1
-  kind: CatalogSource
-  metadata:
-    name: $1
-    namespace: openshift-marketplace
-  spec:
-    displayName: Service Binding Operator build from master
-    image: quay.io/redhat-developer/servicebinding-operator:index
-    priority: 500
-    publisher: Red Hat
-    sourceType: grpc
-    updateStrategy:
-      registryPoll:
-        interval: 10m0s
-EOF
-}
-
 if [ $KUBERNETES == "true" ]; then
   # install "redis-oprator" using "kubectl" in "operators" namespace; use "operatorhubio-catalog" catalog source from "olm" namespace
   install_redis_operator kubectl operators operatorhubio-catalog olm
 else
-  if [ $NIGHTLY == "true" ]; then
-    SBO_CATALOG_SOURCE="service-binding-master"
-    SBO_SUBSCRIPTION_NAME="service-binding-operator"
-
-    # Deploy SBO master catalog source on OCP Nightly test run
-    deploy_service_binding_operator_master $SBO_CATALOG_SOURCE
-  fi
-
   # install "redis-oprator" using "oc" in "openshift-operators" namespace; use "community-operators" catalog source from "openshift-marketplace" namespace
   install_redis_operator oc openshift-operators community-operators openshift-marketplace
-
-  # install "service-binding-operator" using "oc" in "openshift-operators" namespace; use SBO_CATALOG_SOURCE env var catalog source from "openshift-marketplace" namespace
-  install_service_binding_operator oc openshift-operators $SBO_SUBSCRIPTION_NAME $SBO_CATALOG_SOURCE openshift-marketplace
 fi

--- a/tests/integration/cmd_link_unlink_test.go
+++ b/tests/integration/cmd_link_unlink_test.go
@@ -19,7 +19,7 @@ var _ = Describe("odo link and unlink command tests", func() {
 		commonVar = helper.CommonBeforeEach()
 		// wait until timeout(sec) for odo to see all the operators installed by setup script in the namespace
 		odoArgs := []string{"catalog", "list", "services"}
-		operator := "service-binding-operator"
+		operator := "redis-operator"
 		helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
 			return strings.Contains(output, operator)
 		})

--- a/tests/integration/operatorhub/cmd_link_test.go
+++ b/tests/integration/operatorhub/cmd_link_test.go
@@ -276,7 +276,8 @@ var _ = Describe("odo link command tests for OperatorHub", func() {
 				helper.Cmd("odo", "exec", "--context", commonVar.Context, "--", "ls", "/bindings/redis-link/clusterIP").ShouldPass()
 			})
 
-			It("should find owner references on link and service", func() {
+			// Removed from issue https://github.com/openshift/odo/issues/5084
+			XIt("should find owner references on link and service", func() {
 				if os.Getenv("KUBERNETES") == "true" {
 					Skip("This is a OpenShift specific scenario, skipping")
 				}
@@ -346,7 +347,8 @@ var _ = Describe("odo link command tests for OperatorHub", func() {
 				helper.DeleteDir(context1)
 			})
 
-			It("should link the two components successfully with service binding operator", func() {
+			// Removed from issue https://github.com/openshift/odo/issues/5084
+			XIt("should link the two components successfully with service binding operator", func() {
 
 				if os.Getenv("KUBERNETES") == "true" {
 					// service binding operator is not installed on kubernetes

--- a/tests/integration/operatorhub/cmd_service_test.go
+++ b/tests/integration/operatorhub/cmd_service_test.go
@@ -34,9 +34,6 @@ var _ = Describe("odo service command tests for OperatorHub", func() {
 			// wait till odo can see that all operators installed by setup script in the namespace
 			odoArgs := []string{"catalog", "list", "services"}
 			operators := []string{"redis-operator"}
-			if os.Getenv("KUBERNETES") != "true" {
-				operators = append(operators, "service-binding-operator")
-			}
 			for _, operator := range operators {
 				helper.WaitForCmdOut("odo", odoArgs, 5, true, func(output string) bool {
 					return strings.Contains(output, operator)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What does this PR do / why we need it**:

This PR: 
- does not detect the installed Servivce Binding Operator and uses the Service Binding Library in any case.
- removes the script to install the SBO in the cluster
- disable integration tests relative to SBO usage

**Which issue(s) this PR fixes**:

Fixes #5084 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
