### PR TITLE
Fix odo config view

### DIFF
--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -53,6 +54,9 @@ func (o *ViewOptions) Complete(name string, cmd *cobra.Command, args []string) (
 
 // Validate validates the ViewOptions based on completed values
 func (o *ViewOptions) Validate() (err error) {
+	if !o.IsDevfile {
+		return errors.New("the directory doesn't contain a component. Use 'odo create' to create a component")
+	}
 	return
 }
 

--- a/pkg/odo/cli/config/view.go
+++ b/pkg/odo/cli/config/view.go
@@ -25,7 +25,6 @@ var viewExample = ktemplates.Examples(`# For viewing the current configuration f
 type ViewOptions struct {
 	contextDir string
 	*genericclioptions.Context
-	//*clicomponent.PushOptions
 }
 
 // NewViewOptions creates a new ViewOptions instance

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -62,7 +62,7 @@ var _ = Describe("odo preference and config command tests", func() {
 
 		It("should fail if devfile not present in current dir", func() {
 			err := helper.Cmd("odo", "config", "view").ShouldFail().Err()
-			Expect(err).To(ContainSubstring("the directory doesn't contain a component"))
+			Expect(err).To(ContainSubstring("the current directory does not represent an odo component."))
 		})
 	})
 

--- a/tests/integration/cmd_pref_config_test.go
+++ b/tests/integration/cmd_pref_config_test.go
@@ -51,6 +51,21 @@ var _ = Describe("odo preference and config command tests", func() {
 		})
 	})
 
+	When("running odo config view", func() {
+		It("should pass if devfile is present in current dir", func() {
+			helper.Chdir(commonVar.Context)
+			cmpName := helper.RandString(6)
+			helper.Cmd("odo", "create", cmpName, "--devfile", helper.GetExamplePath("source", "devfiles", "nodejs", "devfile.yaml")).ShouldPass()
+			out := helper.Cmd("odo", "config", "view").ShouldPass().Out()
+			helper.MatchAllInOutput(out, []string{"runtime", "Memory: 1024Mi"})
+		})
+
+		It("should fail if devfile not present in current dir", func() {
+			err := helper.Cmd("odo", "config", "view").ShouldFail().Err()
+			Expect(err).To(ContainSubstring("the directory doesn't contain a component"))
+		})
+	})
+
 	Context("When viewing global config", func() {
 		var newContext string
 		// ConsentTelemetry is set to false in helper.CommonBeforeEach so that it does not prompt to set a value


### PR DESCRIPTION
Signed-off-by: anandrkskd <anandrkskd@gmail.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Current `odo config view` fails if we run this command in a dir not containing devfile. 
This PR fixes `odo config view` command for any directory not containing devfile.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit test 

- [x] Integration test 

- [ ] Documentation 

- [x] I have read the [test guidelines](https://github.com/openshift/odo/blob/master/docs/dev/test-architecture.adoc)

**How to test changes / Special notes to the reviewer**:
Steps to test changes
```
make install
cd /path/to/dir
odo config view
```

How to Reproduce the failure
 ```
 neo@matrix [11:07:42 PM] [~/work/demo] 
-> % ls    
nodejs-ex
neo@matrix [11:07:43 PM] [~/work/demo] 
-> % odo config view
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0x2832c23]

goroutine 1 [running]:
github.com/devfile/library/pkg/devfile/parser.DevfileObj.GetMetadataName(...)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/vendor/github.com/devfile/library/pkg/devfile/parser/configurables.go:147
github.com/openshift/odo/pkg/component.ToDevfileRepresentation(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/pkg/component/devfile_repr.go:12 +0xa3
github.com/openshift/odo/pkg/odo/cli/config.(*ViewOptions).Run(0xc0000220b0, 0xc0001afb80, 0x0, 0x0)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/pkg/odo/cli/config/view.go:62 +0x145
github.com/openshift/odo/pkg/odo/genericclioptions.GenericRun(0x35c0680, 0xc0000220b0, 0xc0001afb80, 0x49a2488, 0x0, 0x0)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/pkg/odo/genericclioptions/runnable.go:97 +0x479
github.com/openshift/odo/pkg/odo/cli/config.NewCmdView.func1(0xc0001afb80, 0x49a2488, 0x0, 0x0)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/pkg/odo/cli/config/view.go:89 +0x5e
github.com/spf13/cobra.(*Command).execute(0xc0001afb80, 0x49a2488, 0x0, 0x0, 0xc0001afb80, 0x49a2488)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:856 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003ee280, 0xc00005c0d8, 0x2ec1ec0, 0x49a2488)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:897
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/vendor/github.com/spf13/cobra/command.go:890
main.main()
	/builddir/build/BUILD/gocode/src/github.com/openshift/odo/cmd/odo/odo.go:70 +0x426
neo@matrix [11:07:51 PM] [~/work/demo] 
 ```