### PR TITLE
Retry failing calls to devfile registry

### DIFF
--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -497,7 +498,14 @@ func (co *CreateOptions) devfileRun(cmd *cobra.Command) (err error) {
 					params.Token = token
 				}
 			} else {
-				err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+				maxTries := 4
+				for i := 1; i <= maxTries; i++ {
+					err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+					if err == nil {
+						break
+					}
+					time.Sleep(time.Duration(maxTries) * 100 * time.Millisecond)
+				}
 				if err != nil {
 					return err
 				}
@@ -564,7 +572,15 @@ func (co *CreateOptions) devfileRun(cmd *cobra.Command) (err error) {
 		return errors.Wrapf(err, "unable to save devfile to %s", DevfilePath)
 	}
 	if co.devfileMetadata.devfilePath.value == "" && !devfileExist && !strings.Contains(co.devfileMetadata.devfileRegistry.URL, "github") {
-		err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+
+		maxTries := 4
+		for i := 1; i <= maxTries; i++ {
+			err = registryLibrary.PullStackFromRegistry(co.devfileMetadata.devfileRegistry.URL, co.devfileMetadata.componentType, co.componentContext)
+			if err == nil {
+				break
+			}
+			time.Sleep(time.Duration(maxTries) * 100 * time.Millisecond)
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
/kind bug

**What does this PR do / why we need it**:

Retry the calls to devfile registry when call fails

**Which issue(s) this PR fixes**:

Fixes #5116 

**PR acceptance criteria**:

- [ ] Unit test 

- [ ] Integration test 

- [ ] Documentation 

- [ ] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
