### PR TITLE
WIP: Fix odo overwrites devfile with parent reference with flattened/resolved devfile

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/odo/pkg/log"
 )
 
+// parseDevfile parses and validates the devfile with both devfile and odo validators
 func parseDevfile(args parser.ParserArgs) (parser.DevfileObj, error) {
 	devObj, varWarnings, err := devfile.ParseDevfileAndValidate(args)
 	if err != nil {
@@ -18,6 +19,7 @@ func parseDevfile(args parser.ParserArgs) (parser.DevfileObj, error) {
 	}
 
 	// odo specific validations
+	// TODO: move this to a separate function and only call it when a change is made to the devfile.
 	err = validate.ValidateDevfileData(devObj.Data)
 	if err != nil {
 		return parser.DevfileObj{}, err
@@ -44,6 +46,16 @@ func parseDevfile(args parser.ParserArgs) (parser.DevfileObj, error) {
 // if there are warning it logs them on stdout
 func ParseFromFile(devfilePath string) (parser.DevfileObj, error) {
 	return parseDevfile(parser.ParserArgs{Path: devfilePath})
+}
+
+// DevfileParseFromFile reads, parses and validates a devfile from a file without flattening it
+func DevfileParseFromFile(devfilePath string, flattened bool) (parser.DevfileObj, error) {
+	devObj, _, err := devfile.ParseDevfileAndValidate(parser.ParserArgs{Path: devfilePath, FlattenedDevfile: &flattened})
+	if err != nil {
+		return parser.DevfileObj{}, err
+	}
+
+	return devObj, nil
 }
 
 // ParseFromData parses devfile from []byte and does all the validation

--- a/pkg/odo/cli/component/create.go
+++ b/pkg/odo/cli/component/create.go
@@ -586,7 +586,7 @@ func (co *CreateOptions) devfileRun(cmd *cobra.Command) (err error) {
 
 	// set user provided component name in the devfile
 	if co.devfileMetadata.componentName != "" {
-		devObj, err = devfile.ParseFromFile(co.DevfilePath)
+		devObj, err = devfile.DevfileParseFromFile(co.DevfilePath, false)
 		if err != nil {
 			return fmt.Errorf("failed to create devfile component: %w", err)
 		}

--- a/tests/examples/source/devfiles/nodejs/devfile-with-parent.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-parent.yaml
@@ -1,15 +1,10 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
-  name: nodejs
-  version: 1.0.0
+  name: new-ol-version
+  description: Child devfile to test OL image updating
 parent:
-  uri: https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/devfile.yaml
-commands:
-  - id: devbuild
-    exec:
-      component: runtime
-      commandLine: touch blah.js
-      workingDir: ${PROJECTS_ROOT}
-      group:
-        kind: build
-        isDefault: false
+  uri: https://github.com/OpenLiberty/application-stack/releases/download/maven-0.7.0/devfile.yaml
+  components:
+    - name: dev
+      container:
+        image: maven:3.6-adoptopenjdk-11-openj9

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -290,6 +290,22 @@ var _ = Describe("odo devfile create command tests", func() {
 				Expect(output).To(ContainSubstring("this directory already contains a component"))
 			})
 		})
+		When("devfile contains parent URI", func() {
+			var originalDevfileContent string
+			BeforeEach(func() {
+				var err error
+				devfilePath = filepath.Join(commonVar.Context, devfile)
+				helper.CopyExampleDevFile("", devfilePath)
+				originalDevfileContent, err = helper.ReadFile(devfilePath)
+				Expect(err).To(BeNil())
+			})
+			It("should not replace the original devfile", func() {
+				helper.Cmd("odo", "create").ShouldPass()
+				devfileContent, err := helper.ReadFile(devfilePath)
+				Expect(err).To(BeNil())
+				Expect(devfileContent).To(BeIdenticalTo(originalDevfileContent))
+			})
+		})
 	})
 
 	When("devfile does not exist in the working directory and user specifies the devfile path via --devfile", func() {
@@ -326,6 +342,21 @@ var _ = Describe("odo devfile create command tests", func() {
 			By("using --registry flag", func() {
 				errOut := helper.Cmd("odo", "create", "nodejs", "--devfile", devfilePath, "--registry", "DefaultDevfileRegistry").ShouldFail().Err()
 				Expect(errOut).To(ContainSubstring("you can't specify registry via --registry if you want to use the devfile that is specified via --devfile"))
+			})
+		})
+		When("devfile contains parent URI", func() {
+			var originalDevfileContent string
+			BeforeEach(func() {
+				var err error
+				helper.CopyExampleDevFile("", devfilePath)
+				originalDevfileContent, err = helper.ReadFile(devfilePath)
+				Expect(err).To(BeNil())
+			})
+			It("should not replace the original devfile", func() {
+				helper.Cmd("odo", "create", "--devfile", devfilePath).ShouldPass()
+				devfileContent, err := helper.ReadFile(filepath.Join(commonVar.Context, devfile))
+				Expect(err).To(BeNil())
+				Expect(devfileContent).To(BeIdenticalTo(originalDevfileContent))
 			})
 		})
 	})

--- a/tests/integration/devfile/cmd_devfile_create_test.go
+++ b/tests/integration/devfile/cmd_devfile_create_test.go
@@ -263,7 +263,9 @@ var _ = Describe("odo devfile create command tests", func() {
 			devfilePath = filepath.Join(commonVar.Context, devfile)
 			helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", devfile), devfilePath)
 		})
-
+		AfterEach(func() {
+			helper.Cmd("odo", "delete", "-af").ShouldPass()
+		})
 		It("should successfully create the devfile component", func() {
 			helper.Cmd("odo", "create", "nodejs").ShouldPass()
 		})
@@ -295,7 +297,7 @@ var _ = Describe("odo devfile create command tests", func() {
 			BeforeEach(func() {
 				var err error
 				devfilePath = filepath.Join(commonVar.Context, devfile)
-				helper.CopyExampleDevFile("", devfilePath)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-parent.yaml"), devfilePath)
 				originalDevfileContent, err = helper.ReadFile(devfilePath)
 				Expect(err).To(BeNil())
 			})
@@ -303,7 +305,7 @@ var _ = Describe("odo devfile create command tests", func() {
 				helper.Cmd("odo", "create").ShouldPass()
 				devfileContent, err := helper.ReadFile(devfilePath)
 				Expect(err).To(BeNil())
-				Expect(devfileContent).To(BeIdenticalTo(originalDevfileContent))
+				Expect(len(devfileContent)).To(BeEquivalentTo(len(originalDevfileContent)))
 			})
 		})
 	})
