### PR TITLE
Close JSON debug file

### DIFF
--- a/pkg/debug/info.go
+++ b/pkg/debug/info.go
@@ -90,6 +90,8 @@ func createDebugInfoFile(f *DefaultPortForwarder, portPair string, fs filesystem
 	if err != nil {
 		return err
 	}
+	defer file.Close() // #nosec G307
+
 	_, err = file.Write(odoDebugPathData)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

Fixes #5123

**What does this PR do / why we need it**:

Closes the JSON debug file created by odo. Non closing it makes it impossible to remove it from Windows tests.

