### PR TITLE
Do not run service related tests on Kubernetes

### DIFF
--- a/tests/integration/devfile/cmd_dot_devfile_test.go
+++ b/tests/integration/devfile/cmd_dot_devfile_test.go
@@ -2,6 +2,7 @@ package devfile
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -114,6 +115,10 @@ var _ = Describe("Test suits to check .devfile.yaml compatibility", func() {
 			var odoArgs []string
 			var operators []string
 			BeforeEach(func() {
+				if os.Getenv("KUBERNETES") == "true" {
+					Skip("This is a OpenShift specific scenario, skipping")
+				}
+
 				odoArgs = []string{"catalog", "list", "services"}
 				operators = []string{"redis-operator"}
 				for _, operator := range operators {


### PR DESCRIPTION
**What type of PR is this?**

/kind tests

**What does this PR do / why we need it**:

This PR skips tests on Kubernetes that are expecting operator backed services to be installed: on IBM environment, the Kubernetes cluster does not provide any operator backed service.