@@ -348,15 +350,15 @@ var _ = Describe("odo devfile create command tests", func() {
 			var originalDevfileContent string
 			BeforeEach(func() {
 				var err error
-				helper.CopyExampleDevFile("", devfilePath)
+				helper.CopyExampleDevFile(filepath.Join("source", "devfiles", "nodejs", "devfile-with-parent.yaml"), devfilePath)
 				originalDevfileContent, err = helper.ReadFile(devfilePath)
 				Expect(err).To(BeNil())
 			})
 			It("should not replace the original devfile", func() {
-				helper.Cmd("odo", "create", "--devfile", devfilePath).ShouldPass()
+				helper.Cmd("odo", "create", "mycomp", "--devfile", devfilePath).ShouldPass()
 				devfileContent, err := helper.ReadFile(filepath.Join(commonVar.Context, devfile))
 				Expect(err).To(BeNil())
-				Expect(devfileContent).To(BeIdenticalTo(originalDevfileContent))
+				Expect(len(devfileContent)).To(BeEquivalentTo(len(originalDevfileContent)))
 			})
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Fix: odo overwrites devfile with parent reference with flattened/resolved devfile
**Which issue(s) this PR fixes**:

Fixes #5112 

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:

1. Start with a `devfile.yaml` with a parent reference like:
```yaml
schemaVersion: 2.1.0
metadata:
  name: new-ol-version
  description: Child devfile to test OL image updating
parent:
  uri: "https://github.com/OpenLiberty/application-stack/releases/download/maven-0.7.0/devfile.yaml"
  components:
    - name: dev
      container:
        image: 'maven:3.6-adoptopenjdk-11-openj9'
```
2. `odo create mycomp`

Check the devfile once odo create finishes, it should be unchanged.